### PR TITLE
Low-level thread scheduling

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/IOLimiter.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache;
 
 import java.io.Flushable;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * IOLimiter instances can be passed to the {@link PageCache#flushAndForce(IOLimiter)} and
@@ -101,6 +102,16 @@ public interface IOLimiter
     default void enableLimit()
     {
         // Same as for disableLimit().
+    }
+
+    /**
+     * Get the configured max IOPS that this limiter will target, if any.
+     * @return An {@code Optional.of( the configured limit )}, or {@code Optional.empty()} if there is no configured
+     * limit.
+     */
+    default Optional<Integer> getMaxIOPS()
+    {
+        return Optional.empty();
     }
 
     /**

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -24,7 +24,11 @@ import java.io.Flushable;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
+import org.neo4j.concurrent.Scheduler;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PageEvictionCallback;
@@ -40,7 +44,9 @@ import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
-final class MuninnPagedFile implements PagedFile, Flushable
+import static org.neo4j.concurrent.Scheduler.OnRejection.CALLER_RUNS;
+
+public final class MuninnPagedFile implements PagedFile, Flushable
 {
     private static final int translationTableChunkSizePower = Integer.getInteger(
             "org.neo4j.io.pagecache.impl.muninn.MuninnPagedFile.translationTableChunkSizePower", 12 );
@@ -48,6 +54,15 @@ final class MuninnPagedFile implements PagedFile, Flushable
     private static final long translationTableChunkSizeMask = translationTableChunkSize - 1;
     private static final int translationTableChunkArrayBase = UnsafeUtil.arrayBaseOffset( MuninnPage[].class );
     private static final int translationTableChunkArrayScale = UnsafeUtil.arrayIndexScale( MuninnPage[].class );
+    @SuppressWarnings( "unchecked" )
+    private static final ThreadLocal<MuninnPage[]> flushArrayCache = new ThreadLocal()
+    {
+        @Override
+        protected Object initialValue()
+        {
+            return new MuninnPage[translationTableChunkSize];
+        }
+    };
 
     private static final long headerStateOffset =
             UnsafeUtil.getFieldOffset( MuninnPagedFile.class, "headerState" );
@@ -242,12 +257,116 @@ final class MuninnPagedFile implements PagedFile, Flushable
             throws IOException
     {
         // TODO it'd be awesome if, on Linux, we'd call sync_file_range(2) instead of fsync
-        MuninnPage[] pages = new MuninnPage[translationTableChunkSize];
-        long filePageId = -1; // Start at -1 because we increment at the *start* of the chunk-loop iteration.
-        long limiterStamp = IOLimiter.INITIAL_STAMP;
         Object[][] tt = this.translationTable;
-        for ( Object[] chunk : tt )
+        long filePageId = -1; // Start at -1 because we increment at the *start* of the chunk-loop iteration.
+        int idx = 0;
+        int len = tt.length;
+
+        if ( limiter.getMaxIOPS().isPresent() )
         {
+            // We need to do IOPS accounting, so go with single-threaded flushing for now.
+            // This can still be made faster by filtering unmodified chunks in parallel.
+            flushRange( filePageId, tt, idx, len, flushOpportunity, forClosing, limiter );
+        }
+        else
+        {
+            // We have no IOPS limits imposed upon us. Let's go parallel on this bad boy!
+            flushRangeParallel( filePageId, tt, idx, len, flushOpportunity, forClosing, limiter );
+        }
+
+        swapper.force();
+    }
+
+    private void flushRangeParallel( long filePageId, Object[][] tt, int idx, int len, FlushEventOpportunity flushOpportunity,
+                             boolean forClosing, IOLimiter limiter ) throws IOException
+    {
+        int chunksPerJob = Math.max( 1, len / 1024 );
+        int range = chunksPerJob * translationTableChunkSize;
+        int jobs = len / chunksPerJob;
+        if ( jobs == 1 )
+        {
+            jobs = 0; // Do it in-thread if there's only one job
+        }
+        Future<?>[] futures = new Future[jobs];
+
+        for ( int i = 0; i < jobs; i++ )
+        {
+            FlushRange callable = new FlushRange( filePageId, tt, idx, chunksPerJob, flushOpportunity, forClosing, limiter );
+            futures[i] = Scheduler.executeIOBound( callable, CALLER_RUNS );
+            filePageId += range;
+            idx += chunksPerJob;
+        }
+
+        // Flush any left-over chunks
+        int leftOverRange = len - idx;
+        if ( leftOverRange > 0 )
+        {
+            flushRange( filePageId, tt, idx, leftOverRange, flushOpportunity, forClosing, limiter );
+        }
+
+        // Wait for parallel tasks to complete
+        for ( Future<?> future : futures )
+        {
+            while ( !future.isDone() )
+            {
+                try
+                {
+                    future.get();
+                }
+                catch ( InterruptedException ignore )
+                {
+                }
+                catch ( ExecutionException e )
+                {
+                    if ( e.getCause() instanceof IOException )
+                    {
+                        throw (IOException) e.getCause();
+                    }
+                    throw new IOException( "Exception during parallel file flush", e );
+                }
+            }
+        }
+    }
+
+    private class FlushRange implements Callable<Object>
+    {
+        private final long filePageId;
+        private final Object[][] tt;
+        private final int idx;
+        private final int chunksPerJob;
+        private final FlushEventOpportunity flushOpportunity;
+        private final boolean forClosing;
+        private final IOLimiter limiter;
+
+        private FlushRange( long filePageId, Object[][] tt, int idx, int chunksPerJob,
+                            FlushEventOpportunity flushOpportunity, boolean forClosing, IOLimiter limiter )
+        {
+            this.filePageId = filePageId;
+            this.tt = tt;
+            this.idx = idx;
+            this.chunksPerJob = chunksPerJob;
+            this.flushOpportunity = flushOpportunity;
+            this.forClosing = forClosing;
+            this.limiter = limiter;
+        }
+
+        @Override
+        public Object call() throws Exception
+        {
+            flushRange( filePageId, tt, idx, chunksPerJob, flushOpportunity, forClosing, limiter );
+            return null;
+        }
+    }
+
+    private void flushRange( long filePageId, Object[][] tt, int idx, int len, FlushEventOpportunity flushOpportunity,
+                             boolean forClosing, IOLimiter limiter ) throws IOException
+    {
+        MuninnPage[] pages = flushArrayCache.get();
+        long limiterStamp = IOLimiter.INITIAL_STAMP;
+        int targetIdx = len + idx;
+        for (; idx < targetIdx; idx++ )
+        {
+            Object[] chunk = tt[idx];
             // TODO Look into if we can tolerate flushing a few clean pages if it means we can use larger vectors.
             // TODO The clean pages in question must still be loaded, though. Otherwise we'll end up writing
             // TODO garbage to the file.
@@ -308,8 +427,6 @@ final class MuninnPagedFile implements PagedFile, Flushable
                 limiterStamp = limiter.maybeLimitIO( limiterStamp, pagesGrabbed, this );
             }
         }
-
-        swapper.force();
     }
 
     private void vectoredFlush(

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.File;
+import java.io.Flushable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,6 +39,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -228,10 +230,22 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
 
         AtomicInteger callbackCounter = new AtomicInteger();
         AtomicInteger ioCounter = new AtomicInteger();
-        cache.flushAndForce( (previousStamp, recentlyCompletedIOs, swapper) -> {
-            ioCounter.addAndGet( recentlyCompletedIOs );
-            return callbackCounter.getAndIncrement();
-        });
+        cache.flushAndForce( new IOLimiter()
+        {
+            @Override
+            public long maybeLimitIO( long previousStamp, int recentlyCompletedIOs, Flushable swapper )
+                    throws IOException
+            {
+                ioCounter.addAndGet( recentlyCompletedIOs );
+                return callbackCounter.getAndIncrement();
+            }
+
+            @Override
+            public Optional<Integer> getMaxIOPS()
+            {
+                return Optional.of( 1000 );
+            }
+        } );
         pfA.close();
         pfB.close();
 
@@ -251,10 +265,22 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
 
         AtomicInteger callbackCounter = new AtomicInteger();
         AtomicInteger ioCounter = new AtomicInteger();
-        pf.flushAndForce( (previousStamp, recentlyCompletedIOs, swapper) -> {
-            ioCounter.addAndGet( recentlyCompletedIOs );
-            return callbackCounter.getAndIncrement();
-        });
+        pf.flushAndForce( new IOLimiter()
+        {
+            @Override
+            public long maybeLimitIO( long previousStamp, int recentlyCompletedIOs, Flushable swapper )
+                    throws IOException
+            {
+                ioCounter.addAndGet( recentlyCompletedIOs );
+                return callbackCounter.getAndIncrement();
+            }
+
+            @Override
+            public Optional<Integer> getMaxIOPS()
+            {
+                return Optional.of( 1000 );
+            }
+        } );
         pf.close();
 
         assertThat( callbackCounter.get(), greaterThan( 0 ) );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -254,7 +254,7 @@ public abstract class GraphDatabaseSettings
                   "the database places on the system, as each check-point implies a flushing and forcing of all the " +
                   "store files. The default is '5m' for a check-point every 5 minutes. Other supported units are 's' " +
                   "for seconds, and 'ms' for milliseconds." )
-    public static final Setting<Long> check_point_interval_time = setting( "dbms.checkpoint.interval.time", DURATION, "5m" );
+    public static final Setting<Long> check_point_interval_time = setting( "dbms.checkpoint.interval.time", DURATION, "5m", min( 1L ) );
 
     @Description( "Limit the number of IOs the background checkpoint process will consume per second. " +
                   "This setting is advisory, is ignored in Neo4j Community Edition, and is followed to " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
@@ -20,86 +20,25 @@
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
 import java.io.IOException;
-import java.util.function.BooleanSupplier;
 
-import org.neo4j.function.Predicates;
-import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.impl.util.PeriodicBackgroundTask;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.checkPoint;
 
-public class CheckPointScheduler extends LifecycleAdapter
+public class CheckPointScheduler extends PeriodicBackgroundTask
 {
     private final CheckPointer checkPointer;
-    private final JobScheduler scheduler;
-    private final long recurringPeriodMillis;
-    private final Runnable job = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            try
-            {
-                checkPointing = true;
-                if ( stopped )
-                {
-                    return;
-                }
-                checkPointer.checkPointIfNeeded( new SimpleTriggerInfo( "scheduler" ) );
-            }
-            catch ( IOException e )
-            {
-                // no need to reschedule since the check pointer has raised a kernel panic and a shutdown is expected
-                throw new UnderlyingStorageException( e );
-            }
-            finally
-            {
-                checkPointing = false;
-            }
-
-            // reschedule only if it is not stopped
-            if ( !stopped )
-            {
-                handle = scheduler.schedule( checkPoint, job, recurringPeriodMillis, MILLISECONDS );
-            }
-        }
-    };
-
-    private volatile JobScheduler.JobHandle handle;
-    private volatile boolean stopped;
-    private volatile boolean checkPointing;
-    private final BooleanSupplier checkPointingCondition = new BooleanSupplier()
-    {
-        @Override
-        public boolean getAsBoolean()
-        {
-            return !checkPointing;
-        }
-    };
 
     public CheckPointScheduler( CheckPointer checkPointer, JobScheduler scheduler, long recurringPeriodMillis )
     {
+        super( scheduler, recurringPeriodMillis, checkPoint );
         this.checkPointer = checkPointer;
-        this.scheduler = scheduler;
-        this.recurringPeriodMillis = recurringPeriodMillis;
     }
 
     @Override
-    public void start() throws Throwable
+    protected void performTask() throws IOException
     {
-        handle = scheduler.schedule( checkPoint, job, recurringPeriodMillis, MILLISECONDS );
-    }
-
-    @Override
-    public void stop() throws Throwable
-    {
-        stopped = true;
-        if ( handle != null )
-        {
-            handle.cancel( false );
-        }
-        Predicates.awaitForever( checkPointingCondition, 100, MILLISECONDS );
+        checkPointer.checkPointIfNeeded( new SimpleTriggerInfo( "scheduler" ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -198,9 +198,6 @@ public interface JobScheduler extends Lifecycle
     /** Schedule a new job in the specified group, passing in metadata for the scheduling strategy to use. */
     JobHandle schedule( Group group, Runnable job, Map<String, String> metadata );
 
-    /** Schedule a new job in the specified group with the given delay */
-    JobHandle schedule( Group group, Runnable runnable, long initialDelay, TimeUnit timeUnit );
-
     /** Schedule a recurring job */
     JobHandle scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/PeriodicBackgroundTask.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/PeriodicBackgroundTask.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public abstract class PeriodicBackgroundTask extends LifecycleAdapter
+{
+    private final JobScheduler scheduler;
+    private final long recurringPeriodMillis;
+    private final Runnable job = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            boolean gotExecutionPermit = false;
+            try
+            {
+                int attempts = 100;
+                do
+                {
+                    if ( stopped | --attempts < 0)
+                    {
+                        return;
+                    }
+                }
+                while ( !executionInProcess.tryAcquire( 100, TimeUnit.MILLISECONDS ) );
+                gotExecutionPermit = true;
+                performTask();
+            }
+            catch ( IOException e )
+            {
+                // no need to reschedule since the check pointer has raised a kernel panic and a shutdown is expected
+                throw new UnderlyingStorageException( e );
+            }
+            catch ( InterruptedException e )
+            {
+                // We should not get these in this thread. Ignore it.
+            }
+            finally
+            {
+                if ( gotExecutionPermit )
+                {
+                    executionInProcess.release();
+                }
+            }
+        }
+    };
+
+    private final JobScheduler.Group group;
+    private volatile JobScheduler.JobHandle handle;
+    private volatile boolean stopped;
+    private final Semaphore executionInProcess;
+
+    public PeriodicBackgroundTask( JobScheduler scheduler,
+                                   long recurringPeriodMillis,
+                                   JobScheduler.Group group )
+    {
+        if ( recurringPeriodMillis <= 0 )
+        {
+            throw new IllegalArgumentException(
+                    "Recurring period in milliseconds must be a positive number: " + recurringPeriodMillis );
+        }
+        this.scheduler = scheduler;
+        this.recurringPeriodMillis = recurringPeriodMillis;
+        this.group = group;
+        executionInProcess = new Semaphore( 1 );
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        handle = scheduler.scheduleRecurring(
+                group, job, recurringPeriodMillis, recurringPeriodMillis, MILLISECONDS );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        stopped = true;
+        JobScheduler.JobHandle h = this.handle;
+        if ( h != null )
+        {
+            h.cancel( false );
+        }
+        executionInProcess.acquire();
+    }
+
+    protected abstract void performTask() throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
@@ -83,6 +83,6 @@ public class UsageData extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        featureDecayJob = scheduler.schedule( udc, get( UsageDataKeys.features )::sweep, 1, DAYS );
+        featureDecayJob = scheduler.scheduleRecurring( udc, get( UsageDataKeys.features )::sweep, 1, 1, DAYS );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.OnDemandJobScheduler;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -61,31 +60,8 @@ public class CheckPointSchedulerTest
 
         // then
         assertNotNull( jobScheduler.getJob() );
