### PR TITLE
3.1 default reusable types

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/configuration/EnterpriseEditionSettings.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.store.id.IdType;
 
 /**
  * Enterprise edition specific settings
@@ -32,8 +33,9 @@ import org.neo4j.kernel.configuration.Settings;
 public class EnterpriseEditionSettings
 {
     @Description( "Specified names of id types (comma separated) that should be reused. " +
-                  "Currently only 'RELATIONSHIP' type is supported. " )
+                  "Currently only 'RELATIONSHIP' and 'NODE' type is supported. " )
     public static Setting<List<String>> idTypesToReuse =
-            Settings.setting( "dbms.ids.reuse.types.override", Settings.STRING_LIST, "" );
+            Settings.setting( "dbms.ids.reuse.types.override", Settings.STRING_LIST,
+                    String.join( ",", IdType.RELATIONSHIP.name(), IdType.NODE.name() ) );
 
 }

--- a/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueEnterpriseConcurrencyIT.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueEnterpriseConcurrencyIT.scala
@@ -71,8 +71,6 @@ class CreateUniqueEnterpriseConcurrencyIT extends ExecutionEngineFunSuite with E
 
     threads.foreach(_.start())
     threads.foreach(_.join)
-    if (deadlockCounter.get() > 0)
-      println(s"Deadlocks found: ${deadlockCounter.get()}")
     counter.get()
   }
 


### PR DESCRIPTION
Update dbms.ids.reuse.types.override property that will allow reuse relationship and node ids by default.
