### PR TITLE
Imports initial groups into temporary group store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.file.OpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -76,11 +77,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore<DynamicRe
             String typeDescriptor,
             int dataSizeFromConfiguration,
             RecordFormat<DynamicRecord> recordFormat,
-            String storeVersion )
+            String storeVersion,
+            OpenOption... openOptions )
     {
         super( fileName, conf, idType, idGeneratorFactory, pageCache, logProvider, typeDescriptor,
                 recordFormat, new DynamicStoreHeaderFormat( dataSizeFromConfiguration, recordFormat ),
-                storeVersion );
+                storeVersion, openOptions );
     }
 
     public static void allocateRecordsFromBytes(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.store;
 import java.io.File;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
+import java.nio.file.OpenOption;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -57,10 +58,11 @@ public class DynamicArrayStore extends AbstractDynamicStore
             LogProvider logProvider,
             int dataSizeFromConfiguration,
             RecordFormat<DynamicRecord> recordFormat,
-            String storeVersion )
+            String storeVersion,
+            OpenOption... openOptions )
     {
         super( fileName, configuration, idType, idGeneratorFactory, pageCache,
-                logProvider, TYPE_DESCRIPTOR, dataSizeFromConfiguration, recordFormat, storeVersion );
+                logProvider, TYPE_DESCRIPTOR, dataSizeFromConfiguration, recordFormat, storeVersion, openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicStringStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicStringStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -46,10 +47,11 @@ public class DynamicStringStore extends AbstractDynamicStore
             LogProvider logProvider,
             int dataSizeFromConfiguration,
             RecordFormat<DynamicRecord> recordFormat,
-            String storeVersion )
+            String storeVersion,
+            OpenOption... openOptions )
     {
         super( fileName, configuration, idType, idGeneratorFactory, pageCache,
-                logProvider, TYPE_DESCRIPTOR, dataSizeFromConfiguration, recordFormat, storeVersion );
+                logProvider, TYPE_DESCRIPTOR, dataSizeFromConfiguration, recordFormat, storeVersion, openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -44,11 +45,12 @@ public class LabelTokenStore extends TokenStore<LabelTokenRecord, Token>
             PageCache pageCache,
             LogProvider logProvider,
             DynamicStringStore nameStore,
-            RecordFormats recordFormats)
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( file, config, IdType.LABEL_TOKEN, idGeneratorFactory, pageCache,
                 logProvider, nameStore, TYPE_DESCRIPTOR, new Token.Factory(), recordFormats.labelToken(),
-                recordFormats.storeVersion() );
+                recordFormats.storeVersion(), openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.helpers.Clock;
@@ -148,10 +149,11 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
     MetaDataStore( File fileName, Config conf,
             IdGeneratorFactory idGeneratorFactory,
             PageCache pageCache, LogProvider logProvider, RecordFormat<MetaDataRecord> recordFormat,
-            String storeVersion )
+            String storeVersion,
+            OpenOption... openOptions )
     {
         super( fileName, conf, IdType.NEOSTORE_BLOCK, idGeneratorFactory, pageCache, logProvider,
-                TYPE_DESCRIPTOR, recordFormat, NoStoreHeaderFormat.NO_STORE_HEADER_FORMAT, storeVersion );
+                TYPE_DESCRIPTOR, recordFormat, NoStoreHeaderFormat.NO_STORE_HEADER_FORMAT, storeVersion, openOptions );
         this.transactionCloseWaitLogger = new CappedLogger( logProvider.getLog( MetaDataStore.class ) );
         transactionCloseWaitLogger.setTimeLimit( 30, SECONDS, Clock.SYSTEM_CLOCK );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 import java.util.Arrays;
 import java.util.List;
 
@@ -72,10 +73,11 @@ public class NodeStore extends CommonAbstractStore<NodeRecord,NoStoreHeader>
             PageCache pageCache,
             LogProvider logProvider,
             DynamicArrayStore dynamicLabelStore,
-            RecordFormats recordFormats)
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, config, IdType.NODE, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormats.node(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion() );
+                recordFormats.node(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion(), openOptions );
         this.dynamicLabelStore = dynamicLabelStore;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