-        verify( jobScheduler, times( 1 ) ).schedule( eq( checkPoint ), any( Runnable.class ),
-                eq( 20L ), eq( TimeUnit.MILLISECONDS ) );
-    }
-
-    @Test
-    public void shouldRescheduleTheJobAfterARun() throws Throwable
-    {
-        // given
-        CheckPointScheduler scheduler = new CheckPointScheduler( checkPointer, jobScheduler, 20L );
-
-        assertNull( jobScheduler.getJob() );
-
-        scheduler.start();
-
-        Runnable scheduledJob = jobScheduler.getJob();
-        assertNotNull( scheduledJob );
-
-        // when
-        jobScheduler.runJob();
-
-        // then
-        verify( jobScheduler, times( 2 ) ).schedule( eq( checkPoint ), any( Runnable.class ),
-                eq( 20L ), eq( TimeUnit.MILLISECONDS ) );
-        verify( checkPointer, times( 1 ) ).checkPointIfNeeded( any( TriggerInfo.class ) );
-        assertEquals( scheduledJob, jobScheduler.getJob() );
+        verify( jobScheduler, times( 1 ) ).scheduleRecurring( eq( checkPoint ), any( Runnable.class ),
+                eq( 20L ), eq( 20L ), eq( TimeUnit.MILLISECONDS ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
@@ -75,7 +75,7 @@ public class CheckPointerIntegrationTest
             InterruptedException, IOException
     {
         GraphDatabaseService db = builder
-                .setConfig( GraphDatabaseSettings.check_point_interval_time, 0 + "ms" )
+                .setConfig( GraphDatabaseSettings.check_point_interval_time, 1 + "ms" )
                 .setConfig( GraphDatabaseSettings.check_point_interval_tx, "1" )
                 .setConfig( GraphDatabaseSettings.logical_log_rotation_threshold, "1g" )
                 .newGraphDatabase();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CountingJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/CountingJobScheduler.java
@@ -63,13 +63,6 @@ public class CountingJobScheduler implements JobScheduler
     }
 
     @Override
-    public JobHandle schedule( Group group, Runnable runnable, long initialDelay, TimeUnit timeUnit )
-    {
-        counter.getAndIncrement();
-        return delegate.schedule( group, runnable, initialDelay, timeUnit );
-    }
-
-    @Override
     public JobHandle scheduleRecurring( Group group, Runnable runnable, long period,
                                         TimeUnit timeUnit )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.kernel.lifecycle.LifeSupport;
 
@@ -37,13 +35,11 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.JobScheduler.Group.THREAD_ID;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexPopulation;
 import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.NEW_THREAD;
-import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
 
 public class Neo4jJobSchedulerTest
 {
@@ -153,32 +149,6 @@ public class Neo4jJobSchedulerTest
         {
             unblockThread.countDown();
         }
-    }
-
-    @Test
-    public void shouldRunWithDelay() throws Throwable
-    {
-        // Given
-        life.start();
-
-        final AtomicLong runTime = new AtomicLong();
-        final CountDownLatch latch = new CountDownLatch( 1 );
-
-        long time = System.nanoTime();
-
-        scheduler.schedule( new JobScheduler.Group( "group", POOLED ), new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                runTime.set( System.nanoTime() );
-                latch.countDown();
-            }
-        }, 100, TimeUnit.MILLISECONDS );
-
-        latch.await();
-
-        assertTrue( time + TimeUnit.MILLISECONDS.toNanos( 100 ) <= runTime.get() );
     }
 
     private List<String> threadNames()

--- a/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OnDemandJobScheduler.java
@@ -67,13 +67,6 @@ public class OnDemandJobScheduler extends LifecycleAdapter implements JobSchedul
     }
 
     @Override
