### PR TITLE
Access transaction id and commit time in afterCommit.

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -296,6 +296,18 @@ public class ResetFuzzTest
         }
 
         @Override
+        public long getTransactionId()
+        {
+            return -1;
+        }
+
+        @Override
+        public long getCommitTime()
+        {
+            return -1;
+        }
+
+        @Override
         public Revertable restrict( AccessMode read )
         {
             return null;

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
@@ -34,6 +34,17 @@ import org.neo4j.graphdb.Relationship;
  */
 public interface TransactionData
 {
+
+    /**
+     * Not committed transaction id.
+     */
+    int UNASSIGNED_TRANSACTION_ID = -1;
+
+    /**
+     * Not committed transaction commit time.
+     */
+    int UNASSIGNED_COMMIT_TIME = -1;
+
     /**
      * Get the nodes that were created during the transaction.
      *
@@ -47,7 +58,7 @@ public interface TransactionData
      * @return all nodes that were deleted during the transaction.
      */
     Iterable<Node> deletedNodes();
-    
+
     /**
      * Returns whether or not {@code node} is deleted in this transaction.
      * @param node the {@link Node} to check whether or not it is deleted
@@ -119,7 +130,7 @@ public interface TransactionData
     /**
      * Returns whether or not {@code relationship} is deleted in this
      * transaction.
-     * 
+     *
      * @param relationship the {@link Relationship} to check whether or not it
      *            is deleted in this transaction.
      * @return whether or not {@code relationship} is deleted in this
@@ -159,4 +170,24 @@ public interface TransactionData
      * @return all properties that have been removed from relationships.
      */
     Iterable<PropertyEntry<Relationship>> removedRelationshipProperties();
+
+    /**
+     * Return transaction id if it was already assigned or {@link #UNASSIGNED_TRANSACTION_ID} otherwise.
+     * Transaction id is assigned as soon as transaction committed.
+     * @return transaction id.
+     */
+    default long getTransactionId()
+    {
+        return UNASSIGNED_TRANSACTION_ID;
+    }
+
+    /**
+     * Return transaction commit time if it was already assigned or {@link #UNASSIGNED_COMMIT_TIME} otherwise.
+     * Transaction commit time is assigned as soon as transaction committed.
+     * @return transaction commit time
+     */
+    default long getCommitTime()
+    {
+        return UNASSIGNED_COMMIT_TIME;
+    }
 }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
@@ -36,16 +36,6 @@ public interface TransactionData
 {
 
     /**
-     * Not committed transaction id.
-     */
-    int UNASSIGNED_TRANSACTION_ID = -1;
-
-    /**
-     * Not committed transaction commit time.
-     */
-    int UNASSIGNED_COMMIT_TIME = -1;
-
-    /**
      * Get the nodes that were created during the transaction.
      *
      * @return all nodes that were created during the transaction.
@@ -172,22 +162,22 @@ public interface TransactionData
     Iterable<PropertyEntry<Relationship>> removedRelationshipProperties();
 
     /**
-     * Return transaction id if it was already assigned or {@link #UNASSIGNED_TRANSACTION_ID} otherwise.
-     * Transaction id is assigned as soon as transaction committed.
+     * Return transaction id that assigned during transaction commit process.
      * @return transaction id.
+     * @throws IllegalStateException if transaction id is not assigned yet
      */
     default long getTransactionId()
     {
-        return UNASSIGNED_TRANSACTION_ID;
+        throw new IllegalStateException( "Transaction id is not available." );
     }
 
     /**
-     * Return transaction commit time if it was already assigned or {@link #UNASSIGNED_COMMIT_TIME} otherwise.
-     * Transaction commit time is assigned as soon as transaction committed.
+     * Return transaction commit time (in millis) that assigned during transaction commit process.
      * @return transaction commit time
+     * @throws IllegalStateException if commit time is not assigned yet
      */
     default long getCommitTime()
     {
-        return UNASSIGNED_COMMIT_TIME;
+        throw new IllegalStateException( "Transaction commit time it not available." );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api;
 
+import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
@@ -168,6 +169,26 @@ public interface KernelTransaction extends AutoCloseable
      * @return the transaction type: implicit or explicit
      */
     Type transactionType();
+
+    /**
+     * Return transaction id if it was already assigned or {@link TransactionData#UNASSIGNED_TRANSACTION_ID} otherwise.
+     * Transaction id is assigned as soon as transaction committed.
+     * @return transaction id.
+     */
+    default long getTransactionId()
+    {
+        return TransactionData.UNASSIGNED_TRANSACTION_ID;
+    }
+
+    /**
+     * Return transaction commit time if it was already assigned or {@link TransactionData#UNASSIGNED_COMMIT_TIME} otherwise.
+     * Transaction commit time is assigned as soon as transaction committed.
+     * @return transaction commit time
+     */
+    default long getCommitTime()
+    {
+        return TransactionData.UNASSIGNED_COMMIT_TIME;
+    }
 
     Revertable restrict( AccessMode mode );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -170,16 +170,18 @@ public interface KernelTransaction extends AutoCloseable
     Type transactionType();
 
     /**
-     * Return transaction id if it was already assigned.
-     * Transaction id is assigned as soon as transaction committed.
+     * Return transaction id that assigned during transaction commit process.
+     * @see org.neo4j.kernel.impl.api.TransactionCommitProcess
      * @return transaction id.
+     * @throws IllegalStateException if transaction id is not assigned yet
      */
     long getTransactionId();
 
     /**
-     * Return transaction commit time if it was already assigned.
-     * Transaction commit time is assigned as soon as transaction committed.
+     * Return transaction commit time (in millis) that assigned during transaction commit process.
+     * @see org.neo4j.kernel.impl.api.TransactionCommitProcess
      * @return transaction commit time
+     * @throws IllegalStateException if commit time is not assigned yet
      */
     long getCommitTime();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
@@ -171,24 +170,18 @@ public interface KernelTransaction extends AutoCloseable
     Type transactionType();
 
     /**
-     * Return transaction id if it was already assigned or {@link TransactionData#UNASSIGNED_TRANSACTION_ID} otherwise.
+     * Return transaction id if it was already assigned.
      * Transaction id is assigned as soon as transaction committed.
      * @return transaction id.
      */
-    default long getTransactionId()
-    {
-        return TransactionData.UNASSIGNED_TRANSACTION_ID;
-    }
+    long getTransactionId();
 
     /**
-     * Return transaction commit time if it was already assigned or {@link TransactionData#UNASSIGNED_COMMIT_TIME} otherwise.
+     * Return transaction commit time if it was already assigned.
      * Transaction commit time is assigned as soon as transaction committed.
      * @return transaction commit time
      */
-    default long getCommitTime()
-    {
-        return TransactionData.UNASSIGNED_COMMIT_TIME;
-    }
+    long getCommitTime();
 
     Revertable restrict( AccessMode mode );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionHook.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TransactionHook.java
@@ -28,7 +28,7 @@ import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
  */
 public interface TransactionHook<OUTCOME extends TransactionHook.Outcome>
 {
-    public interface Outcome
+    interface Outcome
     {
         boolean isSuccessful();
         Throwable failure();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.collection.IterableWrapper;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
@@ -62,6 +63,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     private final StorageStatement storeStatement;
     private final RelationshipActions relationshipActions;
     private final StoreReadLayer store;
+    private KernelTransaction transaction;
 
     private final Collection<PropertyEntry<Node>> assignedNodeProperties = new ArrayList<>();
     private final Collection<PropertyEntry<Relationship>> assignedRelationshipProperties = new ArrayList<>();
@@ -74,14 +76,15 @@ public class TxStateTransactionDataSnapshot implements TransactionData
 
     public TxStateTransactionDataSnapshot(
             ReadableTransactionState state,
-            NodeProxy.NodeActions nodeActions, RelationshipProxy.RelationshipActions relationshipActions,
-            StoreReadLayer storeReadLayer, StorageStatement storageStatement )
+            NodeProxy.NodeActions nodeActions, RelationshipActions relationshipActions,
+            StoreReadLayer storeReadLayer, StorageStatement storageStatement, KernelTransaction transaction )
     {
         this.state = state;
         this.nodeActions = nodeActions;
         this.relationshipActions = relationshipActions;
         this.storeStatement = storageStatement;
         this.store = storeReadLayer;
+        this.transaction = transaction;
 
         // Load changes that require store access eagerly, because we won't have access to the after-state
         // after the tx has been committed.
@@ -158,6 +161,18 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     public Iterable<LabelEntry> assignedLabels()
     {
         return assignedLabels;
+    }
+
+    @Override
+    public long getTransactionId()
+    {
+        return transaction.getTransactionId();
+    }
+
+    @Override
+    public long getCommitTime()
+    {
+        return transaction.getCommitTime();
     }
 
     private void takeSnapshot()

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -115,7 +115,7 @@ public class TransactionEventHandlers
 
         TransactionData txData = state == null ? EMPTY_DATA :
                 new TxStateTransactionDataSnapshot( state, nodeActions, relationshipActions,
-                        storeReadLayer, statement );
+                        storeReadLayer, statement, transaction );
 
         TransactionHandlerState handlerStates = new TransactionHandlerState( txData );
         for ( TransactionEventHandler<?> handler : this.transactionEventHandlers )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -36,6 +35,7 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernel
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
@@ -230,6 +230,18 @@ public class ConstraintIndexCreatorTest
                 public Type transactionType()
                 {
                     return null;
+                }
+
+                @Override
+                public long getTransactionId()
+                {
+                    return -1;
+                }
+
+                @Override
+                public long getCommitTime()
+                {
+                    return -1;
                 }
 
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -44,6 +45,7 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,6 +62,7 @@ public class TxStateTransactionDataViewTest
     private final Statement stmt = mock( Statement.class );
     private final StoreReadLayer ops = mock( StoreReadLayer.class );
     private final StoreStatement storeStatement = mock( StoreStatement.class );
+    private final KernelTransaction transaction = mock( KernelTransaction.class );
 
     private final TransactionState state = new TxState();
 
@@ -283,6 +286,19 @@ public class TxStateTransactionDataViewTest
         assertThat( entry.node().getId(), equalTo( 1l ) );
     }
 
+    @Test
+    public void accessTransactionIdAndCommitTime()
+    {
+        long committedTransactionId = 7L;
+        long commitTime = 10L;
+        when( transaction.getTransactionId() ).thenReturn( committedTransactionId );
+        when( transaction.getCommitTime() ).thenReturn( commitTime );
+
+        TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
+        assertEquals( committedTransactionId, transactionDataSnapshot.getTransactionId() );
+        assertEquals( commitTime, transactionDataSnapshot.getCommitTime() );
+    }
+
     private List<Long> idList( Iterable<? extends PropertyContainer> entities )
     {
         List<Long> out = new ArrayList<>();
@@ -297,6 +313,6 @@ public class TxStateTransactionDataViewTest
     {
         NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
         final RelationshipProxy.RelationshipActions relActions = mock( RelationshipProxy.RelationshipActions.class );
-        return new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops, storeStatement );
+        return new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops, storeStatement, transaction );
     }
 }


### PR DESCRIPTION
Add possibility to access transaction id and transaction commit time from KernelTransaction.
Propagate newly available info into TransactionData.

changelog: allow to access transaction id and transaction commit time on afterCommit in TransactionEventHandlers
