### PR TITLE
Adds (disabled) condition for running tests with large clusters

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestRunConditions.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestRunConditions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ha;
+
+import org.apache.commons.lang3.SystemUtils;
+
+/**
+ * This class is expected to contain conditions for various tests, controlling whether they run or not. It is supposed
+ * to be used from {@link org.junit.Assume} statements in tests to save adding and removing {@link org.junit.Ignore}
+ * annotations. Static methods and fields that check for environmental or other conditions should be placed here as
+ * a way to have a central point of control for them.
+ */
+public class TestRunConditions
+{
+    /**
+     * Largest cluster size which can run without (many) problems in a typical windows build
+     */
+    private static final int MAX_WINDOWS_CLUSTER_SIZE = 3;
+
+    /**
+     * Largest cluster size which can run without (many) problems on any plaform
+     */
+    private static final int MAX_CLUSTER_SIZE = 5;
+
+    public static boolean shouldRunAtClusterSize( int clusterSize )
+    {
+        if ( clusterSize <= MAX_WINDOWS_CLUSTER_SIZE )
+        {
+            // If it's less than or equal to the minimum allowed size regardless of platform
+            return true;
+        }
+        if ( clusterSize > MAX_WINDOWS_CLUSTER_SIZE && clusterSize <= MAX_CLUSTER_SIZE && !SystemUtils.IS_OS_WINDOWS )
+        {
+            // If it's below the maximum cluster size but not on windows
+            return true;
+        }
+        // here it's either (above max size) or (below max size and above max windows size and on windows)
+        return false;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.TransientDatabaseFailureException;
+import org.neo4j.ha.TestRunConditions;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberChangeEvent;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberListener;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
@@ -37,6 +39,7 @@ import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState.PENDING;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
@@ -152,6 +155,7 @@ public class ClusterPartitionIT
     public void losingQuorumIncrementallyShouldMakeAllInstancesPendingAndReadOnly() throws Throwable
     {
         int clusterSize = 5; // we need 5 to differentiate between all other instances gone and just quorum being gone
+        assumeTrue( TestRunConditions.shouldRunAtClusterSize( clusterSize ) );
 
         ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
                 .withProvider( ClusterManager.clusterOfSize( clusterSize ) )
@@ -232,6 +236,7 @@ public class ClusterPartitionIT
     public void losingQuorumAbruptlyShouldMakeAllInstancesPendingAndReadOnly() throws Throwable
     {
         int clusterSize = 5; // we need 5 to differentiate between all other instances gone and just quorum being gone
+        assumeTrue( TestRunConditions.shouldRunAtClusterSize( clusterSize ) );
 
         ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
                 .withProvider( ClusterManager.clusterOfSize( clusterSize ) )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,11 +32,13 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.ha.TestRunConditions;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
 import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
@@ -65,16 +68,23 @@ public class FailoverWithAdditionalSlaveFailuresIT
                  * cases the cluster takes longer to form because of cumulative timeouts since the machines we run
                  * these tests on cannot cope with the number of threads spun up. The basic scenario is sufficiently
                  * tested with the 5-size cluster, but the 6 and 7 size cases are good to keep around for posterity,
-                 * since a better, multi machine setup can and should test them.
+                 * since a better, multi machine setup can and should test them. Hence, they are ignored through the
+                 * JUnit assumption in the @Before method
                  */
-//                {6, new int[]{1}},
-//                {6, new int[]{3}},
-//                {6, new int[]{5}},
-//
-//                {7, new int[]{1, 2}},
-//                {7, new int[]{3, 4}},
-//                {7, new int[]{5, 6}},
+                {6, new int[]{1}},
+                {6, new int[]{3}},
+                {6, new int[]{5}},
+
+                {7, new int[]{1, 2}},
+                {7, new int[]{3, 4}},
+                {7, new int[]{5, 6}},
         });
+    }
+
+    @Before
+    public void shouldRun()
+    {
+        assumeTrue( TestRunConditions.shouldRunAtClusterSize( clusterSize ) );
     }
 
     public FailoverWithAdditionalSlaveFailuresIT( int clusterSize, int[] slavesToFail )


### PR DESCRIPTION
Tests with large clusters (5 instances or more) are very hard on GC
 and tend to be flaky. They also cause other tests to fail as they
 don't properly tear down after they timeout. By using the Assume
 mechanism of JUnit and a centralized class for such conditions, we
 can control whether they run or not based on environmental information
 or simply through boolean flags, as is the case with the first use
 of this functionality in this commit.