@@ -20,10 +20,11 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
@@ -45,11 +46,12 @@ public class PropertyKeyTokenStore extends TokenStore<PropertyKeyTokenRecord, To
             PageCache pageCache,
             LogProvider logProvider,
             DynamicStringStore nameStore,
-            RecordFormat<PropertyKeyTokenRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, config, IdType.PROPERTY_KEY_TOKEN, idGeneratorFactory, pageCache, logProvider, nameStore,
-                TYPE_DESCRIPTOR, new Token.Factory(), recordFormat, storeVersion );
+                TYPE_DESCRIPTOR, new Token.Factory(), recordFormats.propertyKeyToken(), recordFormats.storeVersion(),
+                openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -73,10 +74,11 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
             DynamicStringStore stringPropertyStore,
             PropertyKeyTokenStore propertyKeyTokenStore,
             DynamicArrayStore arrayPropertyStore,
-            RecordFormats recordFormats)
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, configuration, IdType.PROPERTY, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormats.property(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion() );
+                recordFormats.property(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion(), openOptions );
         this.stringStore = stringPropertyStore;
         this.propertyKeyTokenStore = propertyKeyTokenStore;
         this.arrayStore = arrayPropertyStore;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
@@ -20,11 +20,12 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
@@ -40,12 +41,13 @@ public class RelationshipGroupStore extends CommonAbstractStore<RelationshipGrou
             IdGeneratorFactory idGeneratorFactory,
             PageCache pageCache,
             LogProvider logProvider,
-            RecordFormat<RelationshipGroupRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, config, IdType.RELATIONSHIP_GROUP, idGeneratorFactory, pageCache,
-                logProvider, TYPE_DESCRIPTOR, recordFormat,
-                new IntStoreHeaderFormat( config.get( GraphDatabaseSettings.dense_node_threshold ) ), storeVersion );
+                logProvider, TYPE_DESCRIPTOR, recordFormats.relationshipGroup(),
+                new IntStoreHeaderFormat( config.get( GraphDatabaseSettings.dense_node_threshold ) ),
+                recordFormats.storeVersion(), openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -44,12 +45,12 @@ public class RelationshipStore extends CommonAbstractStore<RelationshipRecord,No
             IdGeneratorFactory idGeneratorFactory,
             PageCache pageCache,
             LogProvider logProvider,
-            RecordFormats recordFormats)
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, configuration, IdType.RELATIONSHIP, idGeneratorFactory,
                 pageCache, logProvider, TYPE_DESCRIPTOR, recordFormats.relationship(), NO_STORE_HEADER_FORMAT,
-                recordFormats.storeVersion()
-        );
+                recordFormats.storeVersion(), openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
@@ -47,11 +48,12 @@ public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeToken
             PageCache pageCache,
             LogProvider logProvider,
             DynamicStringStore nameStore,
-            RecordFormats recordFormats)
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, config, IdType.RELATIONSHIP_TYPE_TOKEN, idGeneratorFactory, pageCache, logProvider, nameStore,
                 TYPE_DESCRIPTOR, new RelationshipTypeToken.Factory(), recordFormats.relationshipTypeToken(),
-                recordFormats.storeVersion() );
+                recordFormats.storeVersion(), openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.file.OpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -30,7 +31,7 @@ import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.exceptions.schema.MalformedSchemaRuleException;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.AbstractSchemaRule;
@@ -47,7 +48,6 @@ public class SchemaStore extends AbstractDynamicStore implements Iterable<Schema
     public static final String TYPE_DESCRIPTOR = "SchemaStore";
     public static final int BLOCK_SIZE = 56;
 
-    @SuppressWarnings("deprecation")
     public SchemaStore(
             File fileName,
             Config conf,
@@ -55,11 +55,11 @@ public class SchemaStore extends AbstractDynamicStore implements Iterable<Schema
             IdGeneratorFactory idGeneratorFactory,
             PageCache pageCache,
             LogProvider logProvider,
-            RecordFormat<DynamicRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats,
+            OpenOption... openOptions )
     {
         super( fileName, conf, idType, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR, BLOCK_SIZE,
-                recordFormat, storeVersion );
+                recordFormats.dynamic(), recordFormats.storeVersion(), openOptions );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -67,6 +68,7 @@ public class StoreFactory
     private final File neoStoreFileName;
     private final PageCache pageCache;
     private final RecordFormats recordFormats;
