### PR TITLE
Acquiring locks are deferred to commit time

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -78,8 +78,8 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
+import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
@@ -268,7 +268,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
     private final LabelTokenHolder labelTokens;
     private final RelationshipTypeTokenHolder relationshipTypeTokens;
-    private final Locks locks;
+    private final StatementLocksFactory statementLocksFactory;
     private final SchemaWriteGuard schemaWriteGuard;
     private final TransactionEventHandlers transactionEventHandlers;
     private final IdGeneratorFactory idGeneratorFactory;
@@ -323,7 +323,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             PropertyKeyTokenHolder propertyKeyTokens,
             LabelTokenHolder labelTokens,
             RelationshipTypeTokenHolder relationshipTypeTokens,
-            Locks lockManager,
+            StatementLocksFactory statementLocksFactory,
             SchemaWriteGuard schemaWriteGuard,
             TransactionEventHandlers transactionEventHandlers,
             IndexingService.Monitor indexingServiceMonitor,
@@ -357,7 +357,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         this.propertyKeyTokenHolder = propertyKeyTokens;
         this.labelTokens = labelTokens;
         this.relationshipTypeTokens = relationshipTypeTokens;
-        this.locks = lockManager;
+        this.statementLocksFactory = statementLocksFactory;
         this.schemaWriteGuard = schemaWriteGuard;
         this.transactionEventHandlers = transactionEventHandlers;
         this.indexingServiceMonitor = indexingServiceMonitor;
@@ -793,10 +793,10 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 legacyIndexStore ) );
 
         TransactionHooks hooks = new TransactionHooks();
-        KernelTransactions kernelTransactions = life.add( new KernelTransactions( locks, constraintIndexCreator,
-                statementOperations, schemaWriteGuard, transactionHeaderInformationFactory, transactionCommitProcess,
-                indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor, life, tracers, storageEngine,
-                procedures, transactionIdStore, config, Clock.SYSTEM_CLOCK ) );
+        KernelTransactions kernelTransactions = life.add( new KernelTransactions( statementLocksFactory,
+                constraintIndexCreator, statementOperations, schemaWriteGuard, transactionHeaderInformationFactory,
+                transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor,
+                life, tracers, storageEngine, procedures, transactionIdStore, config, Clock.SYSTEM_CLOCK ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, databaseHealth, transactionMonitor, procedures );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -329,6 +329,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         }
 
         // If we find the node - hold a shared lock. If we don't find a node - hold an exclusive lock.
+        // If locks are deferred than both shared and exclusive locks will be taken only at commit time.
         Locks.Client locks = state.locks().optimistic();
         long indexEntryId = indexEntryResourceId( labelId, propertyKeyId, stringVal );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -154,7 +154,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         {
             IndexDescriptor indexDescriptor = new IndexDescriptor( labelId, propertyKeyId );
             assertIndexOnline( state, indexDescriptor );
-            state.locks().acquireExclusive( INDEX_ENTRY,
+            state.locks().optimistic().acquireExclusive( INDEX_ENTRY,
                     indexEntryResourceId( labelId, propertyKeyId, Strings.prettyPrint( value ) ) );
 
             long existing = entityReadOperations.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
@@ -329,7 +329,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         }
 
         // If we find the node - hold a shared lock. If we don't find a node - hold an exclusive lock.
-        Locks.Client locks = state.locks();
+        Locks.Client locks = state.locks().optimistic();
         long indexEntryId = indexEntryResourceId( labelId, propertyKeyId, stringVal );
 
         locks.acquireShared( INDEX_ENTRY, indexEntryId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -104,7 +104,7 @@ public class LockingStatementOperations implements
         //
         // It would be cleaner if the schema and data cakes were separated so that the SchemaReadOperations object used
         // by ConstraintEnforcingEntityOperations included the full cake, with locking included.
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
 
         acquireExclusiveNodeLock( state, nodeId );
         state.assertOpen();
@@ -148,7 +148,7 @@ public class LockingStatementOperations implements
     @Override
     public <K, V> V schemaStateGetOrCreate( KernelStatement state, K key, Function<K,V> creator )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaStateDelegate.schemaStateGetOrCreate( state, key, creator );
     }
@@ -156,7 +156,7 @@ public class LockingStatementOperations implements
     @Override
     public <K> boolean schemaStateContains( KernelStatement state, K key )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaStateDelegate.schemaStateContains( state, key );
     }
@@ -164,7 +164,7 @@ public class LockingStatementOperations implements
     @Override
     public void schemaStateFlush( KernelStatement state )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         schemaStateDelegate.schemaStateFlush( state );
     }
@@ -172,7 +172,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexesGetForLabel( state, labelId );
     }
@@ -180,7 +180,7 @@ public class LockingStatementOperations implements
     @Override
     public IndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKey )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetForLabelAndPropertyKey( state, labelId, propertyKey );
     }
@@ -188,7 +188,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> indexesGetAll( KernelStatement state )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexesGetAll( state );
     }
@@ -197,7 +197,7 @@ public class LockingStatementOperations implements
     public InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetState( state, descriptor );
     }
@@ -206,7 +206,7 @@ public class LockingStatementOperations implements
     public PopulationProgress indexGetPopulationProgress( KernelStatement state, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetPopulationProgress( state, descriptor );
     }
@@ -214,7 +214,7 @@ public class LockingStatementOperations implements
     @Override
     public long indexSize( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexSize( state, descriptor );
     }
@@ -223,7 +223,7 @@ public class LockingStatementOperations implements
     public double indexUniqueValuesPercentage( KernelStatement state,
             IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexUniqueValuesPercentage( state, descriptor );
     }
@@ -231,7 +231,7 @@ public class LockingStatementOperations implements
     @Override
     public Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetOwningUniquenessConstraintId( state, index );
     }
@@ -240,7 +240,7 @@ public class LockingStatementOperations implements
     public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<SchemaRule.Kind> filter )
             throws SchemaRuleNotFoundException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetCommittedId( state, index, filter );
     }
@@ -248,7 +248,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.uniqueIndexesGetForLabel( state, labelId );
     }
@@ -256,7 +256,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> uniqueIndexesGetAll( KernelStatement state )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.uniqueIndexesGetAll( state );
     }
@@ -308,7 +308,7 @@ public class LockingStatementOperations implements
             long endNodeId )
             throws EntityNotFoundException
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         lockRelationshipNodes( state, startNodeId, endNodeId );
         return entityWriteDelegate.relationshipCreate( state, relationshipTypeId, startNodeId, endNodeId );
     }
@@ -370,7 +370,7 @@ public class LockingStatementOperations implements
             int labelId,
             int propertyKeyId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForLabelAndPropertyKey( state, labelId, propertyKeyId );
     }
@@ -378,7 +378,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<NodePropertyConstraint> constraintsGetForLabel( KernelStatement state, int labelId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForLabel( state, labelId );
     }
@@ -388,7 +388,7 @@ public class LockingStatementOperations implements
             KernelStatement state,
             int relTypeId, int propertyKeyId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForRelationshipTypeAndPropertyKey( state, relTypeId, propertyKeyId );
     }
@@ -397,7 +397,7 @@ public class LockingStatementOperations implements
     public Iterator<RelationshipPropertyConstraint> constraintsGetForRelationshipType( KernelStatement state,
             int typeId )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForRelationshipType( state, typeId );
     }
@@ -405,7 +405,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<PropertyConstraint> constraintsGetAll( KernelStatement state )
     {
-        acquireSharedSchemaLock(state);
+        acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.constraintsGetAll( state );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -104,7 +104,7 @@ public class LockingStatementOperations implements
         //
         // It would be cleaner if the schema and data cakes were separated so that the SchemaReadOperations object used
         // by ConstraintEnforcingEntityOperations included the full cake, with locking included.
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
 
         acquireExclusiveNodeLock( state, nodeId );
         state.assertOpen();
@@ -124,7 +124,7 @@ public class LockingStatementOperations implements
     public IndexDescriptor indexCreate( KernelStatement state, int labelId, int propertyKey )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         return schemaWriteDelegate.indexCreate( state, labelId, propertyKey );
     }
@@ -132,7 +132,7 @@ public class LockingStatementOperations implements
     @Override
     public void indexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         schemaWriteDelegate.indexDrop( state, descriptor );
     }
@@ -140,7 +140,7 @@ public class LockingStatementOperations implements
     @Override
     public void uniqueIndexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         schemaWriteDelegate.uniqueIndexDrop( state, descriptor );
     }
@@ -148,7 +148,7 @@ public class LockingStatementOperations implements
     @Override
     public <K, V> V schemaStateGetOrCreate( KernelStatement state, K key, Function<K,V> creator )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaStateDelegate.schemaStateGetOrCreate( state, key, creator );
     }
@@ -156,7 +156,7 @@ public class LockingStatementOperations implements
     @Override
     public <K> boolean schemaStateContains( KernelStatement state, K key )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaStateDelegate.schemaStateContains( state, key );
     }
@@ -164,7 +164,7 @@ public class LockingStatementOperations implements
     @Override
     public void schemaStateFlush( KernelStatement state )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         schemaStateDelegate.schemaStateFlush( state );
     }
@@ -172,7 +172,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexesGetForLabel( state, labelId );
     }
@@ -180,7 +180,7 @@ public class LockingStatementOperations implements
     @Override
     public IndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKey )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexGetForLabelAndPropertyKey( state, labelId, propertyKey );
     }
@@ -188,7 +188,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> indexesGetAll( KernelStatement state )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexesGetAll( state );
     }
@@ -197,7 +197,7 @@ public class LockingStatementOperations implements
     public InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexGetState( state, descriptor );
     }
@@ -206,7 +206,7 @@ public class LockingStatementOperations implements
     public PopulationProgress indexGetPopulationProgress( KernelStatement state, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexGetPopulationProgress( state, descriptor );
     }
@@ -214,7 +214,7 @@ public class LockingStatementOperations implements
     @Override
     public long indexSize( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexSize( state, descriptor );
     }
@@ -223,7 +223,7 @@ public class LockingStatementOperations implements
     public double indexUniqueValuesPercentage( KernelStatement state,
             IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexUniqueValuesPercentage( state, descriptor );
     }
@@ -231,7 +231,7 @@ public class LockingStatementOperations implements
     @Override
     public Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index ) throws SchemaRuleNotFoundException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexGetOwningUniquenessConstraintId( state, index );
     }
@@ -240,7 +240,7 @@ public class LockingStatementOperations implements
     public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<SchemaRule.Kind> filter )
             throws SchemaRuleNotFoundException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.indexGetCommittedId( state, index, filter );
     }
@@ -248,7 +248,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.uniqueIndexesGetForLabel( state, labelId );
     }
@@ -256,7 +256,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<IndexDescriptor> uniqueIndexesGetAll( KernelStatement state )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.uniqueIndexesGetAll( state );
     }
@@ -308,7 +308,7 @@ public class LockingStatementOperations implements
             long endNodeId )
             throws EntityNotFoundException
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         lockRelationshipNodes( state, startNodeId, endNodeId );
         return entityWriteDelegate.relationshipCreate( state, relationshipTypeId, startNodeId, endNodeId );
     }
@@ -342,7 +342,7 @@ public class LockingStatementOperations implements
     public UniquenessConstraint uniquePropertyConstraintCreate( KernelStatement state, int labelId, int propertyKeyId )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         return schemaWriteDelegate.uniquePropertyConstraintCreate( state, labelId, propertyKeyId );
     }
@@ -351,7 +351,7 @@ public class LockingStatementOperations implements
     public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
             int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         return schemaWriteDelegate.nodePropertyExistenceConstraintCreate( state, labelId, propertyKeyId );
     }
@@ -360,7 +360,7 @@ public class LockingStatementOperations implements
     public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         return schemaWriteDelegate.relationshipPropertyExistenceConstraintCreate( state, relTypeId, propertyKeyId );
     }
@@ -370,7 +370,7 @@ public class LockingStatementOperations implements
             int labelId,
             int propertyKeyId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForLabelAndPropertyKey( state, labelId, propertyKeyId );
     }
@@ -378,7 +378,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<NodePropertyConstraint> constraintsGetForLabel( KernelStatement state, int labelId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForLabel( state, labelId );
     }
@@ -388,7 +388,7 @@ public class LockingStatementOperations implements
             KernelStatement state,
             int relTypeId, int propertyKeyId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForRelationshipTypeAndPropertyKey( state, relTypeId, propertyKeyId );
     }
@@ -397,7 +397,7 @@ public class LockingStatementOperations implements
     public Iterator<RelationshipPropertyConstraint> constraintsGetForRelationshipType( KernelStatement state,
             int typeId )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.constraintsGetForRelationshipType( state, typeId );
     }
@@ -405,7 +405,7 @@ public class LockingStatementOperations implements
     @Override
     public Iterator<PropertyConstraint> constraintsGetAll( KernelStatement state )
     {
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock(state);
         state.assertOpen();
         return schemaReadDelegate.constraintsGetAll( state );
     }
@@ -414,7 +414,7 @@ public class LockingStatementOperations implements
     public void constraintDrop( KernelStatement state, NodePropertyConstraint constraint )
             throws DropConstraintFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         schemaWriteDelegate.constraintDrop( state, constraint );
     }
@@ -423,7 +423,7 @@ public class LockingStatementOperations implements
     public void constraintDrop( KernelStatement state, RelationshipPropertyConstraint constraint )
             throws DropConstraintFailureException
     {
-        state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        acquireExclusiveSchemaLock( state );
         state.assertOpen();
         schemaWriteDelegate.constraintDrop( state, constraint );
     }
@@ -443,7 +443,7 @@ public class LockingStatementOperations implements
         //
         // It would be cleaner if the schema and data cakes were separated so that the SchemaReadOperations object used
         // by ConstraintEnforcingEntityOperations included the full cake, with locking included.
-        state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        acquireSharedSchemaLock( state );
 
         acquireExclusiveNodeLock( state, nodeId );
         state.assertOpen();
@@ -482,7 +482,7 @@ public class LockingStatementOperations implements
     @Override
     public Property graphSetProperty( KernelStatement state, DefinedProperty property )
     {
-        state.locks().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
+        state.locks().optimistic().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
         state.assertOpen();
         return entityWriteDelegate.graphSetProperty( state, property );
     }
@@ -490,7 +490,7 @@ public class LockingStatementOperations implements
     @Override
     public Property graphRemoveProperty( KernelStatement state, int propertyKeyId )
     {
-        state.locks().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
+        state.locks().optimistic().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
         state.assertOpen();
         return entityWriteDelegate.graphRemoveProperty( state, propertyKeyId );
     }
