### PR TITLE
Added tests for node id reuse

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -19,8 +19,11 @@
  */
 package org.neo4j.helpers;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Helper functions for working with strings.
@@ -174,6 +177,21 @@ public final class Strings
             result.append( line ).append( System.lineSeparator() );
         }
         return result.toString();
+    }
+
+    /**
+     * Join given elements with the given separator.
+     *
+     * @param separator the element separator.
+     * @param elements objects to join.
+     * @return joined string.
+     * @throws NullPointerException if either {@code separator} or {@code elements} is null.
+     */
+    public static String join( String separator, Object... elements )
+    {
+        Objects.requireNonNull( separator );
+        Objects.requireNonNull( elements );
+        return StringUtils.join( elements, separator );
     }
 
     public static void escape( Appendable output, String arg ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -19,11 +19,8 @@
  */
 package org.neo4j.helpers;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * Helper functions for working with strings.
@@ -177,21 +174,6 @@ public final class Strings
             result.append( line ).append( System.lineSeparator() );
         }
         return result.toString();
-    }
-
-    /**
-     * Join given elements with the given separator.
-     *
-     * @param separator the element separator.
-     * @param elements objects to join.
-     * @return joined string.
-     * @throws NullPointerException if either {@code separator} or {@code elements} is null.
-     */
-    public static String join( String separator, Object... elements )
-    {
-        Objects.requireNonNull( separator );
-        Objects.requireNonNull( elements );
-        return StringUtils.join( elements, separator );
     }
 
     public static void escape( Appendable output, String arg ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.neo4j.graphdb.config.InvalidSettingException;
@@ -34,8 +36,8 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.Functions.map;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.Settings.DURATION;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.MANDATORY;
@@ -43,6 +45,7 @@ import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.basePath;
 import static org.neo4j.kernel.configuration.Settings.isFile;
 import static org.neo4j.kernel.configuration.Settings.list;
@@ -51,7 +54,6 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.range;
 import static org.neo4j.kernel.configuration.Settings.setting;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class SettingsTest
 {
@@ -86,6 +88,25 @@ public class SettingsTest
 
         Setting<List<Integer>> setting3 = setting( "foo", list( ",", INTEGER ), "" );
         assertThat( setting3.apply( map( stringMap() ) ).toString(), equalTo( "[]" ) );
+
+        Setting<List<Integer>> setting4 = setting( "foo", list( ",", INTEGER ), "1,    2,3, 4,   5  " );
+        assertThat( setting4.apply( map( stringMap() ) ).toString(), equalTo( "[1, 2, 3, 4, 5]" ) );
+
+        Setting<List<Integer>> setting5 = setting( "foo", list( ",", INTEGER ), "1,    2,3, 4,   " );
+        assertThat( setting5.apply( map( stringMap() ) ).toString(), equalTo( "[1, 2, 3, 4]" ) );
+    }
+
+    @Test
+    public void testStringList()
+    {
+        Setting<List<String>> setting1 = setting( "apa", STRING_LIST, "foo,bar,baz" );
+        assertEquals( Arrays.asList( "foo", "bar", "baz" ), setting1.apply( map( stringMap() ) ) );
+
+        Setting<List<String>> setting2 = setting( "apa", STRING_LIST, "foo,  bar, BAZ   " );
+        assertEquals( Arrays.asList( "foo", "bar", "BAZ" ), setting2.apply( map( stringMap() ) ) );
+
+        Setting<List<String>> setting3 = setting( "apa", STRING_LIST, "" );
+        assertEquals( Collections.emptyList(), setting3.apply( map( stringMap() ) ) );
     }
 
     @Test

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
@@ -24,7 +24,14 @@ import java.util.List;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
-import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.IdType;
+
+import static org.neo4j.kernel.IdType.NODE;
+import static org.neo4j.kernel.IdType.RELATIONSHIP;
+import static org.neo4j.kernel.configuration.Settings.EMPTY;
+import static org.neo4j.kernel.configuration.Settings.list;
+import static org.neo4j.kernel.configuration.Settings.optionsIgnoreCase;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Enterprise edition specific settings
@@ -32,8 +39,7 @@ import org.neo4j.kernel.configuration.Settings;
 public class EnterpriseEditionSettings
 {
     @Description( "Specified names of id types (comma separated) that should be reused. " +
-                  "Currently only 'NODE' and 'RELATIONSHIP' types are supported. " )
-    public static Setting<List<String>> idTypesToReuse =
-            Settings.setting( "dbms.ids.reuse.types.override", Settings.STRING_LIST, "" );
-
+                  "Currently only 'node' and 'relationship' types are supported. " )
+    public static Setting<List<IdType>> idTypesToReuse = setting(
+            "dbms.ids.reuse.types.override", list( ",", optionsIgnoreCase( NODE, RELATIONSHIP ) ), EMPTY );
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.configuration.Settings;
 public class EnterpriseEditionSettings
 {
     @Description( "Specified names of id types (comma separated) that should be reused. " +
-                  "Currently only 'RELATIONSHIP' type is supported. " )
+                  "Currently only 'NODE' and 'RELATIONSHIP' types are supported. " )
     public static Setting<List<String>> idTypesToReuse =
             Settings.setting( "dbms.ids.reuse.types.override", Settings.STRING_LIST, "" );
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProvider.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProvider.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.enterprise.id;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +34,7 @@ import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
  * Allow to reuse predefined id types that are reused in community and in
  * addition to that allow additional id types to reuse be specified by
  * {@link EnterpriseEditionSettings#idTypesToReuse} setting.
+ *
  * @see IdType
  * @see IdTypeConfiguration
  */
@@ -43,7 +43,7 @@ public class EnterpriseIdTypeConfigurationProvider extends CommunityIdTypeConfig
 
     private final Set<IdType> typesToReuse;
 
-    public EnterpriseIdTypeConfigurationProvider(Config config)
+    public EnterpriseIdTypeConfigurationProvider( Config config )
     {
         typesToReuse = configureReusableTypes( config );
     }
@@ -56,15 +56,9 @@ public class EnterpriseIdTypeConfigurationProvider extends CommunityIdTypeConfig
 
     private EnumSet<IdType> configureReusableTypes( Config config )
     {
-        List<String> typeNames = config.get( EnterpriseEditionSettings.idTypesToReuse );
-        List<IdType> idTypes = new ArrayList<>();
-        for ( String idType : typeNames )
-        {
-            idTypes.add( IdType.valueOf( idType ) );
-        }
-
         EnumSet<IdType> types = EnumSet.copyOf( super.getTypesToReuse() );
-        types.addAll( idTypes );
+        List<IdType> configuredTypes = config.get( EnterpriseEditionSettings.idTypesToReuse );
+        types.addAll( configuredTypes );
         return types;
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettingsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettingsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.enterprise.configuration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings.idTypesToReuse;
+
+public class EnterpriseEditionSettingsTest
+{
+    @Test
+    public void idTypesToReuseAllowedValues()
+    {
+        for ( IdType type : IdType.values() )
+        {
+            if ( type == IdType.NODE || type == IdType.RELATIONSHIP )
+            {
+                assertIdTypesToReuseAllows( type );
+            }
+            else
+            {
+                assertIdTypesToReuseDisallows( type );
+            }
+        }
+
+        assertIdTypesToReuseAllows( IdType.NODE, IdType.RELATIONSHIP );
+        assertIdTypesToReuseAllows( IdType.RELATIONSHIP, IdType.NODE );
+
+        assertIdTypesToReuseDisallows( IdType.NODE, IdType.RELATIONSHIP, IdType.RELATIONSHIP_GROUP );
+        assertIdTypesToReuseDisallows( IdType.SCHEMA, IdType.NEOSTORE_BLOCK );
+    }
+
+    @Test
+    public void idTypesToReuseCaseInsensitive()
+    {
+        Config config1 = new Config( stringMap( idTypesToReuse.name(), "node, relationship" ) );
+        assertEquals( asList( IdType.NODE, IdType.RELATIONSHIP ), config1.get( idTypesToReuse ) );
+
+        Config config2 = new Config( stringMap( idTypesToReuse.name(), "rElAtIoNshiP, NoDe" ) );
+        assertEquals( asList( IdType.RELATIONSHIP, IdType.NODE ), config2.get( idTypesToReuse ) );
+    }
+
+    private static void assertIdTypesToReuseAllows( IdType type, IdType... otherTypes )
+    {
+        Config config = configWithIdTypes( type, otherTypes );
+        List<IdType> types = config.get( idTypesToReuse );
+        assertEquals( asList( type, otherTypes ), types );
+    }
+
+    private static void assertIdTypesToReuseDisallows( IdType type, IdType... otherTypes )
+    {
+        Config config = configWithIdTypes( type, otherTypes );
+        try
+        {
+            config.get( idTypesToReuse );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( InvalidSettingException.class ) );
+        }
+    }
+
+    private static Config configWithIdTypes( IdType type, IdType... otherTypes )
+    {
+        String value = stringList( type, otherTypes );
+        return new Config( stringMap( idTypesToReuse.name(), value ) );
+    }
+
+    @SafeVarargs
+    private static <T> String stringList( T element, T... elements )
+    {
+        return StringUtils.join( asList( element, elements ), "," );
+    }
+
+    @SafeVarargs
+    private static <T> List<T> asList( T element, T... elements )
+    {
+        List<T> list = new ArrayList<>();
+        list.add( element );
+        Collections.addAll( list, elements );
+        return list;
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.IdTypeConfiguration;
@@ -50,6 +51,7 @@ public class EnterpriseIdTypeConfigurationProviderTest
         return Arrays.asList( new Object[]{IdType.PROPERTY},
                 new Object[]{IdType.STRING_BLOCK},
                 new Object[]{IdType.ARRAY_BLOCK},
+                new Object[]{IdType.NODE},
                 new Object[]{IdType.RELATIONSHIP},
                 new Object[]{IdType.NODE_LABELS} );
     }
@@ -63,9 +65,9 @@ public class EnterpriseIdTypeConfigurationProviderTest
     public void nonReusableTypeConfiguration()
     {
         IdTypeConfigurationProvider provider = createIdTypeProvider();
-        IdTypeConfiguration typeConfiguration = provider.getIdTypeConfiguration( IdType.NODE );
-        assertFalse( "Node ids are not reusable.", typeConfiguration.allowAggressiveReuse() );
-        assertEquals( "Node ids are not reusable.", 1024, typeConfiguration.getGrabSize() );
+        IdTypeConfiguration typeConfiguration = provider.getIdTypeConfiguration( IdType.SCHEMA );
+        assertFalse( "Schema record ids are not reusable.", typeConfiguration.allowAggressiveReuse() );
+        assertEquals( "Schema record ids are not reusable.", 1024, typeConfiguration.getGrabSize() );
     }
 
     @Test
@@ -80,7 +82,7 @@ public class EnterpriseIdTypeConfigurationProviderTest
     private IdTypeConfigurationProvider createIdTypeProvider()
     {
         Map<String,String> params = MapUtil.stringMap( EnterpriseEditionSettings.idTypesToReuse.name(),
-                IdType.RELATIONSHIP.name() );
+                Strings.join( ",", IdType.NODE, IdType.RELATIONSHIP ) );
         Config config = new Config( params );
         return new EnterpriseIdTypeConfigurationProvider( config );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/id/EnterpriseIdTypeConfigurationProviderTest.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.IdTypeConfiguration;
@@ -82,7 +81,7 @@ public class EnterpriseIdTypeConfigurationProviderTest
     private IdTypeConfigurationProvider createIdTypeProvider()
     {
         Map<String,String> params = MapUtil.stringMap( EnterpriseEditionSettings.idTypesToReuse.name(),
-                Strings.join( ",", IdType.NODE, IdType.RELATIONSHIP ) );
+                IdType.NODE + "," + IdType.RELATIONSHIP );
         Config config = new Config( params );
         return new EnterpriseIdTypeConfigurationProvider( config );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/IdReuseTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/IdReuseTest.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.EnterpriseDatabaseRule;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -56,8 +55,7 @@ public class IdReuseTest
         protected void configure( GraphDatabaseBuilder builder )
         {
             super.configure( builder );
-            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse,
-                    Strings.join( ",", IdType.NODE, IdType.RELATIONSHIP ) );
+            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE + "," + IdType.RELATIONSHIP );
         }
     };
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/IdReuseTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/IdReuseTest.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.EnterpriseDatabaseRule;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -52,10 +53,11 @@ public class IdReuseTest
     public EmbeddedDatabaseRule dbRule = new EnterpriseDatabaseRule()
     {
         @Override
-        protected void configure(GraphDatabaseBuilder builder )
+        protected void configure( GraphDatabaseBuilder builder )
         {
             super.configure( builder );
-            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.RELATIONSHIP.name() );
+            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse,
+                    Strings.join( ",", IdType.NODE, IdType.RELATIONSHIP ) );
         }
     };
 