+    private final OpenOption[] openOptions;
 
     public StoreFactory( File storeDir, PageCache pageCache, FileSystemAbstraction fileSystem, LogProvider logProvider )
     {
@@ -92,14 +94,23 @@ public class StoreFactory
     public StoreFactory( File storeDir, Config config, IdGeneratorFactory idGeneratorFactory, PageCache pageCache,
             FileSystemAbstraction fileSystemAbstraction, RecordFormats recordFormats, LogProvider logProvider )
     {
+        this( storeDir, MetaDataStore.DEFAULT_NAME, config, idGeneratorFactory, pageCache, fileSystemAbstraction,
+                recordFormats, logProvider );
+    }
+
+    public StoreFactory( File storeDir, String storeName, Config config, IdGeneratorFactory idGeneratorFactory,
+            PageCache pageCache, FileSystemAbstraction fileSystemAbstraction, RecordFormats recordFormats,
+            LogProvider logProvider, OpenOption... openOptions )
+    {
         this.config = config;
         this.idGeneratorFactory = idGeneratorFactory;
         this.fileSystemAbstraction = fileSystemAbstraction;
         this.recordFormats = recordFormats;
+        this.openOptions = openOptions;
         new RecordFormatPropertyConfigurator( recordFormats, config ).configure();
 
         this.logProvider = logProvider;
-        this.neoStoreFileName = new File( storeDir, MetaDataStore.DEFAULT_NAME );
+        this.neoStoreFileName = new File( storeDir, storeName );
         this.pageCache = pageCache;
     }
 
@@ -156,6 +167,6 @@ public class StoreFactory
             }
         }
         return new NeoStores( neoStoreFileName, config, idGeneratorFactory, pageCache, logProvider,
-                fileSystemAbstraction, recordFormats, createStoreIfNotExists, storeTypes );
+                fileSystemAbstraction, recordFormats, createStoreIfNotExists, storeTypes, openOptions );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+import java.nio.file.OpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -62,10 +63,11 @@ public abstract class TokenStore<RECORD extends TokenRecord,TOKEN extends Token>
             String typeDescriptor,
             TokenFactory<TOKEN> tokenFactory,
             RecordFormat<RECORD> recordFormat,
-            String storeVersion )
+            String storeVersion,
+            OpenOption... openOptions )
     {
         super( file, configuration, idType, idGeneratorFactory, pageCache, logProvider, typeDescriptor,
-                recordFormat, NO_STORE_HEADER_FORMAT, storeVersion );
+                recordFormat, NO_STORE_HEADER_FORMAT, storeVersion, openOptions );
         this.nameStore = nameStore;
         this.tokenFactory = tokenFactory;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