@@ -498,28 +498,28 @@ public class LockingStatementOperations implements
     @Override
     public void acquireExclusive( KernelStatement state, ResourceType resourceType, long resourceId )
     {
-        state.locks().acquireExclusive( resourceType, resourceId );
+        state.locks().pessimistic().acquireExclusive( resourceType, resourceId );
         state.assertOpen();
     }
 
     @Override
     public void acquireShared( KernelStatement state, ResourceType resourceType, long resourceId )
     {
-        state.locks().acquireShared( resourceType, resourceId );
+        state.locks().pessimistic().acquireShared( resourceType, resourceId );
         state.assertOpen();
     }
 
     @Override
     public void releaseExclusive( KernelStatement state, ResourceType type, long resourceId )
     {
-        state.locks().releaseExclusive( type, resourceId );
+        state.locks().pessimistic().releaseExclusive( type, resourceId );
         state.assertOpen();
     }
 
     @Override
     public void releaseShared( KernelStatement state, ResourceType type, long resourceId )
     {
-        state.locks().releaseShared( type, resourceId );
+        state.locks().pessimistic().releaseShared( type, resourceId );
         state.assertOpen();
     }
 
@@ -535,7 +535,7 @@ public class LockingStatementOperations implements
     {
         if ( !state.hasTxStateWithChanges() || !state.txState().nodeIsAddedInThisTx( nodeId ) )
         {
-            state.locks().acquireExclusive( ResourceTypes.NODE, nodeId );
+            state.locks().optimistic().acquireExclusive( ResourceTypes.NODE, nodeId );
         }
     }
 
@@ -543,7 +543,17 @@ public class LockingStatementOperations implements
     {
         if ( !state.hasTxStateWithChanges() || !state.txState().relationshipIsAddedInThisTx( relationshipId ) )
         {
-            state.locks().acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
+            state.locks().optimistic().acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
         }
+    }
+
+    private void acquireSharedSchemaLock( KernelStatement state )
+    {
+        state.locks().optimistic().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+    }
+
+    private void acquireExclusiveSchemaLock( KernelStatement state )
+    {
+        state.locks().optimistic().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
@@ -102,7 +102,7 @@ class TwoPhaseNodeForRelationshipLocking
                 PrimitiveLongIterator iterator = nodeIds.iterator();
                 while ( iterator.hasNext() )
                 {
-                    state.locks().acquireExclusive( ResourceTypes.NODE, iterator.next() );
+                    state.locks().optimistic().acquireExclusive( ResourceTypes.NODE, iterator.next() );
                 }
             }
 
@@ -118,7 +118,7 @@ class TwoPhaseNodeForRelationshipLocking
                         PrimitiveLongIterator iterator = nodeIds.iterator();
                         while ( iterator.hasNext() )
                         {
-                            state.locks().releaseExclusive( ResourceTypes.NODE, iterator.next() );
+                            state.locks().optimistic().releaseExclusive( ResourceTypes.NODE, iterator.next() );
                         }
                         nodeIds.clear();
                         break;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -31,6 +32,8 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.AvailabilityGuard;
@@ -59,6 +62,9 @@ import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocksFactory;
+import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.ProcedureGDSFactory;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -110,12 +116,15 @@ public class DataSourceModule
 
     public final AutoIndexing autoIndexing;
 
+    private final Log log;
+
     public DataSourceModule( final GraphDatabaseFacadeFactory.Dependencies dependencies,
             final PlatformModule platformModule, EditionModule editionModule )
     {
         final org.neo4j.kernel.impl.util.Dependencies deps = platformModule.dependencies;
         Config config = platformModule.config;
         LogService logging = platformModule.logging;
+        this.log = logging.getInternalLog( DataSourceModule.class );
         FileSystemAbstraction fileSystem = platformModule.fileSystem;
         DataSourceManager dataSourceManager = platformModule.dataSourceManager;
         LifeSupport life = platformModule.life;
@@ -174,6 +183,9 @@ public class DataSourceModule
                 editionModule.labelTokenHolder,
                 editionModule.relationshipTypeTokenHolder,
                 editionModule.propertyKeyTokenHolder );