-    public JobHandle schedule( Group group, Runnable job, long initialDelay, TimeUnit timeUnit )
-    {
-        this.job = job;
-        return new OnDemandJobHandle();
-    }
-
-    @Override
     public JobHandle scheduleRecurring( Group group, Runnable runnable, long period, TimeUnit timeUnit )
     {
         this.job = runnable;

--- a/community/primitive-collections/pom.xml
+++ b/community/primitive-collections/pom.xml
@@ -49,6 +49,17 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/dump.hprof -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:-OmitStackTraceInFastThrow</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/primitive-collections/pom.xml
+++ b/community/primitive-collections/pom.xml
@@ -49,17 +49,6 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/dump.hprof -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:-OmitStackTraceInFastThrow</argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
@@ -409,8 +409,9 @@ public final class Scheduler
                 throw (RejectedExecutionException) th;
             }
             throw new RejectedExecutionException( th );
+        default:
+            throw new AssertionError( "Missing rejection case: " + onRejection );
         }
-        throw new AssertionError( "Missing rejection case: " + onRejection );
     }
 
     public static Future<?> executeRecurring( Runnable action, long initialDelay, long period, TimeUnit unit )

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
@@ -413,9 +413,9 @@ public final class Scheduler
         throw new AssertionError( "Missing rejection case: " + onRejection );
     }
 
