### PR TITLE
BackupServiceStressTesting dumps threads on failure

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
@@ -49,14 +49,15 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.impl.util.DebugUtil;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
-import static org.junit.Assert.assertTrue;
-
 import static java.lang.System.currentTimeMillis;
+
+import static org.junit.Assert.fail;
 
 public class BackupServiceStressTestingBuilder
 {
@@ -270,7 +271,11 @@ public class BackupServiceStressTestingBuilder
                 }
 
                 executor.shutdown();
-                assertTrue( executor.awaitTermination( 30, TimeUnit.SECONDS ) );
+                if ( !executor.awaitTermination( 30, TimeUnit.SECONDS ) )
+                {
+                    DebugUtil.dumpThreads( System.err );
+                    fail( "Didn't manage to shut down the workers correctly, dumped threads for forensic purposes" );
+                }
 
                 try
                 {


### PR DESCRIPTION
if shutdown takes too long (which seems to be the case recently).
Added DebugUtil#dumpThreads(PrintStream) to get a crude dump
of all threads for forensics purposes.