+
+        StatementLocksFactory locksFactory = createStatementLocksFactory( editionModule.lockManager, config, log );
+
         neoStoreDataSource = deps.satisfyDependency( new NeoStoreDataSource(
                 storeDir,
                 config,
@@ -187,7 +199,7 @@ public class DataSourceModule
                 editionModule.propertyKeyTokenHolder,
                 editionModule.labelTokenHolder,
                 relationshipTypeTokenHolder,
-                editionModule.lockManager,
+                locksFactory,
                 schemaWriteGuard,
                 transactionEventHandlers,
                 platformModule.monitors.newMonitor( IndexingService.Monitor.class ),
@@ -378,6 +390,37 @@ public class DataSourceModule
         procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade );
 
         return procedures;
+    }
+
+    private static StatementLocksFactory createStatementLocksFactory( Locks locks, Config config, Log log )
+    {
+        StatementLocksFactory statementLocksFactory;
+
+        String serviceName = StatementLocksFactory.class.getSimpleName();
+        List<StatementLocksFactory> factories = Iterables.asList( Service.load( StatementLocksFactory.class ) );
+        if ( factories.isEmpty() )
+        {
+            statementLocksFactory = new SimpleStatementLocksFactory();
+
+            log.info( "No services implementing " + serviceName + " found. " +
+                      "Using " + SimpleStatementLocksFactory.class.getSimpleName() );
+        }
+        else if ( factories.size() == 1 )
+        {
+            statementLocksFactory = factories.get( 0 );
+
+            log.info( "Found single implementation of " + serviceName +
+                      ". Namely " + statementLocksFactory.getClass().getSimpleName() );
+        }
+        else
+        {
+            throw new IllegalStateException(
+                    "Found more than one implementation of " + serviceName + ": " + factories );
+        }
+
+        statementLocksFactory.initialize( locks, config );
+
+        return statementLocksFactory;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -74,16 +74,15 @@ public interface Locks
         /**
          * Can be grabbed when there are no locks or only share locks on a resource. If the lock cannot be acquired,
          * behavior is specified by the {@link WaitStrategy} for the given {@link ResourceType}.
+         *
+         * @param resourceType type or resource(s) to lock.
+         * @param resourceIds id(s) of resources to lock. Multiple ids should be ordered consistently by all callers
+         * of this method.
          */
-        void acquireShared( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException;
+        void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
-        /**
-         * Can be grabbed when no other client holds locks on the relevant resources. No other clients can hold locks
-         * while one client holds an exclusive lock. If the lock cannot be acquired,
-         * behavior is specified by the {@link WaitStrategy} for the given {@link ResourceType}.
-         */
         @Override
-        void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException;
+        void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
         /** Try grabbing exclusive lock, not waiting and returning a boolean indicating if we got the lock. */
         boolean tryExclusiveLock( ResourceType resourceType, long resourceId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -25,12 +25,12 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 public class NoOpClient implements Locks.Client
 {
     @Override
-    public void acquireShared( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+    public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+/**
+ * A {@link StatementLocks} implementation that uses given {@link Locks.Client} for both
+ * {@link #optimistic() optimistic} and {@link #pessimistic() pessimistic} locks.
+ */
+public class SimpleStatementLocks implements StatementLocks
+{
+    private final Locks.Client client;
+
+    public SimpleStatementLocks( Locks.Client client )
+    {
+        this.client = client;
+    }
+
+    @Override
+    public Locks.Client pessimistic()
+    {
+        return client;
+    }
+
+    @Override
+    public Locks.Client optimistic()
+    {
+        return client;
+    }
+
+    @Override
+    public void prepareForCommit()
+    {
+        // Locks where grabbed eagerly by client so no need to prepare
+    }
+
+    @Override
+    public void stop()
+    {
+        client.stop();
+    }
+
+    @Override
+    public void close()
+    {
+        client.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocksFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocksFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.kernel.configuration.Config;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link StatementLocksFactory} that creates {@link SimpleStatementLocks}.
+ */
+public class SimpleStatementLocksFactory implements StatementLocksFactory
+{
+    private Locks locks;
+
+    public SimpleStatementLocksFactory()
+    {
+    }
+
+    /**
+     * Creates a new factory initialized with given {@code locks}.
+     * <b>Note:</b> should be used for tests only.
+     *
+     * @param locks the locks to use.
+     */
+    public SimpleStatementLocksFactory( Locks locks )
+    {
+        initialize( locks, null );
+    }
+
+    @Override
+    public void initialize( Locks locks, Config config )
+    {
+        this.locks = requireNonNull( locks );
+    }
+
+    @Override
+    public StatementLocks newInstance()
+    {
+        if ( locks == null )
+        {
+            throw new IllegalStateException( "Factory has not been initialized" );
+        }
+
+        return new SimpleStatementLocks( locks.newClient() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.kernel.impl.api.KernelStatement;
+
+/**
+ * Component used by {@link KernelStatement} to acquire {@link #pessimistic() pessimistic} and
+ * {@link #optimistic() optimistic} locks.
+ */
+public interface StatementLocks extends AutoCloseable
+{
+    /**
+     * Get {@link Locks.Client} responsible for pessimistic locks. Such locks will be grabbed right away.
+     *
+     * @return the locks client to serve pessimistic locks.
+     */
+    Locks.Client pessimistic();
+
+    /**
+     * Get {@link Locks.Client} responsible for optimistic locks. Such locks could potentially be grabbed later at
+     * commit time.
+     *
+     * @return the locks client to serve optimistic locks.
+     */
+    Locks.Client optimistic();
+
+    /**
+     * Prepare the underlying {@link Locks.Client client}(s) for commit. This will grab all locks that have
+     * previously been taken {@link #optimistic() optimistically}.
+     */
+    void prepareForCommit();
+
+    /**
+     * Stop the underlying {@link Locks.Client client}(s).
+     */
+    void stop();
+
+    /**
+     * Close the underlying {@link Locks.Client client}(s).
+     */
+    @Override
+    void close();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocksFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocksFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.kernel.configuration.Config;
+
+/**
+ * Factory to create {@link StatementLocks} instances.
+ */
+public interface StatementLocksFactory
+{
+    /**
+     * Initialize this factory with the given {@code locks} and {@code config}. Callers should ensure this method
+     * is called once during database startup.
+     *
+     * @param locks the locks to use.
+     * @param config the database config that can contain settings interesting for factory implementations.
+     */
+    void initialize( Locks locks, Config config );
+
+    /**
+     * Create new {@link StatementLocks} instance.
+     *
+     * @return new statement locks.
+     */
+    StatementLocks newInstance();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -88,27 +88,30 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( ResourceType resourceType, long resourceId )
+    public void acquireShared( ResourceType resourceType, long...resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try
         {
             PrimitiveLongObjectMap<LockResource> localLocks = localShared( resourceType );
-            LockResource resource = localLocks.get( resourceId );
-            if ( resource != null )
+            for ( long resourceId : resourceIds )
             {
-                resource.acquireReference();
-            }
-            else
-            {
-                resource = new LockResource( resourceType, resourceId );
-                if ( manager.getReadLock( resource, lockTransaction ) )
+                LockResource resource = localLocks.get( resourceId );
+                if ( resource != null )
                 {
-                    localLocks.put( resourceId, resource );
+                    resource.acquireReference();
                 }
                 else
                 {
-                    throw new LockClientStoppedException( this );
+                    resource = new LockResource( resourceType, resourceId );
+                    if ( manager.getReadLock( resource, lockTransaction ) )
+                    {
+                        localLocks.put( resourceId, resource );
+                    }
+                    else
+                    {
+                        throw new LockClientStoppedException( this );
+                    }
                 }
             }
         }
@@ -119,27 +122,30 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long resourceId )
+    public void acquireExclusive( ResourceType resourceType, long...resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try
         {
             PrimitiveLongObjectMap<LockResource> localLocks = localExclusive( resourceType );
-            LockResource resource = localLocks.get( resourceId );
-            if ( resource != null )
+            for ( long resourceId : resourceIds )
             {
-                resource.acquireReference();
-            }
-            else
-            {
-                resource = new LockResource( resourceType, resourceId );
-                if ( manager.getWriteLock( resource, lockTransaction ) )
+                LockResource resource = localLocks.get( resourceId );
+                if ( resource != null )
                 {
-                    localLocks.put( resourceId, resource );
+                    resource.acquireReference();
                 }
                 else
                 {
-                    throw new LockClientStoppedException( this );
+                    resource = new LockResource( resourceType, resourceId );
+                    if ( manager.getWriteLock( resource, lockTransaction ) )
+                    {
+                        localLocks.put( resourceId, resource );
+                    }
+                    else
+                    {
+                        throw new LockClientStoppedException( this );
+                    }
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
@@ -53,53 +53,134 @@ public class PropertyCreator
         this.traverser = traverser;
     }
 
-    public <P extends PrimitiveRecord> void primitiveChangeProperty(
+    public <P extends PrimitiveRecord> void primitiveSetProperty(
             RecordProxy<Long, P, Void> primitiveRecordChange, int propertyKey, Object value,
             RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
     {
+        PropertyBlock block = encodePropertyValue( propertyKey, value );
         P primitive = primitiveRecordChange.forReadingLinkage();
         assert traverser.assertPropertyChain( primitive, propertyRecords );
-        long propertyId = // propertyData.getId();
-                traverser.findPropertyRecordContaining( primitive, propertyKey, propertyRecords, true );
-        PropertyRecord propertyRecord = propertyRecords.getOrLoad( propertyId, primitive ).forChangingData();
-        if ( !propertyRecord.inUse() )
+        int newBlockSizeInBytes = block.getSize();
+
+        // Traverse the existing property chain. Tracking two things along the way:
+        // - (a) Free space for this block (candidateHost)
+        // - (b) Existence of a block with the property key
+        // Chain traversal can be aborted only if:
+        // - (1) (b) occurs and new property block fits where the current is
+        // - (2) (a) occurs and (b) has occurred, but new property block didn't fit
+        // - (3) (b) occurs and (a) has occurred
+        // - (4) Chain ends
+        RecordProxy<Long, PropertyRecord, PrimitiveRecord> freeHostProxy = null;
+        RecordProxy<Long, PropertyRecord, PrimitiveRecord> existingHostProxy = null;
+        long prop = primitive.getNextProp();
+        while ( prop != Record.NO_NEXT_PROPERTY.intValue() ) // <-- (4)
         {
-            throw new IllegalStateException( "Unable to change property["
-                                             + propertyId
-                                             + "] since it has been deleted." );
+            RecordProxy<Long, PropertyRecord, PrimitiveRecord> proxy =
+                    propertyRecords.getOrLoad( prop, primitive );
+            PropertyRecord propRecord = proxy.forReadingLinkage();
+            assert propRecord.inUse() : propRecord;
+
+            // (a) search for free space
+            if ( propertyFitsInside( newBlockSizeInBytes, propRecord ) )
+            {
+                freeHostProxy = proxy;
+                if ( existingHostProxy != null )
+                {
+                    // (2)
+                    PropertyRecord freeHost = proxy.forChangingData();
+                    freeHost.addPropertyBlock( block );
+                    freeHost.setChanged( primitive );
+                    assert traverser.assertPropertyChain( primitive, propertyRecords );
+                    return;
+                }
+            }
+
+            // (b) search for existence of property key
+            PropertyBlock existingBlock = propRecord.getPropertyBlock( propertyKey );
+            if ( existingBlock != null )
+            {
+                // We found an existing property and whatever happens we have to remove the existing
+                // block so that we can add the new one, where ever we decide to place it
+                existingHostProxy = proxy;
+                PropertyRecord existingHost = existingHostProxy.forChangingData();
+                removeProperty( primitive, existingHost, existingBlock );
+
+                // Now see if we at this point can add the new block
+                if ( newBlockSizeInBytes <= existingBlock.getSize() || // cheap check
+                     propertyFitsInside( newBlockSizeInBytes, existingHost ) ) // fallback check
+                {
+                    // (1) yes we could add it right into the host of the existing block
+                    existingHost.addPropertyBlock( block );
+                    assert traverser.assertPropertyChain( primitive, propertyRecords );
+                    return;
+                }
+                else if ( freeHostProxy != null )
+                {
+                    // (3) yes we could add it to a previously found host with sufficiently free space in it
+                    PropertyRecord freeHost = freeHostProxy.forChangingData();
+                    freeHost.addPropertyBlock( block );
+                    freeHost.setChanged( primitive );
+                    assert traverser.assertPropertyChain( primitive, propertyRecords );
+                    return;
+                }
+                // else we can't add it at this point
+            }
+
+            // Continue down the chain
+            prop = propRecord.getNextProp();
         }
-        PropertyBlock block = propertyRecord.getPropertyBlock( propertyKey );
-        if ( block == null )
+
+        // At this point we haven't added the property block, although we may have found room for it
+        // along the way. If we didn't then just create a new record, it's fine
+        PropertyRecord freeHost = null;
+        if ( freeHostProxy == null )
         {
-            throw new IllegalStateException( "Property with index["
-                                             + propertyKey
-                                             + "] is not present in property["
-                                             + propertyId + "]" );
+            // We couldn't find free space along the way, so create a new host record
+            freeHost = propertyRecords.create( propertyRecordIdGenerator.nextId(), primitive ).forChangingData();
+            freeHost.setInUse( true );
+            if ( primitive.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
+            {
+                // This isn't the first property record for the entity, re-shuffle the first one so that
+                // the new one becomes the first
+                PropertyRecord prevProp = propertyRecords.getOrLoad( primitive.getNextProp(),
+                        primitive ).forChangingLinkage();
+                assert prevProp.getPrevProp() == Record.NO_PREVIOUS_PROPERTY.intValue();
+                prevProp.setPrevProp( freeHost.getId() );
+                freeHost.setNextProp( prevProp.getId() );
+                prevProp.setChanged( primitive );
+            }
+
+            // By the way, this is the only condition where the primitive record also needs to change
+            primitiveRecordChange.forChangingLinkage().setNextProp( freeHost.getId() );
         }
-        propertyRecord.setChanged( primitive );
+        else
+        {
+            freeHost = freeHostProxy.forChangingData();
+        }
+
+        // At this point we know that we have a host record with sufficient space in it for the block
+        // to add, so simply add it
+        freeHost.addPropertyBlock( block );
+        assert traverser.assertPropertyChain( primitive, propertyRecords );
+    }
+
+    private void removeProperty( PrimitiveRecord primitive, PropertyRecord host, PropertyBlock block )
+    {
+        host.removePropertyBlock( block.getKeyIndexId() );
+        host.setChanged( primitive );
         for ( DynamicRecord record : block.getValueRecords() )
         {
             assert record.inUse();
             record.setInUse( false, block.getType().intValue() );
-            propertyRecord.addDeletedRecord( record );
+            host.addDeletedRecord( record );
         }
-        encodeValue( block, propertyKey, value );
-        if ( propertyRecord.size() > PropertyType.getPayloadSize() )
-        {
-            propertyRecord.removePropertyBlock( propertyKey );
-            /*
-             * The record should never, ever be above max size. Less obviously, it should
-             * never remain empty. If removing a property because it won't fit when changing
-             * it leaves the record empty it means that this block was the last one which
-             * means that it doesn't fit in an empty record. Where i come from, we call this
-             * weird.
-             *
-             assert propertyRecord.size() <= PropertyType.getPayloadSize() : propertyRecord;
-             assert propertyRecord.size() > 0 : propertyRecord;
-             */
-            addPropertyBlockToPrimitive( block, primitiveRecordChange, propertyRecords );
-        }
-        assert traverser.assertPropertyChain( primitive, propertyRecords );
+    }
+
+    private boolean propertyFitsInside( int newBlockSizeInBytes, PropertyRecord propRecord )
+    {
+        int propSize = propRecord.size();
+        assert propSize >= 0 : propRecord;
+        return propSize + newBlockSizeInBytes <= PropertyType.getPayloadSize();
     }
 
     public PropertyBlock encodePropertyValue( int propertyKey, Object value )
@@ -111,70 +192,6 @@ public class PropertyCreator
     {
         PropertyStore.encodeValue( block, propertyKey, value, stringRecordAllocator, arrayRecordAllocator );
         return block;
-    }
-
-    public <P extends PrimitiveRecord> void primitiveAddProperty(
-            RecordProxy<Long, P, Void> primitive, int propertyKey, Object value,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
-    {
-        P record = primitive.forReadingLinkage();
-        assert traverser.assertPropertyChain( record, propertyRecords );
-        PropertyBlock block = new PropertyBlock();
-        encodeValue( block, propertyKey, value );
-        addPropertyBlockToPrimitive( block, primitive, propertyRecords );
-        assert traverser.assertPropertyChain( record, propertyRecords );
-    }
-
-    private <P extends PrimitiveRecord> void addPropertyBlockToPrimitive(
-            PropertyBlock block, RecordProxy<Long, P, Void> primitiveRecordChange,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
-    {
-        P primitive = primitiveRecordChange.forReadingLinkage();
-        assert traverser.assertPropertyChain( primitive, propertyRecords );
-        int newBlockSizeInBytes = block.getSize();
-
-        // Scan the property record chain for a place to fit this property block
-        PropertyRecord host = null;
-        long prop = primitive.getNextProp();
-        while ( prop != Record.NO_NEXT_PROPERTY.intValue() )
-        {
-            // We do not store in map - might not have enough space
-            RecordProxy<Long, PropertyRecord, PrimitiveRecord> change =
-                    propertyRecords.getOrLoad( prop, primitive );
-            PropertyRecord propRecord = change.forReadingLinkage();
-            assert propRecord.inUse() : propRecord;
-            int propSize = propRecord.size();
-            assert propSize > 0 : propRecord;
-            if ( propSize + newBlockSizeInBytes <= PropertyType.getPayloadSize() )
-            {
-                propRecord = change.forChangingData();
-                host = propRecord;
-                host.addPropertyBlock( block );
-                host.setChanged( primitive );
-                break;
-            }
-            prop = propRecord.getNextProp();
-        }
-
-        if ( host == null )
-        {
-            // There was no room for the propery block in any record in the chain, make new one
-            host = propertyRecords.create( propertyRecordIdGenerator.nextId(), primitive ).forChangingData();
-            if ( primitive.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
-            {
-                PropertyRecord prevProp = propertyRecords.getOrLoad( primitive.getNextProp(),
-                        primitive ).forChangingLinkage();
-                assert prevProp.getPrevProp() == Record.NO_PREVIOUS_PROPERTY.intValue();
-                prevProp.setPrevProp( host.getId() );
-                host.setNextProp( prevProp.getId() );
-                prevProp.setChanged( primitive );
-            }
-            primitiveRecordChange.forChangingLinkage().setNextProp( host.getId() );
-            host.addPropertyBlock( block );
-            host.setInUse( true );
-        }
-        // Ok, here host does for the job. Use it
-        assert traverser.assertPropertyChain( primitive, propertyRecords );
     }
 
     public long createPropertyChain( PrimitiveRecord owner, Iterator<PropertyBlock> properties,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
@@ -81,6 +82,7 @@ public class PropertyTraverser
             toCheck.add( propRecord );
             assert propRecord.inUse() : primitive + "->"
                                         + Arrays.toString( toCheck.toArray() );
+            assert propRecord.size() <= PropertyType.getPayloadSize() : propRecord + " size " + propRecord.size();
             nextIdToFetch = propRecord.getNextProp();
         }
         if ( toCheck.isEmpty() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -376,7 +376,7 @@ public class TransactionRecordState implements RecordState
     public DefinedProperty relChangeProperty( long relId, int propertyKey, Object value )
     {
         RecordProxy<Long, RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
-        propertyCreator.primitiveChangeProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
+        propertyCreator.primitiveSetProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }
 
@@ -392,7 +392,7 @@ public class TransactionRecordState implements RecordState
     public DefinedProperty nodeChangeProperty( long nodeId, int propertyKey, Object value )
     {
         RecordProxy<Long, NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
-        propertyCreator.primitiveChangeProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
+        propertyCreator.primitiveSetProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }
 
@@ -408,7 +408,7 @@ public class TransactionRecordState implements RecordState
     public DefinedProperty relAddProperty( long relId, int propertyKey, Object value )
     {
         RecordProxy<Long, RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
-        propertyCreator.primitiveAddProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
+        propertyCreator.primitiveSetProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }
 
@@ -423,7 +423,7 @@ public class TransactionRecordState implements RecordState
     public DefinedProperty nodeAddProperty( long nodeId, int propertyKey, Object value )
     {
         RecordProxy<Long, NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
-        propertyCreator.primitiveAddProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
+        propertyCreator.primitiveSetProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }
 
@@ -559,7 +559,7 @@ public class TransactionRecordState implements RecordState
      */
     public DefinedProperty graphAddProperty( int propertyKey, Object value )
     {
-        propertyCreator.primitiveAddProperty( getOrLoadNeoStoreRecord(), propertyKey, value,
+        propertyCreator.primitiveSetProperty( getOrLoadNeoStoreRecord(), propertyKey, value,
                 recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }
@@ -574,7 +574,7 @@ public class TransactionRecordState implements RecordState
      */
     public DefinedProperty graphChangeProperty( int propertyKey, Object value )
     {
-        propertyCreator.primitiveChangeProperty( getOrLoadNeoStoreRecord(), propertyKey, value,
+        propertyCreator.primitiveSetProperty( getOrLoadNeoStoreRecord(), propertyKey, value,
                 recordChangeSet.getPropertyRecords() );
         return Property.property( propertyKey, value );
     }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
@@ -19,22 +19,24 @@
  */
 package org.neo4j.storageengine.api.lock;
 
+import java.util.Arrays;
+
 public interface ResourceLocker
 {
     /**
      * Can be grabbed when no other client holds locks on the relevant resources. No other clients can hold locks
      * while one client holds an exclusive lock. If the lock cannot be acquired,
      * behavior is specified by the {@link WaitStrategy} for the given {@link ResourceType}.
+     *
+     * @param resourceType type or resource(s) to lock.
+     * @param resourceIds id(s) of resources to lock. Multiple ids should be ordered consistently by all callers
+     * of this method.
      */
-    void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException;
+    void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
-    ResourceLocker NONE = new ResourceLocker()
+    ResourceLocker NONE = ( resourceType, resourceIds ) ->
     {
-        @Override
-        public void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
-        {
-            throw new UnsupportedOperationException( "Unexpected call to lock a resource " + resourceType +
-                    " " + resourceId );
-        }
+        throw new UnsupportedOperationException(
+                "Unexpected call to lock a resource " + resourceType + " " + Arrays.toString( resourceIds ) );
     };
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -372,24 +372,13 @@ public class BatchInserterImpl implements BatchInserter
         return new IndexCreatorImpl( actions, label );
     }
 
-    private void removePropertyIfExist( RecordProxy<Long, ? extends PrimitiveRecord,Void> recordProxy,
-            int propertyKey, RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords )
-    {
-        if ( propertyTraverser.findPropertyRecordContaining( recordProxy.forReadingData(),
-                propertyKey, propertyRecords, false ) != Record.NO_NEXT_PROPERTY.intValue() )
-        {
-            propertyDeletor.removeProperty( recordProxy, propertyKey, propertyRecords );
-        }
-    }
-
     private void setPrimitiveProperty( RecordProxy<Long,? extends PrimitiveRecord,Void> primitiveRecord,
             String propertyName, Object propertyValue )
     {
         int propertyKey = getOrCreatePropertyKeyId( propertyName );
         RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords = recordAccess.getPropertyRecords();
 
-        removePropertyIfExist( primitiveRecord, propertyKey, propertyRecords );
-        propertyCreator.primitiveAddProperty( primitiveRecord, propertyKey, propertyValue, propertyRecords );
+        propertyCreator.primitiveSetProperty( primitiveRecord, propertyKey, propertyValue, propertyRecords );
     }
 
     private void validateIndexCanBeCreated( int labelId, int propertyKeyId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -32,6 +32,8 @@ import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
+import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -86,7 +88,9 @@ public class KernelTransactionFactory
                 TransactionTracer.NULL,
                 storageEngine, false );
 
-        transaction.initialize( 0, 0, new NoOpClient(), KernelTransaction.Type.implicit, accessMode );
+        StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
+
+        transaction.initialize( 0, 0, statementLocks, KernelTransaction.Type.implicit, accessMode );
 
         return new Instances( transaction, storageEngine, storeReadLayer, storageStatement );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.storageengine.api.StorageCommand;
@@ -374,8 +375,8 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         try ( KernelTransactionImplementation transaction = newTransaction( accessMode() ) )
         {
-            transaction.initialize( 5L, BASE_TX_COMMIT_TIMESTAMP, mock( Locks.Client.class ),
-                    KernelTransaction.Type.implicit,
+            SimpleStatementLocks statementLocks = new SimpleStatementLocks( mock( Locks.Client.class ) );
+            transaction.initialize( 5L, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
                     AccessMode.Static.FULL );
             try ( KernelStatement statement = transaction.acquireStatement() )
             {
@@ -435,7 +436,8 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         // WHEN
         transaction.close();
-        transaction.initialize( 1, BASE_TX_COMMIT_TIMESTAMP, new NoOpClient(), KernelTransaction.Type.implicit,
+        SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
+        transaction.initialize( 1, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
                 accessMode() );
 
         // THEN
@@ -602,7 +604,8 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         initializeAndClose( tx, reuseCount );
 
         Locks.Client locksClient = mock( Locks.Client.class );
-        tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
+        SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, accessMode() );
 
         tx.markForTermination( reuseCount, terminationReason );
 
@@ -621,7 +624,8 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         initializeAndClose( tx, reuseCount );
 
         Locks.Client locksClient = mock( Locks.Client.class );
-        tx.initialize( 42, 42, locksClient, KernelTransaction.Type.implicit, accessMode() );
+        SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, accessMode() );
 
         tx.markForTermination( nextReuseCount, terminationReason );
 
@@ -633,7 +637,8 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     {
         for ( int i = 0; i < times; i++ )
         {
-            tx.initialize( i + 10, i + 10, new NoOpClient(), KernelTransaction.Type.implicit, accessMode() );
+            SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
+            tx.initialize( i + 10, i + 10, statementLocks, KernelTransaction.Type.implicit, accessMode() );
             tx.close();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -372,7 +373,7 @@ public class KernelTransactionTerminationTest
 
         TestKernelTransaction initialize()
         {
-            initialize( 42, 42, new NoOpClient(), Type.implicit, AccessMode.Static.FULL );
+            initialize( 42, 42, new SimpleStatementLocks( new NoOpClient() ), Type.implicit, AccessMode.Static.FULL );
             monitor.reset();
             return this;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -32,6 +32,8 @@ import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
+import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -95,7 +97,9 @@ public class KernelTransactionTestBase
             Locks.Client locks, boolean txTerminationAwareLocks )
     {
         KernelTransactionImplementation tx = newNotInitializedTransaction( txTerminationAwareLocks );
-        tx.initialize( lastTransactionIdWhenStarted, BASE_TX_COMMIT_TIMESTAMP,locks, Type.implicit, accessMode );
+        StatementLocks statementLocks = new SimpleStatementLocks( locks );
+        tx.initialize( lastTransactionIdWhenStarted, BASE_TX_COMMIT_TIMESTAMP, statementLocks, Type.implicit,
+                accessMode );
         return tx;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -43,6 +43,8 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocksFactory;
+import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.TransactionId;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -435,15 +437,18 @@ public class KernelTransactionsTest
         when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new TransactionId( 0, 0, 0 ) );
 
         Tracers tracers = new Tracers( "null", NullLog.getInstance(), new Monitors(), mock( JobScheduler.class ) );
+        StatementLocksFactory statementLocksFactory = new SimpleStatementLocksFactory( locks );
 
         if ( testKernelTransactions )
         {
-            return new TestKernelTransactions( locks, null, null, null, TransactionHeaderInformationFactory.DEFAULT,
+            return new TestKernelTransactions( statementLocksFactory, null, null, null,
+                    TransactionHeaderInformationFactory.DEFAULT,
                     commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
                     tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(),
                     Clock.SYSTEM_CLOCK );
         }
-        return new KernelTransactions( locks, null, null, null, TransactionHeaderInformationFactory.DEFAULT,
+        return new KernelTransactions( statementLocksFactory, null, null, null,
+                TransactionHeaderInformationFactory.DEFAULT,
                 commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
                 tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(), Clock.SYSTEM_CLOCK );
     }
@@ -515,7 +520,7 @@ public class KernelTransactionsTest
 
     private static class TestKernelTransactions extends KernelTransactions
     {
-        TestKernelTransactions( Locks locks,
+        TestKernelTransactions( StatementLocksFactory statementLocksFactory,
                 ConstraintIndexCreator constraintIndexCreator,
                 StatementOperationParts statementOperations, SchemaWriteGuard schemaWriteGuard,
                 TransactionHeaderInformationFactory txHeaderFactory,
@@ -526,9 +531,10 @@ public class KernelTransactionsTest
                 Tracers tracers, StorageEngine storageEngine, Procedures procedures,
                 TransactionIdStore transactionIdStore, Config config, Clock clock )
         {
-            super( locks, constraintIndexCreator, statementOperations, schemaWriteGuard, txHeaderFactory,
-                    transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor,
-                    dataSourceLife, tracers, storageEngine, procedures, transactionIdStore, config, clock );
+            super( statementLocksFactory, constraintIndexCreator, statementOperations, schemaWriteGuard,
+                    txHeaderFactory, transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks,
+                    transactionMonitor, dataSourceLife, tracers, storageEngine, procedures, transactionIdStore,
+                    config, clock );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -86,7 +87,7 @@ public class LockingStatementOperationsTest
         lockingOps = new LockingStatementOperations(
                 entityReadOps, entityWriteOps, schemaReadOps, schemaWriteOps, schemaStateOps
         );
-        state.initialize( locks );
+        state.initialize( new SimpleStatementLocks( locks ) );
         state.acquire();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.storageengine.api.StorageStatement;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
@@ -72,7 +73,7 @@ public abstract class StatementOperationsTestHelper
     public static KernelStatement mockedState( final TransactionState txState )
     {
         KernelStatement state = mock( KernelStatement.class );
-        Locks.Client lockHolder = mock( Locks.Client.class );
+        Locks.Client locks = mock( Locks.Client.class );
         try
         {
             IndexReader indexReader = mock( IndexReader.class );
@@ -93,7 +94,7 @@ public abstract class StatementOperationsTestHelper
                 return txState.hasChanges();
             }
         } );
-        when( state.locks() ).thenReturn( lockHolder );
+        when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
         when( state.readOperations() ).thenReturn( mock( ReadOperations.class ) );
         return state;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.storageengine.api.Direction;
 import org.neo4j.storageengine.api.NodeItem;
 
@@ -48,7 +49,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.Iterators.set;
 
 public class TwoPhaseNodeForRelationshipLockingTest
@@ -59,7 +59,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
     private final long nodeId = 42L;
 
     {
-        when( state.locks() ).thenReturn( locks );
+        when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.impl.api.ConstraintEnforcingEntityOperations;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -59,7 +60,7 @@ public class ConstraintEnforcingEntityOperationsTest
         this.state = mock( KernelStatement.class );
         when( schemaReadOps.indexGetState( state, indexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
         this.locks = mock( Locks.Client.class );
-        when( state.locks() ).thenReturn( locks );
+        when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
 
         this.ops = new ConstraintEnforcingEntityOperations( new StandardConstraintSemantics(), null, readOps, schemaWriteOps, schemaReadOps );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.state;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.PropertyType;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess.Loader;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
+import org.neo4j.unsafe.batchinsert.DirectRecordAccess;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingIdSequence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class PropertyCreatorTest
+{
+    private final IdSequence idGenerator = new BatchingIdSequence();
+    private final PropertyCreator creator = new PropertyCreator( null, null, idGenerator, new PropertyTraverser() );
+
+    // The RecordAccess will take on the role of both store and tx state and the PropertyCreator
+    // will know no difference
+    @SuppressWarnings( "unchecked" )
+    private final RecordAccess<Long,PropertyRecord,PrimitiveRecord> records =
+            new DirectRecordAccess<>( mock( RecordStore.class ), new PropertyRecordLoader() );
+    private final MyPrimitiveProxy primitive = new MyPrimitiveProxy();
+
+    @Test
+    public void shouldAddPropertyToEmptyChain() throws Exception
+    {
+        // GIVEN
+        existingChain();
+
+        // WHEN
+        setProperty( 1, "value" );
+
+        // THEN
+        assertChain( record( property( 1, "value" ) ) );
+    }
+
+    @Test
+    public void shouldAddPropertyToChainContainingOtherFullRecords() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ), property( 6, 6 ), property( 7, 7 ) ) );
+
+        // WHEN
+        setProperty( 10, 10 );
+
+        // THEN
+        assertChain(
+                record( property( 10, 10 ) ),
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ), property( 6, 6 ), property( 7, 7 ) ) );
+    }
+
+    @Test
+    public void shouldAddPropertyToChainContainingOtherNonFullRecords() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ), property( 6, 6 ) ) );
+
+        // WHEN
+        setProperty( 10, 10 );
+
+        // THEN
+        assertChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ), property( 6, 6 ), property( 10, 10 ) ) );
+    }
+
+    @Test
+    public void shouldAddPropertyToChainContainingOtherNonFullRecordsInMiddle() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ) ),
+                record( property( 3, 3 ), property( 4, 4 ), property( 5, 5 ), property( 6, 6 ) ) );
+
+        // WHEN
+        setProperty( 10, 10 );
+
+        // THEN
+        assertChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 10, 10 ) ),
+                record( property( 3, 3 ), property( 4, 4 ), property( 5, 5 ), property( 6, 6 ) ) );
+    }
+
+    @Test
+    public void shouldChangeOnlyProperty() throws Exception
+    {
+        // GIVEN
+        existingChain( record( property( 0, "one" ) ) );
+
+        // WHEN
+        setProperty( 0, "two" );
+
+        // THEN
+        assertChain( record( property( 0, "two" ) ) );
+    }
+
+    @Test
+    public void shouldChangePropertyInChainWithOthersBeforeIt() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, "one" ), property( 1, 1 ) ),
+                record( property( 2, "two" ), property( 3, 3 ) ) );
+
+        // WHEN
+        setProperty( 2, "two*" );
+
+        // THEN
+        assertChain(
+                record( property( 0, "one" ), property( 1, 1 ) ),
+                record( property( 2, "two*" ), property( 3, 3 ) ) );
+    }
+
+    @Test
+    public void shouldChangePropertyInChainWithOthersAfterIt() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, "one" ), property( 1, 1 ) ),
+                record( property( 2, "two" ), property( 3, 3 ) ) );
+
+        // WHEN
+        setProperty( 0, "one*" );
+
+        // THEN
+        assertChain(
+                record( property( 0, "one*" ), property( 1, 1 ) ),
+                record( property( 2, "two" ), property( 3, 3 ) ) );
+    }
+
+    @Test
+    public void shouldChangePropertyToBiggerInFullChain() throws Exception
+    {
+        // GIVEN
+        existingChain( record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ) );
+
+        // WHEN
+        setProperty( 1, Long.MAX_VALUE );
+
+        // THEN
+        assertChain(
+                record( property( 1, Long.MAX_VALUE ) ),
+                record( property( 0, 0 ), property( 2, 2 ), property( 3, 3 ) ) );
+    }
+
+    @Test
+    public void shouldChangePropertyToBiggerInChainWithHoleAfter() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ) ) );
+
+        // WHEN
+        setProperty( 1, Long.MAX_VALUE );
+
+        // THEN
+        assertChain(
+                record( property( 0, 0 ), property( 2, 2 ), property( 3, 3 ) ),
+                record( property( 4, 4 ), property( 5, 5 ), property( 1, Long.MAX_VALUE ) ) );
+    }
+
+    // change property so that it gets bigger and fits in a record earlier in the chain
+    @Test
+    public void shouldChangePropertyToBiggerInChainWithHoleBefore() throws Exception
+    {
+        // GIVEN
+        existingChain(
+                record( property( 0, 0 ), property( 1, 1 ) ),
+                record( property( 2, 2 ), property( 3, 3 ), property( 4, 4 ), property( 5, 5 ) ) );
+
+        // WHEN
+        setProperty( 2, Long.MAX_VALUE );
+
+        // THEN
+        assertChain(
+                record( property( 0, 0 ), property( 1, 1 ), property( 2, Long.MAX_VALUE ) ),
+                record( property( 3, 3 ), property( 4, 4 ), property( 5, 5 ) ) );
+    }
+
+    private void existingChain( ExpectedRecord... initialRecords )
+    {
+        PropertyRecord prev = null;
+        for ( ExpectedRecord initialRecord : initialRecords )
+        {
+            PropertyRecord record = this.records.create( idGenerator.nextId(), primitive.record ).forChangingData();
+            record.setInUse( true );
+            existingRecord( record, initialRecord );
+
+            if ( prev == null )
+            {
+                // This is the first one, update primitive to point to this
+                primitive.record.setNextProp( record.getId() );
+            }
+            else
+            {
+                // link property records together
+                record.setPrevProp( prev.getId() );
+                prev.setNextProp( record.getId() );
+            }
+
+
+            prev = record;
+        }
+    }
+
+    private void existingRecord( PropertyRecord record, ExpectedRecord initialRecord )
+    {
+        for ( ExpectedProperty initialProperty : initialRecord.properties )
+        {
+            PropertyBlock block = new PropertyBlock();
+            PropertyStore.encodeValue( block, initialProperty.key, initialProperty.value, null, null );
+            record.addPropertyBlock( block );
+        }
+        assertTrue( record.size() <= PropertyType.getPayloadSize() );
+    }
+
+    private void setProperty( int key, Object value )
+    {
+        creator.primitiveSetProperty( primitive, key, value, records );
+    }
+
+    private void assertChain( ExpectedRecord... expectedRecords )
+    {
+        long nextProp = primitive.forReadingLinkage().getNextProp();
+        int expectedRecordCursor = 0;
+        while ( !Record.NO_NEXT_PROPERTY.is( nextProp ) )
+        {
+            PropertyRecord record = records.getIfLoaded( nextProp ).forReadingData();
+            assertRecord( record, expectedRecords[expectedRecordCursor++] );
+            nextProp = record.getNextProp();
+        }
+    }
+
+    private void assertRecord( PropertyRecord record, ExpectedRecord expectedRecord )
+    {
+        assertEquals( expectedRecord.properties.length, record.numberOfProperties() );
+        for ( ExpectedProperty expectedProperty : expectedRecord.properties )
+        {
+            PropertyBlock block = record.getPropertyBlock( expectedProperty.key );
+            assertNotNull( block );
+            assertEquals( expectedProperty.value, block.getType().getValue( block, null ) );
+        }
+    }
+
+    private static class ExpectedProperty
+    {
+        private final int key;
+        private final Object value;
+
+        ExpectedProperty( int key, Object value )
+        {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private static class ExpectedRecord
+    {
+        private final ExpectedProperty[] properties;
+
+        ExpectedRecord( ExpectedProperty... properties )
+        {
+            this.properties = properties;
+        }
+    }
+
+    private static ExpectedProperty property( int key, Object value )
+    {
+        return new ExpectedProperty( key, value );
+    }
+
+    private ExpectedRecord record( ExpectedProperty... properties )
+    {
+        return new ExpectedRecord( properties );
+    }
+
+    private static class MyPrimitiveProxy implements RecordProxy<Long,NodeRecord,Void>
+    {
+        private final NodeRecord record = new NodeRecord( 5 );
+        private boolean changed;
+
+        MyPrimitiveProxy()
+        {
+            record.setInUse( true );
+        }
+
+        @Override
+        public Long getKey()
+        {
+            return record.getId();
+        }
+
+        @Override
+        public NodeRecord forChangingLinkage()
+        {
+            changed = true;
+            return record;
+        }
+
+        @Override
+        public NodeRecord forChangingData()
+        {
+            changed = true;
+            return record;
+        }
+
+        @Override
+        public NodeRecord forReadingLinkage()
+        {
+            return record;
+        }
+
+        @Override
+        public NodeRecord forReadingData()
+        {
+            return record;
+        }
+
+        @Override
+        public Void getAdditionalData()
+        {
+            return null;
+        }
+
+        @Override
+        public NodeRecord getBefore()
+        {
+            return record;
+        }
+
+        @Override
+        public boolean isChanged()
+        {
+            return changed;
+        }
+
+        @Override
+        public boolean isCreated()
+        {
+            return false;
+        }
+    }
+
+    private static class PropertyRecordLoader implements Loader<Long,PropertyRecord,PrimitiveRecord>
+    {
+        private final Loader<Long,PropertyRecord,PrimitiveRecord> actual = Loaders.propertyLoader( null );
+
+        @Override
+        public PropertyRecord newUnused( Long key, PrimitiveRecord additionalData )
+        {
+            return actual.newUnused( key, additionalData );
+        }
+
+        @Override
+        public PropertyRecord load( Long key, PrimitiveRecord additionalData )
+        {
+            return null;
+        }
+
+        @Override
+        public void ensureHeavy( PropertyRecord record )
+        {
+        }
+
+        @Override
+        public PropertyRecord clone( PropertyRecord record )
+        {
+            return record.clone();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -115,11 +115,14 @@ public class RelationshipCreatorTest
         }
 
         @Override
-        public void acquireExclusive( ResourceType resourceType, long resourceId )
+        public void acquireExclusive( ResourceType resourceType, long... resourceIds )
                 throws AcquireLockTimeoutException
         {
             assertEquals( ResourceTypes.RELATIONSHIP, resourceType );
-            relationshipLocksAcquired.add( resourceId );
+            for ( long resourceId : resourceIds )
+            {
+                relationshipLocksAcquired.add( resourceId );
+            }
         }
 
         protected void changingRelationship( long relId )

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.SimpleStatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -104,7 +105,8 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 idTypeConfigurationProvider,
                 logService, mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
-                mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locks,
+                mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ),
+                new SimpleStatementLocksFactory( locks ),
                 mock( SchemaWriteGuard.class ), mock( TransactionEventHandlers.class ), IndexingService.NO_MONITOR,
                 fs, mock( TransactionMonitor.class ), databaseHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,

--- a/enterprise/deferred-locks/LICENSE.txt
+++ b/enterprise/deferred-locks/LICENSE.txt
@@ -1,0 +1,682 @@
+NOTICE
+This package contains software licensed under different
+licenses, please refer to the NOTICE.txt file for further
+information and LICENSES.txt for full license texts.
+
+The software ("Software") developed and owned by Network Engine for
+Objects in Lund AB (referred to in this notice as "Neo Technology") is
+licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3 to all
+third parties and that license is included below.
+
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the GNU AFFERO GENERAL PUBLIC
+LICENSE Version 3 and you may use the Software solely pursuant to the
+terms of the relevant Commercial Agreement.
+
+
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license
+for software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are
+designed to take away your freedom to share and change the works.  By
+contrast, our General Public Licenses are intended to guarantee your
+freedom to share and change all versions of a program--to make sure it
+remains free software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public
+License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds
+of works, such as semiconductor masks.
+ 
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further restriction,
+you may remove that term.  If a license document contains a further
+restriction but permits relicensing or conveying under this License, you
+may add to a covered work material governed by the terms of that license
+document, provided that the further restriction does not survive such
+relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have permission
+to link or combine any covered work with a work licensed under version 3
+of the GNU General Public License into a single combined work, and to
+convey the resulting work.  The terms of this License will continue to
+apply to the part which is the covered work, but the work with which it is
+combined will remain governed by version 3 of the GNU General Public
+License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new
+versions will be similar in spirit to the present version, but may differ
+in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero
+General Public License "or any later version" applies to it, you have
+the option of following the terms and conditions either of that
+numbered version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number
+of the GNU Affero General Public License, you may choose any version
+ever published by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that
+proxy's public statement of acceptance of a version permanently
+authorizes you to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                       END OF TERMS AND CONDITIONS
+
+              How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/enterprise/deferred-locks/LICENSES.txt
+++ b/enterprise/deferred-locks/LICENSES.txt
@@ -1,0 +1,214 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+------------------------------------------------------------------------------
+Apache Software License, Version 2.0
+  Apache Commons Lang
+  Lucene Core
+  Lucene Memory
+------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+

--- a/enterprise/deferred-locks/NOTICE.txt
+++ b/enterprise/deferred-locks/NOTICE.txt
@@ -1,0 +1,31 @@
+Neo4j
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
+in this notice as "Neo Technology")
+   [http://neotechnology.com]
+
+This product includes software ("Software") developed by Neo Technology.
+
+The software ("Software") is developed and owned by Network Engine
+for Objects in Lund AB (referred to in this notice as "Neo Technology").
+If you have executed an End User Software License and Services Agreement,
+an OEM Software License and Support Services Agreement, or another
+commercial license agreement (including an Evaluation Agreement) with
+Neo Technology or one of its affiliates (each, a "Commercial Agreement"),
+you may use the Software solely pursuant to the terms of the relevant
+Commercial Agreement.
+
+If you have not executed a Commercial Agreement with Neo Technology, the
+Software is subject to the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/agpl-3.0.html), included
+in the LICENSE.txt file.
+
+Full license texts are found in LICENSES.txt.
+
+Third-party licenses
+--------------------
+
+Apache Software License, Version 2.0
+  Apache Commons Lang
+  Lucene Core
+  Lucene Memory
+

--- a/enterprise/deferred-locks/pom.xml
+++ b/enterprise/deferred-locks/pom.xml
@@ -1,0 +1,90 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.neo4j</groupId>
+    <artifactId>parent</artifactId>
+    <version>3.0.5-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>neo4j-deferred-locks</artifactId>
+  <version>3.0.5-SNAPSHOT</version>
+
+  <name>Neo4j - Deferred Locks</name>
+  <description>Enterprise locks deferred to commit time</description>
+  <packaging>jar</packaging>
+
+  <scm>
+    <url>https://github.com/neo4j/neo4j/tree/3.0/enterprise/deferred-locks</url>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>GNU Affero General Public License, Version 3</name>
+      <url>http://www.gnu.org/licenses/agpl-3.0-standalone.html</url>
+      <comments>The software ("Software") developed and owned by Network Engine for
+        Objects in Lund AB (referred to in this notice as "Neo Technology") is
+        licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3 to all
+        third parties and that license is included below.
+
+        However, if you have executed an End User Software License and Services
+        Agreement or an OEM Software License and Support Services Agreement, or
+        another commercial license agreement with Neo Technology or one of its
+        affiliates (each, a "Commercial Agreement"), the terms of the license in
+        such Commercial Agreement will supersede the GNU AFFERO GENERAL PUBLIC
+        LICENSE Version 3 and you may use the Software solely pursuant to the
+        terms of the relevant Commercial Agreement.
+      </comments>
+    </license>
+  </licenses>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-io</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+public class DeferringLockClient implements Locks.Client
+{
+    private final Locks.Client clientDelegate;
+    private final Map<LockUnit,MutableInt> locks = new TreeMap<>();
+    private volatile boolean stopped;
+
+    public DeferringLockClient( Locks.Client clientDelegate )
+    {
+        this.clientDelegate = clientDelegate;
+    }
+
+    @Override
+    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    {
+        assertNotStopped();
+
+        for ( long resourceId : resourceIds )
+        {
+            addLock( resourceType, resourceId, false );
+        }
+    }
+
+    @Override
+    public void acquireExclusive( ResourceType resourceType, long... resourceIds )
+            throws AcquireLockTimeoutException
+    {
+        assertNotStopped();
+
+        for ( long resourceId : resourceIds )
+        {
+            addLock( resourceType, resourceId, true );
+        }
+    }
+
+    @Override
+    public boolean tryExclusiveLock( ResourceType resourceType, long resourceId )
+    {
+        throw new UnsupportedOperationException( "Should not be needed" );
+    }
+
+    @Override
+    public boolean trySharedLock( ResourceType resourceType, long resourceId )
+    {
+        throw new UnsupportedOperationException( "Should not be needed" );
+    }
+
+    @Override
+    public void releaseShared( ResourceType resourceType, long resourceId )
+    {
+        assertNotStopped();
+
+        removeLock( resourceType, resourceId, false );
+    }
+
+    @Override
+    public void releaseExclusive( ResourceType resourceType, long resourceId )
+    {
+        assertNotStopped();
+
+        removeLock( resourceType, resourceId, true );
+    }
+
+    void acquireDeferredLocks()
+    {
+        assertNotStopped();
+
+        long[] current = new long[10];
+        int cursor = 0;
+        ResourceType currentType = null;
+        boolean currentExclusive = false;
+        for ( LockUnit lockUnit : locks.keySet() )
+        {
+            if ( currentType == null ||
+                 (currentType.typeId() != lockUnit.resourceType().typeId() ||
+                  currentExclusive != lockUnit.isExclusive()) )
+            {
+                // New type, i.e. flush the current array down to delegate in one call
+                flushLocks( current, cursor, currentType, currentExclusive );
+
+                cursor = 0;
+                currentType = lockUnit.resourceType();
+                currentExclusive = lockUnit.isExclusive();
+            }
+
+            // Queue into current batch
+            if ( cursor == current.length )
+            {
+                current = Arrays.copyOf( current, cursor * 2 );
+            }
+            current[cursor++] = lockUnit.resourceId();
+        }
+        flushLocks( current, cursor, currentType, currentExclusive );
+    }
+
+    private void flushLocks( long[] current, int cursor, ResourceType currentType, boolean exclusive )
+    {
+        if ( cursor > 0 )
+        {
+            long[] resourceIds = Arrays.copyOf( current, cursor );
+            if ( exclusive )
+            {
+                clientDelegate.acquireExclusive( currentType, resourceIds );
+            }
+            else
+            {
+                clientDelegate.acquireShared( currentType, resourceIds );
+            }
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        stopped = true;
+        clientDelegate.stop();
+    }
+
+    @Override
+    public void close()
+    {
+        stopped = true;
+        clientDelegate.close();
+    }
+
+    @Override
+    public int getLockSessionId()
+    {
+        return clientDelegate.getLockSessionId();
+    }
+
+    private void assertNotStopped()
+    {
+        if ( stopped )
+        {
+            throw new LockClientStoppedException( this );
+        }
+    }
+
+    private void addLock( ResourceType resourceType, long resourceId, boolean exclusive )
+    {
+        LockUnit lockUnit = new LockUnit( resourceType, resourceId, exclusive );
+        MutableInt lockCount = locks.get( lockUnit );
+        if ( lockCount == null )
+        {
+            lockCount = new MutableInt();
+            locks.put( lockUnit, lockCount );
+        }
+        lockCount.increment();
+    }
+
+    private void removeLock( ResourceType resourceType, long resourceId, boolean exclusive )
+    {
+        LockUnit lockUnit = new LockUnit( resourceType, resourceId, exclusive );
+        MutableInt lockCount = locks.get( lockUnit );
+        if ( lockCount == null )
+        {
+            throw new IllegalStateException(
+                    "Cannot release " + (exclusive ? "exclusive" : "shared") + " lock that it " +
+                    "does not hold: " + resourceType + "[" + resourceId + "]." );
+        }
+
+        lockCount.decrement();
+
+        if ( lockCount.intValue() == 0 )
+        {
+            locks.remove( lockUnit );
+        }
+    }
+}

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+/**
+ * A {@link StatementLocks} implementation that defers {@link #optimistic() optimistic}
+ * locks using {@link DeferringLockClient}.
+ */
+public class DeferringStatementLocks implements StatementLocks
+{
+    private final Locks.Client explicit;
+    private final DeferringLockClient implicit;
+
+    public DeferringStatementLocks( Locks.Client explicit )
+    {
+        this.explicit = explicit;
+        this.implicit = new DeferringLockClient( this.explicit );
+    }
+
+    @Override
+    public Locks.Client pessimistic()
+    {
+        return explicit;
+    }
+
+    @Override
+    public Locks.Client optimistic()
+    {
+        return implicit;
+    }
+
+    @Override
+    public void prepareForCommit()
+    {
+        implicit.acquireDeferredLocks();
+    }
+
+    @Override
+    public void stop()
+    {
+        implicit.stop();
+    }
+
+    @Override
+    public void close()
+    {
+        implicit.close();
+    }
+}

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactory.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.Description;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Internal;
+import org.neo4j.kernel.configuration.Settings;
+
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.kernel.configuration.Settings.setting;
+
+/**
+ * A {@link StatementLocksFactory} that created {@link DeferringStatementLocks} based on the given
+ * {@link Locks} and {@link Config}.
+ */
+public class DeferringStatementLocksFactory implements StatementLocksFactory
+{
+    @Internal
+    @Description( "Enable deferring of locks to commit time. This feature weakens the isolation level. " +
+                  "It can result in both domain and storage level inconsistencies." )
+    public static final Setting<Boolean> deferred_locks_enabled =
+            setting( "unsupported.dbms.deferred_locks.enabled", Settings.BOOLEAN, Settings.FALSE );
+
+    private Locks locks;
+    private boolean deferredLocksEnabled;
+
+    @Override
+    public void initialize( Locks locks, Config config )
+    {
+        this.locks = requireNonNull( locks );
+        this.deferredLocksEnabled = config.get( deferred_locks_enabled );
+    }
+
+    @Override
+    public StatementLocks newInstance()
+    {
+        if ( locks == null )
+        {
+            throw new IllegalStateException( "Factory has not been initialized" );
+        }
+
+        Locks.Client client = locks.newClient();
+        return deferredLocksEnabled ? new DeferringStatementLocks( client ) : new SimpleStatementLocks( client );
+    }
+}

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+/**
+ * Description of a lock that was deferred to commit time.
+ */
+public class LockUnit implements Comparable<LockUnit>
+{
+    private final ResourceType resourceType;
+    private final long resourceId;
+    private final boolean exclusive;
+
+    public LockUnit( ResourceType resourceType, long resourceId, boolean exclusive )
+    {
+        this.resourceType = resourceType;
+        this.resourceId = resourceId;
+        this.exclusive = exclusive;
+    }
+
+    public ResourceType resourceType()
+    {
+        return resourceType;
+    }
+
+    public long resourceId()
+    {
+        return resourceId;
+    }
+
+    public boolean isExclusive()
+    {
+        return exclusive;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (exclusive ? 1231 : 1237);
+        result = prime * result + (int) (resourceId ^ (resourceId >>> 32));
+        result = prime * result + resourceType.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj == null )
+        {
+            return false;
+        }
+        if ( getClass() != obj.getClass() )
+        {
+            return false;
+        }
+        LockUnit other = (LockUnit) obj;
+        if ( exclusive != other.exclusive )
+        {
+            return false;
+        }
+        if ( resourceId != other.resourceId )
+        {
+            return false;
+        }
+        else if ( resourceType.typeId() != other.resourceType.typeId() )
+        {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo( LockUnit o )
+    {
+        // Exclusive locks go first to minimize amount of potential deadlocks
+        int exclusiveCompare = Boolean.compare( exclusive, o.exclusive );
+        if ( exclusiveCompare != 0 )
+        {
+            return -exclusiveCompare;
+        }
+
+        // Then shared/exclusive locks are compared by resourceTypeId and then by resourceId
+        return resourceType.typeId() == o.resourceType.typeId() ? Long.compare( resourceId, o.resourceId )
+                                                                : resourceType.typeId() - o.resourceType.typeId();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Resource [resourceType=" + resourceType + ", resourceId=" + resourceId + ", exclusive=" + exclusive
+               + "]";
+    }
+}

--- a/enterprise/deferred-locks/src/main/resources/META-INF/services/org.neo4j.kernel.impl.locking.StatementLocksFactory
+++ b/enterprise/deferred-locks/src/main/resources/META-INF/services/org.neo4j.kernel.impl.locking.StatementLocksFactory
@@ -1,0 +1,1 @@
+org.neo4j.kernel.impl.locking.DeferringStatementLocksFactory

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
+import org.neo4j.storageengine.api.lock.ResourceType;
+import org.neo4j.test.RandomRule;
+
+import static java.lang.Math.abs;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class DeferringLockClientTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void releaseOfNotHeldSharedLockThrows() throws Exception
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        try
+        {
+            // WHEN
+            client.releaseShared( ResourceTypes.NODE, 42 );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            // THEN
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void releaseOfNotHeldExclusiveLockThrows() throws Exception
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        try
+        {
+            // WHEN
+            client.releaseExclusive( ResourceTypes.NODE, 42 );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            // THEN
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldDeferAllLocks() throws Exception
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        // WHEN
+        Set<LockUnit> expected = new HashSet<>();
+        ResourceType[] types = ResourceTypes.values();
+        for ( int i = 0; i < 10_000; i++ )
+        {
+            boolean exclusive = random.nextBoolean();
+            LockUnit lockUnit = new LockUnit( random.among( types ), abs( random.nextLong() ), exclusive );
+
+            if ( exclusive )
+            {
+                client.acquireExclusive( lockUnit.resourceType(), lockUnit.resourceId() );
+            }
+            else
+            {
+                client.acquireShared( lockUnit.resourceType(), lockUnit.resourceId() );
+            }
+            expected.add( lockUnit );
+        }
+        actualClient.assertRegisteredLocks( Collections.<LockUnit>emptySet() );
+        client.acquireDeferredLocks();
+
+        // THEN
+        actualClient.assertRegisteredLocks( expected );
+    }
+
+    @Test
+    public void shouldStopUnderlyingClient() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        // WHEN
+        client.stop();
+
+        // THEN
+        verify( actualClient ).stop();
+    }
+
+    @Test
+    public void shouldCloseUnderlyingClient() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        // WHEN
+        client.close();
+
+        // THEN
+        verify( actualClient ).close();
+    }
+
+    @Test
+    public void shouldThrowOnAcquireWhenStopped() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.stop();
+
+        try
+        {
+            // WHEN
+            client.acquireExclusive( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( LockClientStoppedException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void shouldThrowOnAcquireWhenClosed() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.close();
+
+        try
+        {
+            // WHEN
+            client.acquireExclusive( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( LockClientStoppedException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenReleaseNotYetAcquiredExclusive() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        try
+        {
+            // WHEN
+            client.releaseExclusive( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenReleaseNotYetAcquiredShared() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        try
+        {
+            // WHEN
+            client.releaseShared( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenReleaseNotMatchingAcquired() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+
+        try
+        {
+            // WHEN
+            client.releaseShared( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenReleasingLockMultipleTimes() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.releaseExclusive( ResourceTypes.NODE, 1 );
+
+        try
+        {
+            // WHEN
+            client.releaseShared( ResourceTypes.NODE, 1 );
+            fail( "Expected exception" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN
+        }
+    }
+
+    @Test
+    public void exclusiveLockAcquiredMultipleTimesCanNotBeReleasedAtOnce() throws Exception
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.releaseExclusive( ResourceTypes.NODE, 1 );
+
+        // WHEN
+        client.acquireDeferredLocks();
+
+        // THEN
+        actualClient.assertRegisteredLocks( Collections.singleton( new LockUnit( ResourceTypes.NODE, 1, true ) ) );
+    }
+
+    @Test
+    public void sharedLockAcquiredMultipleTimesCanNotBeReleasedAtOnce() throws Exception
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.releaseShared( ResourceTypes.NODE, 1 );
+
+        // WHEN
+        client.acquireDeferredLocks();
+
+        // THEN
+        actualClient.assertRegisteredLocks( Collections.singleton( new LockUnit( ResourceTypes.NODE, 1, false ) ) );
+    }
+
+    @Test
+    public void acquireBothSharedAndExclusiveLockThenReleaseShared()
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.releaseShared( ResourceTypes.NODE, 1 );
+
+        // WHEN
+        client.acquireDeferredLocks();
+
+        // THEN
+        actualClient.assertRegisteredLocks( Collections.singleton( new LockUnit( ResourceTypes.NODE, 1, true ) ) );
+    }
+
+    @Test
+    public void exclusiveLocksAcquiredFirst()
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 2 );
+        client.acquireExclusive( ResourceTypes.NODE, 3 );
+        client.acquireExclusive( ResourceTypes.RELATIONSHIP, 1 );
+        client.acquireShared( ResourceTypes.RELATIONSHIP, 2 );
+        client.acquireShared( ResourceTypes.SCHEMA, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 42 );
+
+        // WHEN
+        client.acquireDeferredLocks();
+
+        // THEN
+        Set<LockUnit> expectedLocks = new LinkedHashSet<>(
+                Arrays.asList( new LockUnit( ResourceTypes.NODE, 2, true ),
+                        new LockUnit( ResourceTypes.NODE, 3, true ),
+                        new LockUnit( ResourceTypes.NODE, 42, true ),
+                        new LockUnit( ResourceTypes.RELATIONSHIP, 1, true ),
+                        new LockUnit( ResourceTypes.NODE, 1, false ),
+                        new LockUnit( ResourceTypes.RELATIONSHIP, 2, false ),
+                        new LockUnit( ResourceTypes.SCHEMA, 1, false ) )
+        );
+
+        actualClient.assertRegisteredLocks( expectedLocks );
+    }
+
+    @Test
+    public void acquireBothSharedAndExclusiveLockThenReleaseExclusive()
+    {
+        // GIVEN
+        TestLocks actualLocks = new TestLocks();
+        TestLocksClient actualClient = actualLocks.newClient();
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.releaseExclusive( ResourceTypes.NODE, 1 );
+
+        // WHEN
+        client.acquireDeferredLocks();
+
+        // THEN
+        actualClient.assertRegisteredLocks( Collections.singleton( new LockUnit( ResourceTypes.NODE, 1, false ) ) );
+    }
+
+    private static class TestLocks extends LifecycleAdapter implements Locks
+    {
+        @Override
+        public TestLocksClient newClient()
+        {
+            return new TestLocksClient();
+        }
+
+        @Override
+        public void accept( Visitor visitor )
+        {
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+
+    private static class TestLocksClient implements Locks.Client
+    {
+        private final Set<LockUnit> actualLockUnits = new LinkedHashSet<>();
+
+        @Override
+        public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        {
+            register( resourceType, false, resourceIds );
+        }
+
+        void assertRegisteredLocks( Set<LockUnit> expectedLocks )
+        {
+            assertEquals( expectedLocks, actualLockUnits );
+        }
+
+        private boolean register( ResourceType resourceType, boolean exclusive, long... resourceIds )
+        {
+            for ( long resourceId : resourceIds )
+            {
+                actualLockUnits.add( new LockUnit( resourceType, resourceId, exclusive ) );
+            }
+            return true;
+        }
+
+        @Override
+        public void acquireExclusive( ResourceType resourceType, long... resourceIds )
+                throws AcquireLockTimeoutException
+        {
+            register( resourceType, true, resourceIds );
+        }
+
+        @Override
+        public boolean tryExclusiveLock( ResourceType resourceType, long resourceId )
+        {
+            return register( resourceType, true, resourceId );
+        }
+
+        @Override
+        public boolean trySharedLock( ResourceType resourceType, long resourceId )
+        {
+            return register( resourceType, false, resourceId );
+        }
+
+        @Override
+        public void releaseShared( ResourceType resourceType, long resourceId )
+        {
+        }
+
+        @Override
+        public void releaseExclusive( ResourceType resourceType, long resourceId )
+        {
+        }
+
+        @Override
+        public void stop()
+        {
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public int getLockSessionId()
+        {
+            return 0;
+        }
+    }
+}

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.graphdb.ConstraintViolationException;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.store.InvalidRecordException;
+import org.neo4j.test.Barrier;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
+import org.neo4j.test.OtherThreadRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.Iterables.count;
+
+public class DeferringLocksIT
+{
+    private static final long TEST_TIMEOUT = 30_000;
+
+    private static final Label LABEL = DynamicLabel.label( "label" );
+    private static final String PROPERTY_KEY = "key";
+    private static final String VALUE_1 = "value1";
+    private static final String VALUE_2 = "value2";
+
+    @Rule
+    public final DatabaseRule dbRule = new ImpermanentDatabaseRule().startLazily();
+    @Rule
+    public final OtherThreadRule<Void> t2 = new OtherThreadRule<>();
+    @Rule
+    public final OtherThreadRule<Void> t3 = new OtherThreadRule<>();
+
+    private GraphDatabaseService db;
+
+    @Before
+    public void initDb() throws Exception
+    {
+        dbRule.setConfig( DeferringStatementLocksFactory.deferred_locks_enabled, Settings.TRUE );
+        db = dbRule.getGraphDatabaseAPI();
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void shouldNotFreakOutIfTwoTransactionsDecideToEachAddTheSameProperty() throws Exception
+    {
+        // GIVEN
+        final Barrier.Control barrier = new Barrier.Control();
+        final Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            tx.success();
+        }
+
+        // WHEN
+        t2.execute( new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    node.setProperty( PROPERTY_KEY, VALUE_1 );
+                    tx.success();
+                    barrier.reached();
+                }
+                return null;
+            }
+        } );
+        try ( Transaction tx = db.beginTx() )
+        {
+            barrier.await();
+            node.setProperty( PROPERTY_KEY, VALUE_2 );
+            tx.success();
+            barrier.release();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( 1, count( node.getPropertyKeys() ) );
+            tx.success();
+        }
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void firstRemoveSecondChangeProperty() throws Exception
+    {
+        // GIVEN
+        final Barrier.Control barrier = new Barrier.Control();
+        final Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( PROPERTY_KEY, VALUE_1 );
+            tx.success();
+        }
+
+        // WHEN
+        Future<Void> future = t2.execute( new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    node.removeProperty( PROPERTY_KEY );
+                    tx.success();
+                    barrier.reached();
+                }
+                return null;
+            }
+        } );
+        try ( Transaction tx = db.beginTx() )
+        {
+            barrier.await();
+            node.setProperty( PROPERTY_KEY, VALUE_2 );
+            tx.success();
+            barrier.release();
+        }
+
+        future.get();
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( VALUE_2, node.getProperty( PROPERTY_KEY, VALUE_2 ) );
+            tx.success();
+        }
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void removeNodeChangeNodeProperty() throws Exception
+    {
+        // GIVEN
+        final Barrier.Control barrier = new Barrier.Control();
+        final long nodeId;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            nodeId = node.getId();
+            node.setProperty( PROPERTY_KEY, VALUE_1 );
+            tx.success();
+        }
+
+        // WHEN
+        Future<Void> future = t2.execute( new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.getNodeById( nodeId ).delete();
+                    tx.success();
+                    barrier.reached();
+                }
+                return null;
+            }
+        } );
+        try
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                barrier.await();
+                db.getNodeById( nodeId ).setProperty( PROPERTY_KEY, VALUE_2 );
+                tx.success();
+                barrier.release();
+            }
+        }
+        catch ( TransactionFailureException e )
+        {
+            // Node was already deleted, fine.
+            assertThat( e.getCause(), instanceOf( InvalidRecordException.class ) );
+        }
+
+        future.get();
+        try ( Transaction tx = db.beginTx() )
+        {
+            try
+            {
+                db.getNodeById( nodeId );
+                assertEquals( VALUE_2, db.getNodeById( nodeId ).getProperty( PROPERTY_KEY, VALUE_2 ) );
+            }
+            catch ( NotFoundException e )
+            {
+                // Fine, its gone
+            }
+            tx.success();
+        }
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void readOwnChangesFromRacingIndexNoBlock() throws Throwable
+    {
+        t2.execute( new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    createNodeWithProperty( LABEL, PROPERTY_KEY, VALUE_1 );
+                    assertNodeWith( LABEL, PROPERTY_KEY, VALUE_1 );
+
+                    tx.success();
+                }
+                return null;
+            }
+        } );
+
+        t3.execute( new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    createAndAwaitIndex( LABEL, PROPERTY_KEY );
+                    tx.success();
+                }
+                return null;
+            }
+        } );
+
+        assertInTxNodeWith( LABEL, PROPERTY_KEY, VALUE_1 );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void readOwnChangesWithoutIndex() throws Exception
+    {
+        // WHEN
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( LABEL );
+            node.setProperty( PROPERTY_KEY, VALUE_1 );
+
+            assertNodeWith( LABEL, PROPERTY_KEY, VALUE_1 );
+
+            tx.success();
+        }
+
+        assertInTxNodeWith( LABEL, PROPERTY_KEY, VALUE_1 );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void racingMultipleUniquenessConstraintCreation() throws Exception
+    {
+        final Future<Void> t2ConstraintCreator = t2.execute( createUniquenessConstraintOn( LABEL, PROPERTY_KEY ) );
+        final Future<Void> t3ConstraintCreator = t3.execute( createUniquenessConstraintOn( LABEL, PROPERTY_KEY ) );
+
+        assertOnlyOneSucceeds( t2ConstraintCreator, t3ConstraintCreator, ConstraintViolationException.class );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void racingMultipleIndexCreation() throws Exception
+    {
+        final Future<Void> t2IndexCreator = t2.execute( createIndexOn( LABEL, PROPERTY_KEY ) );
+        final Future<Void> t3IndexCreator = t3.execute( createIndexOn( LABEL, PROPERTY_KEY ) );
+
+        assertOnlyOneSucceeds( t2IndexCreator, t3IndexCreator, ConstraintViolationException.class );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void racingCreationOfNodesWithDuplicatedProperties() throws Exception
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( LABEL ).assertPropertyIsUnique( PROPERTY_KEY ).create();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 1, TimeUnit.MINUTES );
+            tx.success();
+        }
+
+        final Future<Void> t2NodeCreator = t2.execute( createNode( LABEL, PROPERTY_KEY, VALUE_1 ) );
+        final Future<Void> t3NodeCreator = t3.execute( createNode( LABEL, PROPERTY_KEY, VALUE_1 ) );
+
+        assertOnlyOneSucceeds( t2NodeCreator, t3NodeCreator, ConstraintViolationException.class );
+    }
+
+    private void assertOnlyOneSucceeds( Future<Void> action1, Future<Void> action2,
+            Class<? extends Exception> expectedFailure ) throws Exception
+    {
+        try
+        {
+            if ( get( action1 ) == null )
+            {
+                try
+                {
+                    get( action2 );
+                    fail( "Second action should fail if first one succeeds" );
+                }
+                catch ( ExecutionException e )
+                {
+                    // Good
+                    assertThat( e.getCause(), instanceOf( expectedFailure ) );
+                }
+            }
+            else
+            {
+                fail( "First action should either return null or throw" );
+            }
+        }
+        catch ( ExecutionException e )
+        {
+            // Good
+            assertThat( e.getCause(), instanceOf( expectedFailure ) );
+            assertNull( get( action2 ) );
+        }
+    }
+
+    private void assertInTxNodeWith( Label label, String key, Object value )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertNodeWith( label, key, value );
+            tx.success();
+        }
+    }
+
+    private void assertNodeWith( Label label, String key, Object value )
+    {
+        ResourceIterator<Node> nodes = db.findNodes( label, key, value );
+        assertTrue( nodes.hasNext() );
+        Node foundNode = nodes.next();
+        assertTrue( foundNode.hasLabel( label ) );
+        assertEquals( value, foundNode.getProperty( key ) );
+    }
+
+    private Node createNodeWithProperty( Label label, String key, Object value )
+    {
+        Node node = db.createNode( label );
+        node.setProperty( key, value );
+        return node;
+    }
+
+    private WorkerCommand<Void,Void> createNode( final Label label, final String propertyKey,
+            final Object propertyValue )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    Node node = db.createNode( label );
+                    node.setProperty( propertyKey, propertyValue );
+                    tx.success();
+                }
+                return null;
+            }
+        };
+    }
+
+    private WorkerCommand<Void,Void> createIndexOn( final Label label, final String propertyKey )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.schema().indexFor( label ).on( propertyKey ).create();
+                    tx.success();
+                }
+                return null;
+            }
+        };
+    }
+
+    private WorkerCommand<Void,Void> createUniquenessConstraintOn( final Label label, final String propertyKey )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.schema().constraintFor( label ).assertPropertyIsUnique( propertyKey ).create();
+                    tx.success();
+                }
+                return null;
+            }
+        };
+    }
+
+    private WorkerCommand<Void,Void> createAndAwaitIndex( final Label label, final String key )
+    {
+        return new WorkerCommand<Void,Void>()
+        {
+            @Override
+            public Void doWork( Void state ) throws Exception
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.schema().indexFor( label ).on( key ).create();
+                    tx.success();
+                }
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.schema().awaitIndexesOnline( 1, TimeUnit.MINUTES );
+                }
+                return null;
+            }
+        };
+    }
+
+    private static <T> T get( Future<T> future ) throws InterruptedException, ExecutionException, TimeoutException
+    {
+        return future.get( 20, TimeUnit.SECONDS );
+    }
+}

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactoryTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksFactoryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.locking.DeferringStatementLocksFactory.deferred_locks_enabled;
+
+public class DeferringStatementLocksFactoryTest
+{
+    @Test
+    public void initializeThrowsForNullLocks()
+    {
+        DeferringStatementLocksFactory factory = new DeferringStatementLocksFactory();
+        try
+        {
+            factory.initialize( null, Config.empty() );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( NullPointerException.class ) );
+        }
+    }
+
+    @Test
+    public void initializeThrowsForNullConfig()
+    {
+        DeferringStatementLocksFactory factory = new DeferringStatementLocksFactory();
+        try
+        {
+            factory.initialize( mock( Locks.class ), null );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( NullPointerException.class ) );
+        }
+    }
+
+    @Test
+    public void newInstanceThrowsWhenNotInitialized()
+    {
+        DeferringStatementLocksFactory factory = new DeferringStatementLocksFactory();
+        try
+        {
+            factory.newInstance();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void newInstanceCreatesSimpleLocksWhenConfigNotSet()
+    {
+        Locks locks = mock( Locks.class );
+        Locks.Client client = mock( Locks.Client.class );
+        when( locks.newClient() ).thenReturn( client );
+
+        Config config = new Config( stringMap( deferred_locks_enabled.name(), Settings.FALSE ) );
+
+        DeferringStatementLocksFactory factory = new DeferringStatementLocksFactory();
+        factory.initialize( locks, config );
+
+        StatementLocks statementLocks = factory.newInstance();
+
+        assertThat( statementLocks, instanceOf( SimpleStatementLocks.class ) );
+        assertSame( client, statementLocks.optimistic() );
+        assertSame( client, statementLocks.pessimistic() );
+    }
+
+    @Test
+    public void newInstanceCreatesDeferredLocksWhenConfigSet()
+    {
+        Locks locks = mock( Locks.class );
+        Locks.Client client = mock( Locks.Client.class );
+        when( locks.newClient() ).thenReturn( client );
+
+        Config config = new Config( stringMap( deferred_locks_enabled.name(), Settings.TRUE ) );
+
+        DeferringStatementLocksFactory factory = new DeferringStatementLocksFactory();
+        factory.initialize( locks, config );
+
+        StatementLocks statementLocks = factory.newInstance();
+
+        assertThat( statementLocks, instanceOf( DeferringStatementLocks.class ) );
+        assertThat( statementLocks.optimistic(), instanceOf( DeferringLockClient.class ) );
+        assertSame( client, statementLocks.pessimistic() );
+    }
+}

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Test;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class DeferringStatementLocksTest
+{
+    @Test
+    public void shouldUseCorrectClientForImplicitAndExplicit() throws Exception
+    {
+        // GIVEN
+        final Locks.Client client = mock( Locks.Client.class );
+        final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
+
+        // THEN
+        assertSame( client, statementLocks.pessimistic() );
+        assertThat( statementLocks.optimistic(), instanceOf( DeferringLockClient.class ) );
+    }
+
+    @Test
+    public void shouldDoNothingWithClientWhenPreparingForCommitWithNoLocksAcquired() throws Exception
+    {
+        // GIVEN
+        final Locks.Client client = mock( Locks.Client.class );
+        final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
+
+        // WHEN
+        statementLocks.prepareForCommit();
+
+        // THEN
+        verifyNoMoreInteractions( client );
+    }
+
+    @Test
+    public void shouldPrepareExplicitForCommitWhenLocksAcquire() throws Exception
+    {
+        // GIVEN
+        final Locks.Client client = mock( Locks.Client.class );
+        final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
+
+        // WHEN
+        statementLocks.optimistic().acquireExclusive( ResourceTypes.NODE, 1 );
+        statementLocks.optimistic().acquireExclusive( ResourceTypes.RELATIONSHIP, 42 );
+        verify( client, never() ).acquireExclusive( any( ResourceType.class ), anyLong() );
+        statementLocks.prepareForCommit();
+
+        // THEN
+        verify( client ).acquireExclusive( ResourceTypes.NODE, 1 );
+        verify( client ).acquireExclusive( ResourceTypes.RELATIONSHIP, 42 );
+        verifyNoMoreInteractions( client );
+    }
+
+    @Test
+    public void shouldStopUnderlyingClient() throws Exception
+    {
+        // GIVEN
+        final Locks.Client client = mock( Locks.Client.class );
+        final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
+
+        // WHEN
+        statementLocks.stop();
+
+        // THEN
+        verify( client ).stop();
+    }
+
+    @Test
+    public void shouldCloseUnderlyingClient() throws Exception
+    {
+        // GIVEN
+        final Locks.Client client = mock( Locks.Client.class );
+        final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
+
+        // WHEN
+        statementLocks.close();
+
+        // THEN
+        verify( client ).close();
+    }
+}

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/LockUnitTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/LockUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class LockUnitTest
+{
+    @Test
+    public void exclusiveLocksAppearFirst()
+    {
+        LockUnit unit1 = new LockUnit( ResourceTypes.NODE, 1, true );
+        LockUnit unit2 = new LockUnit( ResourceTypes.NODE, 2, false );
+        LockUnit unit3 = new LockUnit( ResourceTypes.RELATIONSHIP, 1, false );
+        LockUnit unit4 = new LockUnit( ResourceTypes.RELATIONSHIP, 2, true );
+        LockUnit unit5 = new LockUnit( ResourceTypes.SCHEMA, 1, false );
+
+        List<LockUnit> list = asList( unit1, unit2, unit3, unit4, unit5 );
+        Collections.sort( list );
+
+        assertEquals( asList( unit1, unit4, unit2, unit3, unit5 ), list );
+    }
+
+    @Test
+    public void exclusiveOrderedByResourceTypes()
+    {
+        LockUnit unit1 = new LockUnit( ResourceTypes.NODE, 1, true );
+        LockUnit unit2 = new LockUnit( ResourceTypes.RELATIONSHIP, 1, true );
+        LockUnit unit3 = new LockUnit( ResourceTypes.NODE, 2, true );
+        LockUnit unit4 = new LockUnit( ResourceTypes.SCHEMA, 1, true );
+        LockUnit unit5 = new LockUnit( ResourceTypes.RELATIONSHIP, 2, true );
+
+        List<LockUnit> list = asList( unit1, unit2, unit3, unit4, unit5 );
+        Collections.sort( list );
+
+        assertEquals( asList( unit1, unit3, unit2, unit5, unit4 ), list );
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPI.java
@@ -29,8 +29,8 @@ import org.neo4j.kernel.impl.util.JobScheduler;
  */
 public class DefaultConversationSPI implements ConversationSPI
 {
-    private Locks locks;
-    private JobScheduler jobScheduler;
+    private final Locks locks;
+    private final JobScheduler jobScheduler;
 
     public DefaultConversationSPI( Locks locks, JobScheduler jobScheduler )
     {
@@ -49,5 +49,4 @@ public class DefaultConversationSPI implements ConversationSPI
     {
         return jobScheduler.scheduleRecurring( group, job, interval, TimeUnit.MILLISECONDS);
     }
-
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.kernel.ha.lock;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.com.ComException;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
@@ -35,10 +37,10 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.locking.LockClientStoppedException;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
-import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
-import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
+import org.neo4j.storageengine.api.lock.ResourceType;
 
 import static org.neo4j.kernel.impl.locking.LockType.READ;
 import static org.neo4j.kernel.impl.locking.LockType.WRITE;
@@ -101,54 +103,52 @@ class SlaveLocksClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         assertNotStopped();
 
-        Map<Long, AtomicInteger> lockMap = getLockMap( sharedLocks, resourceType );
-        AtomicInteger preExistingLock = lockMap.get( resourceId );
-        if ( preExistingLock != null )
+        Map<Long,AtomicInteger> lockMap = getLockMap( sharedLocks, resourceType );
+        long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
+        if ( newResourceIds.length > 0 )
         {
-            // We already hold this lock, just increment the local reference count
-            preExistingLock.incrementAndGet();
-        }
-        else if ( getReadLockOnMaster( resourceType, resourceId ) )
-        {
-            if ( client.trySharedLock( resourceType, resourceId ) )
+            acquireSharedOnMaster( resourceType, newResourceIds );
+            for ( long resourceId : newResourceIds )
             {
-                lockMap.put( resourceId, new AtomicInteger( 1 ) );
-            }
-            else
-            {
-                throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceId, READ );
-
+                if ( client.trySharedLock( resourceType, resourceId ) )
+                {
+                    lockMap.put( resourceId, new AtomicInteger( 1 ) );
+                }
+                else
+                {
+                    throw new LocalDeadlockDetectedException(
+                            client, localLockManager, resourceType, resourceId, READ );
+                }
             }
         }
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long resourceId ) throws
+    public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws
             AcquireLockTimeoutException
     {
         assertNotStopped();
 
         Map<Long, AtomicInteger> lockMap = getLockMap( exclusiveLocks, resourceType );
-
-        AtomicInteger preExistingLock = lockMap.get( resourceId );
-        if ( preExistingLock != null )
+        long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
+        if ( newResourceIds.length > 0 )
         {
-            // We already hold this lock, just increment the local reference count
-            preExistingLock.incrementAndGet();
-        }
-        else if ( acquireExclusiveOnMaster( resourceType, resourceId ) )
-        {
-            if ( client.tryExclusiveLock( resourceType, resourceId ) )
+            acquireExclusiveOnMaster( resourceType, newResourceIds );
+            for ( long resourceId : newResourceIds )
             {
-                lockMap.put( resourceId, new AtomicInteger( 1 ) );
-            }
-            else
-            {
-                throw new LocalDeadlockDetectedException( client, localLockManager, resourceType, resourceId, WRITE );
+                if ( client.tryExclusiveLock( resourceType, resourceId ) )
+                {
+                    lockMap.put( resourceId, new AtomicInteger( 1 ) );
+                }
+                else
+                {
+                    throw new LocalDeadlockDetectedException(
+                            client, localLockManager, resourceType, resourceId, WRITE );
+                }
             }
         }
     }
@@ -269,7 +269,30 @@ class SlaveLocksClient implements Locks.Client
         }
     }
 
-    private boolean getReadLockOnMaster( ResourceType resourceType, long resourceId )
+    private long[] onlyFirstTimeLocks( Map<Long,AtomicInteger> lockMap, long[] resourceIds )
+    {
+        int cursor = 0;
+        for ( int i = 0; i < resourceIds.length; i++ )
+        {
+            AtomicInteger preExistingLock = lockMap.get( resourceIds[i] );
+            if ( preExistingLock != null )
+            {
+                // We already hold this lock, just increment the local reference count
+                preExistingLock.incrementAndGet();
+            }
+            else
+            {
+                resourceIds[cursor++] = resourceIds[i];
+            }
+        }
+        if ( cursor == 0 )
+        {
+            return PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+        }
+        return cursor == resourceIds.length ? resourceIds : Arrays.copyOf( resourceIds, cursor );
+    }
+
+    private void acquireSharedOnMaster( ResourceType resourceType, long... resourceIds )
     {
         if ( resourceType == ResourceTypes.NODE
                 || resourceType == ResourceTypes.RELATIONSHIP
@@ -279,36 +302,32 @@ class SlaveLocksClient implements Locks.Client
             makeSureTxHasBeenInitialized();
 
             RequestContext requestContext = newRequestContextFor( this );
-            try ( Response<LockResult> response = master.acquireSharedLock( requestContext, resourceType, resourceId ) )
+            try ( Response<LockResult> response = master.acquireSharedLock( requestContext, resourceType, resourceIds ) )
             {
-                return receiveLockResponse( response );
+                receiveLockResponse( response );
             }
             catch ( ComException e )
             {
-                throw new DistributedLockFailureException( "Cannot get shared lock on master", master, e );
+                throw new DistributedLockFailureException( "Cannot get shared lock(s) on master", master, e );
             }
-        }
-        else
-        {
-            return true;
         }
     }
 
-    private boolean acquireExclusiveOnMaster( ResourceType resourceType, long resourceId )
+    private void acquireExclusiveOnMaster( ResourceType resourceType, long... resourceIds )
     {
         makeSureTxHasBeenInitialized();
         RequestContext requestContext = newRequestContextFor( this );
-        try ( Response<LockResult> response = master.acquireExclusiveLock( requestContext, resourceType, resourceId ) )
+        try ( Response<LockResult> response = master.acquireExclusiveLock( requestContext, resourceType, resourceIds ) )
         {
-            return receiveLockResponse( response );
+            receiveLockResponse( response );
         }
         catch ( ComException e )
         {
-            throw new DistributedLockFailureException( "Cannot get exclusive lock on master", master, e );
+            throw new DistributedLockFailureException( "Cannot get exclusive lock(s) on master", master, e );
         }
     }
 
-    private boolean receiveLockResponse( Response<LockResult> response )
+    private void receiveLockResponse( Response<LockResult> response )
     {
         LockResult result = response.response();
 
@@ -323,8 +342,6 @@ class SlaveLocksClient implements Locks.Client
             default:
                 throw new UnsupportedOperationException( result.toString() );
         }
-
-        return true;
     }
 
     private void makeSureTxHasBeenInitialized()

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.ha.cluster;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -37,7 +38,7 @@ import static org.mockito.Mockito.verify;
 public class DefaultConversationSPITest
 {
 
-    @Mock
+    @Mock( answer = Answers.RETURNS_MOCKS )
     private Locks locks;
     @Mock
     private JobScheduler jobScheduler;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -158,7 +158,7 @@ public class ForsetiClient implements Locks.Client
                 {
                     // We already have a lock on this, just increment our local reference counter.
                     heldShareLocks.put( resourceId, Math.incrementExact( heldCount ) );
-                    return;
+                    continue;
                 }
 
                 // Second, check if we hold it as an exclusive lock
@@ -168,7 +168,7 @@ public class ForsetiClient implements Locks.Client
                     // When the exclusive lock is released, it will be automatically downgraded to a shared lock,
                     // since we bumped the share lock reference count.
                     heldShareLocks.put( resourceId, 1 );
-                    return;
+                    continue;
                 }
 
                 // We don't hold the lock, so we need to grab it via the global lock map