-    public static Future<?> executeRecurring( Runnable action, long period, TimeUnit unit )
+    public static Future<?> executeRecurring( Runnable action, long initialDelay, long period, TimeUnit unit )
     {
-        return schedulingService.scheduleAtFixedRate( action, 0, period, unit );
+        return schedulingService.scheduleAtFixedRate( action, initialDelay, period, unit );
     }
 
     static boolean awaitQuiesce( long timeout, TimeUnit unit )

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Scheduler.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MutableCallSite;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+
+import static java.lang.invoke.MethodType.methodType;
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.getInteger;
+
+public final class Scheduler
+{
+    public enum OnRejection
+    {
+        SPAWN,
+        THROW,
+        CALLER_RUNS,
+        DROP
+    }
+
+    public interface ThreadPoolFactory
+    {
+        ForkJoinPool buildPool(
+                int parallelismHint,
+                ForkJoinPool.ForkJoinWorkerThreadFactory factory,
+                Thread.UncaughtExceptionHandler handler,
+                boolean asyncModeHint );
+    }
+
+    public static class SchedulerSettings
+    {
+        public int parallelism;
+        public ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory;
+        public ThreadPoolFactory poolFactory;
+    }
+
+    private static final String cpuThreadNamePrefix = "neo4j.compute";
+    private static final String ioThreadNamePrefix = "neo4j.io";
+    private static final String schedNamePrefix = "neo4j.sched";
+    private static final String extraNamePrefix = "neo4j.extra";
+
+    private static int defaultCpuBoundPoolParallelism = getInteger(
+            Scheduler.class, "computeBoundPoolParallelism", Runtime.getRuntime().availableProcessors() );
+    private static int defaultIoBoundPoolParallelism = getInteger(
+            Scheduler.class, "ioBoundPoolParallelism", 2 );
+    private static final ForkJoinPool.ForkJoinWorkerThreadFactory defaultCpuBoundThreadFactory =
+            buildThreadFactory( cpuThreadNamePrefix );
+    private static final ForkJoinPool.ForkJoinWorkerThreadFactory defaultIoBoundThreadFactory =
+            buildThreadFactory( ioThreadNamePrefix );
+    private static final ThreadPoolFactory defaultThreadPoolFactory = ForkJoinPool::new;
+    private static final ThreadFactory schedulerThreadFactory = buildOrdinaryThreadFactory( schedNamePrefix );
+    private static final ThreadFactory extraThreadFactory = buildOrdinaryThreadFactory( extraNamePrefix );
+    private static final AtomicLong spawnedExtraThreads = new AtomicLong();
+
+    private static final ScheduledExecutorService schedulingService =
+            Executors.newSingleThreadScheduledExecutor( schedulerThreadFactory );
+    private static final Future<?> cancelledFuture = new Future<Object>()
+    {
+        @Override
+        public boolean cancel( boolean mayInterruptIfRunning )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isDone()
+        {
+            return true;
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException
+        {
+            throw new CancellationException();
+        }
+
+        @Override
+        public Object get( long timeout, TimeUnit unit )
+                throws InterruptedException, ExecutionException, TimeoutException
+        {
+            throw new CancellationException();
+        }
+    };
+
+    private static ForkJoinPool.ForkJoinWorkerThreadFactory cpuBoundThreadFactory = defaultCpuBoundThreadFactory;
+    private static ForkJoinPool.ForkJoinWorkerThreadFactory ioBoundThreadFactory = defaultIoBoundThreadFactory;
+    private static ThreadPoolFactory cpuBoundPoolFactory = defaultThreadPoolFactory;
+    private static ThreadPoolFactory ioBoundPoolFactory = defaultThreadPoolFactory;
+    private static int currentCpuParallelism = defaultCpuBoundPoolParallelism;
+    private static int currentIoParallelism = defaultIoBoundPoolParallelism;
+    private static boolean cpuInitialised;
+    private static boolean ioInitialised;
+
+    private static final MutableCallSite cpuPoolGetterCallSite;
+    private static final MethodHandle initCpuMethodHandle;
+    private static final MethodHandle cpuBoundPoolGetter;
+    private static final MutableCallSite ioPoolGetterCallSite;
+    private static final MethodHandle initIoMethodHandle;
+    private static final MethodHandle ioBoundPoolGetter;
+
+    static
+    {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try
+        {
+            initCpuMethodHandle = lookup.findStatic( Scheduler.class, "initCpu", methodType( ForkJoinPool.class ) );
+        }
+        catch ( Exception e )
+        {
+            throw new LinkageError( "initCpu", e );
+        }
+        cpuPoolGetterCallSite = new MutableCallSite( initCpuMethodHandle );
+        cpuBoundPoolGetter = cpuPoolGetterCallSite.dynamicInvoker();
+
+        try
+        {
+            initIoMethodHandle = lookup.findStatic( Scheduler.class, "initIo", methodType( ForkJoinPool.class ) );
+        }
+        catch ( Exception e )
+        {
+            throw new LinkageError( "initIo", e );
+        }
+        ioPoolGetterCallSite = new MutableCallSite( initIoMethodHandle );
+        ioBoundPoolGetter = ioPoolGetterCallSite.dynamicInvoker();
+    }
+
+    @SuppressWarnings( "unused" ) // Called through MethodHandles
+    private static synchronized ForkJoinPool initCpu()
+    {
+        if ( !cpuInitialised )
+        {
+            ForkJoinPool pool = cpuBoundPoolFactory.buildPool(
+                    currentCpuParallelism, cpuBoundThreadFactory, null, false );
+            MethodHandle getter = MethodHandles.constant( ForkJoinPool.class, pool );
+            cpuPoolGetterCallSite.setTarget( getter );
+            cpuInitialised = true;
+            syncMutableCallSites();
+        }
+
+        return getCpuBoundPool();
+    }
+
+    @SuppressWarnings( "unused" ) // Called through MethodHandles
+    private static synchronized ForkJoinPool initIo()
+    {
+        if ( !ioInitialised )
+        {
+            ForkJoinPool pool = ioBoundPoolFactory.buildPool(
+                    currentIoParallelism, ioBoundThreadFactory, null, true );
+            MethodHandle getter = MethodHandles.constant( ForkJoinPool.class, pool );
+            ioPoolGetterCallSite.setTarget( getter );
+            ioInitialised = true;
+            syncMutableCallSites();
+        }
+
+        return getIoBoundPool();
+    }
+
+    private static void syncMutableCallSites()
+    {
+        MutableCallSite.syncAll( new MutableCallSite[]{cpuPoolGetterCallSite, ioPoolGetterCallSite} );
+    }
+
+    private static ForkJoinPool.ForkJoinWorkerThreadFactory buildThreadFactory( String namePrefix )
+    {
+        AtomicInteger threadCounter = new AtomicInteger();
+        ForkJoinPool.ForkJoinWorkerThreadFactory motherFactory = ForkJoinPool.commonPool().getFactory();
+        return pool ->
+        {
+            ForkJoinWorkerThread thread = motherFactory.newThread( pool );
+            configureThread( thread, namePrefix, threadCounter );
+            return thread;
+        };
+    }
+
+    private static ThreadFactory buildOrdinaryThreadFactory( String namePrefix )
+    {
+        AtomicInteger threadCounter = new AtomicInteger();
+        return runnable -> configureThread( new Thread( runnable ), namePrefix, threadCounter );
+    }
+
+    private static <T extends Thread> T configureThread( T thread, String namePrefix, AtomicInteger threadCounter )
+    {
+        thread.setDaemon( true );
+        thread.setName( namePrefix + "." + threadCounter.incrementAndGet() );
+        return thread;
+    }
+
+    private static ForkJoinPool getCpuBoundPool()
+    {
+        try
+        {
+            return (ForkJoinPool) cpuBoundPoolGetter.invokeExact();
+        }
+        catch ( Throwable throwable )
+        {
+            throw new LinkageError( "cpuBoundPoolGetter", throwable );
+        }
+    }
+
+    private static ForkJoinPool getIoBoundPool()
+    {
+        try
+        {
+            return (ForkJoinPool) ioBoundPoolGetter.invokeExact();
+        }
+        catch ( Throwable throwable )
+        {
+            throw new LinkageError( "ioBoundPoolGetter", throwable );
+        }
+    }
+
+    public static void resetSchedulerSettings()
+    {
+        modifySchedulerSettings( (cpu, io) ->
+        {
+            cpu.parallelism = defaultCpuBoundPoolParallelism;
+            cpu.threadFactory = defaultCpuBoundThreadFactory;
+            cpu.poolFactory = defaultThreadPoolFactory;
+
+            io.parallelism = defaultIoBoundPoolParallelism;
+            io.threadFactory = defaultIoBoundThreadFactory;
+            io.poolFactory = defaultThreadPoolFactory;
+        });
+    }
+
+    public static void modifySchedulerSettings(
+            BiConsumer<SchedulerSettings, SchedulerSettings> modifier )
+    {
+        List<ForkJoinPool> oldPools = updateAndInstallNewPools(modifier);
+        for ( ForkJoinPool oldPool : oldPools )
+        {
+            oldPool.awaitQuiescence( 5, TimeUnit.SECONDS );
+            oldPool.shutdown();
+        }
+    }
+
+    private static synchronized List<ForkJoinPool> updateAndInstallNewPools(
+            BiConsumer<SchedulerSettings, SchedulerSettings> modifier )
+    {
+        SchedulerSettings cpu = new SchedulerSettings();
+        cpu.parallelism = currentCpuParallelism;
+        cpu.poolFactory = cpuBoundPoolFactory;
+        cpu.threadFactory = cpuBoundThreadFactory;
+        SchedulerSettings io = new SchedulerSettings();
+        io.parallelism = currentIoParallelism;
+        io.poolFactory = ioBoundPoolFactory;
+        io.threadFactory = ioBoundThreadFactory;
+
+        modifier.accept( cpu, io );
+
+        boolean modifiedCpu = false;
+        boolean modifiedIo = false;
+
+        if ( cpu.parallelism > 0 && cpu.parallelism != currentCpuParallelism )
+        {
+            currentCpuParallelism = cpu.parallelism;
+            modifiedCpu = true;
+        }
+
+        if ( cpu.threadFactory != null && cpu.threadFactory != cpuBoundThreadFactory )
+        {
+            cpuBoundThreadFactory = cpu.threadFactory;
+            modifiedCpu = true;
+        }
+
+        if ( cpu.poolFactory != null && cpu.poolFactory != cpuBoundPoolFactory )
+        {
+            cpuBoundPoolFactory = cpu.poolFactory;
+            modifiedCpu = true;
+        }
+
+        if ( io.parallelism > 0 && io.parallelism != currentIoParallelism )
+        {
+            currentIoParallelism = io.parallelism;
+            modifiedIo = true;
+        }
+
+        if ( io.threadFactory != null && io.threadFactory != ioBoundThreadFactory )
+        {
+            ioBoundThreadFactory = io.threadFactory;
+            modifiedIo = true;
+        }
+
+        if ( io.poolFactory != null && io.poolFactory != ioBoundPoolFactory )
+        {
+            ioBoundPoolFactory = io.poolFactory;
+            modifiedIo = true;
+        }
+
+        List<ForkJoinPool> oldPools = new LinkedList<>();
+        if ( modifiedCpu & cpuInitialised )
+        {
+            oldPools.add( getCpuBoundPool() );
+            cpuInitialised = false;
+            cpuPoolGetterCallSite.setTarget( initCpuMethodHandle );
+        }
+        if ( modifiedIo & ioInitialised )
+        {
+            oldPools.add( getIoBoundPool() );
+            ioInitialised = false;
+            ioPoolGetterCallSite.setTarget( initIoMethodHandle );
+        }
+        if ( !oldPools.isEmpty() )
+        {
+            syncMutableCallSites();
+        }
+        return oldPools;
+    }
+
+    public static <T> Future<T> executeComputeBound( Callable<T> callable, OnRejection onRejection )
+    {
+        checkRejectionForNull( onRejection );
+        try
+        {
+            return getCpuBoundPool().submit( callable );
+        }
+        catch ( Throwable th )
+        {
+            return handleRejection( callable, th, onRejection );
+        }
+    }
+
+    public static <T> Future<T> executeIOBound( Callable<T> callable, OnRejection onRejection )
+    {
+        checkRejectionForNull( onRejection );
+        try
+        {
+            return getIoBoundPool().submit( callable );
+        }
+        catch ( Throwable th )
+        {
+            return handleRejection( callable, th, onRejection );
+        }
+    }
+
+    private static void checkRejectionForNull( OnRejection onRejection )
+    {
+        if ( onRejection == null )
+        {
+            throw new IllegalArgumentException( "The OnRejection cannot be null" );
+        }
+    }
+
+    private static <T> Future<T> handleRejection(
+            Callable<T> callable, Throwable th, OnRejection onRejection )
+    {
+        FutureTask<T> task;
+        switch ( onRejection )
+        {
+        case CALLER_RUNS:
+            task = new FutureTask<>( callable );
+            task.run();
+            return task;
+        case DROP:
+            //noinspection unchecked
+            return (Future<T>) cancelledFuture;
+        case SPAWN:
+            task = new FutureTask<>( callable );
+            Thread thread = extraThreadFactory.newThread( task );
+            thread.start();
+            spawnedExtraThreads.getAndIncrement();
+            return task;
+        case THROW:
+            if ( th instanceof RejectedExecutionException )
+            {
+                throw (RejectedExecutionException) th;
+            }
+            throw new RejectedExecutionException( th );
+        }
+        throw new AssertionError( "Missing rejection case: " + onRejection );
+    }
+
+    public static Future<?> executeRecurring( Runnable action, long period, TimeUnit unit )
+    {
+        return schedulingService.scheduleAtFixedRate( action, 0, period, unit );
+    }
+
+    static boolean awaitQuiesce( long timeout, TimeUnit unit )
+    {
+        long halfTimeout = timeout / 2;
+        return getCpuBoundPool().awaitQuiescence( halfTimeout, unit ) &
+               getIoBoundPool().awaitQuiescence( halfTimeout, unit );
+    }
+
+    static long countSpawnedExtraThreads()
+    {
+        return spawnedExtraThreads.get();
+    }
+
+    private Scheduler()
+    {
+        // Disallow instantiation.
+        // All public methods and internal states are static, because we are dealing with system-wide resources.
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerIT.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerIT.java
@@ -21,6 +21,7 @@ package org.neo4j.concurrent;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;
@@ -41,9 +42,9 @@ import static org.neo4j.concurrent.Scheduler.OnRejection.DROP;
 import static org.neo4j.concurrent.Scheduler.OnRejection.SPAWN;
 import static org.neo4j.concurrent.Scheduler.OnRejection.THROW;
 
+@Ignore // This test adds 3 minutes to the build time, and I'm not sure we need to run it every time.
 public class SchedulerIT
 {
-
     private BinaryLatch latch;
     private Callable<Object> callable;
 

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerIT.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.concurrent.Scheduler.OnRejection.CALLER_RUNS;
+import static org.neo4j.concurrent.Scheduler.OnRejection.DROP;
+import static org.neo4j.concurrent.Scheduler.OnRejection.SPAWN;
+import static org.neo4j.concurrent.Scheduler.OnRejection.THROW;
+
+public class SchedulerIT
+{
+
+    private BinaryLatch latch;
+    private Callable<Object> callable;
+
+    @Before
+    public void resetSchedulerSettings()
+    {
+        Scheduler.resetSchedulerSettings();
+        latch = new BinaryLatch();
+        callable = () -> { latch.await(); return null; };
+    }
+
+    @After
+    public void quiesceScheduler()
+    {
+        latch.release();
+        boolean quiesced;
+        do
+        {
+            quiesced = Scheduler.awaitQuiesce( 1, TimeUnit.SECONDS );
+        }
+        while ( !quiesced );
+    }
+
+    @Test
+    public void callerMustRunComputeBoundIfExecutedWithCallerRunsRejection() throws Exception
+    {
+        assertCallerRunsExcessTasks( Scheduler::executeComputeBound );
+    }
+
+    @Test
+    public void callerMustRunIoBoundIfExecuteWithCallerRunsRejection() throws Exception
+    {
+        assertCallerRunsExcessTasks( Scheduler::executeIOBound );
+    }
+
+    private void assertCallerRunsExcessTasks( BiConsumer<Callable<?>,Scheduler.OnRejection> execute )
+    {
+        Thread callerThread = Thread.currentThread();
+        AtomicBoolean observedCallerThread = new AtomicBoolean();
+        BinaryLatch latch = new BinaryLatch();
+        Callable<?> callable = () ->
+        {
+            if ( Thread.currentThread() == callerThread )
+            {
+                observedCallerThread.set( true );
+                latch.release();
+            }
+            else
+            {
+                latch.await();
+            }
+            return null;
+        };
+
+        while ( !observedCallerThread.get() )
+        {
+            execute.accept( callable, CALLER_RUNS );
+        }
+    }
+
+    @Test
+    public void mustDropExcessComputeBoundCallablesWithDropRejection() throws Exception
+    {
+        assertExcessTasksAreDroppedWithDropRejection( Scheduler::executeComputeBound );
+    }
+
+    @Test
+    public void mustDropExcessIoBoundCallablesWithDropRejection() throws Exception
+    {
+        assertExcessTasksAreDroppedWithDropRejection( Scheduler::executeIOBound );
+    }
+
+    private void assertExcessTasksAreDroppedWithDropRejection(
+            BiFunction<Callable<Object>,Scheduler.OnRejection,Future<Object>> execute )
+    {
+        try
+        {
+            Future<Object> future;
+            do
+            {
+                future = execute.apply( callable, DROP );
+            }
+            while ( !future.isCancelled() );
+        }
+        finally
+        {
+            latch.release();
+        }
+    }
+
+    @Test
+    public void mustSpawnThreadForExcessComputeBoundTaskWithSpawnRejection() throws Exception
+    {
+        assertExcessTasksSpawnNewThreads( Scheduler::executeComputeBound, ( cpu, io ) -> cpu.parallelism = 1 );
+    }
+
+    @Test
+    public void mustSpawnThreadForExcessIoBoundTaskWithSpawnRejection() throws Exception
+    {
+        assertExcessTasksSpawnNewThreads( Scheduler::executeIOBound, ( cpu, io ) -> io.parallelism = 1 );
+    }
+
+    private void assertExcessTasksSpawnNewThreads(
+            BiFunction<Callable<Object>,Scheduler.OnRejection,Future<Object>> execute,
+            BiConsumer<Scheduler.SchedulerSettings,Scheduler.SchedulerSettings> settings ) throws Exception
+    {
+        Scheduler.modifySchedulerSettings( settings );
+        long initialExtraThreadCount = Scheduler.countSpawnedExtraThreads();
+        Future<?> future;
+        do
+        {
+            future = execute.apply( callable, SPAWN );
+            assertThat( future, is( not( nullValue() ) ) );
+        }
+        while ( Scheduler.countSpawnedExtraThreads() < initialExtraThreadCount + 1 );
+        latch.release();
+        future.get();
+    }
+
+    @Test
+    public void mustThrowOnExcessComputeBoundTasksWithThrowRejection() throws Exception
+    {
+        assertThrowsOnRejectingExcessTasks( Scheduler::executeComputeBound );
+    }
+
+    @Test
+    public void mustThrowOnExcessIoBoundTasksWithThrowRejection() throws Exception
+    {
+        assertThrowsOnRejectingExcessTasks( Scheduler::executeIOBound );
+    }
+
+    private void assertThrowsOnRejectingExcessTasks( BiConsumer<Callable<?>,Scheduler.OnRejection> execute )
+    {
+        long counter = 0;
+        try
+        {
+            //noinspection InfiniteLoopStatement
+            for (;;)
+            {
+                execute.accept( callable, THROW );
+                counter++;
+            }
+        }
+        catch ( RejectedExecutionException e )
+        {
+            assertThat( counter, greaterThan( 100L ) );
+        }
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerTest.java
@@ -81,7 +81,7 @@ public class SchedulerTest
     public void recurringTaskMustExecuteUntilCancelled() throws Exception
     {
         Semaphore latch = new Semaphore( 0 );
-        Future<?> future = Scheduler.executeRecurring( latch::release, 1, TimeUnit.MILLISECONDS );
+        Future<?> future = Scheduler.executeRecurring( latch::release, 0, 1, TimeUnit.MILLISECONDS );
         latch.acquire();
         long start = System.currentTimeMillis();
         latch.acquire( 9 );

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/SchedulerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.concurrent.Scheduler.OnRejection.DROP;
+import static org.neo4j.concurrent.Scheduler.OnRejection.THROW;
+
+public class SchedulerTest
+{
+    @Before
+    public void resetSchedulerSettings()
+    {
+        Scheduler.resetSchedulerSettings();
+    }
+
+    @Test
+    public void mustExecuteComputeBoundWork() throws Exception
+    {
+        Future<Integer> future = Scheduler.executeComputeBound(
+                () -> Arrays.stream( new int[]{1, 2, 3, 4} ).parallel().sum(), THROW );
+        assertThat( future.get(), equalTo( 10 ) );
+    }
+
+    @Test
+    public void mustExecuteIoBoundWork() throws Exception
+    {
+        Future<Integer> future = Scheduler.executeIOBound(
+                () -> Arrays.stream( new int[]{1, 2, 3, 4} ).parallel().sum(), THROW );
+        assertThat( future.get(), equalTo( 10 ) );
+    }
+
+    @Test
+    public void mustExecuteComputeBoundWorkInPooledThread() throws Exception
+    {
+        Future<Thread> future = Scheduler.executeComputeBound( Thread::currentThread, THROW );
+        assertThat( future.get(), is( not( sameInstance( Thread.currentThread() ) ) ) );
+    }
+
+    @Test
+    public void mustExecuteIoBoundWorkInPooledThread() throws Exception
+    {
+        Future<Thread> future = Scheduler.executeIOBound( Thread::currentThread, THROW );
+        assertThat( future.get(), is( not( sameInstance( Thread.currentThread() ) ) ) );
+    }
+
+    @Test
+    public void recurringTaskMustExecuteUntilCancelled() throws Exception
+    {
+        Semaphore latch = new Semaphore( 0 );
+        Future<?> future = Scheduler.executeRecurring( latch::release, 1, TimeUnit.MILLISECONDS );
+        latch.acquire();
+        long start = System.currentTimeMillis();
+        latch.acquire( 9 );
+        long elapsed = System.currentTimeMillis() - start;
+        // We should get a permit released about once every millisecond, which ideally means our 9 requested permits
+        // should be delivered in about 9 milliseconds. With virtual machines, thread wake-up time can be pretty long,
+        // so lets add a good bit of slack, and assert that we get all of our permits in less than 100 milliseconds.
+        assertThat( elapsed, lessThan( 100L ) );
+        // Now cancel the future and sleep for 100 milliseconds. We should observe that no new permits are released.
+        future.cancel( true );
+        latch.drainPermits();
+        Thread.sleep( 100 );
+        assertThat( latch.drainPermits(), lessThan( 50 ) );
+    }
+
+    @Test
+    public void changingCpuParallelismMustRebuildPool() throws Exception
+    {
+        int before = measureParallelism( Scheduler::executeComputeBound );
+        Scheduler.modifySchedulerSettings( (cpu, io) -> cpu.parallelism += 1 );
+        int after = measureParallelism( Scheduler::executeComputeBound );
+        assertThat( after, is( before + 1 ) );
+    }
+
+    @Test
+    public void changingIoParallelismMustRebuildPool() throws Exception
+    {
+        int before = measureParallelism( Scheduler::executeIOBound );
+        Scheduler.modifySchedulerSettings( (cpu, io) -> io.parallelism += 1 );
+        int after = measureParallelism( Scheduler::executeIOBound );
+        assertThat( after, is( before + 1 ) );
+    }
+
+    private int measureParallelism( BiConsumer<Callable<?>,Scheduler.OnRejection> execute ) throws InterruptedException
+    {
+        BinaryLatch latch = new BinaryLatch();
+        AtomicInteger counter = new AtomicInteger();
+        Callable<?> callable = () ->
+        {
+            counter.incrementAndGet();
+            latch.await();
+            counter.decrementAndGet();
+            return null;
+        };
+
+        try
+        {
+            for ( int i = 0; i < 500; i++ )
+            {
+                execute.accept( callable, DROP );
+            }
+            Thread.sleep( 100 );
+            return counter.get();
+        }
+        finally
+        {
+            latch.release();
+            boolean quiesced;
+            do
+            {
+                quiesced = Scheduler.awaitQuiesce( 1, TimeUnit.SECONDS );
+            }
+            while ( !quiesced );
+        }
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void nullComputeRejectionMustThrow() throws Exception
+    {
+        Scheduler.executeComputeBound( () -> null, null );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void nullIoRejectionMustThrow() throws Exception
+    {
+        Scheduler.executeIOBound( () -> null, null );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/PruningScheduler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/PruningScheduler.java
@@ -19,87 +19,26 @@
  */
 package org.neo4j.coreedge.raft.log.pruning;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import java.io.IOException;
+
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.PeriodicBackgroundTask;
+
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.raftLogPruning;
 
-import java.io.IOException;
-import java.util.function.BooleanSupplier;
-
-import org.neo4j.function.Predicates;
-import org.neo4j.kernel.impl.store.UnderlyingStorageException;
-import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-
-public class PruningScheduler extends LifecycleAdapter
+public class PruningScheduler extends PeriodicBackgroundTask
 {
     private final LogPruner logPruner;
-    private final JobScheduler scheduler;
-    private final long recurringPeriodMillis;
-    private final Runnable job = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            try
-            {
-                checkPointing = true;
-                if ( stopped )
-                {
-                    return;
-                }
-                logPruner.prune();
-            }
-            catch ( IOException e )
-            {
-                // no need to reschedule since the check pointer has raised a kernel panic and a shutdown is expected
-                throw new UnderlyingStorageException( e );
-            }
-            finally
-            {
-                checkPointing = false;
-            }
-
-            // reschedule only if it is not stopped
-            if ( !stopped )
-            {
-                handle = scheduler.schedule( raftLogPruning, job, recurringPeriodMillis, MILLISECONDS );
-            }
-        }
-    };
-
-    private volatile JobScheduler.JobHandle handle;
-    private volatile boolean stopped;
-    private volatile boolean checkPointing;
-    private final BooleanSupplier checkPointingCondition = new BooleanSupplier()
-    {
-        @Override
-        public boolean getAsBoolean()
-        {
-            return !checkPointing;
-        }
-    };
 
     public PruningScheduler( LogPruner logPruner, JobScheduler scheduler, long recurringPeriodMillis )
     {
+        super( scheduler, recurringPeriodMillis, raftLogPruning );
         this.logPruner = logPruner;
-        this.scheduler = scheduler;
-        this.recurringPeriodMillis = recurringPeriodMillis;
     }
 
     @Override
-    public void start() throws Throwable
+    protected void performTask() throws IOException
     {
-        handle = scheduler.schedule( raftLogPruning, job, recurringPeriodMillis, MILLISECONDS );
-    }
-
-    @Override
-    public void stop() throws Throwable
-    {
-        stopped = true;
-        if ( handle != null )
-        {
-            handle.cancel( false );
-        }
-        Predicates.awaitForever( checkPointingCondition, 100, MILLISECONDS );
+        logPruner.prune();
     }
 }


### PR DESCRIPTION
This adds low-level thread scheduling, and configures static pools for compute and IO bound workloads. The pools are static because they represent system-wode resources. The pools are also configurable in limited ways, which will be useful since at a later time, we might want to allocate more threads to IO if we can determine that the database is stored on SSD or NVMe storage devices, or better.

The `Neo4jJobScheduler` has been reimplemented to make use of the new `Scheduler` infrastructure.

The page cache can now also traverse its translation tables in parallel, using this new piece of infrastructure. In Enterprise, this is only enabled if the `dbms.checkpoint.iops.limit` setting is set to `-1` in `neo4j.conf`, which disables the IO limiter. Community ignores the IO limiter, so it's not a problem there.
