### PR TITLE
Expand DH key size to 2048 bits

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/security/ssl/Certificates.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/ssl/Certificates.java
@@ -92,7 +92,7 @@ public class Certificates
             throws GeneralSecurityException, IOException, OperatorCreationException
     {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance( DEFAULT_ENCRYPTION );
-        keyGen.initialize( 1024, random );
+        keyGen.initialize( 2048, random );
         KeyPair keypair = keyGen.generateKeyPair();
 
         // Prepare the information required for generating an X.509 certificate.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -57,6 +57,10 @@ dbms.jvm.additional=-XX:+DisableExplicitGC
 # Some systems cannot discover host name automatically, and need this line configured:
 #dbms.jvm.additional=-Djava.rmi.server.hostname=$THE_NEO4J_SERVER_HOSTNAME
 
+# Expand Diffie Hellman (DH) key size from default 1024 to 2048 for DH-RSA cipher suites used in server TLS handshakes.
+# This is to protect the server from any potential passive eavesdropping.
+dbms.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -57,6 +57,10 @@ dbms.jvm.additional=-XX:+DisableExplicitGC
 # Some systems cannot discover host name automatically, and need this line configured:
 #dbms.jvm.additional=-Djava.rmi.server.hostname=$THE_NEO4J_SERVER_HOSTNAME
 
+# Expand Diffie Hellman (DH) key size from default 1024 to 2048 for DH-RSA cipher suites used in server TLS handshakes.
+# This is to protect the server from any potential passive eavesdropping.
+dbms.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************


### PR DESCRIPTION
As it is recommended and finally becomes available in java 8, we expand to use 2048 bits DH key to protect from any potential passive eavesdropping on TLS encrypted connections.
