### PR TITLE
Simpler ReadRecordsStep

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
@@ -71,6 +71,7 @@ public class NodeSetFirstGroupStep extends ProcessorStep<RelationshipGroupRecord
     {
         for ( RelationshipGroupRecord group : batch )
         {
+            assert group.inUse();
             long nodeId = group.getOwningNode();
             if ( cache.getByte( nodeId, 0 ) == 0 )
             {


### PR DESCRIPTION
- unused records are always skipped (because all usages of it did anyway)
- reserved record ids are skipped w/o reading instead of reading and
  filter later on
- no additional filter provided, because there was no use for it

This fixes at least one problem where there were processors using data
from unused records as indexes into cache arrays (potentially off-heap)
causing memory issues.
