### PR TITLE
Check for null after re-opening lucene IndexReader

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/FullTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/FullTxData.java
@@ -379,7 +379,7 @@ class FullTxData extends TxData
             IndexReader newReader = this.reader == null ?
                                     DirectoryReader.open( this.writer ) :
                                     DirectoryReader.openIfChanged( (DirectoryReader) this.reader );
-            if ( newReader == this.reader )
+            if ( newReader == null )
             {
                 return this.searcher;
             }

--- a/community/lucene-index/src/test/java/org/neo4j/index/legacy/LegacyIndexRegressionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/legacy/LegacyIndexRegressionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.legacy;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
+import org.neo4j.index.lucene.QueryContext;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+public class LegacyIndexRegressionTest
+{
+    @Rule
+    public final DatabaseRule graphdb = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldAccessAndUpdateIndexInSameTransaction() throws Exception
+    {
+        try ( Transaction tx = graphdb.beginTx() )
+        {
+            Index<Node> version = graphdb.index().forNodes( "version" );
+            for ( int v = 0; v < 10; v++ )
+            {
+                createNode( version, v );
+            }
+            tx.success();
+        }
+    }
+
+    private void createNode( Index<Node> index, long version )
+    {
+        highest( "version", index.query( new QueryContext( "version:*" ) ) );
+        {
+            Node node = graphdb.createNode();
+            node.setProperty( "version", version );
+            index.add( node, "version", version );
+        }
+        {
+            Node node = index.get( "version", version ).getSingle();
+            Node current = highest( "version", index.get( "current", "current" ) );
+            if ( current != null )
+            {
+                index.remove( current, "current" );
+            }
+            index.add( node, "current", "current" );
+        }
+    }
+
+    private Node highest( String key, IndexHits<Node> query )
+    {
+        try ( IndexHits<Node> hits = query )
+        {
+            long highestValue = Long.MIN_VALUE;
+            Node highestNode = null;
+            while ( hits.hasNext() )
+            {
+                Node node = hits.next();
+                long value = ((Number) node.getProperty( key )).longValue();
+                if ( value > highestValue )
+                {
+                    highestValue = value;
+                    highestNode = node;
+                }
+            }
+            return highestNode;
+        }
+    }
+}


### PR DESCRIPTION
With Lucene 3.6 we re-opened IndexReaders by using IndexReader.reopen(), this returned the same object if no changes had occurred in the index. When upgrading to Lucene 5.5 the (deprecated) reopen() method has been removed, so instead we switched to using the (recommended) DirectoryReader.openIfChanged() method instead, which returns null if there are no changes. However, the check for whether nothing has changed remained an identity check rather than a null check.

Now we change this to the appropriate check along with the introduction of a test case that reliably triggers the error condition.

changelog: [3.0, lucene-index] Fixes a rare issue with loading new changes into a lucene reader
