### PR TITLE
Minor cleanup around KTI handle

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -64,8 +64,10 @@ public interface KernelTransactionHandle
      * Mark the underlying transaction for termination.
      *
      * @param reason the reason for termination.
+     * @return {@code true} if the underlying transaction was marked for termination, {@code false} otherwise
+     * (when this handle represents an old transaction that has been closed).
      */
-    void markForTermination( Status reason );
+    boolean markForTermination( Status reason );
 
     /**
      * Access mode of underlying transaction that transaction has when handle was created.
@@ -81,6 +83,11 @@ public interface KernelTransactionHandle
      */
     Optional<Status> terminationReason();
 
-    // TODO: remove
-    boolean isSameTransaction( KernelTransaction tx );
+    /**
+     * Check if this handle points to the same underlying transaction as the given one.
+     *
+     * @param tx the expected transaction.
+     * @return {@code true} if this handle represents {@code tx}, {@code false} otherwise.
+     */
+    boolean isUnderlyingTransaction( KernelTransaction tx );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -253,15 +253,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         return terminationReason;
     }
 
-    void markForTermination( long expectedReuseCount, Status reason )
+    boolean markForTermination( long expectedReuseCount, Status reason )
     {
         terminationReleaseLock.lock();
         try
         {
-            if ( expectedReuseCount == reuseCount )
-            {
-                markForTerminationIfPossible( reason );
-            }
+            return expectedReuseCount == reuseCount && markForTerminationIfPossible( reason );
         }
         finally
         {
@@ -289,7 +286,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         }
     }
 
-    private void markForTerminationIfPossible( Status reason )
+    private boolean markForTerminationIfPossible( Status reason )
     {
         if ( canBeTerminated() )
         {
@@ -300,7 +297,9 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 locks.stop();
             }
             transactionMonitor.transactionTerminated( hasTxStateWithChanges() );
+            return true;
         }
+        return false;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -78,9 +78,9 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     }
 
     @Override
-    public void markForTermination( Status reason )
+    public boolean markForTermination( Status reason )
     {
-        tx.markForTermination( txReuseCount, reason );
+        return tx.markForTermination( txReuseCount, reason );
     }
 
     @Override
@@ -96,7 +96,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     }
 
     @Override
-    public boolean isSameTransaction( KernelTransaction tx )
+    public boolean isUnderlyingTransaction( KernelTransaction tx )
     {
         return this.tx == tx;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandleTest.java
@@ -26,6 +26,8 @@ import org.neo4j.kernel.api.exceptions.Status;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -102,5 +104,27 @@ public class KernelTransactionImplementationHandleTest
         handle.markForTermination( terminationReason );
 
         verify( tx ).markForTermination( reuseCount, terminationReason );
+    }
+
+    @Test
+    public void markForTerminationReturnsTrueWhenSuccessful()
+    {
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.getReuseCount() ).thenReturn( 42 );
+        when( tx.markForTermination( anyLong(), any() ) ).thenReturn( true );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+        assertTrue( handle.markForTermination( Status.Transaction.Terminated ) );
+    }
+
+    @Test
+    public void markForTerminationReturnsFalseWhenNotSuccessful()
+    {
+        KernelTransactionImplementation tx = mock( KernelTransactionImplementation.class );
+        when( tx.getReuseCount() ).thenReturn( 42 );
+        when( tx.markForTermination( anyLong(), any() ) ).thenReturn( false );
+
+        KernelTransactionImplementationHandle handle = new KernelTransactionImplementationHandle( tx );
+        assertFalse( handle.markForTermination( Status.Transaction.Terminated ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -639,7 +640,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         Locks.Client locksClient = mock( Locks.Client.class );
         tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
 
-        tx.markForTermination( reuseCount, terminationReason );
+        assertTrue( tx.markForTermination( reuseCount, terminationReason ) );
 
         assertEquals( terminationReason, tx.getReasonIfTerminated() );
         verify( locksClient ).stop();
@@ -658,7 +659,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         Locks.Client locksClient = mock( Locks.Client.class );
         tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
 
-        tx.markForTermination( nextReuseCount, terminationReason );
+        assertFalse( tx.markForTermination( nextReuseCount, terminationReason ) );
 
         assertNull( tx.getReasonIfTerminated() );
         verify( locksClient, never() ).stop();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -64,9 +64,10 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
-    public void markForTermination( Status reason )
+    public boolean markForTermination( Status reason )
     {
         tx.markForTermination( reason );
+        return true;
     }
 
     @Override
@@ -82,9 +83,9 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
-    public boolean isSameTransaction( KernelTransaction tx )
+    public boolean isUnderlyingTransaction( KernelTransaction tx )
     {
-        return false;
+        return this.tx == tx;
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
@@ -252,16 +252,19 @@ public class AuthProcedures
 
     private Stream<TransactionTerminationResult> terminateTransactionsForValidUser( String username )
     {
-        Long killCount = 0L;
+        long terminatedCount = 0;
         for ( KernelTransactionHandle tx : getActiveTransactions() )
         {
-            if ( tx.mode().name().equals( username ) && !tx.isSameTransaction( this.tx) )
+            if ( tx.mode().name().equals( username ) && !tx.isUnderlyingTransaction( this.tx ) )
             {
-                tx.markForTermination( Status.Transaction.Terminated );
-                killCount += 1;
+                boolean marked = tx.markForTermination( Status.Transaction.Terminated );
+                if ( marked )
+                {
+                    terminatedCount++;
+                }
             }
         }
-        return Stream.of( new TransactionTerminationResult( username, killCount ) );
+        return Stream.of( new TransactionTerminationResult( username, terminatedCount ) );
     }
 
     private Stream<SessionResult> terminateSessionsForValidUser( String username )


### PR DESCRIPTION
Rename method `#isSameTransaction()` to `#hasUnderlyingTransaction()` and propagate if marking tx for termination succeeded or not.
