### PR TITLE
CheckTxLogs Uses existing mechanisms to extract transactions from multiple logs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogEntryCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogEntryCursor.java
@@ -32,6 +32,7 @@ public class LogEntryCursor implements IOCursor<LogEntry>
 {
     private final LogEntryReader<ReadableLogChannel> logEntryReader;
     private final ReadableLogChannel channel;
+    private final LogPositionMarker position = new LogPositionMarker();
     private LogEntry entry;
 
     public LogEntryCursor( ReadableLogChannel channel )
@@ -63,5 +64,17 @@ public class LogEntryCursor implements IOCursor<LogEntry>
     public void close() throws IOException
     {
         channel.close();
+    }
+
+    /**
+     * Reading {@link LogEntry log entries} may have the source move over physically multiple log files.
+     * This accessor returns the log version of the most recent call to {@link #next()}.
+     *
+     * @return the log version of the most recent {@link LogEntry} returned from {@link #next().
+     */
+    public long getCurrentLogVersion() throws IOException
+    {
+        channel.getCurrentPosition( position );
+        return position.getLogVersion();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryReader.java
@@ -23,7 +23,20 @@ import java.io.IOException;
 
 import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
 
+/**
+* Reads a stream of {@link LogEntry log entries} from a {@link ReadableLogChannel}.
+*
+* @param <S> type of source to read from
+*/
 public interface LogEntryReader<S extends ReadableLogChannel>
 {
+    /**
+     * Reads next {@link LogEntry} from the source.
+     *
+     * @param source to read from.
+     * @return the read {@link LogEntry}.
+     * @throws IOException on error reading from source.
+     * @throws ReadPastEndException if there were no more {@link LogEntry log entries} to read.
+     */
     LogEntry readLogEntry( S source ) throws IOException;
 }

--- a/tools/src/main/java/org/neo4j/tools/txlog/LogRecord.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/LogRecord.java
@@ -45,6 +45,11 @@ class LogRecord<R extends Abstract64BitRecord>
         return record;
     }
 
+    long logVersion()
+    {
+        return logVersion;
+    }
+
     @Override
     public String toString()
     {


### PR DESCRIPTION
instead of checking each individual log file. Reason being that order is vital
to correct results and less and simpler code in CheckTxLogs as well.
