### PR TITLE
Log errors when stopping unsuccessful lock session

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -631,7 +631,7 @@ public class HighlyAvailableEditionModule
                                        LifeSupport modeSwitchersLife, final Config config,
                                        DelegateInvocationHandler<Master> masterDelegateInvocationHandler,
                                        RequestContextFactory requestContextFactory,
-                                       AvailabilityGuard availabilityGuard, final LogService logging )
+                                       AvailabilityGuard availabilityGuard, final LogService logService )
     {
         DelegateInvocationHandler<Locks> lockManagerDelegate = new DelegateInvocationHandler<>( Locks.class );
         final Locks lockManager = (Locks) newProxyInstance( Locks.class.getClassLoader(),
@@ -644,9 +644,9 @@ public class HighlyAvailableEditionModule
             @Override
             public Locks newInstance()
             {
-                return CommunityEditionModule.createLockManager( config, logging );
+                return CommunityEditionModule.createLockManager( config, logService );
             }
-        }, config ) );
+        }, logService.getInternalLogProvider(), config ) );
         return lockManager;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockManagerModeSwitcher.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.logging.LogProvider;
 
 public class LockManagerModeSwitcher extends AbstractModeSwitcher<Locks>
 {
@@ -36,18 +37,20 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<Locks>
     private final RequestContextFactory requestContextFactory;
     private final AvailabilityGuard availabilityGuard;
     private final Factory<Locks> locksFactory;
+    private final LogProvider logProvider;
     private final Config config;
 
     public LockManagerModeSwitcher( ModeSwitcherNotifier modeSwitcherNotifier,
                                     DelegateInvocationHandler<Locks> delegate, DelegateInvocationHandler<Master> master,
                                     RequestContextFactory requestContextFactory, AvailabilityGuard availabilityGuard,
-                                    Factory<Locks> locksFactory, Config config )
+                                    Factory<Locks> locksFactory, LogProvider logProvider, Config config )
     {
         super( modeSwitcherNotifier, delegate );
         this.master = master;
         this.requestContextFactory = requestContextFactory;
         this.availabilityGuard = availabilityGuard;
         this.locksFactory = locksFactory;
+        this.logProvider = logProvider;
         this.config = config;
     }
 
@@ -61,6 +64,6 @@ public class LockManagerModeSwitcher extends AbstractModeSwitcher<Locks>
     protected Locks getSlaveImpl( LifeSupport life )
     {
         return life.add( new SlaveLockManager( locksFactory.newInstance(), requestContextFactory, master.cement(),
-                availabilityGuard, config ) );
+                availabilityGuard, logProvider, config ) );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -26,6 +26,7 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.LogProvider;
 
 public class SlaveLockManager extends LifecycleAdapter implements Locks
 {
@@ -33,15 +34,17 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
     private final Locks local;
     private final Master master;
     private final AvailabilityGuard availabilityGuard;
+    private final LogProvider logProvider;
     private final boolean txTerminationAwareLocks;
 
     public SlaveLockManager( Locks localLocks, RequestContextFactory requestContextFactory, Master master,
-                             AvailabilityGuard availabilityGuard, Config config )
+            AvailabilityGuard availabilityGuard, LogProvider logProvider, Config config )
     {
         this.requestContextFactory = requestContextFactory;
         this.availabilityGuard = availabilityGuard;
         this.local = localLocks;
         this.master = master;
+        this.logProvider = logProvider;
         this.txTerminationAwareLocks = config.get( KernelTransactions.tx_termination_aware_locks );
     }
 
@@ -49,7 +52,7 @@ public class SlaveLockManager extends LifecycleAdapter implements Locks
     public Client newClient()
     {
         Client client = local.newClient();
-        return new SlaveLocksClient( master, client, local, requestContextFactory, availabilityGuard,
+        return new SlaveLocksClient( master, client, local, requestContextFactory, availabilityGuard, logProvider,
                 txTerminationAwareLocks );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLockManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLockManagerTest.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.logging.NullLog;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
@@ -87,6 +88,7 @@ public class SlaveLockManagerTest
 
     private SlaveLockManager newSlaveLockManager( Locks localLocks )
     {
-        return new SlaveLockManager( localLocks, requestContextFactory, master, availabilityGuard, new Config() );
+        return new SlaveLockManager( localLocks, requestContextFactory, master, availabilityGuard,
+                NullLogProvider.getInstance(), new Config() );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.enterprise.lock.forseti.ForsetiLockManager;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -110,7 +111,7 @@ public class SlaveLocksClientConcurrentTest
     private SlaveLocksClient createClient()
     {
         return new SlaveLocksClient( master, lockManager.newClient(), lockManager,
-                requestContextFactory, availabilityGuard, false );
+                requestContextFactory, availabilityGuard, NullLogProvider.getInstance(), false );
     }
 
     private static class LockedOnMasterAnswer implements Answer


### PR DESCRIPTION
When KTI is terminated, it stops the associated locks client. For slave write transactions this results in a `END_LOCK_SESSION` request to master. Such request can often be unsuccessful because transactions can be terminated during HA state switch when communication between cluster members is broken.

This commit makes `SlaveLocksClient` only log and not rethrow errors from the `END_LOCK_SESSION` request. Such errors can otherwise delay/prevent HA state machine from switching to slave/master.
