### PR TITLE
core-edge: Do not try to lookup terms ahead of log.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/log/segmented/SegmentedRaftLog.java
@@ -227,6 +227,10 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
     @Override
     public long readEntryTerm( long logIndex ) throws IOException
     {
+        if ( logIndex > state.appendIndex )
+        {
+            return -1;
+        }
         long term = state.terms.get( logIndex );
         if ( term == -1 && logIndex >= state.prevIndex )
         {


### PR DESCRIPTION
They are -1 by definition.
