### PR TITLE
core-edge: raft log ship empty instead of single append entries

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Appending.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Appending.java
@@ -105,12 +105,9 @@ class Appending
                 state, request.prevLogIndex() + request.entries().length, request.leaderCommit(), outcome );
 
         long endMatchIndex = request.prevLogIndex() + request.entries().length; // this is the index of the last incoming entry
-        if ( endMatchIndex >= 0 )
-        {
-            RaftMessages.AppendEntries.Response appendResponse = new RaftMessages.AppendEntries.Response(
-                    state.myself(), request.leaderTerm(), true, endMatchIndex, endMatchIndex );
-            outcome.addOutgoingMessage( new RaftMessages.Directed( request.from(), appendResponse ) );
-        }
+        RaftMessages.AppendEntries.Response appendResponse = new RaftMessages.AppendEntries.Response(
+                state.myself(), request.leaderTerm(), true, endMatchIndex, endMatchIndex );
+        outcome.addOutgoingMessage( new RaftMessages.Directed( request.from(), appendResponse ) );
     }
 
     static  void appendNewEntry( ReadableRaftState ctx, Outcome outcome, ReplicatedContent content ) throws IOException

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Heart.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Heart.java
@@ -28,7 +28,7 @@ import org.neo4j.logging.Log;
 
 class Heart
 {
-    static  void beat( ReadableRaftState state, Outcome outcome, RaftMessages.Heartbeat request, Log log ) throws IOException
+    static void beat( ReadableRaftState state, Outcome outcome, RaftMessages.Heartbeat request, Log log ) throws IOException
     {
         if ( request.leaderTerm() < state.term() )
         {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/consensus/shipping/RaftLogShipperTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/consensus/shipping/RaftLogShipperTest.java
@@ -45,7 +45,7 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.test.matchers.Matchers;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -121,7 +121,8 @@ public class RaftLogShipperTest
         startLogShipper();
 
         // then
-        assertThat( outbound.sentTo( follower ), Matchers.hasRaftLogEntries( singletonList( entry1 ) ) );
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, 0, entry0.term(), RaftLogEntry.empty, leaderCommit );
+        assertThat( outbound.sentTo( follower ), hasItem( expected ) );
     }
 
     @Test
@@ -137,7 +138,8 @@ public class RaftLogShipperTest
         logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
 
         // then
-        assertThat( outbound.sentTo( follower ), Matchers.hasRaftLogEntries( singletonList( entry0 ) ) );
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, -1, -1, RaftLogEntry.empty, leaderCommit );
+        assertThat( outbound.sentTo( follower ), hasItem( expected ) );
     }
 
     @Test
@@ -156,8 +158,8 @@ public class RaftLogShipperTest
         logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
 
         // then
-        assertTrue( outbound.hasEntriesTo( follower, entry0 ) );
-        assertThat( outbound.sentTo( follower ), Matchers.hasRaftLogEntries( singletonList( entry0 ) ) );
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, -1, -1, RaftLogEntry.empty, leaderCommit );
+        assertThat( outbound.sentTo( follower ), hasItem( expected ) );
     }
 
     @Test
@@ -214,7 +216,7 @@ public class RaftLogShipperTest
         logShipper.onNewEntries( 1, 0, new RaftLogEntry[]{entry2}, new LeaderContext( 0, 0 ) );
 
         // then
-        assertEquals( outbound.sentTo( follower ).size(), 0 );
+        assertEquals( 0, outbound.sentTo( follower ).size() );
     }
 
     @Test
@@ -235,7 +237,8 @@ public class RaftLogShipperTest
         logShipper.onMismatch( 1, new LeaderContext( 0, 0 ) );
 
         // then
-        assertThat( outbound.sentTo( follower ), Matchers.hasRaftLogEntries( singletonList( entry2 ) ) );
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, 1, entry1.term(), RaftLogEntry.empty, leaderCommit );
+        assertThat( outbound.sentTo( follower ), hasItem( expected ) );
     }
 
     @Test
@@ -258,8 +261,8 @@ public class RaftLogShipperTest
         startLogShipper();
 
         // back-tracking stage
-        RaftLogEntry firstEntry = new RaftLogEntry( 0, ReplicatedInteger.valueOf( 0 ) );
-        while ( !outbound.hasEntriesTo( follower, firstEntry ) )
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, -1, -1, RaftLogEntry.empty, leaderCommit );
+        while ( !outbound.sentTo( follower ).contains( expected ) )
         {
             logShipper.onMismatch( -1, new LeaderContext( 0, 0 ) );
         }
@@ -297,8 +300,8 @@ public class RaftLogShipperTest
         logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
 
         //then
-        assertTrue( outbound.hasAnyEntriesTo( follower ) );
-        assertThat( outbound.sentTo( follower ), Matchers.hasRaftLogEntries( singletonList( entry3 ) ) );
+        RaftMessages.AppendEntries.Request expected = new RaftMessages.AppendEntries.Request( leader, leaderTerm, 2, entry2.term(), RaftLogEntry.empty, leaderCommit );
+        assertThat( outbound.sentTo( follower ), hasItem( expected ) );
     }
 
     @Test


### PR DESCRIPTION
It is unnecessary to read each entry in the mismatch phase and some
other scenarios since they will be discarded anyway. Only when shipping
ranges after a match will the actual entries now be populated.
