### PR TITLE
Logs timestamp information when terminating unsafe tx

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.Kernel;
 
 /**
  * Represents a transaction of changes to the underlying graph.
@@ -128,6 +129,17 @@ public interface KernelTransaction extends AutoCloseable
      * @return The timestamp of the last transaction that was committed to the store when this transaction started.
      */
     long lastTransactionTimestampWhenStarted();
+
+    /**
+     * @return The id of the last transaction that was committed to the store when this transaction started.
+     */
+    long lastTransactionIdWhenStarted();
+
+    /**
+     * @return start time of this transaction, i.e. basically {@link System#currentTimeMillis()} when user called
+     * {@link Kernel#newTransaction()}.
+     */
+    long localStartTime();
 
     /**
      * Register a {@link CloseListener} to be invoked after commit, but before transaction events "after" hooks

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -274,6 +274,18 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     }
 
     @Override
+    public long localStartTime()
+    {
+        return startTimeMillis;
+    }
+
+    @Override
+    public long lastTransactionIdWhenStarted()
+    {
+        return lastTransactionIdWhenStarted;
+    }
+
+    @Override
     public void success()
     {
         this.success = true;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -218,6 +218,18 @@ public class ConstraintIndexCreatorTest
                 public void registerCloseListener( CloseListener listener )
                 {
                 }
+
+                @Override
+                public long lastTransactionIdWhenStarted()
+                {
+                    return 0;
+                }
+
+                @Override
+                public long localStartTime()
+                {
+                    return 0;
+                }
             };
         }
 


### PR DESCRIPTION
logged at info since this is typically very rarely logged and
makes sense to have enabled by default for visibility
