### PR TITLE
Ensures panic is seen by all tx appending threads

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogAppendEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/tracing/LogAppendEvent.java
@@ -25,8 +25,7 @@ package org.neo4j.kernel.impl.transaction.tracing;
  */
 public interface LogAppendEvent extends LogForceEvents, AutoCloseable
 {
-
-    LogAppendEvent NULL = new LogAppendEvent()
+    class Empty implements LogAppendEvent
     {
         @Override
         public void close()
@@ -62,7 +61,9 @@ public interface LogAppendEvent extends LogForceEvents, AutoCloseable
         {
             return LogForceEvent.NULL;
         }
-    };
+    }
+
+    LogAppendEvent NULL = new Empty();
 
     /**
      * Mark the end of the process of appending a transaction to the transaction log.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
@@ -25,27 +25,52 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 
+import org.neo4j.adversaries.Adversary;
+import org.neo4j.adversaries.ClassGuardedAdversary;
+import org.neo4j.adversaries.CountingAdversary;
+import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
+import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.KernelHealth;
+import org.neo4j.kernel.impl.core.KernelPanicEventGenerator;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
 import org.neo4j.kernel.impl.transaction.DeadSimpleTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+import org.neo4j.kernel.impl.transaction.tracing.LogForceWaitEvent;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
 import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.NullLog;
+import org.neo4j.test.Race;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.io.ByteUnit.kibiBytes;
+import static org.neo4j.test.DoubleLatch.awaitLatch;
 import static org.neo4j.test.ThreadTestUtils.awaitThreadState;
 import static org.neo4j.test.ThreadTestUtils.fork;
 
@@ -226,5 +251,114 @@ public class BatchingTransactionAppenderConcurrencyTest
             otherThread.join();
         }
         assertTrue( channelCommandQueue.isEmpty() );
+    }
+
+    /*
+     * There was an issue where if multiple concurrent appending threads did append and they moved on
+     * to await a force, where the force would fail and the one doing the force would raise a panic...
+     * the other threads may not notice the panic and move on to mark those transactions as committed
+     * and notice the panic later (which would be too late).
+     */
+    @Test
+    public void shouldHaveAllConcurrentAppendersSeePanic() throws Throwable
+    {
+        // GIVEN
+        Adversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, true ),
+                failMethod( BatchingTransactionAppender.class, "force" ) );
+        EphemeralFileSystemAbstraction efs = new EphemeralFileSystemAbstraction();
+        life.add( asLifecycle( efs ) ); // <-- so that it gets automatically shut down after the test
+        File directory = new File( "dir" ).getCanonicalFile();
+        efs.mkdirs( directory );
+        FileSystemAbstraction fs = new AdversarialFileSystemAbstraction( adversary, efs );
+        KernelHealth kernelHealth = new KernelHealth( mock( KernelPanicEventGenerator.class ), NullLog.getInstance() );
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( directory, fs );
+        LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, kibiBytes( 10 ), transactionIdStore,
+                new DeadSimpleLogVersionRepository( 0 ), new PhysicalLogFile.Monitor.Adapter(),
+                transactionMetadataCache ) );
+        final BatchingTransactionAppender appender = life.add( new BatchingTransactionAppender(
+                logFile, logRotation, transactionMetadataCache, transactionIdStore,
+                legacyIndexTransactionOrdering, kernelHealth ) );
+        life.start();
+
+        // WHEN
+        int numberOfAppenders = 10;
+        final CountDownLatch trap = new CountDownLatch( numberOfAppenders );
+        final LogAppendEvent beforeForceTrappingEvent = new LogAppendEvent.Empty()
+        {
+            @Override
+            public LogForceWaitEvent beginLogForceWait()
+            {
+                trap.countDown();
+                awaitLatch( trap );
+                return super.beginLogForceWait();
+            }
+        };
+        Race race = new Race();
+        for ( int i = 0; i < numberOfAppenders; i++ )
+        {
+            race.addContestant( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try
+                    {
+                        // Append to the log, the LogAppenderEvent will have all of the appending threads
+                        // do wait for all of the other threads to start the force thing
+                        appender.append( tx(), beforeForceTrappingEvent );
+                        fail( "No transaction should be considered appended" );
+                    }
+                    catch ( IOException e )
+                    {
+                        // Good, we know that this test uses an adversarial file system which will throw
+                        // an exception in BatchingTransactionAppender#force, and since all these transactions
+                        // will append and be forced in the same batch, where the force will fail then
+                        // all these transactions should fail. If there's any transaction not failing then
+                        // it just didn't notice the panic, which would be potentially hazardous.
+                    }
+                }
+            } );
+        }
+
+        // THEN perform the race. The relevant assertions are made inside the contestants.
+        race.go();
+    }
+
+    private Lifecycle asLifecycle( final EphemeralFileSystemAbstraction efs )
+    {
+        return new LifecycleAdapter()
+        {
+            @Override
+            public void shutdown() throws Throwable
+            {
+                efs.shutdown();
+            }
+        };
+    }
+
+    protected TransactionRepresentation tx()
+    {
+        Command.NodeCommand nodeCommand = new Command.NodeCommand();
+        NodeRecord before = new NodeRecord( 0 );
+        NodeRecord after = new NodeRecord( 0 );
+        after.setInUse( true );
+        nodeCommand.init( before, after );
+        PhysicalTransactionRepresentation tx = new PhysicalTransactionRepresentation(
+                asList( (Command) nodeCommand ) );
+        tx.setHeader( new byte[0], 0, 0, 0, 0, 0, 0 );
+        return tx;
+    }
+
+    private Predicate<StackTraceElement> failMethod( final Class<?> klass, final String methodName )
+    {
+        return new Predicate<StackTraceElement>()
+        {
+            @Override
+            public boolean test( StackTraceElement element )
+            {
+                return element.getClassName().equals( klass.getName() ) &&
+                        element.getMethodName().equals( methodName );
+            }
+        };
     }
 }


### PR DESCRIPTION
Transactions, when committing, are appended one by one under synchronization
and forced in batch so that multiple transactions which appends roughly at
the same time will likely end up being forced by a single call.
If that force call fails for some reason a kernel panic is raised and thrown,
but only thrown in the one thread, out of all doing the concurrent append,
actually doing the force. The other threads wouldn't notice the panic and
move on to mark their transactions as committed, updating the meta data store
with this information. If the store would get flushed after this it would
appear that the last committed transaction would be a transaction that
didn't exist in the log... which would be a problem.

This commit ensures that "the other" threads not doing the force will
check the kernel health before moving on to mark the transaction
as committed.

changelog: Fixes an issue where failure during forcing of transaction log after multiple concurrent threads appending to it wouldn't have all threads notice the kernel panic before marking their transactions as committed. In rare cases the effect may be that there could be a skipped transaction id in the otherwise sequential gap-free transaction log.
