### PR TITLE
Fix theoretical data-race in SequenceLock

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SequenceLock.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/SequenceLock.java
@@ -155,6 +155,7 @@ public class SequenceLock
             n = s + CNT_UNIT;
             if ( compareAndSetState( s, n ) )
             {
+                UnsafeUtil.storeFence();
                 return true;
             }
         }
@@ -215,7 +216,9 @@ public class SequenceLock
     public boolean tryExclusiveLock()
     {
         long s = getState();
-        return ((s & UNL_MASK) == 0) && compareAndSetState( s, s + EXL_MASK );
+        boolean res = ((s & UNL_MASK) == 0) && compareAndSetState( s, s + EXL_MASK );
+        UnsafeUtil.storeFence();
+        return res;
     }
 
     /**
@@ -271,7 +274,9 @@ public class SequenceLock
     public boolean tryFlushLock()
     {
         long s = getState();
-        return ((s & FAE_MASK) == 0) && compareAndSetState( s, s + FLS_MASK );
+        boolean res = ((s & FAE_MASK) == 0) && compareAndSetState( s, s + FLS_MASK );
+        UnsafeUtil.storeFence();
+        return res;
     }
 
     /**

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -252,6 +252,14 @@ public final class UnsafeUtil
     }
 
     /**
+     * Orders stores before the fence, with loads and stores after the fence.
+     */
+    public static void storeFence()
+    {
+        unsafe.storeFence();
+    }
+
+    /**
      * Atomically compare the current value of the given long field with the expected value, and if they are the
      * equal, set the field to the updated value and return true. Otherwise return false.
      * <p>


### PR DESCRIPTION
The `compareAndSwap` method is meant to atomically take a memory location and compare its value to an expected value, and then change it on a match. And it does so with the visibility semantics of a volatile read, followed by a volatile write. The keyword here is 'atomically' and what this actually means. It doesn't actually mean that the method is indivisible, only that it's observable effect is. That is, that no change can happen to the given memory location between the test and the set. This atomicity does not apply to _other_ memory locations.

To illustrate, it is perfectly reasonable (in terms of semantics, but probably not in terms of performance) to implement `compareAndSwap` with a lock:

```
synchronized (SWAP_LOCK) {
  if (field == expected) { // volatile read
    field = update; // volatile write
  }
}
```

The volatile-read has the same ordering semantics as its preceding monitor-enter, and the volatile-write has the same ordering semantics as the monitor-exit that follows it. Therefor, these can be merged from four to two synchronizing actions. The synchronized block can then "grow" in scope, as the roach motel model illustrates. This means that loads and stores can move _into_ the synchronized block, but not out of it. Since these loads and stores are now inside the synchronized block, there are no longer any synchronizing actions separating them, and they are thus free to reorder in any way that doesn't violate program order, and maintains the volatile-read/monitor-enter as the first action, and the volatile-write/monitor-exit as the last action.

This is perfectly fine when we are releasing a lock, since the write of the updated lock-word is the last action. However, we run into trouble when we are taking a write-lock. Let's look at a bigger example:

```
// Take write-lock
synchronized (SWAP_LOCK) {
  word lw = lockword_field; // volatile read
  if (isUnlocked(lw)) {
    lw = takeLock(lw);
    lockword_field = lw; // volatile write
  } else {
    goto lock_failed;
  }
}
field = 1; // normal store in critical section
lockword_field = releaseLock(lw); // volatile write
```

Normal loads and stores are not allowed to reorder with following volatile-writes or monitor-exits, but the _are_ allowed to reorder with _preceding_ volatile-writes and monitor-exits. This means that the normal store `field = 1` can move up above the `lockword_field = lw` volatile-write inside the locking code. Unless we put a store-store barrier after the write of the updated lock word.

In practice this is _probably_ not a problem, since on x86 `compareAndSwap` is implemented with `LOCK:CMPXCHG` which really is atomic. And on POWER and ARM, the linked load and store operations are unlikely to see anything reorder in between them, since an unrelated store before the linked store could potentially cause the linked store to fail permanently, for instance if the unrelated store goes to the same cache-line.

Never the less, this failure mode is a theoretical possibility for our `SequenceLock`, and it is fixed by putting a store fence after the `compareAndSwap` method calls in the write-locking methods, `tryWriteLock`, `tryExclusiveLock` and `tryFlushLock`.

The concurrency-interest thread that debates this possibility for `j.u.c.l.StampedLock` starts here: http://cs.oswego.edu/pipermail/concurrency-interest/2016-June/015237.html
