### PR TITLE
Fix buffer leak in Bolt output

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -39,15 +39,13 @@ import org.neo4j.bolt.transport.Netty4LogBridge;
 import org.neo4j.bolt.transport.NettyServer;
 import org.neo4j.bolt.transport.NettyServer.ProtocolInitializer;
 import org.neo4j.bolt.transport.SocketTransport;
-import org.neo4j.bolt.v1.messaging.Neo4jPack;
-import org.neo4j.bolt.v1.messaging.PackStreamMessageFormatV1;
 import org.neo4j.bolt.v1.runtime.MonitoredSessions;
+import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.Sessions;
 import org.neo4j.bolt.v1.runtime.internal.EncryptionRequiredSessions;
 import org.neo4j.bolt.v1.runtime.internal.StandardSessions;
 import org.neo4j.bolt.v1.runtime.internal.concurrent.ThreadedSessions;
 import org.neo4j.bolt.v1.transport.BoltProtocolV1;
-import org.neo4j.bolt.v1.transport.ChunkedOutput;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Configuration;
@@ -218,9 +216,8 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
                 BoltProtocolV1.VERSION,
                 ( channel, isEncrypted ) -> {
                     String descriptor = format( "\tclient%s\tserver%s", channel.remoteAddress(), channel.localAddress() );
-                    ChunkedOutput output = new ChunkedOutput( channel, 8192 );
-                    return new BoltProtocolV1( logging, sessions.newSession( descriptor, isEncrypted ),
-                            new PackStreamMessageFormatV1.Writer( new Neo4jPack.Packer( output ), output ) );
+                    Session session = sessions.newSession( descriptor, isEncrypted );
+                    return new BoltProtocolV1( session, channel, logging );
                 }
         );
         return availableVersions;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
@@ -36,7 +36,6 @@ import org.neo4j.bolt.v1.messaging.message.Message;
 import org.neo4j.bolt.v1.packstream.BufferedChannelOutput;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.transport.BoltProtocolV1;
-import org.neo4j.bolt.v1.transport.ChunkedOutput;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.HexPrinter;
 
@@ -116,9 +115,7 @@ public class FragmentedMessageDeliveryTest
         ChannelHandlerContext ctx = mock( ChannelHandlerContext.class );
         when(ctx.channel()).thenReturn( ch );
 
-        ChunkedOutput output = new ChunkedOutput( ch, 8192 );
-        BoltProtocolV1 protocol = new BoltProtocolV1( NullLogService.getInstance(), sess,
-                new PackStreamMessageFormatV1.Writer( new Neo4jPack.Packer( output ), output ) );
+        BoltProtocolV1 protocol = new BoltProtocolV1( sess, ch, NullLogService.getInstance() );
 
         // When data arrives split up according to the current permutation
         for ( ByteBuf fragment : fragments )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/SocketTransportHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/SocketTransportHandlerTest.java
@@ -29,11 +29,8 @@ import java.util.function.BiFunction;
 
 import org.neo4j.bolt.transport.BoltProtocol;
 import org.neo4j.bolt.transport.SocketTransportHandler;
-import org.neo4j.bolt.v1.messaging.Neo4jPack;
-import org.neo4j.bolt.v1.messaging.PackStreamMessageFormatV1;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.transport.BoltProtocolV1;
-import org.neo4j.bolt.v1.transport.ChunkedOutput;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.AssertableLogProvider;
@@ -106,11 +103,7 @@ public class SocketTransportHandlerTest
     {
         PrimitiveLongObjectMap<BiFunction<Channel,Boolean,BoltProtocol>> availableVersions = longObjectMap();
         availableVersions.put( BoltProtocolV1.VERSION,
-                ( channel, isSecure ) -> {
-                    ChunkedOutput output = new ChunkedOutput( channel, 8192 );
-                    return new BoltProtocolV1( NullLogService.getInstance(), session,
-                            new PackStreamMessageFormatV1.Writer( new Neo4jPack.Packer( output ), output ));
-                }
+                ( channel, isSecure ) -> new BoltProtocolV1( session, channel, NullLogService.getInstance() )
         );
 
         return new SocketTransportHandler.ProtocolChooser( availableVersions, true );


### PR DESCRIPTION
`BoltProtocolV1` is a container for inbound and outbound Netty-based connections. There exists a protocol instance for each neo4j client. Previously outbound connection, represented by `ChunkedOutput` class, was passed in as a parameter and never closed. This caused a native memory leak because connections allocate native byte buffers to put them into channel.

This commit makes `BoltProtocolV1` responsible for `ChunkedOutput` lifecycle. It is created in constructor and closed when the protocol instance is closed.