@@ -19,14 +19,10 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.SchemaStore;
-import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
@@ -41,7 +37,6 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRecord;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.Loader;
-import org.neo4j.storageengine.api.Token;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
@@ -59,14 +54,35 @@ public class Loaders
 
     public Loaders( NeoStores neoStores )
     {
-        nodeLoader = nodeLoader( neoStores.getNodeStore() );
-        propertyLoader = propertyLoader( neoStores.getPropertyStore() );
-        relationshipLoader = relationshipLoader( neoStores.getRelationshipStore() );
-        relationshipGroupLoader = relationshipGroupLoader( neoStores.getRelationshipGroupStore() );
-        schemaRuleLoader = schemaRuleLoader( neoStores.getSchemaStore() );
-        propertyKeyTokenLoader = propertyKeyTokenLoader( neoStores.getPropertyKeyTokenStore() );
-        labelTokenLoader = labelTokenLoader( neoStores.getLabelTokenStore() );
-        relationshipTypeTokenLoader = relationshipTypeTokenLoader( neoStores.getRelationshipTypeTokenStore() );
+        this(
+                neoStores.getNodeStore(),
+                neoStores.getPropertyStore(),
+                neoStores.getRelationshipStore(),
+                neoStores.getRelationshipGroupStore(),
+                neoStores.getPropertyKeyTokenStore(),
+                neoStores.getRelationshipTypeTokenStore(),
+                neoStores.getLabelTokenStore(),
+                neoStores.getSchemaStore() );
+    }
+
+    public Loaders(
+            RecordStore<NodeRecord> nodeStore,
+            PropertyStore propertyStore,
+            RecordStore<RelationshipRecord> relationshipStore,
+            RecordStore<RelationshipGroupRecord> relationshipGroupStore,
+            RecordStore<PropertyKeyTokenRecord> propertyKeyTokenStore,
+            RecordStore<RelationshipTypeTokenRecord> relationshipTypeTokenStore,
+            RecordStore<LabelTokenRecord> labelTokenStore,
+            SchemaStore schemaStore )
+    {
+        nodeLoader = nodeLoader( nodeStore );
+        propertyLoader = propertyLoader( propertyStore );
+        relationshipLoader = relationshipLoader( relationshipStore );
+        relationshipGroupLoader = relationshipGroupLoader( relationshipGroupStore );
+        schemaRuleLoader = schemaRuleLoader( schemaStore );
+        propertyKeyTokenLoader = propertyKeyTokenLoader( propertyKeyTokenStore );
+        labelTokenLoader = labelTokenLoader( labelTokenStore );
+        relationshipTypeTokenLoader = relationshipTypeTokenLoader( relationshipTypeTokenStore );
     }
 
     public Loader<Long,NodeRecord,Void> nodeLoader()
@@ -109,7 +125,7 @@ public class Loaders
         return relationshipTypeTokenLoader;
     }
 