@@ -125,6 +127,29 @@ public class IdReuseTest
     }
 
     @Test
+    public void sequentialOperationNodeIdReuse()
+    {
+        Label marker = DynamicLabel.label( "marker" );
+
+        long node1 = createNode( marker );
+        long node2 = createNode( marker );
+        long node3 = createNode( marker );
+
+        assertEquals( "Ids should be sequential", node1 + 1, node2 );
+        assertEquals( "Ids should be sequential", node2 + 1, node3 );
+
+        NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
+
+        deleteNodesByLabel( marker );
+
+        idMaintenanceController.maintenance();
+
+        assertEquals( "Nodes have reused id", node1, createNode( marker ) );
+        assertEquals( "Nodes have reused id", node2, createNode( marker ) );
+        assertEquals( "Nodes have reused id", node3, createNode( marker ) );
+    }
+
+    @Test
     public void sequentialOperationRelationshipIdReuse()
     {
         Label marker = DynamicLabel.label( "marker" );
@@ -136,7 +161,7 @@ public class IdReuseTest
         assertEquals( "Ids should be sequential", relationship1 + 1, relationship2 );
         assertEquals( "Ids should be sequential", relationship2 + 1, relationship3 );
 
-        final NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
+        NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
 
         deleteRelationshipByLabelAndRelationshipType( marker );
 
@@ -148,12 +173,40 @@ public class IdReuseTest
     }
 
     @Test
