### PR TITLE
Safer KTI termination

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -148,7 +148,7 @@ public interface KernelTransaction extends AutoCloseable
 
     /**
      * @return start time of this transaction, i.e. basically {@link System#currentTimeMillis()} when user called
-     * {@link Kernel#newTransaction()}.
+     * {@link Kernel#newTransaction(Type, AccessMode)}.
      */
     long localStartTime();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * View of a {@link KernelTransaction} that provides a limited set of actions against the transaction.
+ */
+public interface KernelTransactionHandle
+{
+    /**
+     * The timestamp of the last transaction that was committed to the store when the underlying transaction started.
+     *
+     * @return the timestamp value obtained with {@link System#currentTimeMillis()}.
+     */
+    long lastTransactionTimestampWhenStarted();
+
+    /**
+     * Check if the underlying transaction is open.
+     *
+     * @return {@code true} if the underlying transaction ({@link KernelTransaction#close()} was not called),
+     * {@code false} otherwise.
+     */
+    boolean isOpen();
+
+    /**
+     * Mark the underlying transaction for termination.
+     *
+     * @param reason the reason for termination.
+     */
+    void markForTermination( Status reason );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -20,6 +20,8 @@
 package org.neo4j.kernel.api;
 
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.impl.api.Kernel;
 
 /**
  * View of a {@link KernelTransaction} that provides a limited set of actions against the transaction.
@@ -27,11 +29,26 @@ import org.neo4j.kernel.api.exceptions.Status;
 public interface KernelTransactionHandle
 {
     /**
+     * The id of the last transaction that was committed to the store when the underlying transaction started.
+     *
+     * @return the committed transaction id.
+     */
+    long lastTransactionIdWhenStarted();
+
+    /**
      * The timestamp of the last transaction that was committed to the store when the underlying transaction started.
      *
      * @return the timestamp value obtained with {@link System#currentTimeMillis()}.
      */
     long lastTransactionTimestampWhenStarted();
+
+    /**
+     * The start time of the underlying transaction. I.e. basically {@link System#currentTimeMillis()} when user
+     * called {@link Kernel#newTransaction(KernelTransaction.Type, AccessMode)}.
+     *
+     * @return the transaction start time.
+     */
+    long localStartTime();
 
     /**
      * Check if the underlying transaction is open.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.neo4j.kernel.api.KernelTransactionHandle;
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * A {@link KernelTransactionHandle} that wraps the given {@link KernelTransactionImplementation}.
+ * This handle knows that {@link KernelTransactionImplementation}s can be reused and represents a single logical
+ * transaction. This means that methods like {@link #markForTermination(Status)} can only terminate running
+ * transaction this handle was created for.
+ */
+class KernelTransactionImplementationHandle implements KernelTransactionHandle
+{
+    private final long txReuseCount;
+    private final KernelTransactionImplementation tx;
+
+    KernelTransactionImplementationHandle( KernelTransactionImplementation tx )
+    {
+        this.txReuseCount = tx.getReuseCount();
+        this.tx = tx;
+    }
+
+    @Override
+    public long lastTransactionTimestampWhenStarted()
+    {
+        return tx.lastTransactionTimestampWhenStarted();
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return tx.isOpen() && txReuseCount == tx.getReuseCount();
+    }
+
+    @Override
+    public void markForTermination( Status reason )
+    {
+        tx.markForTermination( txReuseCount, reason );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        KernelTransactionImplementationHandle that = (KernelTransactionImplementationHandle) o;
+        return txReuseCount == that.txReuseCount && tx.equals( that.tx );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 31 * (int) (txReuseCount ^ (txReuseCount >>> 32)) + tx.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "KernelTransactionImplementationHandle{txReuseCount=" + txReuseCount + ", tx=" + tx + "}";
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -31,11 +31,13 @@ import org.neo4j.kernel.api.exceptions.Status;
 class KernelTransactionImplementationHandle implements KernelTransactionHandle
 {
     private final long txReuseCount;
+    private final long lastTransactionTimestampWhenStarted;
     private final KernelTransactionImplementation tx;
 
     KernelTransactionImplementationHandle( KernelTransactionImplementation tx )
     {
         this.txReuseCount = tx.getReuseCount();
+        this.lastTransactionTimestampWhenStarted = tx.lastTransactionTimestampWhenStarted();
         this.tx = tx;
     }
 
@@ -48,7 +50,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     @Override
     public long lastTransactionTimestampWhenStarted()
     {
-        return tx.lastTransactionTimestampWhenStarted();
+        return lastTransactionTimestampWhenStarted;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -31,20 +31,24 @@ import org.neo4j.kernel.api.exceptions.Status;
 class KernelTransactionImplementationHandle implements KernelTransactionHandle
 {
     private final long txReuseCount;
+    private final long lastTransactionIdWhenStarted;
     private final long lastTransactionTimestampWhenStarted;
+    private final long localStartTime;
     private final KernelTransactionImplementation tx;
 
     KernelTransactionImplementationHandle( KernelTransactionImplementation tx )
     {
         this.txReuseCount = tx.getReuseCount();
+        this.lastTransactionIdWhenStarted = tx.lastTransactionIdWhenStarted();
         this.lastTransactionTimestampWhenStarted = tx.lastTransactionTimestampWhenStarted();
+        this.localStartTime = tx.localStartTime();
         this.tx = tx;
     }
 
     @Override
     public long lastTransactionIdWhenStarted()
     {
-        return tx.lastTransactionIdWhenStarted();
+        return lastTransactionIdWhenStarted;
     }
 
     @Override
@@ -56,7 +60,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     @Override
     public long localStartTime()
     {
-        return tx.localStartTime();
+        return localStartTime;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -40,9 +40,21 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     }
 
     @Override
+    public long lastTransactionIdWhenStarted()
+    {
+        return tx.lastTransactionIdWhenStarted();
+    }
+
+    @Override
     public long lastTransactionTimestampWhenStarted()
     {
         return tx.lastTransactionTimestampWhenStarted();
+    }
+
+    @Override
+    public long localStartTime()
+    {
+        return tx.localStartTime();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
@@ -39,6 +39,21 @@ public class KernelTransactionImplementationHandleTest
 
         KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
         when( tx.lastTransactionTimestampWhenStarted() ).thenReturn( lastCommittedTxTimestamp );
+        when( tx.isOpen() ).thenReturn( true );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+
+        assertEquals( lastCommittedTxTimestamp, handle.lastTransactionTimestampWhenStarted() );
+    }
+
+    @Test
+    public void returnsCorrectLastTransactionTimestampWhenStartedForClosedTx()
+    {
+        long lastCommittedTxTimestamp = 4242;
+
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.lastTransactionTimestampWhenStarted() ).thenReturn( lastCommittedTxTimestamp );
+        when( tx.isOpen() ).thenReturn( false );
 
         KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KernelTransactionImplementationHandleTest
+{
+    @Test
+    public void returnsCorrectLastTransactionTimestampWhenStarted()
+    {
+        long lastCommittedTxTimestamp = 42;
+
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.lastTransactionTimestampWhenStarted() ).thenReturn( lastCommittedTxTimestamp );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+
+        assertEquals( lastCommittedTxTimestamp, handle.lastTransactionTimestampWhenStarted() );
+    }
+
+    @Test
+    public void isOpenForUnchangedKernelTransactionImplementation()
+    {
+        int reuseCount = 42;
+
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.isOpen() ).thenReturn( true );
+        when( tx.getReuseCount() ).thenReturn( reuseCount );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+
+        assertTrue( handle.isOpen() );
+    }
+
+    @Test
+    public void isOpenForReusedKernelTransactionImplementation()
+    {
+        int initialReuseCount = 42;
+        int nextReuseCount = 4242;
+
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.isOpen() ).thenReturn( true );
+        when( tx.getReuseCount() ).thenReturn( initialReuseCount ).thenReturn( nextReuseCount );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+
+        assertFalse( handle.isOpen() );
+    }
+
+    @Test
+    public void markForTerminationCallsKernelTransactionImplementation()
+    {
+        int reuseCount = 42;
+        Status.Transaction terminationReason = Status.Transaction.Terminated;
+
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.getReuseCount() ).thenReturn( reuseCount );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+        handle.markForTermination( terminationReason );
+
+        verify( tx ).markForTermination( reuseCount, terminationReason );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -589,5 +590,51 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         tx.markForTermination( Status.Transaction.Terminated );
         tx.close();
         assertNull( tx.getReasonIfTerminated() );
+    }
+
+    @Test
+    public void markForTerminationWithCorrectReuseCount() throws Exception
+    {
+        int reuseCount = 10;
+        Status.Transaction terminationReason = Status.Transaction.Terminated;
+
+        KernelTransactionImplementation tx = newNotInitializedTransaction( true );
+        initializeAndClose( tx, reuseCount );
+
+        Locks.Client locksClient = mock( Locks.Client.class );
+        tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
+
+        tx.markForTermination( reuseCount, terminationReason );
+
+        assertEquals( terminationReason, tx.getReasonIfTerminated() );
+        verify( locksClient ).stop();
+    }
+
+    @Test
+    public void markForTerminationWithIncorrectReuseCount() throws Exception
+    {
+        int reuseCount = 13;
+        int nextReuseCount = reuseCount + 2;
+        Status.Transaction terminationReason = Status.Transaction.Terminated;
+
+        KernelTransactionImplementation tx = newNotInitializedTransaction( true );
+        initializeAndClose( tx, reuseCount );
+
+        Locks.Client locksClient = mock( Locks.Client.class );
+        tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
+
+        tx.markForTermination( nextReuseCount, terminationReason );
+
+        assertNull( tx.getReasonIfTerminated() );
+        verify( locksClient, never() ).stop();
+    }
+
+    private void initializeAndClose( KernelTransactionImplementation tx, int times ) throws Exception
+    {
+        for ( int i = 0; i < times; i++ )
+        {
+            tx.initialize( i + 10, i + 10, new NoOpClient(), KernelTransaction.Type.implicit, accessMode() );
+            tx.close();
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -34,18 +34,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.neo4j.helpers.Clock;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.TransactionId;
-import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
@@ -93,7 +92,7 @@ public class KernelTransactionsTest
     public void shouldListActiveTransactions() throws Exception
     {
         // Given
-        KernelTransactions registry = newKernelTransactions();
+        KernelTransactions registry = newTestKernelTransactions();
 
         // When
         KernelTransaction first = registry.newInstance( KernelTransaction.Type.implicit, AccessMode.Static.NONE );
@@ -103,7 +102,7 @@ public class KernelTransactionsTest
         first.close();
 
         // Then
-        assertThat( Iterables.asUniqueSet( registry.activeTransactions() ), equalTo( asSet( second, third ) ) );
+        assertThat( registry.activeTransactions(), equalTo( asSet( newHandle( second ), newHandle( third ) ) ) );
     }
 
     @Test
@@ -256,7 +255,7 @@ public class KernelTransactionsTest
     @Test
     public void transactionCloseRemovesTxFromActiveTransactions() throws Exception
     {
-        KernelTransactions kernelTransactions = newKernelTransactions();
+        KernelTransactions kernelTransactions = newTestKernelTransactions();
 
         KernelTransaction tx1 = kernelTransactions.newInstance( KernelTransaction.Type.implicit, AccessMode.Static.NONE );
         KernelTransaction tx2 = kernelTransactions.newInstance( KernelTransaction.Type.implicit,AccessMode.Static.NONE );
@@ -265,21 +264,7 @@ public class KernelTransactionsTest
         tx1.close();
         tx3.close();
 
-        assertEquals( asSet( tx2 ), kernelTransactions.activeTransactions() );
-    }
-
-    @Test
-    public void transactionRemovesItselfFromActiveTransactions() throws Exception
-    {
-        KernelTransactions kernelTransactions = newKernelTransactions();
-
-        KernelTransaction tx1 = kernelTransactions.newInstance( KernelTransaction.Type.implicit, AccessMode.Static.NONE );
-        KernelTransaction tx2 = kernelTransactions.newInstance( KernelTransaction.Type.implicit, AccessMode.Static.NONE );
-        KernelTransaction tx3 = kernelTransactions.newInstance( KernelTransaction.Type.implicit, AccessMode.Static.NONE );
-
-        tx2.close();
-
-        assertEquals( asSet( tx1, tx3 ), kernelTransactions.activeTransactions() );
+        assertEquals( asSet( newHandle( tx2 ) ), kernelTransactions.activeTransactions() );
     }
 
     @Test
@@ -398,17 +383,26 @@ public class KernelTransactionsTest
         return newKernelTransactions( mock( TransactionCommitProcess.class ) );
     }
 
+    private static KernelTransactions newTestKernelTransactions() throws Exception
+    {
+        return newKernelTransactions( true, mock( TransactionCommitProcess.class ), mock( StorageStatement.class ) );
+    }
+
     private static KernelTransactions newKernelTransactions( TransactionCommitProcess commitProcess ) throws Exception
     {
-        return newKernelTransactions( commitProcess, mock( StorageStatement.class ) );
+        return newKernelTransactions( false, commitProcess, mock( StorageStatement.class ) );
     }
 
     private static KernelTransactions newKernelTransactions( TransactionCommitProcess commitProcess,
             StorageStatement firstStoreStatements, StorageStatement... otherStorageStatements ) throws Exception
     {
-        LifeSupport life = new LifeSupport();
-        life.start();
+        return newKernelTransactions( false, commitProcess, firstStoreStatements, otherStorageStatements );
+    }
 
+    private static KernelTransactions newKernelTransactions( boolean testKernelTransactions,
+            TransactionCommitProcess commitProcess, StorageStatement firstStoreStatements,
+            StorageStatement... otherStorageStatements ) throws Exception
+    {
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
@@ -417,7 +411,8 @@ public class KernelTransactionsTest
 
         StorageEngine storageEngine = mock( StorageEngine.class );
         when( storageEngine.storeReadLayer() ).thenReturn( readLayer );
-        doAnswer( invocation -> {
+        doAnswer( invocation ->
+        {
             invocation.getArgumentAt( 0, Collection.class ).add( mock( StorageCommand.class ) );
             return null;
         } ).when( storageEngine ).createCommands(
@@ -427,22 +422,34 @@ public class KernelTransactionsTest
                 any( ResourceLocker.class ),
                 anyLong() );
 
+        return newKernelTransactions( locks, storageEngine, commitProcess, testKernelTransactions );
+    }
+
+    private static KernelTransactions newKernelTransactions( Locks locks, StorageEngine storageEngine,
+            TransactionCommitProcess commitProcess, boolean testKernelTransactions )
+    {
+        LifeSupport life = new LifeSupport();
+        life.start();
+
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new TransactionId( 0, 0, 0 ) );
 
-        Tracers tracers =
-                new Tracers( "null", NullLog.getInstance(), mock( Monitors.class ), mock( JobScheduler.class ) );
-        return new KernelTransactions( locks,
-                null, null, null, TransactionHeaderInformationFactory.DEFAULT,
-                commitProcess, null,
-                null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
-                tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(),
-                Clock.SYSTEM_CLOCK );
+        Tracers tracers = new Tracers( "null", NullLog.getInstance(), new Monitors(), mock( JobScheduler.class ) );
+
+        if ( testKernelTransactions )
+        {
+            return new TestKernelTransactions( locks, null, null, null, TransactionHeaderInformationFactory.DEFAULT,
+                    commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
+                    tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(),
+                    Clock.SYSTEM_CLOCK );
+        }
+        return new KernelTransactions( locks, null, null, null, TransactionHeaderInformationFactory.DEFAULT,
+                commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
+                tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(), Clock.SYSTEM_CLOCK );
     }
 
     private static TransactionCommitProcess newRememberingCommitProcess( final TransactionRepresentation[] slot )
             throws TransactionFailureException
-
     {
         TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
 
@@ -498,6 +505,36 @@ public class KernelTransactionsTest
         catch ( Exception e )
         {
             assertThat( e, instanceOf( TimeoutException.class ) );
+        }
+    }
+
+    private static KernelTransactionHandle newHandle( KernelTransaction tx )
+    {
+        return new TestKernelTransactionHandle( tx );
+    }
+
+    private static class TestKernelTransactions extends KernelTransactions
+    {
+        TestKernelTransactions( Locks locks,
+                ConstraintIndexCreator constraintIndexCreator,
+                StatementOperationParts statementOperations, SchemaWriteGuard schemaWriteGuard,
+                TransactionHeaderInformationFactory txHeaderFactory,
+                TransactionCommitProcess transactionCommitProcess,
+                IndexConfigStore indexConfigStore,
+                LegacyIndexProviderLookup legacyIndexProviderLookup, TransactionHooks hooks,
+                TransactionMonitor transactionMonitor, LifeSupport dataSourceLife,
+                Tracers tracers, StorageEngine storageEngine, Procedures procedures,
+                TransactionIdStore transactionIdStore, Config config, Clock clock )
+        {
+            super( locks, constraintIndexCreator, statementOperations, schemaWriteGuard, txHeaderFactory,
+                    transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor,
+                    dataSourceLife, tracers, storageEngine, procedures, transactionIdStore, config, clock );
+        }
+
+        @Override
+        KernelTransactionHandle createHandle( KernelTransactionImplementation tx )
+        {
+            return new TestKernelTransactionHandle( tx );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -38,9 +38,21 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
+    public long lastTransactionIdWhenStarted()
+    {
+        return tx.lastTransactionIdWhenStarted();
+    }
+
+    @Override
     public long lastTransactionTimestampWhenStarted()
     {
         return tx.lastTransactionTimestampWhenStarted();
+    }
+
+    @Override
+    public long localStartTime()
+    {
+        return tx.localStartTime();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.Objects;
+
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.KernelTransactionHandle;
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * A test implementation of {@link KernelTransactionHandle} that simply wraps a given {@link KernelTransaction}.
+ */
+public class TestKernelTransactionHandle implements KernelTransactionHandle
+{
+    private final KernelTransaction tx;
+
+    public TestKernelTransactionHandle( KernelTransaction tx )
+    {
+        this.tx = Objects.requireNonNull( tx );
+    }
+
+    @Override
+    public long lastTransactionTimestampWhenStarted()
+    {
+        return tx.lastTransactionTimestampWhenStarted();
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return tx.isOpen();
+    }
+
+    @Override
+    public void markForTermination( Status reason )
+    {
+        tx.markForTermination( reason );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        TestKernelTransactionHandle that = (TestKernelTransactionHandle) o;
+        return tx.equals( that.tx );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return tx.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TestKernelTransactionHandle{tx=" + tx + "}";
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.com.storecopy;
 
-import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.KernelTransactions;
@@ -122,7 +122,7 @@ class TransactionBatchCommitter implements TransactionQueue.Applier
         long lastCommittedTimestamp = last.transactionRepresentation().getTimeCommitted();
         long earliestSafeTimestamp = lastCommittedTimestamp - idReuseSafeZoneTime;
 
-        for ( KernelTransaction tx : kernelTransactions.activeTransactions() )
+        for ( KernelTransactionHandle tx : kernelTransactions.activeTransactions() )
         {
             long commitTimestamp = tx.lastTransactionTimestampWhenStarted();
 

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionBatchCommitter.java
@@ -122,9 +122,9 @@ class TransactionBatchCommitter implements TransactionQueue.Applier
         long lastCommittedTimestamp = last.transactionRepresentation().getTimeCommitted();
         long earliestSafeTimestamp = lastCommittedTimestamp - idReuseSafeZoneTime;
 
-        for ( KernelTransactionHandle tx : kernelTransactions.activeTransactions() )
+        for ( KernelTransactionHandle txHandle : kernelTransactions.activeTransactions() )
         {
-            long commitTimestamp = tx.lastTransactionTimestampWhenStarted();
+            long commitTimestamp = txHandle.lastTransactionTimestampWhenStarted();
 
             if ( commitTimestamp != TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP &&
                  commitTimestamp < earliestSafeTimestamp )
@@ -141,10 +141,11 @@ class TransactionBatchCommitter implements TransactionQueue.Applier
                         ", safeZoneDuration:" + informativeDuration( idReuseSafeZoneTime ) +
                         "\n" +
                         "  Transaction: lastCommittedTimestamp:" +
-                        informativeTimestamp( tx.lastTransactionTimestampWhenStarted() ) +
-                        ", lastCommittedTxId:" + tx.lastTransactionIdWhenStarted() +
-                        ", localStartTimestamp:" + informativeTimestamp( tx.localStartTime() ) );
-                tx.markForTermination( Status.Transaction.Outdated );
+                        informativeTimestamp( txHandle.lastTransactionTimestampWhenStarted() ) +
+                        ", lastCommittedTxId:" + txHandle.lastTransactionIdWhenStarted() +
+                        ", localStartTimestamp:" + informativeTimestamp( txHandle.localStartTime() ) );
+
+                txHandle.markForTermination( Status.Transaction.Outdated );
             }
         }
     }


### PR DESCRIPTION
Previously it was possible for an external observer to get list of active transactions and terminate wrong ones. This could happen because of KTI pooling which means instance of KTI can represent multiple logical transactions during it's lifetime.

This commit makes active transactions listing return special objects and not KTI instances. These objects are not reused/pooled and guarantee that the right transaction will be terminated.

**Note:** I'll forward-merge this PR myself because `KernelTrasnactions#activeTransactions()` is used in more places in 3.1.