-    public static Loader<Long,NodeRecord,Void> nodeLoader( final NodeStore store )
+    public static Loader<Long,NodeRecord,Void> nodeLoader( final RecordStore<NodeRecord> store )
     {
         return new Loader<Long,NodeRecord,Void>()
         {
@@ -184,7 +200,8 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,RelationshipRecord,Void> relationshipLoader( final RelationshipStore store )
+    public static Loader<Long,RelationshipRecord,Void> relationshipLoader(
+            final RecordStore<RelationshipRecord> store )
     {
         return new Loader<Long, RelationshipRecord, Void>()
         {
@@ -280,7 +297,7 @@ public class Loaders
     }
 
     public static Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader(
-            final TokenStore<PropertyKeyTokenRecord, Token> store )
+            final RecordStore<PropertyKeyTokenRecord> store )
     {
         return new Loader<Integer, PropertyKeyTokenRecord, Void>()
         {
@@ -311,7 +328,7 @@ public class Loaders
     }
 
     public static Loader<Integer,LabelTokenRecord,Void> labelTokenLoader(
-            final TokenStore<LabelTokenRecord, Token> store )
+            final RecordStore<LabelTokenRecord> store )
     {
         return new Loader<Integer, LabelTokenRecord, Void>()
         {
@@ -342,7 +359,7 @@ public class Loaders
     }
 
     public static Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader(
-            final TokenStore<RelationshipTypeTokenRecord, RelationshipTypeToken> store )
+            final RecordStore<RelationshipTypeTokenRecord> store )
     {
         return new Loader<Integer, RelationshipTypeTokenRecord, Void>()
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
@@ -19,15 +19,10 @@
  */
 package org.neo4j.unsafe.batchinsert;
 
-import org.neo4j.kernel.impl.store.LabelTokenStore;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.store.PropertyKeyTokenStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RelationshipGroupStore;
-import org.neo4j.kernel.impl.store.RelationshipStore;
-import org.neo4j.kernel.impl.store.RelationshipTypeTokenStore;
+import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
@@ -55,14 +50,29 @@ public class DirectRecordAccessSet implements RecordAccessSet
 
     public DirectRecordAccessSet( NeoStores neoStores )
     {
-        Loaders loaders = new Loaders( neoStores );
-        NodeStore nodeStore = neoStores.getNodeStore();
-        PropertyStore propertyStore = neoStores.getPropertyStore();
-        RelationshipStore relationshipStore = neoStores.getRelationshipStore();
-        RecordStore<RelationshipGroupRecord> relationshipGroupStore = neoStores.getRelationshipGroupStore();
-        PropertyKeyTokenStore propertyKeyTokenStore = neoStores.getPropertyKeyTokenStore();
-        RelationshipTypeTokenStore relationshipTypeTokenStore = neoStores.getRelationshipTypeTokenStore();
-        LabelTokenStore labelTokenStore = neoStores.getLabelTokenStore();
+        this(
+                neoStores.getNodeStore(),
+                neoStores.getPropertyStore(),
+                neoStores.getRelationshipStore(),
+                neoStores.getRelationshipGroupStore(),
+                neoStores.getPropertyKeyTokenStore(),
+                neoStores.getRelationshipTypeTokenStore(),
+                neoStores.getLabelTokenStore(),
+                neoStores.getSchemaStore() );
+    }
+
+    public DirectRecordAccessSet(
+            RecordStore<NodeRecord> nodeStore,
+            PropertyStore propertyStore,
+            RecordStore<RelationshipRecord> relationshipStore,
+            RecordStore<RelationshipGroupRecord> relationshipGroupStore,
+            RecordStore<PropertyKeyTokenRecord> propertyKeyTokenStore,
+            RecordStore<RelationshipTypeTokenRecord> relationshipTypeTokenStore,
+            RecordStore<LabelTokenRecord> labelTokenStore,
+            SchemaStore schemaStore )
+    {
+        Loaders loaders = new Loaders( nodeStore, propertyStore, relationshipStore, relationshipGroupStore,
+                propertyKeyTokenStore, relationshipTypeTokenStore, labelTokenStore, schemaStore );
         nodeRecords = new DirectRecordAccess<>( nodeStore, loaders.nodeLoader() );
         propertyRecords = new DirectRecordAccess<>( propertyStore, loaders.propertyLoader() );
         relationshipRecords = new DirectRecordAccess<>( relationshipStore, loaders.relationshipLoader() );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchInsertRelationshipsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/BatchInsertRelationshipsStage.java
@@ -36,7 +36,7 @@ public class BatchInsertRelationshipsStage extends Stage
         add( new RelationshipPreparationStep( control(), config, idMapper ) );
         add( new PropertyEncoderStep<>( control(), config, store.getPropertyKeyRepository(),
                 store.getPropertyStore() ) );
-        add( new BatchInsertRelationshipsStep( control(), config, store.getNeoStores(),
+        add( new BatchInsertRelationshipsStep( control(), config, store,
                 store.getRelationshipTypeRepository(), nextRelationshipId ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
@@ -24,18 +24,17 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
 import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
-import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 
 /**
  * Stage for counting groups per node, populates {@link RelationshipGroupCache}.
  */
 public class CountGroupsStage extends Stage
 {
-    public CountGroupsStage( Configuration config, BatchingNeoStores neoStore, RelationshipGroupCache groupCache )
+    public CountGroupsStage( Configuration config, RecordStore<RelationshipGroupRecord> store,
+            RelationshipGroupCache groupCache )
     {
         super( "Count groups", config );
 
-        RecordStore<RelationshipGroupRecord> store = neoStore.getRelationshipGroupStore();
         add( new ReadRecordsStep<>( control(), config, store, RecordIdIteration.allIn( store ) ) );
         add( new CountGroupsStep( control(), config, groupCache ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -298,7 +298,8 @@ public class ParallelBatchImporter implements BatchImporter
 
             // Stage 4a -- set node nextRel fields for dense nodes
             executeStages( new NodeFirstRelationshipStage( topic, config, neoStore.getNodeStore(),
-                    neoStore.getRelationshipGroupStore(), nodeRelationshipCache, true/*dense*/, currentTypeId ) );
+                    neoStore.getTemporaryRelationshipGroupStore(), nodeRelationshipCache, true/*dense*/,
+                    currentTypeId ) );
 
             // Stage 5a -- link relationship chains together for dense nodes
             nodeRelationshipCache.setForwardScan( false );
@@ -313,7 +314,7 @@ public class ParallelBatchImporter implements BatchImporter
         nodeRelationshipCache.setForwardScan( true );
         // Stage 4b -- set node nextRel fields for sparse nodes
         executeStages( new NodeFirstRelationshipStage( topic, config, neoStore.getNodeStore(),
-                neoStore.getRelationshipGroupStore(), nodeRelationshipCache, false/*sparse*/, -1 ) );
+                neoStore.getTemporaryRelationshipGroupStore(), nodeRelationshipCache, false/*sparse*/, -1 ) );
 
         // Stage 5b -- link relationship chains together for sparse nodes
         nodeRelationshipCache.setForwardScan( false );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
@@ -20,7 +20,6 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
@@ -59,13 +58,15 @@ public class RelationshipGroupDefragmenter
         {
             try
             {
+                // Read from the temporary relationship group store...
+                RecordStore<RelationshipGroupRecord> fromStore = neoStore.getTemporaryRelationshipGroupStore();
+                // and write into the main relationship group store
+                RecordStore<RelationshipGroupRecord> toStore = neoStore.getRelationshipGroupStore();
+
                 // Count all nodes, how many groups each node has each
-                executeStage( new CountGroupsStage( config, neoStore, groupCache ) );
+                executeStage( new CountGroupsStage( config, fromStore, groupCache ) );
                 long fromNodeId = 0;
                 long toNodeId = 0;
-                RecordStore<RelationshipGroupRecord> fromStore = neoStore.getRelationshipGroupStore();
-                RecordStore<RelationshipGroupRecord> toStore =
-                        neoStore.getReplacementNeoStores( StoreType.RELATIONSHIP_GROUP ).getRelationshipGroupStore();
                 while ( fromNodeId < highNodeId )
                 {
                     // See how many nodes' groups we can fit into the cache this iteration of the loop.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
@@ -137,7 +137,7 @@ public class BatchingIdGeneratorFactory implements IdGeneratorFactory
         @Override
         public void delete()
         {
-            throw new UnsupportedOperationException();
+            // This would be equivalent of not doing anything because close() will create the file
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -27,6 +27,7 @@ import org.mockito.InOrder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.OpenOption;
 import java.util.Arrays;
 
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -36,6 +37,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.RecordingPageCacheTracer;
 import org.neo4j.io.pagecache.RecordingPageCacheTracer.Pin;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
@@ -50,6 +52,7 @@ import org.neo4j.kernel.impl.store.id.validation.ReservedIdException;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
@@ -59,6 +62,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -74,6 +78,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+
+import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
+
 import static org.neo4j.io.pagecache.RecordingPageCacheTracer.Event;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
@@ -92,7 +99,7 @@ public class CommonAbstractStoreTest
     private final PageCache pageCache = mock( PageCache.class );
     private final Config config = Config.empty();
     private final File storeFile = new File( "store" );
-    private RecordFormat<TheRecord> recordFormat = mock( RecordFormat.class );
+    private final RecordFormat<TheRecord> recordFormat = mock( RecordFormat.class );
     private final IdType idType = IdType.RELATIONSHIP; // whatever
 
     private static final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
@@ -196,7 +203,7 @@ public class CommonAbstractStoreTest
     }
 
     @Test
-    public void recordCursorGetAll() throws IOException
+    public void recordCursorGetAll()
     {
         TheStore store = newStore();
         RecordCursor<TheRecord> cursor = spy( store.newRecordCursor( store.newRecord() ) );
@@ -260,6 +267,28 @@ public class CommonAbstractStoreTest
         }
     }
 
+    @Test
+    public void shouldDeleteOnCloseIfOpenOptionsSaysSo() throws Exception
+    {
+        // GIVEN
+        File file = dir.file( "store" ).getAbsoluteFile();
+        File idFile = new File( file.getParentFile(), StoreFileType.ID.augment( file.getName() ) );
+        PageCache pageCache = pageCacheRule.getPageCache( fs, PageCacheTracer.NULL, Config.empty() );
+        TheStore store = new TheStore( file, config, idType, new DefaultIdGeneratorFactory( fs ), pageCache,
+                NullLogProvider.getInstance(), recordFormat, DELETE_ON_CLOSE );
+        store.initialise( true );
+        store.makeStoreOk();
+        assertTrue( fs.fileExists( file ) );
+        assertTrue( fs.fileExists( idFile ) );
+
+        // WHEN
+        store.close();
+
+        // THEN
+        assertFalse( fs.fileExists( file ) );
+        assertFalse( fs.fileExists( idFile ) );
+    }
+
     private TheStore newStore()
     {
         LogProvider log = NullLogProvider.getInstance();
@@ -289,10 +318,11 @@ public class CommonAbstractStoreTest
     private static class TheStore extends CommonAbstractStore<TheRecord,NoStoreHeader>
     {
         TheStore( File fileName, Config configuration, IdType idType, IdGeneratorFactory idGeneratorFactory,
-                PageCache pageCache, LogProvider logProvider, RecordFormat<TheRecord> recordFormat )
+                PageCache pageCache, LogProvider logProvider, RecordFormat<TheRecord> recordFormat,
+                OpenOption... openOptions )
         {
             super( fileName, configuration, idType, idGeneratorFactory, pageCache, logProvider, "TheType",
-                    recordFormat, NoStoreHeaderFormat.NO_STORE_HEADER_FORMAT, "v1" );
+                    recordFormat, NoStoreHeaderFormat.NO_STORE_HEADER_FORMAT, "v1", openOptions );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -101,7 +101,7 @@ public class RelationshipGroupDefragmenterTest
         // GIVEN some nodes which has their groups scattered
         int nodeCount = 10_000;
         int relationshipTypeCount = 50;
-        RecordStore<RelationshipGroupRecord> groupStore = stores.getRelationshipGroupStore();
+        RecordStore<RelationshipGroupRecord> groupStore = stores.getTemporaryRelationshipGroupStore();
         RelationshipGroupRecord groupRecord = groupStore.newRecord();
         RecordStore<NodeRecord> nodeStore = stores.getNodeStore();
         NodeRecord nodeRecord = nodeStore.newRecord();
@@ -122,6 +122,7 @@ public class RelationshipGroupDefragmenterTest
                     nodeRecord.initialize( true, -1, true, groupRecord.getId(), 0 );
                     nodeRecord.setId( nodeId );
                     nodeStore.updateRecord( nodeRecord );
+                    nodeStore.setHighestPossibleIdInUse( nodeId );
                 }
             }
         }
@@ -139,7 +140,7 @@ public class RelationshipGroupDefragmenterTest
         // GIVEN some nodes which has their groups scattered
         int nodeCount = 10_000;
         int relationshipTypeCount = 50;
-        RecordStore<RelationshipGroupRecord> groupStore = stores.getRelationshipGroupStore();
+        RecordStore<RelationshipGroupRecord> groupStore = stores.getTemporaryRelationshipGroupStore();
         RelationshipGroupRecord groupRecord = groupStore.newRecord();
         RecordStore<NodeRecord> nodeStore = stores.getNodeStore();
         NodeRecord nodeRecord = nodeStore.newRecord();
@@ -167,6 +168,7 @@ public class RelationshipGroupDefragmenterTest
                         nodeRecord.initialize( true, -1, true, groupRecord.getId(), 0 );
                         nodeRecord.setId( nodeId );
                         nodeStore.updateRecord( nodeRecord );
+                        nodeStore.setHighestPossibleIdInUse( nodeId );
                         initializedNodes.set( nodeId );
                     }
                 }
@@ -189,7 +191,7 @@ public class RelationshipGroupDefragmenterTest
 
     private void verifyGroupsAreSequentiallyOrderedByNode()
     {
-        RecordStore<RelationshipGroupRecord> store = stores.getReplacementNeoStores().getRelationshipGroupStore();
+        RecordStore<RelationshipGroupRecord> store = stores.getRelationshipGroupStore();
         long firstId = store.getNumberOfReservedLowIds();
         long groupCount = store.getHighId() - firstId;
         RelationshipGroupRecord groupRecord = store.newRecord();


### PR DESCRIPTION
to later be defragmented into the main store, this to better try and
not go outside of the functionality which the PageCache provides in
order to support as many platforms as possible. This commit will
change the import behaviour regarding relationship groups

from:
- import into main group store
- defragment into replacement store
- replace main group store with the replacement store

to:
- import into temporary group store
- defragment into main store
- temporary store will be deleted on close
