### PR TITLE
AdminTool internals refactorings

### DIFF
--- a/community/command-line/NOTICE.txt
+++ b/community/command-line/NOTICE.txt
@@ -5,19 +5,20 @@ in this notice as "Neo Technology")
 
 This product includes software ("Software") developed by Neo Technology.
 
-The software ("Software") is developed and owned by Network Engine
-for Objects in Lund AB (referred to in this notice as "Neo Technology").
-If you have executed an End User Software License and Services Agreement,
-an OEM Software License and Support Services Agreement, or another
-commercial license agreement (including an Evaluation Agreement) with
-Neo Technology or one of its affiliates (each, a "Commercial Agreement"),
-you may use the Software solely pursuant to the terms of the relevant
-Commercial Agreement.
+The copyright in the bundled Neo4j graph database (including the
+Software) is owned by Neo Technology. The Software developed and owned
+by Neo Technology is licensed under the GNU GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/gpl-3.0.html) ("GPL")
+to all third parties and that license, as required by the GPL, is
+included in the LICENSE.txt file.
 
-If you have not executed a Commercial Agreement with Neo Technology, the
-Software is subject to the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-Version 3 (http://www.fsf.org/licensing/licenses/agpl-3.0.html), included
-in the LICENSE.txt file.
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the GPL and you may use the
+software solely pursuant to the terms of the relevant Commercial
+Agreement.
 
 Full license texts are found in LICENSES.txt.
 

--- a/community/command-line/pom.xml
+++ b/community/command-line/pom.xml
@@ -13,6 +13,32 @@
   <name>Neo4j - Command Line</name>
   <version>3.0.4-SNAPSHOT</version>
 
+  <properties>
+    <short-name>command-line</short-name>
+    <license-text.header>GPL-3-header.txt</license-text.header>
+    <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>GNU General Public License, Version 3</name>
+      <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+      <comments>The software ("Software") developed and owned by Network Engine for
+        Objects in Lund AB (referred to in this notice as "Neo Technology") is
+        licensed under the GNU GENERAL PUBLIC LICENSE Version 3 to all third
+        parties and that license is included below.
+
+        However, if you have executed an End User Software License and Services
+        Agreement or an OEM Software License and Support Services Agreement, or
+        another commercial license agreement with Neo Technology or one of its
+        affiliates (each, a "Commercial Agreement"), the terms of the license in
+        such Commercial Agreement will supersede the GNU GENERAL PUBLIC LICENSE
+        Version 3 and you may use the Software solely pursuant to the terms of
+        the relevant Commercial Agreement.
+      </comments>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -23,12 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Supplier;
-
-import org.neo4j.helpers.Service;
-import org.neo4j.helpers.collection.Iterables;
 
 import static java.lang.String.format;
 
@@ -41,9 +36,9 @@ public class AdminTool
         String extraHelp = System.getenv( "NEO4J_EXTRA_HELP" );
         boolean debug = System.getenv( "NEO4J_DEBUG" ) != null;
 
-        new AdminTool( new ServiceCommandLocator(), System.out::println, extraHelp, debug )
-                .execute( homeDir, configDir, args )
-                .exit();
+        AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), System.out::println, extraHelp, debug );
+        Result result = tool.execute( homeDir, configDir, args );
+        result.exit();
     }
 
     private final String scriptName = "neo4j-admin";