@@ -260,7 +260,7 @@ public class ForsetiClient implements Locks.Client
                 {
                     // We already have a lock on this, just increment our local reference counter.
                     heldLocks.put( resourceId, Math.incrementExact( heldCount ) );
-                    return;
+                    continue;
                 }
 
                 // Grab the global lock

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -136,7 +136,7 @@ public class ForsetiClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         hasLocks = true;
         stateHolder.incrementActiveClients( this );
@@ -150,87 +150,91 @@ public class ForsetiClient implements Locks.Client
             PrimitiveLongIntMap heldShareLocks = sharedLockCounts[resourceType.typeId()];
             PrimitiveLongIntMap heldExclusiveLocks = exclusiveLockCounts[resourceType.typeId()];
 
-            // First, check if we already hold this as a shared lock
-            int heldCount = heldShareLocks.get( resourceId );
-            if ( heldCount != -1 )
+            for ( long resourceId : resourceIds )
             {
-                // We already have a lock on this, just increment our local reference counter.
-                heldShareLocks.put( resourceId, Math.incrementExact( heldCount ) );
-                return;
-            }
-
-            // Second, check if we hold it as an exclusive lock
-            if ( heldExclusiveLocks.containsKey( resourceId ) )
-            {
-                // We already have an exclusive lock, so just leave that in place. When the exclusive lock is released,
-                // it will be automatically downgraded to a shared lock, since we bumped the share lock reference count.
-                heldShareLocks.put( resourceId, 1 );
-                return;
-            }
-
-            // We don't hold the lock, so we need to grab it via the global lock map
-            int tries = 0;
-            SharedLock mySharedLock = null;
-
-            // Retry loop
-            while ( true )
-            {
-                assertNotStopped();
-
-                // Check if there is a lock for this entity in the map
-                ForsetiLockManager.Lock existingLock = lockMap.get( resourceId );
-
-                // No lock
-                if ( existingLock == null )
+                // First, check if we already hold this as a shared lock
+                int heldCount = heldShareLocks.get( resourceId );
+                if ( heldCount != -1 )
                 {
-                    // Try to create a new shared lock
-                    if ( mySharedLock == null )
+                    // We already have a lock on this, just increment our local reference counter.
+                    heldShareLocks.put( resourceId, Math.incrementExact( heldCount ) );
+                    return;
+                }
+
+                // Second, check if we hold it as an exclusive lock
+                if ( heldExclusiveLocks.containsKey( resourceId ) )
+                {
+                    // We already have an exclusive lock, so just leave that in place.
+                    // When the exclusive lock is released, it will be automatically downgraded to a shared lock,
+                    // since we bumped the share lock reference count.
+                    heldShareLocks.put( resourceId, 1 );
+                    return;
+                }
+
+                // We don't hold the lock, so we need to grab it via the global lock map
+                int tries = 0;
+                SharedLock mySharedLock = null;
+
+                // Retry loop
+                while ( true )
+                {
+                    assertNotStopped();
+
+                    // Check if there is a lock for this entity in the map
+                    ForsetiLockManager.Lock existingLock = lockMap.get( resourceId );
+
+                    // No lock
+                    if ( existingLock == null )
                     {
-                        mySharedLock = new SharedLock( this );
+                        // Try to create a new shared lock
+                        if ( mySharedLock == null )
+                        {
+                            mySharedLock = new SharedLock( this );
+                        }
+
+                        if ( lockMap.putIfAbsent( resourceId, mySharedLock ) == null )
+                        {
+                            // Success, we now hold the shared lock.
+                            break;
+                        }
+                        else
+                        {
+                            continue;
+                        }
                     }
 
-                    if ( lockMap.putIfAbsent( resourceId, mySharedLock ) == null )
+                    // Someone holds shared lock on this entity, try and get in on that action
+                    else if ( existingLock instanceof SharedLock )
                     {
-                        // Success, we now hold the shared lock.
-                        break;
+                        if ( ((SharedLock) existingLock).acquire( this ) )
+                        {
+                            // Success!
+                            break;
+                        }
+                    }
+
+                    // Someone holds an exclusive lock on this entity
+                    else if ( existingLock instanceof ExclusiveLock )
+                    {
+                        // We need to wait, just let the loop run.
                     }
                     else
                     {
-                        continue;
+                        throw new UnsupportedOperationException( "Unknown lock type: " + existingLock );
                     }
+
+                    applyWaitStrategy( resourceType, tries++ );
+
+                    // And take note of who we are waiting for. This is used for deadlock detection.
+                    markAsWaitingFor( existingLock, resourceType, resourceId );
                 }
 
-                // Someone holds shared lock on this entity, try and get in on that action
-                else if ( existingLock instanceof SharedLock )
-                {
-                    if ( ((SharedLock) existingLock).acquire( this ) )
-                    {
-                        // Success!
-                        break;
-                    }
-                }
+                // Got the lock, no longer waiting for anyone.
+                clearWaitList();
 
-                // Someone holds an exclusive lock on this entity
-                else if ( existingLock instanceof ExclusiveLock )
-                {
-                    // We need to wait, just let the loop run.
-                }
-                else
-                {
-                    throw new UnsupportedOperationException( "Unknown lock type: " + existingLock );
-                }
-
-                applyWaitStrategy( resourceType, tries++ );
-
-                // And take note of who we are waiting for. This is used for deadlock detection.
-                markAsWaitingFor( existingLock, resourceType, resourceId );
+                // Make a local note about the fact that we now hold this lock
+                heldShareLocks.put( resourceId, 1 );
             }