+    public void nodeIdReusableOnlyAfterTransactionFinish()
+    {
+        Label testLabel = DynamicLabel.label( "testLabel" );
+        long nodeId = createNode( testLabel );
+
+        NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
+
+        try ( Transaction tx = dbRule.beginTx();
+              ResourceIterator<Node> nodes = dbRule.findNodes( testLabel ) )
+        {
+            while ( nodes.hasNext() )
+            {
+                nodes.next().delete();
+            }
+
+            idMaintenanceController.maintenance();
+
+            Node newNode = dbRule.createNode( testLabel );
+
+            assertNotEquals( "Nodes should have different ids.", nodeId, newNode.getId() );
+            tx.success();
+        }
+
+        idMaintenanceController.maintenance();
+        assertEquals( "New node should have id of a removed node", nodeId, createNode( testLabel ) );
+    }
+
+    @Test
     public void relationshipIdReusableOnlyAfterTransactionFinish()
     {
         Label testLabel = DynamicLabel.label( "testLabel" );
         long relationshipId = createRelationship( testLabel );
 
-        final NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
+        NeoStoreDataSource.BufferedIdMaintenanceController idMaintenanceController = getIdMaintenanceController();
 
         try ( Transaction transaction = dbRule.beginTx();
               ResourceIterator<Node> nodes = dbRule.findNodes( testLabel ) )
@@ -177,6 +230,23 @@ public class IdReuseTest
 
             assertNotEquals( "Relatioships should have different ids.", relationshipId, relationshipTo.getId() );
             transaction.success();
+        }
+
+        idMaintenanceController.maintenance();
+        assertEquals( "New relationship should have id of a removed relationship", relationshipId,
+                createRelationship( testLabel ) );
+    }
+
+    private void deleteNodesByLabel( Label marker )
+    {
+        try ( Transaction tx = dbRule.beginTx();
+              ResourceIterator<Node> nodes = dbRule.findNodes( marker ) )
+        {
+            while ( nodes.hasNext() )
+            {
+                nodes.next().delete();
+            }
+            tx.success();
         }
     }
 
