### PR TITLE
CsvInput parses data in parallel

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/AutoReadingSource.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/AutoReadingSource.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import java.io.IOException;
+
+/**
+ * In a scenario where there's one thread, or perhaps a {@link ThreadAheadReadable} doing both the
+ * reading and parsing one {@link BufferedCharSeeker} is used over a stream of chunks, where the next
+ * chunk seamlessly transitions into the next, this class comes in handy. It uses a {@link CharReadable}
+ * and {@link SectionedCharBuffer} to do this.
+ */
+public class AutoReadingSource implements Source
+{
+    private final CharReadable reader;
+    private SectionedCharBuffer charBuffer;
+
+    public AutoReadingSource( CharReadable reader, int bufferSize )
+    {
+        this.reader = reader;
+        this.charBuffer = new SectionedCharBuffer( bufferSize );
+    }
+
+    @Override
+    public Chunk nextChunk( int seekStartPos ) throws IOException
+    {
+        charBuffer = reader.read( charBuffer, seekStartPos == -1 ? charBuffer.pivot() : seekStartPos );
+
+        return new Chunk()
+        {
+            @Override
+            public int startPosition()
+            {
+                return charBuffer.pivot();
+            }
+
+            @Override
+            public String sourceDescription()
+            {
+                return reader.sourceDescription();
+            }
+
+            @Override
+            public int backPosition()
+            {
+                return charBuffer.back();
+            }
+
+            @Override
+            public int length()
+            {
+                return charBuffer.available();
+            }
+
+            @Override
+            public int maxFieldSize()
+            {
+                return charBuffer.pivot();
+            }
+
+            @Override
+            public char[] data()
+            {
+                return charBuffer.array();
+            }
+
+            @Override
+            public void close()
+            {   // Nothing to close
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        reader.close();
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharReadable.java
@@ -56,6 +56,13 @@ public interface CharReadable extends Closeable, SourceTraceability
      */
     SectionedCharBuffer read( SectionedCharBuffer buffer, int from ) throws IOException;
 
+    /**
+     * Reads characters into the given array starting at {@code offset}, reading {@code length} number of characters.
+     *
+     * Similar to {@link Reader#read(char[], int, int)}
+     */
+    int read( char[] into, int offset, int length ) throws IOException;
+
     public static abstract class Adapter extends SourceTraceability.Adapter implements CharReadable
     {
         @Override

--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
@@ -47,7 +47,7 @@ public class CharSeekers
         }
 
         // Give the reader to the char seeker
-        return new BufferedCharSeeker( reader, config );
+        return new BufferedCharSeeker( new AutoReadingSource( reader, config.bufferSize() ), config );
     }
 
     /**

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractor.java
@@ -32,7 +32,7 @@ package org.neo4j.csv.reader;
  *
  * @see Extractors for a collection of very common extractors.
  */
-public interface Extractor<T>
+public interface Extractor<T> extends Cloneable
 {
     /**
      * Extracts value of type {@code T} from the given character data.
@@ -54,4 +54,6 @@ public interface Extractor<T>
      */
     @Override
     String toString();
+
+    Extractor<T> clone();
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -248,6 +248,20 @@ public class Extractors
         {
             return toString;
         }
+
+        @Override
+        public Extractor<T> clone()
+        {
+            try
+            {
+                return (Extractor<T>) super.clone();
+            }
+            catch ( CloneNotSupportedException e )
+            {
+                throw new AssertionError( Extractor.class.getName() + " implements " + Cloneable.class.getSimpleName() +
+                        ", at least this implementation assumes that. This doesn't seem to be the case anymore", e );
+            }
+        }
     }
 
     private static abstract class AbstractSingleValueExtractor<T> extends AbstractExtractor<T>

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ProcessingSource.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ProcessingSource.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.neo4j.csv.reader.Source.Chunk;
+
+/**
+ * In a scenario where there's one reader reading chunks of data, handing those chunks to one or
+ * more processors (parsers) of that data, this class comes in handy. This pattern allows for
+ * multiple {@link BufferedCharSeeker seeker instances}, each operating over one chunk, not transitioning itself
+ * into the next.
+ */
+public class ProcessingSource implements Closeable
+{
+    // Marker for a buffer slot being unallocated
+    private static final char[] UNALLOCATED = new char[0];
+    // Marker for a buffer being allocated, although currently used
+    private static final char[] IN_USE = new char[0];
+
+    private final CharReadable reader;
+    private final int chunkSize;
+    private char[] backBuffer; // grows on demand
+    private int backBufferCursor;
+
+    // Buffer reuse. Each item starts out as UNALLOCATED, transitions into IN_USE and tied to a Chunk,
+    // which will put its allocated buffer back into that slot on Chunk#close(). After that flipping between
+    // an allocated char[] and IN_USE.
+    private final AtomicReferenceArray<char[]> buffers;
+
+    public ProcessingSource( CharReadable reader, int chunkSize, int maxNumberOfBufferedChunks )
+    {
+        this.reader = reader;
+        this.chunkSize = chunkSize;
+        this.backBuffer = new char[chunkSize >> 4];
+        this.buffers = new AtomicReferenceArray<>( maxNumberOfBufferedChunks );
+        for ( int i = 0; i < buffers.length(); i++ )
+        {
+            buffers.set( i, UNALLOCATED );
+        }
+    }
+
+    /**
+     * Must be called by a single thread, the same thread every time.
+     *
+     * @return the next {@link Chunk} of data, ending with a new-line or not for the last chunk.
+     * @throws IOException on reading error.
+     */
+    public Chunk nextChunk() throws IOException
+    {
+        Buffer buffer = newBuffer();
+        int offset = 0;
+
+        if ( backBufferCursor > 0 )
+        {   // Read from and reset back buffer
+            assert backBufferCursor < chunkSize;
+            System.arraycopy( backBuffer, 0, buffer.data, 0, backBufferCursor );
+            offset += backBufferCursor;
+            backBufferCursor = 0;
+        }
+
+        int leftToRead = chunkSize - offset;
+        int read = reader.read( buffer.data, offset, leftToRead );
+        if ( read == leftToRead )
+        {   // Read from reader. We read data into the whole buffer and there seems to be more data left in reader.
+            // This means we're most likely not at the end so seek backwards to the last newline character and
+            // put the characters after the newline character(s) into the back buffer.
+            int newlineOffset = offsetOfLastNewline( buffer.data );
+            if ( newlineOffset > -1 )
+            {   // We found a newline character some characters back
+                backBufferCursor = chunkSize - (newlineOffset + 1);
+                System.arraycopy( buffer.data, newlineOffset + 1, backBuffer( backBufferCursor ), 0, backBufferCursor );
+                read -= backBufferCursor;
+            }
+            else
+            {   // There was no newline character, isn't that weird?
+                throw new IllegalStateException( "Weird input data, no newline character in the whole buffer " +
+                        chunkSize + ", not supported a.t.m." );
+            }
+        }
+        // else we couldn't completely fill the buffer, this means that we're at the end of a data source, we're good.
+
+        if ( read > -1 )
+        {
+            offset += read;
+        }
+
+        return new ProcessingChunk( buffer, offset, reader.sourceDescription() );
+    }
+
+    private char[] backBuffer( int length )
+    {
+        if ( length > backBuffer.length )
+        {
+            backBuffer = Arrays.copyOf( backBuffer, length );
+        }
+        return backBuffer;
+    }
+
+    private Buffer newBuffer()
+    {
+        // Scan through the array to find one
+        for ( int i = 0; i < buffers.length(); i++ )
+        {
+            char[] current = buffers.get( i );
+            if ( current == UNALLOCATED || current != IN_USE )
+            {
+                // Mark that this buffer is currently being used
+                buffers.set( i, IN_USE );
+                return new Buffer( current == UNALLOCATED ? new char[chunkSize] : current, i );
+            }
+        }
+
+        // With external push-back this shouldn't be an issue, but instead of introducing blocking
+        // here just fall back to creating a new buffer which will not be eligible for reuse.
+        return new Buffer( new char[chunkSize], -1 );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        reader.close();
+    }
+
+    private static int offsetOfLastNewline( char[] buffer )
+    {
+        for ( int i = buffer.length-1; i >= 0; i-- )
+        {
+            if ( buffer[i] == '\n' )
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private class ProcessingChunk implements Chunk
+    {
+        private final Buffer buffer;
+        private final int length;
+        private final String sourceDescription;
+
+        public ProcessingChunk( Buffer buffer, int length, String sourceDescription )
+        {
+            this.buffer = buffer;
+            this.length = length;
+            this.sourceDescription = sourceDescription;
+        }
+
+        @Override
+        public int startPosition()
+        {
+            return 0;
+        }
+
+        @Override
+        public String sourceDescription()
+        {
+            return sourceDescription;
+        }
+
+        @Override
+        public int maxFieldSize()
+        {
+            return chunkSize;
+        }
+
+        @Override
+        public int length()
+        {
+            return length;
+        }
+
+        @Override
+        public char[] data()
+        {
+            return buffer.data;
+        }
+
+        @Override
+        public int backPosition()
+        {
+            return 0;
+        }
+
+        @Override
+        public void close()
+        {
+            if ( buffer.reuseIndex != -1 )
+            {
+                // Give the buffer back to the source so that it can be reused
+                buffers.set( buffer.reuseIndex, buffer.data );
+            }
+            // else this was a detached buffer which we cannot really put back into a reuse slot
+        }
+    }
+
+    private static class Buffer
+    {
+        private final char[] data;
+        private final int reuseIndex;
+
+        Buffer( char[] data, int reuseIndex )
+        {
+            this.data = data;
+            this.reuseIndex = reuseIndex;
+        }
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
@@ -77,6 +77,12 @@ public class Readables
         {
             return "EMPTY";
         }
+
+        @Override
+        public int read( char[] into, int offset, int length ) throws IOException
+        {
+            return -1;
+        }
     };
 
     public static CharReadable wrap( final InputStream stream, final String sourceName, Charset charset )
@@ -126,6 +132,22 @@ public class Readables
                 buffer.readFrom( reader );
                 position += buffer.available();
                 return buffer;
+            }
+
+            @Override
+            public int read( char[] into, int offset, int length ) throws IOException
+            {
+                int totalRead = 0;
+                while ( totalRead < length )
+                {
+                    int read = reader.read( into, offset + totalRead, length - totalRead );
+                    if ( read == -1 )
+                    {
+                        break;
+                    }
+                    totalRead += read;
+                }
+                return totalRead;
             }
 
             @Override

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Source.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Source.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Source of data chunks to read.
+ */
+public interface Source extends Closeable
+{
+    Chunk nextChunk( int seekStartPos ) throws IOException;
+
+    /**
+     * One chunk of data to read.
+     */
+    public interface Chunk
+    {
+        /**
+         * @return character data to read
+         */
+        char[] data();
+
+        /**
+         * @return number of effective characters in the {@link #data()}
+         */
+        int length();
+
+        /**
+         * @return effective capacity of the {@link #data()} array
+         */
+        int maxFieldSize();
+
+        /**
+         * @return source description of the source this chunk was read from
+         */
+        String sourceDescription();
+
+        /**
+         * @return position in the {@link #data()} array to start reading from
+         */
+        int startPosition();
+
+        /**
+         * @return position in the {@link #data()} array where the current field which is being
+         * read starts. Some characters of the current field may have started in the previous chunk
+         * and so those characters are transfered over to this data array before {@link #startPosition()}
+         */
+        int backPosition();
+
+        /**
+         * Close this chunk and any resources attached to it
+         */
+        void close();
+    }
+
+    Chunk EMPTY_CHUNK = new Chunk()
+    {
+        @Override
+        public int startPosition()
+        {
+            return 0;
+        }
+
+        @Override
+        public String sourceDescription()
+        {
+            return "EMPTY";
+        }
+
+        @Override
+        public int maxFieldSize()
+        {
+            return 0;
+        }
+
+        @Override
+        public int length()
+        {
+            return 0;
+        }
+
+        @Override
+        public char[] data()
+        {
+            return null;
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public int backPosition()
+        {
+            return 0;
+        }
+    };
+
+    public static Source singleChunk( Chunk chunk )
+    {
+        return new Source()
+        {
+            private boolean returned;
+
+            @Override
+            public void close() throws IOException
+            {   // Nothing to close
+            }
+
+            @Override
+            public Chunk nextChunk( int seekStartPos ) throws IOException
+            {
+                if ( !returned )
+                {
+                    returned = true;
+                    return chunk;
+                }
+                return EMPTY_CHUNK;
+            }
+        };
+    }
+}

--- a/community/csv/src/main/java/org/neo4j/csv/reader/SourceTraceability.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/SourceTraceability.java
@@ -49,7 +49,7 @@ public interface SourceTraceability
      */
     long position();
 
-    public static abstract class Adapter implements SourceTraceability
+    abstract class Adapter implements SourceTraceability
     {
         @Override
         public long lineNumber()
@@ -63,4 +63,13 @@ public interface SourceTraceability
             return 0;
         }
     }
+
+    SourceTraceability EMPTY = new Adapter()
+    {
+        @Override
+        public String sourceDescription()
+        {
+            return "EMPTY";
+        }
+    };
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/ThreadAheadReadable.java
@@ -71,6 +71,12 @@ public class ThreadAheadReadable extends ThreadAhead implements CharReadable
     }
 
     @Override
+    public int read( char[] into, int offset, int length ) throws IOException
+    {
+        throw new UnsupportedOperationException( "Unsupported for now" );
+    }
+
+    @Override
     protected boolean readAhead() throws IOException
     {
         theOtherBuffer = actual.read( theOtherBuffer, theOtherBuffer.front() );

--- a/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/BufferedCharSeekerTest.java
@@ -826,6 +826,12 @@ public class BufferedCharSeekerTest
         }
 
         @Override
+        public int read( char[] into, int offset, int length ) throws IOException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public long position()
         {
             return position;

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
@@ -223,6 +223,27 @@ public class ExtractorsTest
         assertNull( extracted );
     }
 
+    @Test
+    public void shouldCloneExtractor() throws Exception
+    {
+        // GIVEN
+        Extractors extractors = new Extractors( ';' );
+        Extractor<String> e1 = extractors.string();
+        Extractor<String> e2 = e1.clone();
+
+        // WHEN
+        String v1 = "abc";
+        e1.extract( v1.toCharArray(), 0, v1.length(), false );
+        assertEquals( v1, e1.value() );
+        assertNull( e2.value() );
+
+        // THEN
+        String v2 = "def";
+        e2.extract( v2.toCharArray(), 0, v2.length(), false );
+        assertEquals( v2, e2.value() );
+        assertEquals( v1, e1.value() );
+    }
+
     private String toString( long[] values, char delimiter )
     {
         StringBuilder builder = new StringBuilder();

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ProcessingSourceTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ProcessingSourceTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.csv.reader;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.csv.reader.Source.Chunk;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static java.util.Arrays.copyOfRange;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.csv.reader.Source.EMPTY_CHUNK;
+
+public class ProcessingSourceTest
+{
+    @Test
+    public void shouldBackUpChunkToClosestNewline() throws Exception
+    {
+        // GIVEN
+        CharReadable reader = Readables.wrap( new StringReader( "1234567\n8901234\n5678901234" ) );
+        // (next chunks):                                                     ^            ^
+        // (actual chunks):                                               ^        ^
+        try ( ProcessingSource source = new ProcessingSource( reader, 12, 1 ) )
+        {
+            // WHEN
+            Chunk first = source.nextChunk();
+            assertArrayEquals( "1234567\n".toCharArray(), charactersOf( first ) );
+            Chunk second = source.nextChunk();
+            assertArrayEquals( "8901234\n".toCharArray(), charactersOf( second ) );
+            Chunk third = source.nextChunk();
+            assertArrayEquals( "5678901234".toCharArray(), charactersOf( third ) );
+
+            // THEN
+            assertEquals( 0, source.nextChunk().length() );
+        }
+    }
+
+    @Test
+    public void shouldFailIfNoNewlineInChunk() throws Exception
+    {
+        // GIVEN
+        CharReadable reader = Readables.wrap( new StringReader( "1234567\n89012345678901234" ) );
+        // (next chunks):                                                     ^
+        // (actual chunks):                                               ^
+        try ( ProcessingSource source = new ProcessingSource( reader, 12, 1 ) )
+        {
+            // WHEN
+            Chunk first = source.nextChunk();
+            assertArrayEquals( "1234567\n".toCharArray(), charactersOf( first ) );
+            try
+            {
+                source.nextChunk();
+                fail( "Should have failed here" );
+            }
+            catch ( IllegalStateException e )
+            {
+                // THEN good
+            }
+        }
+    }
+
+    @Test
+    public void shouldReuseBuffers() throws Exception
+    {
+        // GIVEN
+        ProcessingSource source = new ProcessingSource( dataWithLines( 2 ), 100, 1 );
+
+        // WHEN
+        Chunk firstChunk = source.nextChunk();
+        char[] firstBuffer = firstChunk.data();
+        firstChunk.close();
+
+        // THEN
+        Chunk secondChunk = source.nextChunk();
+        char[] secondBuffer = secondChunk.data();
+        secondChunk.close();
+        assertSame( firstBuffer, secondBuffer );
+        source.close();
+    }
+
+    @Test
+    public void shouldReuseBuffersEventually() throws Exception
+    {
+        // GIVEN
+        ProcessingSource source = new ProcessingSource( dataWithLines( 5 ), 100, 2 );
+        Chunk firstChunk = source.nextChunk();
+        char[] firstBuffer = firstChunk.data();
+
+        // WHEN
+        Chunk secondChunk = source.nextChunk();
+        char[] secondBuffer = secondChunk.data();
+        assertNotSame( secondBuffer, firstBuffer );
+
+        // THEN
+        firstChunk.close();
+        Chunk thirdChunk = source.nextChunk();
+        char[] thirdBuffer = thirdChunk.data();
+        assertSame( firstBuffer, thirdBuffer );
+
+        secondChunk.close();
+        thirdChunk.close();
+        source.close();
+    }
+
+    @Test
+    public void shouldStressReuse() throws Exception
+    {
+        // GIVEN
+        int nThreads = 10;
+        ProcessingSource source = new ProcessingSource( dataWithLines( 3_000 ), 100, nThreads );
+        ExecutorService executor = newFixedThreadPool( nThreads );
+        AtomicInteger activeProcessors = new AtomicInteger();
+
+        // WHEN
+        Chunk chunk = EMPTY_CHUNK;
+        Set<char[]> observedDataArrays = new HashSet<>();
+        do
+        {
+            while ( activeProcessors.get() == nThreads )
+            {   // Provide push-back which normally happens when using a ProcessingSource, although perhaps not
+            }   // with a busy-wait like this, but that's not really important.
+
+            // Get next chunk and register the array instance we got
+            chunk = source.nextChunk();
+            observedDataArrays.add( chunk.data() );
+
+            // Update data for push-back of the load in this test
+            activeProcessors.incrementAndGet();
+
+            // Submit this chunk for processing (no-op) and closing (reuse)
+            Chunk currentChunk = chunk;
+            executor.submit( () ->
+            {
+                currentChunk.close();
+                activeProcessors.decrementAndGet();
+            } );
+        }
+        while ( chunk.length() > 0 );
+        executor.shutdown();
+        executor.awaitTermination( 100, SECONDS );
+
+        // THEN
+        source.close();
+        assertTrue( "" + observedDataArrays.size(),
+                observedDataArrays.size() >= 1 && observedDataArrays.size() <= nThreads );
+    }
+
+    private CharReadable dataWithLines( int lineCount )
+    {
+        return new CharReadable.Adapter()
+        {
+            private int line;
+
+            @Override
+            public String sourceDescription()
+            {
+                return "test";
+            }
+
+            @Override
+            public int read( char[] into, int offset, int length ) throws IOException
+            {
+                assert offset == 0 : "This test assumes offset is 0, "
+                        + "which it always was for this use case at the time of writing";
+                if ( line++ == lineCount )
+                {
+                    return -1;
+                }
+
+                // We cheat here and simply say that we read the requested amount of characters
+                into[length-1] = '\n';
+                return length;
+            }
+
+            @Override
+            public SectionedCharBuffer read( SectionedCharBuffer buffer, int from ) throws IOException
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private char[] charactersOf( Chunk chunk )
+    {
+        return copyOfRange( chunk.data(), chunk.startPosition(), chunk.startPosition() + chunk.length() );
+    }
+}

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ReadablesTest.java
@@ -21,6 +21,10 @@ package org.neo4j.csv.reader;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,6 +37,8 @@ import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -46,8 +52,35 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith( Parameterized.class )
 public class ReadablesTest
 {
+    @Parameters
+    public static Collection<ReadMethod> readMethods()
+    {
+        return Arrays.asList(
+                (readable,length) ->
+                {
+                    SectionedCharBuffer readText = new SectionedCharBuffer( length );
+                    readable.read( readText, readText.front() );
+                    return copyOfRange( readText.array(), readText.pivot(), readText.front() );
+                },
+                (readable,length) ->
+                {
+                    char[] result = new char[length];
+                    readable.read( result, 0, length );
+                    return result;
+                } );
+    }
+
+    interface ReadMethod
+    {
+        char[] read( CharReadable readable, int length ) throws IOException;
+    }
+
+    @Parameter
+    public ReadMethod readMethod;
+
     @Test
     public void shouldReadTextCompressedInZipArchiveWithSingleFileIn() throws Exception
     {
@@ -304,9 +337,8 @@ public class ReadablesTest
 
     private void assertReadText( CharReadable readable, String text ) throws IOException
     {
-        SectionedCharBuffer readText = new SectionedCharBuffer( text.toCharArray().length );
-        readable.read( readText, readText.front() );
-        assertArrayEquals( text.toCharArray(), copyOfRange( readText.array(), readText.pivot(), readText.front() ) );
+        char[] readText = readMethod.read( readable, text.toCharArray().length );
+        assertArrayEquals( readText, text.toCharArray() );
     }
 
     public final @Rule TestDirectory directory = new TestDirectory();

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ThreadAheadReadableTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ThreadAheadReadableTest.java
@@ -123,6 +123,12 @@ public class ThreadAheadReadableTest
             }
         }
 
+        @Override
+        public int read( char[] into, int offset, int length ) throws IOException
+        {
+            throw new UnsupportedOperationException();
+        }
+
         private SectionedCharBuffer registerBytesRead( SectionedCharBuffer buffer )
         {
             bytesRead += buffer.available();

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -319,6 +319,7 @@ public class ImportTool
         boolean skipBadRelationships, skipDuplicateNodes, ignoreExtraColumns;
         Config dbConfig;
         OutputStream badOutput = null;
+        org.neo4j.unsafe.impl.batchimport.Configuration configuration = null;
 
         boolean success = false;
         try
@@ -348,11 +349,13 @@ public class ImportTool
             Collector badCollector = badCollector( badOutput, badTolerance, collect( skipBadRelationships,
                     skipDuplicateNodes, ignoreExtraColumns ) );
 
-            input = new CsvInput( nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
-                    relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),
-                    idType, csvConfiguration( args, defaultSettingsSuitableForTests ), badCollector );
             dbConfig = loadDbConfig( args.interpretOption( Options.DATABASE_CONFIG.key(), Converters.<File>optional(),
                     Converters.toFile(), Validators.REGEX_FILE_EXISTS ) );
+            configuration = importConfiguration( processors, defaultSettingsSuitableForTests, dbConfig );
+            input = new CsvInput( nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
+                    relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),
+                    idType, csvConfiguration( args, defaultSettingsSuitableForTests ), badCollector,
+                    configuration.maxNumberOfProcessors() );
             success = true;
         }
         catch ( IllegalArgumentException e )
@@ -376,8 +379,6 @@ public class ImportTool
         LogService logService = life.add( StoreLogService.inLogsDirectory( fs, storeDir ) );
 
         life.start();
-        org.neo4j.unsafe.impl.batchimport.Configuration configuration =
-                importConfiguration( processors, defaultSettingsSuitableForTests, dbConfig );
         BatchImporter importer = new ParallelBatchImporter( storeDir,
                 configuration,
                 logService,

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CsvOutput.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CsvOutput.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.function.Function;
+
+import org.neo4j.unsafe.impl.batchimport.BatchImporter;
+import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.input.Input;
+import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Deserialization;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Header;
+
+public class CsvOutput implements BatchImporter
+{
+    private final File targetDirectory;
+    private final Header nodeHeader;
+    private final Header relationshipHeader;
+    private final Deserialization<String> deserialization;
+
+    public CsvOutput( File targetDirectory, Header nodeHeader, Header relationshipHeader, Configuration config )
+    {
+        this.targetDirectory = targetDirectory;
+        assert targetDirectory.isDirectory();
+        this.nodeHeader = nodeHeader;
+        this.relationshipHeader = relationshipHeader;
+        this.deserialization = new StringDeserialization( config );
+        targetDirectory.mkdirs();
+    }
+
+    @Override
+    public void doImport( Input input ) throws IOException
+    {
+        consume( "nodes.csv", input.nodes(), nodeHeader, (node) ->
+        {
+            deserialization.clear();
+            for ( Header.Entry entry : nodeHeader.entries() )
+            {
+                switch ( entry.type() )
+                {
+                case ID:
+                    deserialization.handle( entry, node.id() );
+                    break;
+                case PROPERTY:
+                    deserialization.handle( entry, property( node, entry.name() ) );
+                    break;
+                case LABEL:
+                    deserialization.handle( entry, node.labels() );
+                    break;
+                }
+            }
+            return deserialization.materialize();
+        } );
+        consume( "relationships.csv", input.relationships(), relationshipHeader, (relationship) ->
+        {
+            deserialization.clear();
+            for ( Header.Entry entry : relationshipHeader.entries() )
+            {
+                switch ( entry.type() )
+                {
+                case PROPERTY:
+                    deserialization.handle( entry, property( relationship, entry.name() ) );
+                    break;
+                case TYPE:
+                    deserialization.handle( entry, relationship.type() );
+                    break;
+                case START_ID:
+                    deserialization.handle( entry, relationship.startNode() );
+                    break;
+                case END_ID:
+                    deserialization.handle( entry, relationship.endNode() );
+                    break;
+                }
+            }
+            return deserialization.materialize();
+        } );
+    }
+
+    private Object property( InputEntity entity, String key )
+    {
+        Object[] properties = entity.properties();
+        for ( int i = 0; i < properties.length; i += 2 )
+        {
+            if ( properties[i].equals( key ) )
+            {
+                return properties[i+1];
+            }
+        }
+        return null;
+    }
+
+    private <ENTITY extends InputEntity> void consume( String name, InputIterable<ENTITY> entities, Header header,
+            Function<ENTITY,String> deserializer ) throws IOException
+    {
+        try ( PrintStream out = file( name ) )
+        {
+            serialize( out, header );
+            try ( InputIterator<ENTITY> iterator = entities.iterator() )
+            {
+                while ( iterator.hasNext() )
+                {
+                    out.println( deserializer.apply( iterator.next() ) );
+                }
+            }
+        }
+    }
+
+    private void serialize( PrintStream out, Header header )
+    {
+        deserialization.clear();
+        for ( Header.Entry entry : header.entries() )
+        {
+            deserialization.handle( entry, entry.toString() );
+        }
+        out.println( deserialization.materialize() );
+    }
+
+    private PrintStream file( String name ) throws IOException
+    {
+        return new PrintStream( new File( targetDirectory, name ) );
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
@@ -40,6 +40,7 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     private final Distribution<String> relationshipTypes;
     private final Groups groups = new Groups();
     private final IdType idType;
+    private final String className = getClass().getSimpleName();
 
     public SimpleDataGenerator( Header nodeHeader, Header relationshipHeader, long randomSeed,
             long nodeCount, int labelCount, int relationshipTypeCount, IdType idType )
@@ -82,6 +83,6 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     @Override
     public String sourceDescription()
     {
-        return getClass().getSimpleName();
+        return className;
     }
 }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/StringDeserialization.java
@@ -53,10 +53,13 @@ class StringDeserialization implements Deserialization<String>
         {
             builder.append( config.delimiter() );
         }
-        stringify( entry, value );
+        if ( value != null )
+        {
+            stringify( value );
+        }
     }
 
-    private void stringify( Entry entry, Object value )
+    private void stringify( Object value )
     {
         if ( value instanceof String )
         {
@@ -82,7 +85,7 @@ class StringDeserialization implements Deserialization<String>
                 {
                     builder.append( config.arrayDelimiter() );
                 }
-                stringify( entry, item );
+                stringify( item );
             }
         }
         else if ( value instanceof Number )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -515,7 +515,10 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
         @Override
         public void close()
         {
-            array.close();
+            if ( array != null )
+            {
+                array.close();
+            }
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -83,34 +83,42 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
             return processors.length;
         }
 
-        int requestedNumber = processors.length + delta;
-        if ( delta > 0 )
+        synchronized ( this )
         {
-            requestedNumber = min( requestedNumber, maxProcessorCount );
-            if ( requestedNumber > processors.length )
+            if ( shutDown )
             {
-                Processor[] newProcessors = Arrays.copyOf( processors, requestedNumber );
-                for ( int i = processors.length; i < requestedNumber; i++ )
-                {
-                    newProcessors[i] = new Processor( processorThreadNamePrefix + "-" + i );
-                }
-                this.processors = newProcessors;
+                return processors.length;
             }
-        }
-        else
-        {
-            requestedNumber = max( 1, requestedNumber );
-            if ( requestedNumber < processors.length )
+
+            int requestedNumber = processors.length + delta;
+            if ( delta > 0 )
             {
-                Processor[] newProcessors = Arrays.copyOf( processors, requestedNumber );
-                for ( int i = newProcessors.length; i < processors.length; i++ )
+                requestedNumber = min( requestedNumber, maxProcessorCount );
+                if ( requestedNumber > processors.length )
                 {
-                    processors[i].shutDown = true;
+                    Processor[] newProcessors = Arrays.copyOf( processors, requestedNumber );
+                    for ( int i = processors.length; i < requestedNumber; i++ )
+                    {
+                        newProcessors[i] = new Processor( processorThreadNamePrefix + "-" + i );
+                    }
+                    this.processors = newProcessors;
                 }
-                this.processors = newProcessors;
             }
+            else
+            {
+                requestedNumber = max( 1, requestedNumber );
+                if ( requestedNumber < processors.length )
+                {
+                    Processor[] newProcessors = Arrays.copyOf( processors, requestedNumber );
+                    for ( int i = newProcessors.length; i < processors.length; i++ )
+                    {
+                        processors[i].processorShutDown = true;
+                    }
+                    this.processors = newProcessors;
+                }
+            }
+            return processors.length;
         }
-        return processors.length;
     }
 
     @Override
@@ -157,17 +165,13 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
             return;
         }
 
-        this.shutDown = true;
         boolean awaitAllCompleted = (flags & TaskExecutor.SF_AWAIT_ALL_COMPLETED) != 0;
         while ( awaitAllCompleted && !queue.isEmpty() && panic == null /*all bets are off in the event of panic*/ )
         {
             parkAWhile();
         }
+        this.shutDown = true;
         this.abortQueued = (flags & TaskExecutor.SF_ABORT_QUEUED) != 0;
-        for ( Processor processor : processors )
-        {
-            processor.shutDown = true;
-        }
         while ( awaitAllCompleted && anyAlive() && panic == null /*all bets are off in the event of panic*/ )
         {
             parkAWhile();
@@ -201,7 +205,9 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
 
     private class Processor extends Thread
     {
-        private volatile boolean shutDown;
+        // In addition to the global shutDown flag in the executor each processor has a local flag
+        // so that an individual processor can be shut down, for example when reducing number of processors
+        private volatile boolean processorShutDown;
 
         Processor( String name )
         {
@@ -215,7 +221,7 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
         {
             // Initialized here since it's the thread itself that needs to call it
             final LOCAL threadLocalState = initialLocalState.get();
-            while ( !abortQueued && !shutDown )
+            while ( !shutDown && !processorShutDown )
             {
                 Task<LOCAL> task = queue.poll();
                 if ( task != null )
@@ -233,7 +239,7 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
                 }
                 else
                 {
-                    if ( shutDown )
+                    if ( processorShutDown )
                     {
                         break;
                     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -132,11 +132,11 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
         {
             if ( panic != null )
             {
-                throw new IllegalStateException( "Executor has been shut down in panic", panic );
+                throw new TaskExecutionPanicException( "Executor has been shut down in panic", panic );
             }
             if ( abortQueued )
             {
-                throw new IllegalStateException( "Executor has been shut down, aborting queued" );
+                throw new TaskExecutionPanicException( "Executor has been shut down, aborting queued" );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutionPanicException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutionPanicException.java
@@ -17,21 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.input.csv;
+package org.neo4j.unsafe.impl.batchimport.executor;
 
-import java.util.function.Function;
-
-import org.neo4j.csv.reader.CharReadable;
-import org.neo4j.csv.reader.CharSeeker;
-import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
-
-/**
- * Produces a {@link CharSeeker} that can seek and extract values from a csv/tsv style data stream.
- * A decorator also comes with it which can specify global overrides/defaults of extracted input entities.
- */
-public interface Data<ENTITY extends InputEntity>
+public class TaskExecutionPanicException extends IllegalStateException
 {
-    CharReadable stream();
+    public TaskExecutionPanicException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
 
-    Function<ENTITY,ENTITY> decorator();
+    public TaskExecutionPanicException( String message )
+    {
+        super( message );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
@@ -39,8 +39,8 @@ public abstract class InputEntity implements SourceTraceability
     private Object[] properties;
     private Long firstPropertyId;
     private final String sourceDescription;
-    private final long lineNumber;
-    private final long position;
+    private long lineNumber;
+    private long position;
 
     public InputEntity( String sourceDescription, long sourceLineNumber, long sourcePosition,
             Object[] properties, Long firstPropertyId )
@@ -161,6 +161,12 @@ public abstract class InputEntity implements SourceTraceability
     public long position()
     {
         return position;
+    }
+
+    public void rebase( long baseLineNumber, long basePosition )
+    {
+        lineNumber += baseLineNumber;
+        position += basePosition;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -79,12 +79,12 @@ public class Inputs
     }
 
     public static Input csv( File nodes, File relationships, IdType idType,
-            Configuration configuration, Collector badCollector )
+            Configuration configuration, Collector badCollector, int maxProcessors )
     {
         return new CsvInput(
                 nodeData( data( NO_NODE_DECORATOR, defaultCharset(), nodes ) ), defaultFormatNodeFileHeader(),
                 relationshipData( data( NO_RELATIONSHIP_DECORATOR, defaultCharset(), relationships ) ),
                 defaultFormatRelationshipFileHeader(), idType, configuration,
-                badCollector );
+                badCollector, maxProcessors );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -34,7 +34,6 @@ import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
-import org.neo4j.unsafe.impl.batchimport.input.MissingRelationshipDataException;
 
 /**
  * Provides {@link Input} from data contained in tabular/csv form. Expects factories for instantiating
@@ -145,23 +144,7 @@ public class CsvInput implements Input
                     {
                         return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputRelationshipDeserialization( dataStream, dataHeader, groups ),
-                                decorator, entity -> {
-                                    if ( entity.startNode() == null )
-                                    {
-                                        throw new MissingRelationshipDataException(Type.START_ID,
-                                                            entity + " is missing " + Type.START_ID + " field" );
-                                    }
-                                    if ( entity.endNode() == null )
-                                    {
-                                        throw new MissingRelationshipDataException(Type.END_ID,
-                                                            entity + " is missing " + Type.END_ID + " field" );
-                                    }
-                                    if ( !entity.hasTypeId() && entity.type() == null )
-                                    {
-                                        throw new MissingRelationshipDataException(Type.TYPE,
-                                                            entity + " is missing " + Type.TYPE + " field" );
-                                    }
-                                }, badCollector );
+                                decorator, new InputRelationshipValidator(), badCollector );
                     }
                 };
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -123,17 +123,7 @@ public class DataFactories
      */
     public static Header.Factory defaultFormatNodeFileHeader()
     {
-        return new DefaultNodeFileHeaderParser( READ_FROM_DATA_SEEKER );
-    }
-
-    /**
-     * Header parser that will read header information, using the default node header format,
-     * from a {@link Readable} containing that data.
-     * @param reader {@link Readable} containing header data.
-     */
-    public static Header.Factory defaultFormatNodeFileHeader( CharReadable reader )
-    {
-        return new DefaultNodeFileHeaderParser( new HeaderFromSeparateReaderFactory( reader ) );
+        return new DefaultNodeFileHeaderParser();
     }
 
     /**
@@ -145,115 +135,31 @@ public class DataFactories
      */
     public static Header.Factory defaultFormatRelationshipFileHeader()
     {
-        return new DefaultRelationshipFileHeaderParser( READ_FROM_DATA_SEEKER );
-    }
-
-    /**
-     * Header parser that will read header information, using the default relationship header format,
-     * from a {@link Readable} containing that data.
-     * @param reader {@link Readable} containing header data.
-     */
-    public static Header.Factory defaultFormatRelationshipFileHeader( CharReadable reader )
-    {
-        return new DefaultRelationshipFileHeaderParser( new HeaderFromSeparateReaderFactory( reader ) );
-    }
-
-    /**
-     * Provides {@link CharSeeker} to read and parse header information from.
-     */
-    private interface HeaderCharSeekerFactory
-    {
-        /**
-         * @param seeker the {@link CharSeeker} for the data file, if that's what we want.
-         * @param config
-         * @return the {@link CharSeeker} to extract header information from.
-         * @throws IOException if {@link CharSeeker} couldn't be provided.
-         */
-        CharSeeker open( CharSeeker seeker, Configuration config ) throws IOException;
-
-        /**
-         * Closes the header {@link CharSeeker}. Only close if {@link #open(CharSeeker, Configuration)} opens its own.
-         * @param seeker {@link CharSeeker} returned from {@link #open(CharSeeker, Configuration)}.
-         */
-        void close( CharSeeker seeker );
-    }
-
-    /**
-     * Just uses the provided {@link CharSeeker} containing the data itself.
-     */
-    private static final HeaderCharSeekerFactory READ_FROM_DATA_SEEKER = new HeaderCharSeekerFactory()
-    {
-        @Override
-        public CharSeeker open( CharSeeker seeker, Configuration config )
-        {
-            return seeker;
-        }
-
-        @Override
-        public void close( CharSeeker seeker )
-        {   // Leave it open for data reading later
-        }
-    };
-
-    private static abstract class SeparateHeaderReaderFactory implements HeaderCharSeekerFactory
-    {
-        @Override
-        public void close( CharSeeker seeker )
-        {
-            try
-            {
-                seeker.close();
-            }
-            catch ( IOException e )
-            {
-                throw new RuntimeException( "Unable to close header reader", e );
-            }
-        }
-    }
-
-    private static class HeaderFromSeparateReaderFactory extends SeparateHeaderReaderFactory
-    {
-        private final CharReadable readable;
-
-        HeaderFromSeparateReaderFactory( CharReadable readable )
-        {
-            this.readable = readable;
-        }
-
-        @Override
-        public CharSeeker open( CharSeeker seeker, Configuration config ) throws IOException
-        {
-            return charSeeker( readable, config, true );
-        }
+        return new DefaultRelationshipFileHeaderParser();
     }
 
     private static abstract class AbstractDefaultFileHeaderParser implements Header.Factory
     {
         private final Type[] mandatoryTypes;
-        private final HeaderCharSeekerFactory headerCharSeekerFactory;
 
-        protected AbstractDefaultFileHeaderParser( HeaderCharSeekerFactory headerCharSeekerFactory,
-                Type... mandatoryTypes )
+        protected AbstractDefaultFileHeaderParser( Type... mandatoryTypes )
         {
-            this.headerCharSeekerFactory = headerCharSeekerFactory;
             this.mandatoryTypes = mandatoryTypes;
         }
 
         @Override
         public Header create( CharSeeker dataSeeker, Configuration config, IdType idType )
         {
-            CharSeeker headerSeeker = null;
             try
             {
-                headerSeeker = headerCharSeekerFactory.open( dataSeeker, config );
                 Mark mark = new Mark();
                 Extractors extractors = new Extractors( config.arrayDelimiter(), config.emptyQuotedStringsAsNull() );
                 Extractor<?> idExtractor = idType.extractor( extractors );
                 int delimiter = config.delimiter();
                 List<Header.Entry> columns = new ArrayList<>();
-                for ( int i = 0; !mark.isEndOfLine() && headerSeeker.seek( mark, delimiter ); i++ )
+                for ( int i = 0; !mark.isEndOfLine() && dataSeeker.seek( mark, delimiter ); i++ )
                 {
-                    String entryString = headerSeeker.tryExtract( mark, extractors.string() )
+                    String entryString = dataSeeker.tryExtract( mark, extractors.string() )
                             ? extractors.string().value() : null;
                     HeaderEntrySpec spec = new HeaderEntrySpec( entryString );
 
@@ -274,13 +180,6 @@ public class DataFactories
             catch ( IOException e )
             {
                 throw new RuntimeException( e );
-            }
-            finally
-            {
-                if ( headerSeeker != null )
-                {
-                    headerCharSeekerFactory.close( headerSeeker );
-                }
             }
         }
 
@@ -383,11 +282,6 @@ public class DataFactories
 
     private static class DefaultNodeFileHeaderParser extends AbstractDefaultFileHeaderParser
     {
-        public DefaultNodeFileHeaderParser( HeaderCharSeekerFactory headerCharSeekerFactory )
-        {
-            super( headerCharSeekerFactory );
-        }
-
         @Override
         protected Header.Entry entry( int index, String name, String typeSpec, String groupName, Extractors extractors,
                 Extractor<?> idExtractor )
@@ -427,10 +321,10 @@ public class DataFactories
 
     private static class DefaultRelationshipFileHeaderParser extends AbstractDefaultFileHeaderParser
     {
-        protected DefaultRelationshipFileHeaderParser( HeaderCharSeekerFactory headerCharSeekerFactory )
+        protected DefaultRelationshipFileHeaderParser()
         {
             // Don't have TYPE as mandatory since a decorator could provide that
-            super( headerCharSeekerFactory, Type.START_ID, Type.END_ID );
+            super( Type.START_ID, Type.END_ID );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -45,7 +45,6 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.input.MissingHeaderException;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
 
-import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 import static org.neo4j.csv.reader.Readables.files;
 
 /**
@@ -70,11 +69,11 @@ public class DataFactories
         return config -> new Data<ENTITY>()
         {
             @Override
-            public CharSeeker stream()
+            public CharReadable stream()
             {
                 try
                 {
-                    return charSeeker( files( charset, files ), config, true );
+                    return files( charset, files );
                 }
                 catch ( IOException e )
                 {
@@ -101,9 +100,9 @@ public class DataFactories
         return config -> new Data<ENTITY>()
         {
             @Override
-            public CharSeeker stream()
+            public CharReadable stream()
             {
-                return charSeeker( readable.get(), config, true );
+                return readable.get();
             }
 
             @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -28,6 +28,8 @@ import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
 
+import static org.neo4j.csv.reader.CharSeekers.charSeeker;
+
 /**
  * Pulls in properties from an external CSV source and amends them to the "main" input nodes.
  * Imagine some node input source:
@@ -62,7 +64,7 @@ public class ExternalPropertiesDecorator implements Function<InputNode,InputNode
             Configuration config, IdType idType, UpdateBehaviour updateBehaviour, Collector badCollector )
     {
         this.updateBehaviour = updateBehaviour;
-        CharSeeker dataStream = data.create( config ).stream();
+        CharSeeker dataStream = charSeeker( data.create( config ).stream(), config, true );
         Header header = headerFactory.create( dataStream, config, idType );
         this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
                 new InputNodeDeserialization( dataStream, header, new Groups(), idType.idsAreExternal() ),

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Header.java
@@ -28,7 +28,7 @@ import org.neo4j.csv.reader.Extractor;
  * Header of tabular/csv data input, specifying meta data about values in each "column", for example
  * semantically of which {@link Type} they are and which {@link Extractor type of value} they are.
  */
-public class Header
+public class Header implements Cloneable
 {
     public interface Factory
     {
@@ -76,7 +76,18 @@ public class Header
         return Arrays.toString( entries );
     }
 
-    public static class Entry
+    @Override
+    public Header clone()
+    {
+        Entry[] entries = new Entry[this.entries.length];
+        for ( int i = 0; i < entries.length; i++ )
+        {
+            entries[i] = this.entries[i].clone();
+        }
+        return new Header( entries );
+    }
+
+    public static class Entry implements Cloneable
     {
         private final String name;
         private final Type type;
@@ -151,6 +162,12 @@ public class Header
             Entry other = (Entry) obj;
             return nullSafeEquals( name, other.name ) && type == other.type &&
                     nullSafeEquals( groupName, other.groupName ) && extractorEquals( extractor, other.extractor );
+        }
+
+        @Override
+        public Entry clone()
+        {
+            return new Entry( name, type, groupName, extractor != null ? extractor.clone() : null );
         }
 
         private boolean nullSafeEquals( Object o1, Object o2 )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -21,18 +21,18 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 
 import java.util.Iterator;
 import java.util.function.Function;
-
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.helpers.collection.NestingIterator;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 
 /**
  * Able to deserialize one input group. An input group is a list of one or more input files containing
  * its own header. An import can read multiple input groups. Each group is deserialized by
  * {@link InputEntityDeserializer}.
  */
-abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
+class InputGroupsDeserializer<ENTITY extends InputEntity>
         extends NestingIterator<ENTITY,DataFactory<ENTITY>>
         implements InputIterator<ENTITY>
 {
@@ -41,15 +41,30 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
     private final IdType idType;
     private InputIterator<ENTITY> currentInput = new InputIterator.Empty<>();
     private long previousInputsCollectivePositions;
+    private int previousInputProcessors = 1;
     private boolean currentInputOpen;
+    private final int maxProcessors;
+    private final DeserializerFactory<ENTITY> factory;
+    private final Class<ENTITY> entityClass;
+
+    @FunctionalInterface
+    public interface DeserializerFactory<ENTITY extends InputEntity>
+    {
+        InputEntityDeserializer<ENTITY> create( CharSeeker dataStream, Header dataHeader,
+                Function<ENTITY,ENTITY> decorator );
+    }
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
-                             Configuration config, IdType idType )
+            Configuration config, IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory,
+            Class<ENTITY> entityClass )
     {
         super( dataFactory );
         this.headerFactory = headerFactory;
         this.config = config;
         this.idType = idType;
+        this.maxProcessors = maxProcessors;
+        this.factory = factory;
+        this.entityClass = entityClass;
     }
 
     @Override
@@ -59,19 +74,41 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
 
         // Open the data stream. It's closed by the batch importer when execution is done.
         Data<ENTITY> data = dataFactory.create( config );
-        CharSeeker dataStream = data.stream();
+        if ( config.multilineFields() )
+        {
+            // Use a single-threaded reading and parsing because if we can expect multi-line fields it's
+            // nearly impossible to deduce where one row ends and another starts when diving into
+            // an arbitrary position in the file.
 
-        // Read the header, given the data stream. This allows the header factory to be able to
-        // parse the header from the data stream directly. Or it can decide to grab the header
-        // from somewhere else, it's up to that factory.
-        Header dataHeader = headerFactory.create( dataStream, config, idType );
+            CharSeeker dataStream = charSeeker( data.stream(), config, true );
 
-        InputEntityDeserializer<ENTITY> input = entityDeserializer( dataStream, dataHeader, data.decorator() );
-        // It's important that we assign currentInput before calling initialize(), so that if something
-        // goes wrong in initialize() and our close() is called we close it properly.
-        currentInput = input;
-        currentInputOpen = true;
-        input.initialize();
+            // Read the header, given the data stream. This allows the header factory to be able to
+            // parse the header from the data stream directly. Or it can decide to grab the header
+            // from somewhere else, it's up to that factory.
+            Header dataHeader = headerFactory.create( dataStream, config, idType );
+
+            InputEntityDeserializer<ENTITY> input = factory.create( dataStream, dataHeader, data.decorator() );
+            // It's important that we assign currentInput before calling initialize(), so that if something
+            // goes wrong in initialize() and our close() is called we close it properly.
+            currentInput = input;
+            currentInputOpen = true;
+            input.initialize();
+        }
+        else
+        {
+            // If the input fields aren't expected to contain multi-line fields we can do an optimization
+            // where we have one reader, reading chunks of data, handing over them to one or more parsing
+            // threads. The reader will read from its current position and N bytes ahead. When it gets there
+            // it will search backwards for the first new-line character and set the chunk end position
+            // to that position, effectively un-reading those characters back. This way each chunk will have
+            // complete rows of data and can be parsed individually by multiple threads.
+
+            currentInput = new ParallelInputEntityDeserializer<>( data, headerFactory, config, idType,
+                    maxProcessors, factory, entityClass  );
+            currentInput.processors( previousInputProcessors );
+            currentInputOpen = true;
+        }
+
         return currentInput;
     }
 
@@ -80,13 +117,11 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
         if ( currentInputOpen )
         {
             previousInputsCollectivePositions += currentInput.position();
+            previousInputProcessors = currentInput.processors( 0 );
             currentInput.close();
             currentInputOpen = false;
         }
     }
-
-    protected abstract InputEntityDeserializer<ENTITY> entityDeserializer( CharSeeker dataStream, Header dataHeader,
-            Function<ENTITY,ENTITY> decorator );
 
     @Override
     public void close()
@@ -110,5 +145,11 @@ abstract class InputGroupsDeserializer<ENTITY extends InputEntity>
     public long lineNumber()
     {
         return currentInput.lineNumber();
+    }
+
+    @Override
+    public int processors( int delta )
+    {
+        return currentInput.processors( delta );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import org.neo4j.kernel.impl.util.Validator;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.input.MissingRelationshipDataException;
+
+class InputRelationshipValidator implements Validator<InputRelationship>
+{
+    @Override
+    public void validate( InputRelationship entity )
+    {
+        if ( entity.startNode() == null )
+        {
+            throw new MissingRelationshipDataException(Type.START_ID,
+                                entity + " is missing " + Type.START_ID + " field" );
+        }
+        if ( entity.endNode() == null )
+        {
+            throw new MissingRelationshipDataException(Type.END_ID,
+                                entity + " is missing " + Type.END_ID + " field" );
+        }
+        if ( !entity.hasTypeId() && entity.type() == null )
+        {
+            throw new MissingRelationshipDataException(Type.TYPE,
+                                entity + " is missing " + Type.TYPE + " field" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.neo4j.csv.reader.BufferedCharSeeker;
+import org.neo4j.csv.reader.CharSeeker;
+import org.neo4j.csv.reader.ProcessingSource;
+import org.neo4j.csv.reader.SourceTraceability;
+import org.neo4j.csv.reader.Source.Chunk;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.impl.util.collection.ContinuableArrayCursor;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
+import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
+import org.neo4j.unsafe.impl.batchimport.input.InputException;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
+import org.neo4j.unsafe.impl.batchimport.staging.TicketedProcessing;
+
+import static org.neo4j.csv.reader.Source.singleChunk;
+
+/**
+ * Deserializes CSV into {@link InputNode} and {@link InputRelationship} and does so by reading characters
+ * in a dedicated thread while letting one or more threads parse the data. This can only safely be used if
+ * {@link Configuration#multilineFields()} is {@code false}. Initially only one parsing thread is assigned,
+ * more can be assigned at any point in time using {@link #processors(int)}.
+ *
+ * This class accepts {@link DeserializerFactory}, which normally instantiates {@link InputEntityDeserializer}
+ * instances.
+ *
+ * @param <ENTITY> type of {@link InputEntity} to deserialize into
+ */
+public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends InputIterator.Adapter<ENTITY>
+{
+    private final ProcessingSource source;
+    private final TicketedProcessing<CharSeeker,Header,ENTITY[]> processing;
+    private final ContinuableArrayCursor<ENTITY> cursor;
+    private SourceTraceability last = SourceTraceability.EMPTY;
+
+    @SuppressWarnings( "unchecked" )
+    public ParallelInputEntityDeserializer( Data<ENTITY> data, Header.Factory headerFactory, Configuration config,
+            IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory, Class<ENTITY> entityClass )
+    {
+        // Reader of chunks, characters aligning to nearest newline
+        source = new ProcessingSource( data.stream(), config.bufferSize(), maxProcessors );
+        try
+        {
+            // Read first chunk explicitly here since it contains the header
+            Chunk firstChunk = source.nextChunk();
+            if ( firstChunk.length() == 0 )
+            {
+                throw new InputException( "No header defined" );
+            }
+            CharSeeker firstSeeker = new BufferedCharSeeker( singleChunk( firstChunk ), config );
+            Header dataHeader = headerFactory.create( firstSeeker, config, idType );
+
+            // Initialize the processing logic for parsing the data in the first chunk, as well as in all other chunk
+            processing = new TicketedProcessing<>( "Parallel input parser", maxProcessors, (seeker, header) ->
+            {
+                InputEntityDeserializer<ENTITY> chunkDeserializer = factory.create( seeker, header, data.decorator() );
+                chunkDeserializer.initialize();
+                List<ENTITY> entities = new ArrayList<>();
+                while ( chunkDeserializer.hasNext() )
+                {
+                    ENTITY next = chunkDeserializer.next();
+                    entities.add( next );
+                }
+                return entities.toArray( (ENTITY[]) Array.newInstance( entityClass, entities.size() ) );
+            },
+            () -> dataHeader.clone() /*We need to clone the stateful header to each processing thread*/ );
+
+            // Utility cursor which takes care of moving over processed results from chunk to chunk
+            cursor = new ContinuableArrayCursor<>( rebaseBatches( processing ) );
+
+            // Start an asynchronous slurp of the chunks fed directly into the processors
+            processing.slurp( seekers( firstSeeker, source, config ), true );
+        }
+        catch ( IOException e )
+        {
+            throw new InputException( "Couldn't read first chunk from input", e );
+        }
+    }
+
+    @Override
+    protected ENTITY fetchNextOrNull()
+    {
+        boolean hasNext;
+        try
+        {
+            hasNext = cursor.next();
+        }
+        catch ( TaskExecutionPanicException e )
+        {
+            // Getting this exception here means that a processor got an exception and put
+            // the executor in panic mode. The user would like to see the actual exception
+            // so we're going to do a little thing here where we take the cause of this
+            // IllegalStateException and throw it, since this ISE is just a wrapper.
+            throw Exceptions.launderedException( e.getCause() );
+        }
+
+        if ( hasNext )
+        {
+            ENTITY next = cursor.get();
+            // We keep a reference to the last fetched so that the methods from SourceTraceability can
+            // be implemented and executed correctly.
+            last = next;
+            return next;
+        }
+        return null;
+    }
+
+    private static <ENTITY extends InputEntity> Supplier<ENTITY[]> rebaseBatches(
+            TicketedProcessing<CharSeeker,Header,ENTITY[]> processing )
+    {
+        return () -> processing.next();
+    }
+
+    private static Iterator<CharSeeker> seekers( CharSeeker firstSeeker, ProcessingSource source, Configuration config )
+    {
+        return new PrefetchingIterator<CharSeeker>()
+        {
+            private boolean firstReturned;
+
+            @Override
+            protected CharSeeker fetchNextOrNull()
+            {
+                // We have the first here explicitly since we read it before starting the general processing
+                // and extract the header. We want to read the data in it as well and that's why we get it here
+                if ( !firstReturned )
+                {
+                    firstReturned = true;
+                    return firstSeeker;
+                }
+
+                // Continue read the next chunk from the source file(s)
+                try
+                {
+                    Chunk chunk = source.nextChunk();
+                    return chunk.length() > 0 ? new BufferedCharSeeker( singleChunk( chunk ), config ) : null;
+                }
+                catch ( IOException e )
+                {
+                    throw new InputException( "Couldn't get chunk from source", e );
+                }
+            }
+        };
+    }
+
+    @Override
+    public void close()
+    {
+        processing.shutdown( true );
+        try
+        {
+            source.close();
+        }
+        catch ( IOException e )
+        {
+            throw new InputException( "Couldn't close source of data chunks", e );
+        }
+        finally
+        {
+            super.close();
+        }
+    }
+
+    @Override
+    public int processors( int delta )
+    {
+        return processing.processors( delta );
+    }
+
+    @Override
+    public String sourceDescription()
+    {
+        return last.sourceDescription();
+    }
+
+    @Override
+    public long lineNumber()
+    {
+        return last.lineNumber();
+    }
+
+    @Override
+    public long position()
+    {
+        return last.position();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -66,6 +66,7 @@ import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
+import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -97,7 +98,8 @@ public class CsvInputBatchImportIT
         try
         {
             importer.doImport( csv( nodeDataAsFile( nodeData ), relationshipDataAsFile( relationshipData ),
-                    IdType.STRING, lowBufferSize( COMMAS ), silentBadCollector( 0 ) ) );
+                    IdType.STRING, lowBufferSize( COMMAS ), silentBadCollector( 0 ),
+                    getRuntime().availableProcessors() ) );
             // THEN
             verifyImportedData( nodeData, relationshipData );
             success = true;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -27,8 +27,8 @@ import java.util.function.Function;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.csv.reader.BufferedCharSeeker;
 import org.neo4j.csv.reader.CharSeeker;
+import org.neo4j.csv.reader.CharSeekers;
 import org.neo4j.csv.reader.Extractor;
 import org.neo4j.csv.reader.Extractors;
 import org.neo4j.graphdb.ResourceIterator;
@@ -940,7 +940,7 @@ public class CsvInputTest
 
     private static CharSeeker charSeeker( String data )
     {
-        return new BufferedCharSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG );
+        return CharSeekers.charSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG, false );
     }
 
     @SuppressWarnings( { "rawtypes", "unchecked" } )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -25,8 +25,8 @@ import java.io.StringReader;
 
 import org.junit.Test;
 
-import org.neo4j.csv.reader.BufferedCharSeeker;
 import org.neo4j.csv.reader.CharSeeker;
+import org.neo4j.csv.reader.CharSeekers;
 import org.neo4j.csv.reader.Extractor;
 import org.neo4j.csv.reader.Extractors;
 import org.neo4j.unsafe.impl.batchimport.input.DuplicateHeaderException;
@@ -38,8 +38,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+
 import static org.neo4j.csv.reader.Readables.sources;
 import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.helpers.ArrayUtil.array;
@@ -176,27 +175,6 @@ public class DataFactoriesTest
     }
 
     @Test
-    public void shouldParseHeaderFromSeparateReader() throws Exception
-    {
-        // GIVEN
-        CharSeeker dataSeeker = mock( CharSeeker.class );
-        Header.Factory headerFactory =
-                defaultFormatNodeFileHeader( wrap( new StringReader( "id:ID\tname:String\tbirth_date:long" ) ) );
-        Extractors extractors = new Extractors( ';' );
-
-        // WHEN
-        Header header = headerFactory.create( dataSeeker, TABS, IdType.ACTUAL );
-
-        // THEN
-        assertArrayEquals( array(
-                entry( "id", Type.ID, extractors.long_() ),
-                entry( "name", Type.PROPERTY, extractors.string() ),
-                entry( "birth_date", Type.PROPERTY, extractors.long_() ) ), header.entries() );
-        verifyZeroInteractions( dataSeeker );
-        dataSeeker.close();
-    }
-
-    @Test
     public void shouldParseHeaderFromFirstLineOfFirstInputFile() throws Exception
     {
         // GIVEN
@@ -300,7 +278,7 @@ public class DataFactoriesTest
 
     private CharSeeker seeker( String data )
     {
-        return new BufferedCharSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG );
+        return CharSeekers.charSeeker( wrap( new StringReader( data ) ), SEEKER_CONFIG, false );
     }
 
     private static Configuration withBufferSize( Configuration config, final int bufferSize )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -194,7 +194,7 @@ public class DataFactoriesTest
         Extractors extractors = new Extractors( ';' );
 
         // WHEN
-        CharSeeker seeker = dataFactory.create( TABS ).stream();
+        CharSeeker seeker = CharSeekers.charSeeker( dataFactory.create( TABS ).stream(), TABS, false );
         Header header = headerFactory.create( seeker, TABS, IdType.ACTUAL );
 
         // THEN

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Function;
+
+import org.neo4j.csv.reader.CharReadable;
+import org.neo4j.kernel.impl.util.Validators;
+import org.neo4j.test.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.csv.reader.Readables.wrap;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.IdType.ACTUAL;
+
+public class ParallelInputEntityDeserializerTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule().withSeed( 1468928804595L );
+
+    @Test
+    public void shouldParseDataInParallel() throws Exception
+    {
+        // GIVEN
+        int entities = 500;
+        Data<InputNode> data = testData( entities );
+        Configuration config = new Configuration.Overriden( COMMAS )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 100;
+            }
+        };
+        IdType idType = ACTUAL;
+        Collector badCollector = mock( Collector.class );
+        Groups groups = new Groups();
+        Set<Thread> observedProcessingThreads = new CopyOnWriteArraySet<>();
+        int threads = 4;
+        DeserializerFactory<InputNode> deserializerFactory = (chunk,header,decorator) ->
+        {
+            observedProcessingThreads.add( Thread.currentThread() );
+            // Make sure there will be 4 different processing threads doing this
+            while ( observedProcessingThreads.size() < threads );
+            return new InputEntityDeserializer<>( header, chunk, config.delimiter(),
+                    new InputNodeDeserialization( chunk, header, groups, idType.idsAreExternal() ), decorator,
+                    Validators.<InputNode>emptyValidator(), badCollector );
+        };
+        try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,
+                defaultFormatNodeFileHeader(), config, idType, threads, deserializerFactory, InputNode.class ) )
+        {
+            deserializer.processors( threads );
+
+            // WHEN/THEN
+            for ( long i = 0; i < entities; i++ )
+            {
+                assertTrue( deserializer.hasNext() );
+                InputNode entity = deserializer.next();
+                assertEquals( i, ((Long) entity.id()).longValue() );
+                assertEquals( "name", entity.properties()[0] );
+                assertTrue( entity.properties()[1].toString().startsWith( i + "-" ) );
+            }
+            assertFalse( deserializer.hasNext() );
+            assertEquals( threads, observedProcessingThreads.size() );
+        }
+    }
+
+    private Data<InputNode> testData( int entities )
+    {
+        StringBuilder string = new StringBuilder();
+        string.append( ":ID,name\n" );
+        for ( int i = 0; i < entities; i++ )
+        {
+            string.append( i ).append( "," ).append( i + "-" + random.string() ).append( "\n" );
+        }
+        return data( string.toString() );
+    }
+
+    private Data<InputNode> data( String string )
+    {
+        return new Data<InputNode>()
+        {
+            @Override
+            public CharReadable stream()
+            {
+                return wrap( new StringReader( string ) );
+            }
+
+            @Override
+            public Function<InputNode,InputNode> decorator()
+            {
+                return item -> item;
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -84,6 +84,8 @@ public class ParallelInputEntityDeserializerTest
             deserializer.processors( threads );
 
             // WHEN/THEN
+            long previousLineNumber = -1;
+            long previousPosition = -1;
             for ( long i = 0; i < entities; i++ )
             {
                 assertTrue( deserializer.hasNext() );
@@ -91,6 +93,12 @@ public class ParallelInputEntityDeserializerTest
                 assertEquals( i, ((Long) entity.id()).longValue() );
                 assertEquals( "name", entity.properties()[0] );
                 assertTrue( entity.properties()[1].toString().startsWith( i + "-" ) );
+
+                assertTrue( entity.lineNumber() > previousLineNumber );
+                previousLineNumber = entity.lineNumber();
+
+                assertTrue( entity.position() > previousPosition );
+                previousPosition = entity.position();
             }
             assertFalse( deserializer.hasNext() );
             assertEquals( threads, observedProcessingThreads.size() );


### PR DESCRIPTION
takes advantage of being able to determine where any data row starts
and another ends if multi-line fields are disallowed. In this case
chunks of csv data can be read and handed off to one or more threads
parsing the data, to finally end up merged back in the same order as
they were read from the csv source.
From the outside there's no difference, it still provides `InputIterator`
for nodes and relationships.

changelog: [3.0, import-tool] Improves the performance of CSV input data reading by parsing data in parallel if multi-line fields are disallowed.