@@ -54,7 +49,7 @@ public class AdminTool
 
     public AdminTool( CommandLocator locator, Output out, String extraHelp, boolean debug )
     {
-        this.locator = new AppendingLocator( help(), locator );
+        this.locator = CommandLocator.withAdditionalCommand( help(), locator );
         this.out = out;
         this.debug = debug;
         this.usage = new Usage( scriptName, out, this.locator, extraHelp );
@@ -152,55 +147,5 @@ public class AdminTool
     private static Result success()
     {
         return () -> System.exit( 0 );
-    }
-
-    private interface Result
-    {
-        void exit();
-    }
-
-    public interface CommandLocator
-            extends Function<String, AdminCommand.Provider>, Supplier<Iterable<AdminCommand.Provider>>
-    {
-    }
-
-    private static class ServiceCommandLocator implements CommandLocator
-    {
-        @Override
-        public AdminCommand.Provider apply( String name )
-        {
-            return Service.load( AdminCommand.Provider.class, name );
-        }
-
-        @Override
-        public Iterable<AdminCommand.Provider> get()
-        {
-            return Service.load( AdminCommand.Provider.class );
-        }
-    }
-
-    private class AppendingLocator implements CommandLocator
-    {
-        private final Supplier<AdminCommand.Provider> command;
-        private final CommandLocator commands;
-
-        public AppendingLocator( Supplier<AdminCommand.Provider> command, CommandLocator commands )
-        {
-            this.command = command;
-            this.commands = commands;
-        }
-
-        @Override
-        public AdminCommand.Provider apply( String name )
-        {
-            AdminCommand.Provider provider = command.get();
-            return Objects.equals( name, provider.name() ) ? provider : commands.apply( name );
-        }
-
-        @Override
-        public Iterable<AdminCommand.Provider> get()
-        {
-            return Iterables.append( command.get(), commands.get() );
-        }
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -65,7 +65,7 @@ public class AdminTool
             AdminCommand.Provider provider;
             try
             {
-                provider = locator.apply( name );
+                provider = locator.findProvider( name );
             }
             catch ( NoSuchElementException e )
             {

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandLocator.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandLocator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.neo4j.helpers.Service;
+import org.neo4j.helpers.collection.Iterables;
+
+/**
+ * The CommandLocator locates named commands for the AdminTool, or supplies the set of available commands for printing
+ * help output.
+ */
+public interface CommandLocator
+        extends Function<String, AdminCommand.Provider>, Supplier<Iterable<AdminCommand.Provider>>
+{
+
+    static CommandLocator fromServiceLocator()
+    {
+        return new CommandLocator()
+        {
+            @Override
+            public AdminCommand.Provider apply( String name )
+            {
+                return Service.load( AdminCommand.Provider.class, name );
+            }
+
+            @Override
+            public Iterable<AdminCommand.Provider> get()
+            {
+                return Service.load( AdminCommand.Provider.class );
+            }
+        };
+    }
+
+    static CommandLocator withAdditionalCommand( Supplier<AdminCommand.Provider> command, CommandLocator commands )
+    {
+        return new CommandLocator()
+        {
+            @Override
+            public AdminCommand.Provider apply( String name )
+            {
+                AdminCommand.Provider provider = command.get();
+                return Objects.equals( name, provider.name() ) ? provider : commands.apply( name );
+            }
+
+            @Override
+            public Iterable<AdminCommand.Provider> get()
+            {
+                return Iterables.append( command.get(), commands.get() );
+            }
+        };
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/IncorrectUsage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/IncorrectUsage.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Output.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Output.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Result.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Result.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin;
+
+/**
+ * The result of an admin command execution, with a delayed program termination action.
+ */
+public interface Result
+{
+    void exit();
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -19,20 +19,17 @@
  */
 package org.neo4j.commandline.admin;
 
-import java.util.function.Supplier;
-
 import static java.lang.String.format;
-
 import static org.neo4j.helpers.Args.splitLongLine;
 
 public class Usage
 {
     private final String scriptName;
     private final Output out;
-    private final Supplier<Iterable<AdminCommand.Provider>> commands;
+    private final CommandLocator commands;
     private final String extraHelp;
 
-    public Usage( String scriptName, Output out, Supplier<Iterable<AdminCommand.Provider>> commands, String extraHelp )
+    public Usage( String scriptName, Output out, CommandLocator commands, String extraHelp )
     {
         this.scriptName = scriptName;
         this.out = out;
@@ -45,7 +42,7 @@ public class Usage
         out.line( "Usage:" );
         out.line( "" );
 
-        for ( AdminCommand.Provider command : commands.get() )
+        for ( AdminCommand.Provider command : commands.getAllProviders() )
         {
             new CommandUsage( command, out, scriptName ).print();
         }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -94,7 +94,7 @@ public class AdminToolTest
         }
     }
 
-    private static class CannedLocator implements AdminTool.CommandLocator
+    private static class CannedLocator implements CommandLocator
     {
         private final RecordingCommand command;
 
@@ -116,7 +116,7 @@ public class AdminToolTest
         }
     }
 
-    private static class NullCommandLocator implements AdminTool.CommandLocator
+    private static class NullCommandLocator implements CommandLocator
     {
         @Override
         public AdminCommand.Provider apply( String s )

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -19,14 +19,12 @@
  */
 package org.neo4j.commandline.admin;
 
+import org.junit.Test;
+
 import java.nio.file.Path;
 import java.util.Optional;
 
-import org.junit.Test;
-
 import org.neo4j.helpers.collection.Iterables;
-
-import static java.util.Arrays.asList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -39,7 +37,9 @@ public class AdminToolTest
     public void shouldExecuteTheCommand()
     {
         RecordingCommand command = new RecordingCommand();
-        new AdminTool( new CannedLocator( command ), new NullOutput(), "", false ).execute( null, null, "foo" );
+        AdminCommand.Provider provider = command.provider();
+        AdminTool tool = new AdminTool( new CannedLocator( provider ), new NullOutput(), "", false );
+        tool.execute( null, null, provider.name() );
         assertThat( command.executed, is( true ) );
     }
 
@@ -94,38 +94,16 @@ public class AdminToolTest
         }
     }
 
-    private static class CannedLocator implements CommandLocator
-    {
-        private final RecordingCommand command;
-
-        public CannedLocator( RecordingCommand command )
-        {
-            this.command = command;
-        }
-
-        @Override
-        public AdminCommand.Provider apply( String s )
-        {
-            return command.provider();
-        }
-
-        @Override
-        public Iterable<AdminCommand.Provider> get()
-        {
-            return asList( command.provider() );
-        }
-    }
-
     private static class NullCommandLocator implements CommandLocator
     {
         @Override
-        public AdminCommand.Provider apply( String s )
+        public AdminCommand.Provider findProvider( String s )
         {
             throw new UnsupportedOperationException( "not implemented" );
         }
 
         @Override
-        public Iterable<AdminCommand.Provider> get()
+        public Iterable<AdminCommand.Provider> getAllProviders()
         {
             return Iterables.empty();
         }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/CannedLocator.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/CannedLocator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class CannedLocator implements CommandLocator
+{
+    private final Map<String,AdminCommand.Provider> commands;
+
+    public CannedLocator( AdminCommand.Provider... commands )
+    {
+        this.commands = new HashMap<>();
+        for ( AdminCommand.Provider provider : commands )
+        {
+            this.commands.put( provider.name(), provider );
+        }
+    }
+
+    @Override
+    public AdminCommand.Provider findProvider( String s )
+    {
+        return commands.get( s );
+    }
+
+    @Override
+    public Iterable<AdminCommand.Provider> getAllProviders()
+    {
+        return commands.values();
+    }
+}

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.commandline.admin;
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.commandline.admin;
 
-import java.nio.file.Path;
-import java.util.Optional;
-
 import org.junit.Test;
 import org.mockito.InOrder;
 
-import static java.util.Arrays.asList;
+import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -37,13 +35,15 @@ public class UsageTest
     {
         Output out = mock( Output.class );
 
-        Iterable<AdminCommand.Provider> commands = asList(
-                new StubProvider( "restore",
-                        Optional.of( "---from <backup-directory> --database=<database-name> [--force]" ),
-                        "Restores a database backed up using the neo4j-backup tool." ),
-                new StubProvider( "bam", Optional.empty(), "Some description" ) );
+        AdminCommand.Provider[] commands = new AdminCommand.Provider[]
+                {
+                        new StubProvider( "restore",
+                                Optional.of( "---from <backup-directory> --database=<database-name> [--force]" ),
+                                "Restores a database backed up using the neo4j-backup tool." ),
+                        new StubProvider( "bam", Optional.empty(), "Some description" )
+                };
         String extraHelp = "some extra help or other\nmaybe over multiple lines\n";
-        new Usage( "neo4j-admin", out, () -> commands, extraHelp ).print();
+        new Usage( "neo4j-admin", out, new CannedLocator( commands ), extraHelp ).print();
 
         InOrder ordered = inOrder( out );
         ordered.verify( out ).line( "Usage:" );

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -5,19 +5,20 @@ in this notice as "Neo Technology")
 
 This product includes software ("Software") developed by Neo Technology.
 
-The software ("Software") is developed and owned by Network Engine
-for Objects in Lund AB (referred to in this notice as "Neo Technology").
-If you have executed an End User Software License and Services Agreement,
-an OEM Software License and Support Services Agreement, or another
-commercial license agreement (including an Evaluation Agreement) with
-Neo Technology or one of its affiliates (each, a "Commercial Agreement"),
-you may use the Software solely pursuant to the terms of the relevant
-Commercial Agreement.
+The copyright in the bundled Neo4j graph database (including the
+Software) is owned by Neo Technology. The Software developed and owned
+by Neo Technology is licensed under the GNU GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/gpl-3.0.html) ("GPL")
+to all third parties and that license, as required by the GPL, is
+included in the LICENSE.txt file.
 
-If you have not executed a Commercial Agreement with Neo Technology, the
-Software is subject to the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-Version 3 (http://www.fsf.org/licensing/licenses/agpl-3.0.html), included
-in the LICENSE.txt file.
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the GPL and you may use the
+software solely pursuant to the terms of the relevant Commercial
+Agreement.
 
 Full license texts are found in LICENSES.txt.
 

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -12,6 +12,12 @@
   <name>Neo4j - Database Management System</name>
   <version>3.0.4-SNAPSHOT</version>
 
+  <properties>
+    <short-name>dbms</short-name>
+    <license-text.header>GPL-3-header.txt</license-text.header>
+    <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+  </properties>
+
   <description>
     This component provides management functionality and product surface for Neo4j instances.
   </description>

--- a/community/dbms/src/main/java/org/neo4j/dbms/ConfigFactory.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/ConfigFactory.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.dbms;
 

--- a/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.dbms;
 

--- a/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.dbms;
 


### PR DESCRIPTION
This makes it slightly easier to test command providers, and also aligns the visibilities.
For instance, methods that returned `Result` objects were publicly visible, while the `Result` interface was private.