@@ -202,6 +272,16 @@ public class IdReuseTest
     {
         return dbRule.getDependencyResolver()
                 .resolveDependency( NeoStoreDataSource.BufferedIdMaintenanceController.class );
+    }
+
+    private long createNode( Label label )
+    {
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            Node node = dbRule.createNode( label );
+            tx.success();
+            return node.getId();
+        }
     }
 
     private long createRelationship( Label label )

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.enterprise.store.id;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.EnterpriseDatabaseRule;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.Race;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class NodeIdReuseStressIT
+{
+    private static final int CONTESTANTS_COUNT = 12;
+    private static final int INITIAL_NODE_COUNT = 10_000;
+    private static final int OPERATIONS_COUNT = 10_000;
+
+    @Rule
+    public EmbeddedDatabaseRule db = new EnterpriseDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            super.configure( builder );
+            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE.name() );
+        }
+    };
+
+    @Before
+    public void verifyParams() throws Exception
+    {
+        assertThat( CONTESTANTS_COUNT, greaterThan( 0 ) );
+        assertThat( CONTESTANTS_COUNT % 2, equalTo( 0 ) );
+        assertThat( INITIAL_NODE_COUNT, greaterThan( 0 ) );
+        assertThat( OPERATIONS_COUNT, greaterThan( 1_000 ) );
+    }
+
+    @Test
+    public void nodeIdsReused() throws Throwable
+    {
+        createInitialNodes( db );
+        long initialHighestNodeId = highestNodeId( db );
+
+        Race race = new Race();
+
+        for ( int i = 0; i < CONTESTANTS_COUNT; i++ )
+        {
+            if ( i % 2 == 0 )
+            {
+                race.addContestant( new NodeCreator( db ) );
+            }
+            else
+            {
+                race.addContestant( new NodeRemover( db ) );
+            }
+        }
+
+        race.go();
+
+        int writeContestants = CONTESTANTS_COUNT / 2;
+        int createdNodes = writeContestants * OPERATIONS_COUNT;
+        long highestNodeIdWithoutReuse = initialHighestNodeId + createdNodes;
+
+        long currentHighestNodeId = highestNodeId( db );
+
+        assertThat( currentHighestNodeId, lessThan( highestNodeIdWithoutReuse ) );
+
+        System.out.println( "highestNodeIdWithoutReuse = " + highestNodeIdWithoutReuse );
+        System.out.println( "currentHighestNodeId = " + currentHighestNodeId );
+    }
+
+    private static void createInitialNodes( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < INITIAL_NODE_COUNT; i++ )
+            {
+                db.createNode();
+            }
+            tx.success();
+        }
+    }
+
+    private static long highestNodeId( GraphDatabaseService db )
+    {
+        DependencyResolver resolver = dependencyResolver( db );
+        NeoStores neoStores = resolver.resolveDependency( NeoStores.class );
+        NodeStore nodeStore = neoStores.getNodeStore();
+        return nodeStore.getHighestPossibleIdInUse();
+    }
+
+    private static void maybeRunIdMaintenance( GraphDatabaseService db, int iteration )
+    {
+        if ( iteration % 100 == 0 && ThreadLocalRandom.current().nextBoolean() )
+        {
+            DependencyResolver resolver = dependencyResolver( db );
+            resolver.resolveDependency( NeoStoreDataSource.BufferedIdMaintenanceController.class ).maintenance();
+        }
+    }
+
+    private static DependencyResolver dependencyResolver( GraphDatabaseService db )
+    {
+        return ((GraphDatabaseAPI) db).getDependencyResolver();
+    }
+
+    private static class NodeCreator implements Runnable
+    {
+        final GraphDatabaseService db;
+
+        NodeCreator( GraphDatabaseService db )
+        {
+            this.db = db;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int i = 0; i < OPERATIONS_COUNT; i++ )
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.createNode();
+                    tx.success();
+                }
+
+                maybeRunIdMaintenance( db, i );
+            }
+        }
+    }
+
+    private static class NodeRemover implements Runnable
+    {
+        final GraphDatabaseService db;
+
+        NodeRemover( GraphDatabaseService db )
+        {
+            this.db = db;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int i = 0; i < OPERATIONS_COUNT; i++ )
+            {
+                long highestId = highestNodeId( db );
+                if ( highestId > 0 )
+                {
+                    long id = ThreadLocalRandom.current().nextLong( highestId );
+
+                    try ( Transaction tx = db.beginTx() )
+                    {
+                        db.getNodeById( id ).delete();
+                        tx.success();
+                    }
+                    catch ( NotFoundException ignore )
+                    {
+                        // same node was removed concurrently
+                    }
+                }
+
+                maybeRunIdMaintenance( db, i );
+            }
+        }
+    }
+}


### PR DESCRIPTION
To make sure it is possible to specify `NODE` as well as `RELATIONSHIP` in
`dbms.ids.reuse.types.override` setting.

changelog: [enterprise] Made possible to allow node id reuse using 'dbms.ids.reuse.types.override' setting.
