### PR TITLE
Open legacy indexes in read only mode in case database started in read only mode.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/CleanupRule.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.test;
 
+import org.junit.rules.ExternalResource;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
-
-import org.junit.rules.ExternalResource;
 
 /**
  * Simple means of cleaning up after a test. It has two purposes:
@@ -82,6 +82,7 @@ public class CleanupRule extends ExternalResource
             try
             {
                 Method method = cls.getMethod( methodName );
+                method.setAccessible( true );
                 add( closeable( method, toClose ) );
                 return toClose;
             }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexReferenceFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Factory that build appropriate (read only or writable) {@link IndexReference} for provided {@link IndexIdentifier}
+ * or refresh previously constructed instance.
+ */
+abstract class IndexReferenceFactory
+{
+    private final File baseStorePath;
+    private final IndexTypeCache typeCache;
+    private final LuceneDataSource.LuceneFilesystemFacade filesystemFacade;
+
+    IndexReferenceFactory( LuceneDataSource.LuceneFilesystemFacade filesystemFacade, File baseStorePath,
+            IndexTypeCache typeCache )
+    {
+        this.filesystemFacade = filesystemFacade;
+        this.baseStorePath = baseStorePath;
+        this.typeCache = typeCache;
+    }
+
+    /**
+     * Create new {@link IndexReference} for provided {@link IndexIdentifier}.
+     * @param indexIdentifier index identifier to build index for.
+     * @return newly create {@link IndexReference}
+     *
+     * @throws IOException in case of exception during accessing lucene reader/writer.
+     */
+    abstract IndexReference createIndexReference( IndexIdentifier indexIdentifier ) throws IOException;
+
+    /**
+     * Refresh previously constructed indexReference.
+     * @param indexReference index reference to refresh
+     * @return refreshed index reference
+     */
+    abstract IndexReference refresh( IndexReference indexReference );
+
+    Directory getIndexDirectory( IndexIdentifier identifier ) throws IOException
+    {
+        return filesystemFacade.getDirectory( baseStorePath, identifier );
+    }
+
+    IndexSearcher newIndexSearcher( IndexIdentifier identifier, IndexReader reader )
+    {
+        IndexSearcher searcher = new IndexSearcher( reader );
+        IndexType type = getType( identifier );
+        if ( type.getSimilarity() != null )
+        {
+            searcher.setSimilarity( type.getSimilarity() );
+        }
+        return searcher;
+    }
+
+    IndexType getType( IndexIdentifier identifier )
+    {
+        return typeCache.getIndexType( identifier, false );
+    }
+}
+

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReference.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReference.java
@@ -19,27 +19,41 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.cache.ClockCache;
-
-public class IndexClockCache extends ClockCache<IndexIdentifier, IndexReference>
+public class ReadOnlyIndexReference extends IndexReference
 {
-    public IndexClockCache( int maxSize )
+
+    ReadOnlyIndexReference( IndexIdentifier identifier, IndexSearcher searcher )
     {
-        super( "IndexSearcherCache", maxSize );
+        super(identifier, searcher);
     }
 
     @Override
-    public void elementCleaned( IndexReference searcher )
+    public IndexWriter getWriter()
     {
-        try
-        {
-            searcher.dispose();
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        throw new UnsupportedOperationException( "Read only indexes do not have index writers." );
     }
+
+    @Override
+    public synchronized void dispose() throws IOException
+    {
+        disposeSearcher();
+    }
+
+    @Override
+    public boolean checkAndClearStale()
+    {
+        return false;
+    }
+
+    @Override
+    public void setStale()
+    {
+        throw new UnsupportedOperationException("Read only indexes can't be marked as stale.");
+    }
+
 }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ReadOnlyIndexReferenceFactory extends IndexReferenceFactory
+{
+    public ReadOnlyIndexReferenceFactory( LuceneDataSource.LuceneFilesystemFacade filesystemFacade, File baseStorePath,
+            IndexTypeCache typeCache )
+    {
+        super( filesystemFacade, baseStorePath, typeCache );
+    }
+
+    @Override
+    IndexReference createIndexReference( IndexIdentifier identifier ) throws IOException
+    {
+        IndexReader reader = DirectoryReader.open( getIndexDirectory( identifier ) );
+        IndexSearcher indexSearcher = newIndexSearcher( identifier, reader );
+        return new ReadOnlyIndexReference( identifier, indexSearcher );
+    }
+
+    @Override
+    IndexReference refresh( IndexReference indexReference )
+    {
+        return indexReference;
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReference.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReference.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class WritableIndexReference extends IndexReference
+{
+    private final IndexWriter writer;
+    private boolean writerIsClosed;
+    private final AtomicBoolean stale = new AtomicBoolean();
+
+    WritableIndexReference( IndexIdentifier identifier, IndexSearcher searcher, IndexWriter writer )
+    {
+        super(identifier, searcher );
+        this.writer = writer;
+    }
+
+    @Override
+    public IndexWriter getWriter()
+    {
+        return writer;
+    }
+
+    @Override
+    public synchronized void dispose() throws IOException
+    {
+        disposeSearcher();
+        disposeWriter();
+    }
+
+    @Override
+    public boolean checkAndClearStale()
+    {
+        return stale.compareAndSet( true, false );
+    }
+
+    @Override
+    public void setStale()
+    {
+        stale.set( true );
+    }
+
+    private void disposeWriter() throws IOException
+    {
+        if ( !writerIsClosed )
+        {
+            writer.close();
+            writerIsClosed = true;
+        }
+    }
+
+    boolean isWriterClosed()
+    {
+        return writerIsClosed;
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.store.Directory;
+
+import java.io.File;
+import java.io.IOException;
+
+class WritableIndexReferenceFactory extends IndexReferenceFactory
+{
+    WritableIndexReferenceFactory( LuceneDataSource.LuceneFilesystemFacade filesystemFacade, File baseStorePath,
+            IndexTypeCache typeCache )
+    {
+        super( filesystemFacade, baseStorePath, typeCache );
+    }
+
+    @Override
+    IndexReference createIndexReference( IndexIdentifier identifier ) throws IOException
+    {
+        IndexWriter writer = newIndexWriter( identifier );
+        IndexReader reader = DirectoryReader.open( writer, true );
+        IndexSearcher indexSearcher = newIndexSearcher( identifier, reader );
+        return new WritableIndexReference( identifier, indexSearcher, writer );
+    }
+
+    /**
+     * If nothing has changed underneath (since the searcher was last created
+     * or refreshed) {@code searcher} is returned. But if something has changed a
+     * refreshed searcher is returned. It makes use if the
+     * {@link DirectoryReader#openIfChanged(DirectoryReader, IndexWriter, boolean)} which faster than opening an index
+     * from
+     * scratch.
+     *
+     * @param indexReference the {@link IndexReference} to refresh.
+     * @return a refreshed version of the searcher or, if nothing has changed,
+     *         {@code null}.
+     * @throws RuntimeException if there's a problem with the index.
+     */
+    @Override
+    IndexReference refresh( IndexReference indexReference )
+    {
+        try
+        {
+            DirectoryReader reader = (DirectoryReader) indexReference.getSearcher().getIndexReader();
+            IndexWriter writer = indexReference.getWriter();
+            IndexReader reopened = DirectoryReader.openIfChanged( reader, writer );
+            if ( reopened != null )
+            {
+                IndexSearcher newSearcher = newIndexSearcher( indexReference.getIdentifier(), reopened );
+                indexReference.detachOrClose();
+                return new WritableIndexReference( indexReference.getIdentifier(), newSearcher, writer );
+            }
+            return indexReference;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private IndexWriter newIndexWriter( IndexIdentifier identifier )
+    {
+        try
+        {
+            Directory indexDirectory = getIndexDirectory( identifier );
+            IndexType type = getType( identifier );
+            IndexWriterConfig writerConfig = new IndexWriterConfig( type.analyzer );
+            writerConfig.setIndexDeletionPolicy( new MultipleBackupDeletionPolicy() );
+            Similarity similarity = type.getSimilarity();
+            if ( similarity != null )
+            {
+                writerConfig.setSimilarity( similarity );
+            }
+            return new IndexWriter( indexDirectory, writerConfig );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/CloseTrackingIndexReader.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/CloseTrackingIndexReader.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.CompositeReader;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.Term;
+
+import java.io.IOException;
+import java.util.List;
+
+
+public class CloseTrackingIndexReader extends CompositeReader
+{
+
+    private boolean closed = false;
+
+    @Override
+    protected List<? extends IndexReader> getSequentialSubReaders()
+    {
+        return null;
+    }
+
+    @Override
+    public Fields getTermVectors( int docID ) throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public int numDocs()
+    {
+        return 0;
+    }
+
+    @Override
+    public int maxDoc()
+    {
+        return 0;
+    }
+
+    @Override
+    public void document( int docID, StoredFieldVisitor visitor ) throws IOException
+    {
+
+    }
+
+    @Override
+    protected void doClose() throws IOException
+    {
+        closed = true;
+    }
+
+    @Override
+    public int docFreq( Term term ) throws IOException
+    {
+        return 0;
+    }
+
+    @Override
+    public long totalTermFreq( Term term ) throws IOException
+    {
+        return 0;
+    }
+
+    @Override
+    public long getSumDocFreq( String field ) throws IOException
+    {
+        return 0;
+    }
+
+    @Override
+    public int getDocCount( String field ) throws IOException
+    {
+        return 0;
+    }
+
+    @Override
+    public long getSumTotalTermFreq( String field ) throws IOException
+    {
+        return 0;
+    }
+
+    public boolean isClosed()
+    {
+        return closed;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
@@ -23,8 +23,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.neo4j.graphdb.Node;
@@ -40,6 +42,7 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -48,29 +51,78 @@ public class LuceneDataSourceTest
 {
     private final LifeRule life = new LifeRule( true );
     private final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    private final ExpectedException expectedException = ExpectedException.none();
 
     @Rule
-    public final RuleChain ruleChain = RuleChain.outerRule( directory )
-            .around( life );
+    public final RuleChain ruleChain = RuleChain.outerRule( directory ).around( life ).around( expectedException );
 
     private IndexConfigStore indexStore;
     private LuceneDataSource dataSource;
 
     @Before
-    public void setup()
+    public void setUp()
     {
         indexStore = new IndexConfigStore( directory.directory(), new DefaultFileSystemAbstraction() );
         addIndex( "foo" );
     }
 
-    private void addIndex( String name )
+    @Test
+    public void doNotTryToCommitWritersOnForceInReadOnlyMode() throws IOException
     {
-        indexStore.set( Node.class, name, MapUtil.stringMap( IndexManager.PROVIDER, "lucene", "type", "fulltext" ) );
+        IndexIdentifier indexIdentifier = identifier( "foo" );
+        prepareIndexesByIdentifiers( indexIdentifier );
+
+        Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
+        LuceneDataSource readOnlyDataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig,
+                indexStore, new DefaultFileSystemAbstraction() ) );
+        assertNotNull( readOnlyDataSource.getIndexSearcher( indexIdentifier ) );
+
+        readOnlyDataSource.force();
     }
 
-    private IndexIdentifier identifier( String name )
+    @Test
+    public void notAllowIndexDeletionInReadOnlyMode() throws IOException
     {
-        return new IndexIdentifier( IndexEntityType.Node, name );
+        IndexIdentifier indexIdentifier = identifier( "foo" );
+        prepareIndexesByIdentifiers( indexIdentifier );
+
+        Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
+        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+        expectedException.expect( IllegalStateException.class );
+        expectedException.expectMessage("Index deletion in read only mode is not supported.");
+        dataSource.deleteIndex( indexIdentifier, false );
+    }
+
+    @Test
+    public void useReadOnlyIndexSearcherInReadOnlyMode() throws IOException
+    {
+        IndexIdentifier indexIdentifier = identifier( "foo" );
+        prepareIndexesByIdentifiers( indexIdentifier );
+
+        Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
+        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+
+        IndexReference indexSearcher = dataSource.getIndexSearcher( indexIdentifier );
+        assertTrue( "Read only index reference should be used in read only mode.",
+                ReadOnlyIndexReference.class.isInstance( indexSearcher ) );
+    }
+
+    @Test
+    public void refreshReadOnlyIndexSearcherInReadOnlyMode() throws IOException
+    {
+        IndexIdentifier indexIdentifier = identifier( "foo" );
+        prepareIndexesByIdentifiers( indexIdentifier );
+
+        Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
+        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+
+        IndexReference indexSearcher = dataSource.getIndexSearcher( indexIdentifier );
+        IndexReference indexSearcher2 = dataSource.getIndexSearcher( indexIdentifier );
+        IndexReference indexSearcher3 = dataSource.getIndexSearcher( indexIdentifier );
+        IndexReference indexSearcher4 = dataSource.getIndexSearcher( indexIdentifier );
+        assertSame( "Refreshed read only searcher should be the same.", indexSearcher, indexSearcher2 );
+        assertSame( "Refreshed read only searcher should be the same.", indexSearcher2, indexSearcher3 );
+        assertSame( "Refreshed read only searcher should be the same.", indexSearcher3, indexSearcher4 );
     }
 
     @Test
@@ -180,6 +232,32 @@ public class LuceneDataSourceTest
 
     private Map<String, String> config()
     {
-        return MapUtil.stringMap( "store_dir", directory.directory().getPath() );
+        return MapUtil.stringMap();
     }
+
+    private void prepareIndexesByIdentifiers( IndexIdentifier indexIdentifier )
+    {
+        Config config = new Config( config(), GraphDatabaseSettings.class );
+        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource.getIndexSearcher( indexIdentifier );
+        dataSource.force();
+    }
+
+    private Map<String, String> readOnlyConfig()
+    {
+        Map<String,String> config = config();
+        config.put( GraphDatabaseSettings.read_only.name(), "true" );
+        return config;
+    }
+
+    private void addIndex( String name )
+    {
+        indexStore.set( Node.class, name, MapUtil.stringMap( IndexManager.PROVIDER, "lucene", "type", "fulltext" ) );
+    }
+
+    private IndexIdentifier identifier( String name )
+    {
+        return new IndexIdentifier( IndexEntityType.Node, name );
+    }
+
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
@@ -71,6 +71,7 @@ public class LuceneDataSourceTest
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
+        stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
         LuceneDataSource readOnlyDataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig,
@@ -85,6 +86,7 @@ public class LuceneDataSourceTest
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
+        stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
         dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
@@ -98,6 +100,7 @@ public class LuceneDataSourceTest
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
+        stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
         dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
@@ -112,6 +115,7 @@ public class LuceneDataSourceTest
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
+        stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
         dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
@@ -228,6 +232,11 @@ public class LuceneDataSourceTest
         IndexWriter newFooIndexWriter = dataSource.getIndexSearcher( fooIdentifier ).getWriter();
         assertNotSame( oldFooIndexWriter, newFooIndexWriter );
         assertTrue( newFooIndexWriter.isOpen() );
+    }
+
+    private void stopDataSource() throws IOException
+    {
+        dataSource.shutdown();
     }
 
     private Map<String, String> config()

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexEntityType;
+import org.neo4j.test.CleanupRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertSame;
+
+public class ReadOnlyIndexReferenceFactoryTest
+{
+    private TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    private ExpectedException expectedException = ExpectedException.none();
+    private CleanupRule cleanupRule = new CleanupRule();
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( cleanupRule ).around( expectedException ).around( testDirectory );
+
+    private static final String INDEX_NAME = "testIndex";
+    private LuceneDataSource.LuceneFilesystemFacade filesystemFacade = LuceneDataSource.LuceneFilesystemFacade.FS;
+    private IndexIdentifier indexIdentifier = new IndexIdentifier( IndexEntityType.Node, INDEX_NAME );
+    private IndexConfigStore indexStore;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        setupIndexInfrastructure();
+    }
+
+    @Test
+    public void createReadOnlyIndexReference() throws Exception
+    {
+        ReadOnlyIndexReferenceFactory indexReferenceFactory = getReadOnlyIndexReferenceFactory();
+        IndexReference indexReference = indexReferenceFactory.createIndexReference( indexIdentifier );
+        cleanupRule.add( indexReference );
+
+        expectedException.expect( UnsupportedOperationException.class );
+        indexReference.getWriter();
+    }
+
+    @Test
+    public void refreshReadOnlyIndexReference() throws IOException
+    {
+        ReadOnlyIndexReferenceFactory indexReferenceFactory = getReadOnlyIndexReferenceFactory();
+        IndexReference indexReference = indexReferenceFactory.createIndexReference( indexIdentifier );
+        cleanupRule.add( indexReference );
+
+        IndexReference refreshedIndex = indexReferenceFactory.refresh( indexReference );
+        assertSame("Refreshed instance should be the same.", indexReference, refreshedIndex);
+    }
+
+    private void setupIndexInfrastructure() throws IOException
+    {
+        DefaultFileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction();
+        File storeDir = getStoreDir();
+        indexStore = new IndexConfigStore( storeDir, fileSystemAbstraction );
+        indexStore.set( Node.class, INDEX_NAME, MapUtil.stringMap( IndexManager.PROVIDER, "lucene", "type", "fulltext" ) );
+        LuceneDataSource luceneDataSource = new LuceneDataSource( storeDir, new Config( MapUtil.stringMap() ),
+                indexStore, fileSystemAbstraction );
+        try
+        {
+            luceneDataSource.init();
+            luceneDataSource.getIndexSearcher( indexIdentifier );
+        }
+        finally
+        {
+            luceneDataSource.shutdown();
+        }
+    }
+
+    private ReadOnlyIndexReferenceFactory getReadOnlyIndexReferenceFactory()
+    {
+        return new ReadOnlyIndexReferenceFactory( filesystemFacade, new File( getStoreDir(), "index"),
+                new IndexTypeCache( indexStore ) );
+    }
+
+    private File getStoreDir()
+    {
+        return testDirectory.directory();
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReadOnlyIndexReferenceTest
+{
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private IndexIdentifier identifier = mock( IndexIdentifier.class );
+    private IndexSearcher searcher = mock( IndexSearcher.class );
+    private CloseTrackingIndexReader reader = new CloseTrackingIndexReader();
+    private ReadOnlyIndexReference indexReference = new ReadOnlyIndexReference( identifier, searcher );
+
+    @Before
+    public void setUp()
+    {
+        when( searcher.getIndexReader() ).thenReturn( reader );
+    }
+
+    @Test
+    public void obtainingWriterIsUnsupported() throws Exception
+    {
+        expectedException.expect( UnsupportedOperationException.class );
+        expectedException.expectMessage( "Read only indexes do not have index writers." );
+        indexReference.getWriter();
+    }
+
+    @Test
+    public void markAsStaleIsUnsupported()
+    {
+        expectedException.expect( UnsupportedOperationException.class );
+        expectedException.expectMessage( "Read only indexes can't be marked as stale." );
+        indexReference.setStale();
+    }
+
+    @Test
+    public void checkAndClearStaleAlwaysFalse()
+    {
+        assertFalse( indexReference.checkAndClearStale() );
+    }
+
+    @Test
+    public void disposeClosingSearcherAndMarkAsClosed() throws IOException
+    {
+        indexReference.dispose();
+
+        assertTrue( reader.isClosed() );
+        assertTrue( indexReference.isClosed() );
+    }
+
+    @Test
+    public void detachIndexReferenceWhenSomeReferencesExist() throws IOException
+    {
+        indexReference.incRef();
+        indexReference.detachOrClose();
+
+        assertTrue( "Should leave index in detached state.", indexReference.isDetached() );
+    }
+
+    @Test
+    public void closeIndexReferenceWhenNoReferenceExist() throws IOException
+    {
+        indexReference.detachOrClose();
+
+        assertFalse( "Should leave index in closed state.", indexReference.isDetached() );
+        assertTrue( reader.isClosed() );
+        assertTrue( indexReference.isClosed() );
+    }
+
+    @Test
+    public void doNotCloseInstanceWhenSomeReferenceExist()
+    {
+        indexReference.incRef();
+        assertFalse( indexReference.close() );
+
+        assertFalse( indexReference.isClosed() );
+    }
+
+    @Test
+    public void closeDetachedIndexReferencedOnlyOnce() throws IOException
+    {
+        indexReference.incRef();
+        indexReference.detachOrClose();
+
+        assertTrue( "Should leave index in detached state.", indexReference.isDetached() );
+
+        assertTrue( indexReference.close() );
+        assertTrue( reader.isClosed() );
+        assertTrue( indexReference.isClosed() );
+    }
+
+    @Test
+    public void doNotCloseDetachedIndexReferencedMoreThenOnce() throws IOException
+    {
+        indexReference.incRef();
+        indexReference.incRef();
+        indexReference.detachOrClose();
+
+        assertTrue( "Should leave index in detached state.", indexReference.isDetached() );
+
+        assertFalse( indexReference.close() );
+    }
+
+    @Test
+    public void doNotCloseReferencedIndex()
+    {
+        indexReference.incRef();
+        assertFalse( indexReference.close() );
+        assertFalse( indexReference.isClosed() );
+    }
+
+    @Test
+    public void closeNotReferencedIndex()
+    {
+        assertTrue( indexReference.close() );
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactoryTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexEntityType;
+import org.neo4j.test.CleanupRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class WritableIndexReferenceFactoryTest
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public CleanupRule cleanupRule = new CleanupRule();
+
+    private static final String INDEX_NAME = "testIndex";
+
+    private LuceneDataSource.LuceneFilesystemFacade filesystemFacade = LuceneDataSource.LuceneFilesystemFacade.FS;
+    private IndexIdentifier indexIdentifier = new IndexIdentifier( IndexEntityType.Node, INDEX_NAME );
+    private IndexConfigStore indexStore;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        setupIndexInfrastructure();
+    }
+
+    @Test
+    public void createWritableIndexReference() throws Exception
+    {
+        WritableIndexReferenceFactory indexReferenceFactory = createFactory();
+        IndexReference indexReference = createIndexReference( indexReferenceFactory );
+
+        assertNotNull( "Index should have writer.", indexReference.getWriter() );
+    }
+
+    @Test
+    public void refreshNotChangedWritableIndexReference() throws Exception
+    {
+        WritableIndexReferenceFactory indexReferenceFactory = createFactory();
+        IndexReference indexReference = createIndexReference( indexReferenceFactory );
+
+        IndexReference refreshedInstance = indexReferenceFactory.refresh( indexReference );
+        assertSame( indexReference, refreshedInstance );
+    }
+
+    @Test
+    public void refreshChangedWritableIndexReference() throws Exception
+    {
+        WritableIndexReferenceFactory indexReferenceFactory = createFactory();
+        IndexReference indexReference = createIndexReference( indexReferenceFactory );
+
+        writeSomething( indexReference );
+
+        IndexReference refreshedIndexReference = indexReferenceFactory.refresh( indexReference );
+        cleanupRule.add( refreshedIndexReference );
+
+        assertNotSame( "Should return new refreshed index reference.", indexReference, refreshedIndexReference );
+    }
+
+    private void writeSomething( IndexReference indexReference ) throws IOException
+    {
+        IndexWriter writer = indexReference.getWriter();
+        writer.addDocument( new Document() );
+        writer.commit();
+    }
+
+    private IndexReference createIndexReference( WritableIndexReferenceFactory indexReferenceFactory ) throws IOException
+    {
+        IndexReference indexReference = indexReferenceFactory.createIndexReference( indexIdentifier );
+        cleanupRule.add( indexReference );
+        return indexReference;
+    }
+
+    private WritableIndexReferenceFactory createFactory()
+    {
+        return new WritableIndexReferenceFactory( filesystemFacade,  new File( getStoreDir(), "index"),
+                new IndexTypeCache( indexStore ) );
+    }
+
+    private void setupIndexInfrastructure() throws IOException
+    {
+        DefaultFileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction();
+        File storeDir = getStoreDir();
+        indexStore = new IndexConfigStore( storeDir, fileSystemAbstraction );
+        indexStore.set( Node.class, INDEX_NAME, MapUtil.stringMap( IndexManager.PROVIDER, "lucene", "type", "fulltext" ) );
+    }
+
+    private File getStoreDir()
+    {
+        return testDirectory.directory();
+    }
+
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WritableIndexReferenceTest
+{
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private IndexIdentifier identifier = mock( IndexIdentifier.class );
+    private IndexSearcher searcher = mock( IndexSearcher.class );
+    private IndexWriter indexWriter = mock( IndexWriter.class );
+    private CloseTrackingIndexReader reader = new CloseTrackingIndexReader();
+    private WritableIndexReference indexReference = new WritableIndexReference( identifier, searcher, indexWriter);
+
+    @Before
+    public void setUp()
+    {
+        when( searcher.getIndexReader() ).thenReturn( reader );
+    }
+
+
+    @Test
+    public void useProvidedWriterAsIndexWriter() throws Exception
+    {
+        assertSame( indexWriter, indexReference.getWriter() );
+    }
+
+    @Test
+    public void stalingWritableIndex() throws Exception
+    {
+        assertFalse( "Index is not stale by default.", indexReference.checkAndClearStale() );
+        indexReference.setStale();
+        assertTrue( "We should be able to reset stale index state.", indexReference.checkAndClearStale() );
+        assertFalse( "Index is not stale anymore.", indexReference.checkAndClearStale() );
+
+    }
+
+    @Test
+    public void disposeWritableIndex() throws Exception
+    {
+        indexReference.dispose();
+        assertTrue( "Reader should be closed.", reader.isClosed() );
+        assertTrue( "Writer should be closed.", indexReference.isWriterClosed() );
+    }
+
+}


### PR DESCRIPTION
Using lucene index in write mode can cause index corruption/complete deletion in cases if user code use/rely on interrupts.
To avoid such cases as much as possible indexes will be opened in read only mode in case if database was started with read only mode.
As result after interruption lucene will raise ClosedByInterruptException exception as soon as code will try to get something from index again, but index itself will be untouched.

changelog:
Open lucene indexes in read only mode when database started in read only mode (not applicable to ha setup) to prevent cases when usage of interrupts will result in deleted index. 