-
-            // Got the lock, no longer waiting for anyone.
-            clearWaitList();
-
-            // Make a local note about the fact that we now hold this lock
-            heldShareLocks.put( resourceId, 1 );
         }
         finally
         {
@@ -239,7 +243,7 @@ public class ForsetiClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+    public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         hasLocks = true;
         stateHolder.incrementActiveClients( this );
@@ -249,40 +253,43 @@ public class ForsetiClient implements Locks.Client
             ConcurrentMap<Long,ForsetiLockManager.Lock> lockMap = lockMaps[resourceType.typeId()];
             PrimitiveLongIntMap heldLocks = exclusiveLockCounts[resourceType.typeId()];
 
-            int heldCount = heldLocks.get( resourceId );
-            if ( heldCount != -1 )
+            for ( long resourceId : resourceIds )
             {
-                // We already have a lock on this, just increment our local reference counter.
-                heldLocks.put( resourceId, Math.incrementExact( heldCount ) );
-                return;
-            }
-
-            // Grab the global lock
-            ForsetiLockManager.Lock existingLock;
-            int tries = 0;
-            while ( (existingLock = lockMap.putIfAbsent( resourceId, myExclusiveLock )) != null )
-            {
-                assertNotStopped();
-
-                // If this is a shared lock:
-                // Given a grace period of tries (to try and not starve readers), grab an update lock and wait for it
-                // to convert to an exclusive lock.
-                if ( tries > 50 && existingLock instanceof SharedLock )
+                int heldCount = heldLocks.get( resourceId );
+                if ( heldCount != -1 )
                 {
-                    // Then we should upgrade that lock
-                    SharedLock sharedLock = (SharedLock) existingLock;
-                    if ( tryUpgradeSharedToExclusive( resourceType, lockMap, resourceId, sharedLock ) )
-                    {
-                        break;
-                    }
+                    // We already have a lock on this, just increment our local reference counter.
+                    heldLocks.put( resourceId, Math.incrementExact( heldCount ) );
+                    return;
                 }
 
-                applyWaitStrategy( resourceType, tries++ );
-                markAsWaitingFor( existingLock, resourceType, resourceId );
-            }
+                // Grab the global lock
+                ForsetiLockManager.Lock existingLock;
+                int tries = 0;
+                while ( (existingLock = lockMap.putIfAbsent( resourceId, myExclusiveLock )) != null )
+                {
+                    assertNotStopped();
 
-            clearWaitList();
-            heldLocks.put( resourceId, 1 );
+                    // If this is a shared lock:
+                    // Given a grace period of tries (to try and not starve readers), grab an update lock and wait
+                    // for it to convert to an exclusive lock.
+                    if ( tries > 50 && existingLock instanceof SharedLock )
+                    {
+                        // Then we should upgrade that lock
+                        SharedLock sharedLock = (SharedLock) existingLock;
+                        if ( tryUpgradeSharedToExclusive( resourceType, lockMap, resourceId, sharedLock ) )
+                        {
+                            break;
+                        }
+                    }
+
+                    applyWaitStrategy( resourceType, tries++ );
+                    markAsWaitingFor( existingLock, resourceType, resourceId );
+                }
+
+                clearWaitList();
+                heldLocks.put( resourceId, 1 );
+            }
         }
         finally
         {

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -40,6 +40,7 @@
     <module>server-enterprise</module>
     <module>neo4j-harness-enterprise</module>
     <module>management</module>
+    <module>deferred-locks</module>
   </modules>
 
   <licenses>


### PR DESCRIPTION
This is a reimplementation of PR #7545 for 3.0 branch.

Deferred locks is a kernel extension and jar is not part of the distribution
but is published to maven.

It is also guarded by `unsupported.dbms.deferred_locks.enabled` setting which
is off by default.

We separate between optimistic and pessimistic locking:

**Optimistic locking**
Acquire locks triggered by some write or read event through the `Statement` cake.
Instead of grabbing those locks we only remind what resources we want to lock
and then acquire the them right before commit.

**Pessimistic locking**
Locks grabbed explicitly by the user or grabbed on master by a slave. Those
locks are taken immediately.

**Note**
Grabbing locks just before commit guards for store inconsistencies but not
logical inconsistencies.

**Warning**
This feature should not be used. Most of all code in Neo4j is assumed to be
executed under some sort of lock, exclusive or shared. This commit makes that
assumption false and there has not been enough investigation to foresee what
consequences that will have for transaction execution. These problems are
still in the unknown but there are also known, purposely undocumented,
problems.
