### PR TITLE
Fixed references encoding in enterprise format

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -485,7 +485,7 @@ public class CompositePageCursor extends PageCursor
 
     /**
      * Build a CompositePageCursor that is a view of the first page cursor from its current offset through the given
-     * length, concaternated with the second cursor from its current offset through the given length. The offsets are
+     * length, concatenated with the second cursor from its current offset through the given length. The offsets are
      * changed as part of accessing the underlying cursors through the composite cursor. However, the size and position
      * of the view does NOT change if the offsets of the underlying cursors are changed after constructing the composite
      * cursor.

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -41,7 +41,7 @@ public class StubPageCursor extends PageCursor
     private String cursorErrorMessage;
     private boolean closed;
     private boolean needsRetry;
-    private StubPageCursor linkedCursor;
+    protected StubPageCursor linkedCursor;
 
     public StubPageCursor( long initialPageId, int pageSize )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -41,6 +41,9 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
     private boolean requiresSecondaryUnit;
     private boolean inUse;
     private boolean created;
+    // Flag that indicates usage of fixed references format.
+    // Fixed references format allows to avoid encoding/decoding of references in variable length format and as result
+    // speed up records read/write operations.
     private boolean useFixedReferences;
 
     protected AbstractBaseRecord( long id )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -41,6 +41,7 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
     private boolean requiresSecondaryUnit;
     private boolean inUse;
     private boolean created;
+    private boolean useFixedReferences;
 
     protected AbstractBaseRecord( long id )
     {
@@ -54,6 +55,7 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
         this.created = false;
         this.secondaryUnitId = NO_ID;
         this.requiresSecondaryUnit = false;
+        this.useFixedReferences = false;
         return this;
     }
 
@@ -69,6 +71,7 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
         created = false;
         secondaryUnitId = NO_ID;
         requiresSecondaryUnit = false;
+        this.useFixedReferences = false;
     }
 
     public long getId()
@@ -141,6 +144,16 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
     public final boolean isCreated()
     {
         return created;
+    }
+
+    public boolean isUseFixedReferences()
+    {
+        return useFixedReferences;
+    }
+
+    public void setUseFixedReferences( boolean useFixedReferences )
+    {
+        this.useFixedReferences = useFixedReferences;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -183,25 +183,10 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
         throw new UnsupportedOperationException();
     }
 
-    @SuppressWarnings( "rawtypes" )
-    private static final Predicate IN_USE_FILTER = new Predicate<AbstractBaseRecord>()
-    {
-        @Override
-        public boolean test( AbstractBaseRecord item )
-        {
-            return item.inUse();
-        }
-    };
+    private static final Predicate IN_USE_FILTER = (Predicate<AbstractBaseRecord>) AbstractBaseRecord::inUse;
 
     @SuppressWarnings( "rawtypes" )
-    private static final Predicate NOT_IN_USE_FILTER = new Predicate<AbstractBaseRecord>()
-    {
-        @Override
-        public boolean test( AbstractBaseRecord item )
-        {
-            return !item.inUse();
-        }
-    };
+    private static final Predicate NOT_IN_USE_FILTER = (Predicate<AbstractBaseRecord>) item -> !item.inUse();
 
     /**
      * @return {@link Predicate filter} which only records that are {@link #inUse() in use} passes.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.RandomRule;
+import org.neo4j.test.SuppressOutput;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingIdSequence;
 
 import static java.lang.System.currentTimeMillis;
@@ -69,9 +70,10 @@ public abstract class RecordFormatTest
 
     private final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     private final PageCacheRule pageCacheRule = new PageCacheRule();
+    private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
 
     @Rule
-    public final RuleChain ruleChain = RuleChain.outerRule( pageCacheRule ).around( fsRule );
+    public final RuleChain ruleChain = RuleChain.outerRule( pageCacheRule ).around( fsRule ).around( suppressOutput );
 
     public RecordKeys keys = FullyCoveringRecordKeys.INSTANCE;
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -84,7 +84,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
     static final long NULL = Record.NULL_REFERENCE.intValue();
     static final int HEADER_BIT_RECORD_UNIT = 0b0000_0010;
     static final int HEADER_BIT_FIRST_RECORD_UNIT = 0b0000_0100;
-    static final int HEADER_BIT_FIXED_REFERENCE = 0b0000_0100;
+    static final int HEADER_BIT_INVERTED_FIXED_REFERENCE = 0b0000_0100;
 
     protected BaseHighLimitRecordFormat( Function<StoreHeader,Integer> recordSize, int recordHeaderSize )
     {
@@ -142,9 +142,14 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
         }
         else
         {
-            record.setUseFixedReferences( has( headerByte, HEADER_BIT_FIXED_REFERENCE ) );
+            record.setUseFixedReferences( isUseFixedReferences( headerByte ) );
             doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
         }
+    }
+
+    private boolean isUseFixedReferences( byte headerByte )
+    {
+        return !has( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE );
     }
 
     private String illegalSecondaryReferenceMessage( long secondaryId )
@@ -173,7 +178,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
             }
             else
             {
-                headerByte = set( headerByte, HEADER_BIT_FIXED_REFERENCE, record.isUseFixedReferences() );
+                headerByte = set( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE, !record.isUseFixedReferences() );
             }
             primaryCursor.putByte( headerByte );
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -84,7 +84,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
     static final long NULL = Record.NULL_REFERENCE.intValue();
     static final int HEADER_BIT_RECORD_UNIT = 0b0000_0010;
     static final int HEADER_BIT_FIRST_RECORD_UNIT = 0b0000_0100;
-    private static final int HEADER_BIT_FIXED_REFERENCE = 0b0000_0100;
+    static final int HEADER_BIT_FIXED_REFERENCE = 0b0000_0100;
 
     protected BaseHighLimitRecordFormat( Function<StoreHeader,Integer> recordSize, int recordHeaderSize )
     {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -98,6 +98,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
         byte headerByte = primaryCursor.getByte();
         boolean inUse = isInUse( headerByte );
         boolean doubleRecordUnit = has( headerByte, HEADER_BIT_RECORD_UNIT );
+        record.setUseFixedReferences( false );
         if ( doubleRecordUnit )
         {
             boolean firstRecordUnit = has( headerByte, HEADER_BIT_FIRST_RECORD_UNIT );

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -79,7 +79,7 @@ import static org.neo4j.kernel.impl.store.RecordPageLocationCalculator.pageIdFor
 abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
         extends BaseOneByteHeaderRecordFormat<RECORD>
 {
-    private static final int HEADER_BYTE = Byte.BYTES;
+    static final int HEADER_BYTE = Byte.BYTES;
 
     static final long NULL = Record.NULL_REFERENCE.intValue();
     static final int HEADER_BIT_RECORD_UNIT = 0b0000_0010;
@@ -242,7 +242,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
     {
         if ( record.inUse() )
         {
-            record.setUseFixedReferences( canUseFixedReferences( record ));
+            record.setUseFixedReferences( canUseFixedReferences( record, recordSize ));
             if ( !record.isUseFixedReferences() )
             {
                 int requiredLength = HEADER_BYTE + requiredDataLength( record );
@@ -258,7 +258,7 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
         }
     }
 
-    protected abstract boolean canUseFixedReferences( RECORD record );
+    protected abstract boolean canUseFixedReferences( RECORD record, int recordSize );
 
     /**
      * Required length of the data in the given record (without the header byte).

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -43,13 +43,13 @@ import static org.neo4j.kernel.impl.store.format.standard.DynamicRecordFormat.re
  *
  * => 12B + data size
  */
-class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
+public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
 {
     private static final int RECORD_HEADER_SIZE = 1/*header byte*/ + 3/*# of bytes*/ + 8/*max size of next reference*/;
                                             // = 12
     private static final int START_RECORD_BIT = 0x8;
 
-    protected DynamicRecordFormat()
+    public DynamicRecordFormat()
     {
         super( INT_STORE_HEADER_READER, RECORD_HEADER_SIZE, IN_USE_BIT, HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
     }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -41,12 +41,12 @@ import org.neo4j.kernel.impl.store.record.Record;
 class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
 {
     static final int RECORD_SIZE = 16;
-    private static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
-                                                        Byte.BYTES /* modifiers */ +
-                                                        Integer.BYTES /* next relationship */ +
-                                                        Integer.BYTES /* next property */ +
-                                                        Integer.BYTES /* labels */ +
-                                                        Byte.BYTES /* labels */;
+    static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
+                                                Byte.BYTES /* modifiers */ +
+                                                Integer.BYTES /* next relationship */ +
+                                                Integer.BYTES /* next property */ +
+                                                Integer.BYTES /* labels */ +
+                                                Byte.BYTES /* labels */;
 
     private static final long NULL_LABELS = Record.NO_LABELS_FIELD.intValue();
     private static final int DENSE_NODE_BIT       = 0b0000_1000;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -129,8 +129,8 @@ class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
     protected boolean canUseFixedReferences( NodeRecord record, int recordSize )
     {
         return  (isRecordBigEnoughForFixedReferences( recordSize ) &&
-                 ((record.getNextProp() != NULL) && ((record.getNextProp() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)) &&
-                 ((record.getNextRel() != NULL) && ((record.getNextRel() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)));
+                 ((record.getNextProp() == NULL) || ((record.getNextProp() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)) &&
+                 ((record.getNextRel() == NULL) || ((record.getNextRel() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)));
     }
 
     private boolean isRecordBigEnoughForFixedReferences( int recordSize )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -41,6 +41,12 @@ import org.neo4j.kernel.impl.store.record.Record;
 class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
 {
     static final int RECORD_SIZE = 16;
+    private static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
+                                                        Byte.BYTES /* modifiers */ +
+                                                        Integer.BYTES /* next relationship */ +
+                                                        Integer.BYTES /* next property */ +
+                                                        Integer.BYTES /* labels */ +
+                                                        Byte.BYTES /* labels */;
 
     private static final long NULL_LABELS = Record.NO_LABELS_FIELD.intValue();
     private static final int DENSE_NODE_BIT       = 0b0000_1000;
@@ -111,10 +117,16 @@ class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
     }
 
     @Override
-    protected boolean canUseFixedReferences( NodeRecord record )
+    protected boolean canUseFixedReferences( NodeRecord record, int recordSize )
     {
-        return (((record.getNextProp() != NULL) && ((record.getNextProp() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)) &&
-                ((record.getNextRel() != NULL) && ((record.getNextRel() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)));
+        return  (isRecordBigEnoughForFixedReferences( recordSize ) &&
+                 ((record.getNextProp() != NULL) && ((record.getNextProp() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)) &&
+                 ((record.getNextRel() != NULL) && ((record.getNextRel() & HIGH_DWORD_LOWER_NIBBLE_MASK) == 0)));
+    }
+
+    private boolean isRecordBigEnoughForFixedReferences( int recordSize )
+    {
+        return FIXED_FORMAT_RECORD_SIZE <= recordSize;
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -184,8 +184,8 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
     private boolean canUseFixedReferences( PropertyRecord record, int recordSize )
     {
         return ( isRecordBigEnoughForFixedReferences( recordSize ) &&
-                ((record.getNextProp() != NULL) && ((record.getNextProp() & HIGH_DWORD_LOWER_WORD_CHECK_MASK) == 0)) &&
-                ((record.getPrevProp() != NULL) && ((record.getPrevProp() & HIGH_DWORD_LOWER_WORD_CHECK_MASK) == 0)));
+                ((record.getNextProp() == NULL) || ((record.getNextProp() & HIGH_DWORD_LOWER_WORD_CHECK_MASK) == 0)) &&
+                ((record.getPrevProp() == NULL) || ((record.getPrevProp() & HIGH_DWORD_LOWER_WORD_CHECK_MASK) == 0)));
     }
 
     private boolean isRecordBigEnoughForFixedReferences( int recordSize )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -82,7 +82,7 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
         int offset = cursor.getOffset();
         byte headerByte = cursor.getByte();
         boolean inUse = isInUse( headerByte );
-        boolean useFixedReferences = !has( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE );
+        boolean useFixedReferences = has( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE );
         if ( mode.shouldLoad( inUse ) )
         {
             int blockCount = headerByte >>> 4;
@@ -120,7 +120,7 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
             byte headerByte = (byte) ((record.inUse() ? IN_USE_BIT : 0) | numberOfBlocks( record ) << 4);
             boolean canUseFixedReferences = canUseFixedReferences( record, recordSize );
             record.setUseFixedReferences( canUseFixedReferences );
-            headerByte = set( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE, !canUseFixedReferences );
+            headerByte = set( headerByte, HEADER_BIT_INVERTED_FIXED_REFERENCE, canUseFixedReferences );
             cursor.putByte( headerByte );
 
             long recordId = record.getId();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
@@ -38,7 +38,7 @@ import static java.lang.String.format;
  *
  * @author Mattias Persson
  */
-enum Reference
+public enum Reference
 {
     // bit masks below contain one bit for 's' (sign) so actual address space is one bit less than advertised
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -160,11 +160,11 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     protected boolean canUseFixedReferences( RelationshipGroupRecord record, int recordSize )
     {
         return (isRecordBigEnoughForFixedReferences( recordSize ) &&
-                (record.getNext() != NULL) && ((record.getNext() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                (record.getFirstOut() != NULL) && ((record.getFirstOut() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                (record.getFirstIn() != NULL) && ((record.getFirstIn() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                (record.getFirstLoop() != NULL) && ((record.getFirstLoop() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                (record.getOwningNode() != NULL) && ((record.getOwningNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0));
+                ((record.getNext() == NULL) || ((record.getNext() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                ((record.getFirstOut() == NULL) || ((record.getFirstOut() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                ((record.getFirstIn() == NULL) || ((record.getFirstIn() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                ((record.getFirstLoop() == NULL) || ((record.getFirstLoop() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                ((record.getOwningNode() == NULL) || ((record.getOwningNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)));
     }
 
     private boolean isRecordBigEnoughForFixedReferences( int recordSize )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -37,8 +37,18 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
  * VB   first loop relationships
  * VB   owning node
  * VB   next relationship group record
- *
  * => 18B-43B
+ *
+ * Fixed reference format:
+ * 1B   header
+ * 1B   modifiers
+ * 2B   relationship type
+ * 4B   next relationship
+ * 4B   first outgoing relationship
+ * 4B   first incoming relationship
+ * 4B   first loop
+ * 4B   owning node
+ * => 24B
  */
 class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<RelationshipGroupRecord>
 {
@@ -88,6 +98,7 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     {
         if ( record.isUseFixedReferences() )
         {
+            // read record in fixed references format
             readFixedReferencesMethod( record, cursor, inUse );
             record.setUseFixedReferences( true );
         }
@@ -131,6 +142,7 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     {
         if ( record.isUseFixedReferences() )
         {
+            // write record in fixed references format
             writeFixedReferencesRecord( record, cursor );
         }
         else

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
-import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 
 /**
@@ -50,13 +49,14 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     private static final int HAS_LOOP_BIT     = 0b0010_0000;
     private static final int HAS_NEXT_BIT     = 0b0100_0000;
 
+    private static final int NEXT_RECORD_BIT = 0b0000_0001;
+    private static final int FIRST_OUT_BIT = 0b0000_0010;
+    private static final int FIRST_IN_BIT = 0b0000_0100;
+    private static final int FIRST_LOOP_BIT = 0b0000_1000;
+    private static final int OWNING_NODE_BIT = 0b0001_0000;
+
     private static final long ONE_BIT_OVERFLOW_BIT_MASK = 0xFFFF_FFFE_0000_0000L;
-    private static final long FIXED_REFERENCE_BIT_MASK = 0x100000000L;
-    private static final int NEXT_RECORD_BIT_MASK = 0b0000_0001;
-    private static final int FIRST_OUT_BIT_MASK = 0b0000_0010;
-    private static final int FIRST_IN_BIT_MASK = 0b0000_0100;
-    private static final int FIRST_LOOP_BIT_MASK = 0b0000_1000;
-    private static final int OWNING_NODE_BIT_MASK = 0b0001_0000;
+    private static final long HIGH_DWORD_LAST_BIT_MASK = 0x100000000L;
 
     public RelationshipGroupRecordFormat()
     {
@@ -81,6 +81,7 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
         if ( record.isUseFixedReferences() )
         {
             readFixedReferencesMethod( record, cursor, inUse );
+            record.setUseFixedReferences( true );
         }
         else
         {
@@ -138,11 +139,11 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     @Override
     protected boolean canUseFixedReferences( RelationshipGroupRecord record )
     {
-        return !((record.getNext() != NULL) && ((record.getNext() & ONE_BIT_OVERFLOW_BIT_MASK) != 0) ||
-                 (record.getFirstOut() != NULL) && ((record.getFirstOut() & ONE_BIT_OVERFLOW_BIT_MASK) != 0) ||
-                 (record.getFirstIn() != NULL) && ((record.getFirstIn() & ONE_BIT_OVERFLOW_BIT_MASK) != 0) ||
-                 (record.getFirstLoop() != NULL) && ((record.getFirstLoop() & ONE_BIT_OVERFLOW_BIT_MASK) != 0) ||
-                 (record.getOwningNode() != NULL) && ((record.getOwningNode() & ONE_BIT_OVERFLOW_BIT_MASK) != 0));
+        return ((record.getNext() != NULL) && ((record.getNext() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
+                (record.getFirstOut() != NULL) && ((record.getFirstOut() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
+                (record.getFirstIn() != NULL) && ((record.getFirstIn() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
+                (record.getFirstLoop() != NULL) && ((record.getFirstLoop() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
+                (record.getOwningNode() != NULL) && ((record.getOwningNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0));
     }
 
     private void readFixedReferencesMethod( RelationshipGroupRecord record, PageCursor cursor, boolean inUse )
@@ -162,11 +163,11 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
         long firstLoopLowBits = cursor.getInt() & 0xFFFFFFFFL;
         long owningNodeLowBits = cursor.getInt() & 0xFFFFFFFFL;
 
-        long nextMod = (modifiers & NEXT_RECORD_BIT_MASK) << 32;
-        long firstOutMod = (modifiers & FIRST_OUT_BIT_MASK) << 31;
-        long firstInMod = (modifiers & FIRST_IN_BIT_MASK) << 30;
-        long firstLoopMod = (modifiers & FIRST_LOOP_BIT_MASK) << 29;
-        long owningNodeMod = (modifiers & OWNING_NODE_BIT_MASK) << 28;
+        long nextMod = (modifiers & NEXT_RECORD_BIT) << 32;
+        long firstOutMod = (modifiers & FIRST_OUT_BIT) << 31;
+        long firstInMod = (modifiers & FIRST_IN_BIT) << 30;
+        long firstLoopMod = (modifiers & FIRST_LOOP_BIT) << 29;
+        long owningNodeMod = (modifiers & OWNING_NODE_BIT) << 28;
 
         record.initialize( inUse, type,
                 BaseRecordFormat.longFromIntAndMod( firstOutLowBits, firstOutMod ),
@@ -178,11 +179,11 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
 
     private void writeFixedReferencesRecord( RelationshipGroupRecord record, PageCursor cursor )
     {
-        long nextMod = record.getNext() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getNext() & FIXED_REFERENCE_BIT_MASK) >> 32;
-        long firstOutMod = record.getFirstOut() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstOut() & FIXED_REFERENCE_BIT_MASK) >> 31;
-        long firstInMod = record.getFirstIn() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstIn() & FIXED_REFERENCE_BIT_MASK) >> 30;
-        long firstLoopMod = record.getFirstLoop() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstLoop() & FIXED_REFERENCE_BIT_MASK) >> 29;
-        long owningNodeMod = record.getOwningNode() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getOwningNode() & FIXED_REFERENCE_BIT_MASK) >> 28;
+        long nextMod = record.getNext() == NULL ? 0 : (record.getNext() & HIGH_DWORD_LAST_BIT_MASK) >> 32;
+        long firstOutMod = record.getFirstOut() == NULL ? 0 : (record.getFirstOut() & HIGH_DWORD_LAST_BIT_MASK) >> 31;
+        long firstInMod = record.getFirstIn() == NULL ? 0 : (record.getFirstIn() & HIGH_DWORD_LAST_BIT_MASK) >> 30;
+        long firstLoopMod = record.getFirstLoop() == NULL ? 0 : (record.getFirstLoop() & HIGH_DWORD_LAST_BIT_MASK) >> 29;
+        long owningNodeMod = record.getOwningNode() == NULL ? 0 : (record.getOwningNode() & HIGH_DWORD_LAST_BIT_MASK) >> 28;
 
         // [    ,   x] high next bits
         // [    ,  x ] high firstOut bits

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.store.format.highlimit;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
+import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 
 /**
@@ -68,13 +70,47 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     protected void doReadInternal( RelationshipGroupRecord record, PageCursor cursor, int recordSize, long headerByte,
                                    boolean inUse )
     {
-        record.initialize( inUse,
-                cursor.getShort() & 0xFFFF,
-                decodeCompressedReference( cursor, headerByte, HAS_OUTGOING_BIT, NULL ),
-                decodeCompressedReference( cursor, headerByte, HAS_INCOMING_BIT, NULL ),
-                decodeCompressedReference( cursor, headerByte, HAS_LOOP_BIT, NULL ),
-                decodeCompressedReference( cursor ),
-                decodeCompressedReference( cursor, headerByte, HAS_NEXT_BIT, NULL ) );
+        if ( record.isUseFixedReferences() )
+        {
+
+            // [    ,   x] high next bits
+            // [    ,  x ] high firstOut bits
+            // [    , x  ] high firstIn bits
+            // [    ,x   ] high firstLoop bits
+            // [   x,    ] high owner bits
+            long modifiers = cursor.getByte();
+
+            int type = cursor.getShort() & 0xFFFF;
+
+            long nextLowBits = cursor.getInt() & 0xFFFFFFFFL;
+            long nextOutLowBits = cursor.getInt() & 0xFFFFFFFFL;
+            long nextInLowBits = cursor.getInt() & 0xFFFFFFFFL;
+            long nextLoopLowBits = cursor.getInt() & 0xFFFFFFFFL;
+            long owningNode = cursor.getInt() & 0xFFFFFFFFL;
+
+            long nextMod = (modifiers & 0b0000_0001) << 32;
+            long nextOutMod = (modifiers & 0b0000_0010) << 31;
+            long nextInMod = (modifiers & 0b0000_0100) << 30;
+            long nextLoopMod = (modifiers & 0b0000_1000) << 29;
+            long owningNodeMod = (modifiers & 0b0001_0000) << 28;
+
+            record.initialize( inUse, type,
+                    BaseRecordFormat.longFromIntAndMod( nextOutLowBits, nextOutMod ),
+                    BaseRecordFormat.longFromIntAndMod( nextInLowBits, nextInMod ),
+                    BaseRecordFormat.longFromIntAndMod( nextLoopLowBits, nextLoopMod ),
+                    BaseRecordFormat.longFromIntAndMod( owningNode, owningNodeMod ),
+                    BaseRecordFormat.longFromIntAndMod( nextLowBits, nextMod ) );
+        }
+        else
+        {
+            record.initialize( inUse,
+                    cursor.getShort() & 0xFFFF,
+                    decodeCompressedReference( cursor, headerByte, HAS_OUTGOING_BIT, NULL ),
+                    decodeCompressedReference( cursor, headerByte, HAS_INCOMING_BIT, NULL ),
+                    decodeCompressedReference( cursor, headerByte, HAS_LOOP_BIT, NULL ),
+                    decodeCompressedReference( cursor ),
+                    decodeCompressedReference( cursor, headerByte, HAS_NEXT_BIT, NULL ) );
+        }
     }
 
     @Override
@@ -103,11 +139,46 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
     protected void doWriteInternal( RelationshipGroupRecord record, PageCursor cursor )
             throws IOException
     {
-        cursor.putShort( (short) record.getType() );
-        encode( cursor, record.getFirstOut(), NULL );
-        encode( cursor, record.getFirstIn(), NULL );
-        encode( cursor, record.getFirstLoop(), NULL );
-        encode( cursor, record.getOwningNode() );
-        encode( cursor, record.getNext(), NULL );
+        if ( record.isUseFixedReferences() )
+        {
+            long nextMod = record.getNext() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getNext() & 0x100000000L) >> 32;
+            long nextOutMod = record.getFirstOut() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstOut() & 0x100000000L) >> 31;
+            long nextInMod = record.getFirstIn() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstIn() & 0x100000000L) >> 30;
+            long nextLoopMod = record.getFirstLoop() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getFirstLoop() & 0x100000000L) >> 29;
+            long ownerMod = record.getOwningNode() == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (record.getOwningNode() & 0x100000000L) >> 28;
+
+            // [    ,   x] high next bits
+            // [    ,  x ] high firstOut bits
+            // [    , x  ] high firstIn bits
+            // [    ,x   ] high firstLoop bits
+            // [   x,    ] high owner bits
+            cursor.putByte( (byte) (nextMod | nextOutMod | nextInMod | nextLoopMod | ownerMod) );
+
+            cursor.putShort( (short) record.getType() );
+            cursor.putInt( (int) record.getNext() );
+            cursor.putInt( (int) record.getFirstOut() );
+            cursor.putInt( (int) record.getFirstIn() );
+            cursor.putInt( (int) record.getFirstLoop() );
+            cursor.putInt( (int) record.getOwningNode() );
+        }
+        else
+        {
+            cursor.putShort( (short) record.getType() );
+            encode( cursor, record.getFirstOut(), NULL );
+            encode( cursor, record.getFirstIn(), NULL );
+            encode( cursor, record.getFirstLoop(), NULL );
+            encode( cursor, record.getOwningNode() );
+            encode( cursor, record.getNext(), NULL );
+        }
+    }
+
+    @Override
+    protected boolean canUseFixedReferences( RelationshipGroupRecord record )
+    {
+        return !((record.getNext() != NULL) && ((record.getNext() & 0xFFFF_FFFE_0000_0000L) != 0) ||
+                 (record.getFirstOut() != NULL) && ((record.getFirstOut() & 0xFFFF_FFFE_0000_0000L) != 0) ||
+                 (record.getFirstIn() != NULL) && ((record.getFirstIn() & 0xFFFF_FFFE_0000_0000L) != 0) ||
+                 (record.getFirstLoop() != NULL) && ((record.getFirstLoop() & 0xFFFF_FFFE_0000_0000L) != 0) ||
+                 (record.getOwningNode() != NULL) && ((record.getOwningNode() & 0xFFFF_FFFE_0000_0000L) != 0));
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -43,14 +43,14 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<RelationshipGroupRecord>
 {
     static final int RECORD_SIZE = 32;
-    private static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
-                                                        Byte.BYTES /* modifiers */ +
-                                                        Short.BYTES /* type */ +
-                                                        Integer.BYTES /* next */ +
-                                                        Integer.BYTES /* first out */ +
-                                                        Integer.BYTES /* first in */ +
-                                                        Integer.BYTES /* first loop */ +
-                                                        Integer.BYTES /* owning node */;
+    static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
+                                                Byte.BYTES /* modifiers */ +
+                                                Short.BYTES /* type */ +
+                                                Integer.BYTES /* next */ +
+                                                Integer.BYTES /* first out */ +
+                                                Integer.BYTES /* first in */ +
+                                                Integer.BYTES /* first loop */ +
+                                                Integer.BYTES /* owning node */;
 
     private static final int HAS_OUTGOING_BIT = 0b0000_1000;
     private static final int HAS_INCOMING_BIT = 0b0001_0000;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
-import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toAbsolute;
@@ -56,18 +55,19 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     private static final int HAS_SECOND_CHAIN_NEXT_BIT = 0b0100_0000;
     private static final int HAS_PROPERTY_BIT = 0b1000_0000;
 
+    private static final long FIRST_NODE_BIT = 0b0000_0001L;
+    private static final long SECOND_NODE_BIT = 0b0000_0010L;
+    private static final long FIRST_PREV_REL_BIT = 0b0000_0100L;
+    private static final long FIRST_NEXT_REL_BIT = 0b0000_1000L;
+    private static final long SECOND_RREV_REL_BIT = 0b0001_0000L;
+    private static final long SECOND_NEXT_REL_BIT = 0b0010_0000L;
+    private static final long NEXT_PROP_BIT = 0b1100_0000L;
+
     private static final long ONE_BIT_OVERFLOW_BIT_MASK = 0xFFFF_FFFE_0000_0000L;
     private static final long THREE_BITS_OVERFLOW_BIT_MASK = 0xFFFF_FFFC_0000_0000L;
-    private static final long FIXED_REFERENCE_BIT_MASK = 0x100000000L;
-    private static final long THREE_BIT_FIXED_REFERENCE_BIT_MASK = 0x300000000L;
+    private static final long HIGH_DWORD_LAST_BIT_MASK = 0x100000000L;
 
-    private static final long FIRST_NODE_BIT_MASK = 0b0000_0001L;
-    private static final long SECOND_NODE_BIT_MASK = 0b0000_0010L;
-    private static final long FIRST_PREV_REL_BIT_MASK = 0b0000_0100L;
-    private static final long FIRST_NEXT_REL_BIT_MASK = 0b0000_1000L;
-    private static final long SECOND_RREV_REL_BIT_MASK = 0b0001_0000L;
-    private static final long SECOND_NEXT_REL_BIT_MASK = 0b0010_0000L;
-    private static final long NEXT_PROP_BIT_MASK = 0b1100_0000L;
+    private static final long THREE_BIT_FIXED_REFERENCE_BIT_MASK = 0x300000000L;
 
     public RelationshipRecordFormat()
     {
@@ -90,13 +90,14 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
             RelationshipRecord record, PageCursor cursor, int recordSize, long headerByte, boolean inUse )
     {
         int type = cursor.getShort() & 0xFFFF;
-        long recordId = record.getId();
         if (record.isUseFixedReferences())
         {
             readFixedReferencesRecord( record, cursor, headerByte, inUse, type );
+            record.setUseFixedReferences( true );
         }
         else
         {
+            long recordId = record.getId();
             record.initialize( inUse,
                     decodeCompressedReference( cursor, headerByte, HAS_PROPERTY_BIT, NULL ),
                     decodeCompressedReference( cursor ),
@@ -109,13 +110,6 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
                     has( headerByte, FIRST_IN_FIRST_CHAIN_BIT ),
                     has( headerByte, FIRST_IN_SECOND_CHAIN_BIT ) );
         }
-    }
-
-    private long decodeAbsoluteOrRelative( PageCursor cursor, long headerByte, int firstInStartBit, long recordId )
-    {
-        return has( headerByte, firstInStartBit ) ?
-               decodeCompressedReference( cursor ) :
-               toAbsolute( decodeCompressedReference( cursor ), recordId );
     }
 
     @Override
@@ -149,13 +143,13 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
             throws IOException
     {
         cursor.putShort( (short) record.getType() );
-        long recordId = record.getId();
         if (record.isUseFixedReferences())
         {
             writeFixedReferencesRecord( record, cursor );
         }
         else
         {
+            long recordId = record.getId();
             encode( cursor, record.getNextProp(), NULL );
             encode( cursor, record.getFirstNode() );
             encode( cursor, record.getSecondNode() );
@@ -178,11 +172,18 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     {
            return ((record.getFirstNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
                   ((record.getSecondNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                  ((record.getFirstPrevRel() == NULL) || ((record.getFirstPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getFirstNextRel() == NULL) || ((record.getFirstNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getSecondPrevRel() == NULL) || ((record.getSecondPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getSecondNextRel() == NULL) || ((record.getSecondNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getNextProp() == NULL) || ((record.getNextProp() & THREE_BITS_OVERFLOW_BIT_MASK) == 0));
+                  ((record.getFirstPrevRel() != NULL) && ((record.getFirstPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getFirstNextRel() != NULL) && ((record.getFirstNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getSecondPrevRel() != NULL) && ((record.getSecondPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getSecondNextRel() != NULL) && ((record.getSecondNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getNextProp() != NULL) && ((record.getNextProp() & THREE_BITS_OVERFLOW_BIT_MASK) == 0));
+    }
+
+    private long decodeAbsoluteOrRelative( PageCursor cursor, long headerByte, int firstInStartBit, long recordId )
+    {
+        return has( headerByte, firstInStartBit ) ?
+               decodeCompressedReference( cursor ) :
+               toAbsolute( decodeCompressedReference( cursor ), recordId );
     }
 
     private long getSecondPrevReference( RelationshipRecord record, long recordId )
@@ -220,25 +221,25 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
         long modifiers = cursor.getByte();
 
         long firstNode = cursor.getInt() & 0xFFFFFFFFL;
-        long firstNodeMod = (modifiers & FIRST_NODE_BIT_MASK) << 32;
+        long firstNodeMod = (modifiers & FIRST_NODE_BIT) << 32;
 
         long secondNode = cursor.getInt() & 0xFFFFFFFFL;
-        long secondNodeMod = (modifiers & SECOND_NODE_BIT_MASK) << 31;
+        long secondNodeMod = (modifiers & SECOND_NODE_BIT) << 31;
 
         long firstPrevRel = cursor.getInt() & 0xFFFFFFFFL;
-        long firstPrevRelMod = (modifiers & FIRST_PREV_REL_BIT_MASK) << 30;
+        long firstPrevRelMod = (modifiers & FIRST_PREV_REL_BIT) << 30;
 
         long firstNextRel = cursor.getInt() & 0xFFFFFFFFL;
-        long firstNextRelMod = (modifiers & FIRST_NEXT_REL_BIT_MASK) << 29;
+        long firstNextRelMod = (modifiers & FIRST_NEXT_REL_BIT) << 29;
 
         long secondPrevRel = cursor.getInt() & 0xFFFFFFFFL;
-        long secondPrevRelMod = (modifiers & SECOND_RREV_REL_BIT_MASK) << 28;
+        long secondPrevRelMod = (modifiers & SECOND_RREV_REL_BIT) << 28;
 
         long secondNextRel = cursor.getInt() & 0xFFFFFFFFL;
-        long secondNextRelMod = (modifiers & SECOND_NEXT_REL_BIT_MASK) << 27;
+        long secondNextRelMod = (modifiers & SECOND_NEXT_REL_BIT) << 27;
 
         long nextProp = cursor.getInt() & 0xFFFFFFFFL;
-        long nextPropMod = (modifiers & NEXT_PROP_BIT_MASK) << 26;
+        long nextPropMod = (modifiers & NEXT_PROP_BIT) << 26;
 
         record.initialize( inUse,
                 BaseRecordFormat.longFromIntAndMod( nextProp, nextPropMod ),
@@ -256,25 +257,25 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     private void writeFixedReferencesRecord( RelationshipRecord record, PageCursor cursor )
     {
         long firstNode = record.getFirstNode();
-        short firstNodeMod = (short)((firstNode & FIXED_REFERENCE_BIT_MASK) >> 32);
+        short firstNodeMod = (short)((firstNode & HIGH_DWORD_LAST_BIT_MASK) >> 32);
 
         long secondNode = record.getSecondNode();
-        long secondNodeMod = (secondNode & FIXED_REFERENCE_BIT_MASK) >> 31;
+        long secondNodeMod = (secondNode & HIGH_DWORD_LAST_BIT_MASK) >> 31;
 
         long firstPrevRel = record.getFirstPrevRel();
-        long firstPrevRelMod = firstPrevRel == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (firstPrevRel & FIXED_REFERENCE_BIT_MASK) >> 30;
+        long firstPrevRelMod = firstPrevRel == NULL ? 0 : (firstPrevRel & HIGH_DWORD_LAST_BIT_MASK) >> 30;
 
         long firstNextRel = record.getFirstNextRel();
-        long firstNextRelMod = firstNextRel == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (firstNextRel & FIXED_REFERENCE_BIT_MASK) >> 29;
+        long firstNextRelMod = firstNextRel == NULL ? 0 : (firstNextRel & HIGH_DWORD_LAST_BIT_MASK) >> 29;
 
         long secondPrevRel = record.getSecondPrevRel();
-        long secondPrevRelMod = secondPrevRel == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (secondPrevRel & FIXED_REFERENCE_BIT_MASK) >> 28;
+        long secondPrevRelMod = secondPrevRel == NULL ? 0 : (secondPrevRel & HIGH_DWORD_LAST_BIT_MASK) >> 28;
 
         long secondNextRel = record.getSecondNextRel();
-        long secondNextRelMod = secondNextRel == Record.NO_NEXT_RELATIONSHIP.intValue() ? 0 : (secondNextRel & FIXED_REFERENCE_BIT_MASK) >> 27;
+        long secondNextRelMod = secondNextRel == NULL ? 0 : (secondNextRel & HIGH_DWORD_LAST_BIT_MASK) >> 27;
 
         long nextProp = record.getNextProp();
-        long nextPropMod = nextProp == Record.NO_NEXT_PROPERTY.intValue() ? 0 : (nextProp & THREE_BIT_FIXED_REFERENCE_BIT_MASK) >> 26;
+        long nextPropMod = nextProp == NULL ? 0 : (nextProp & THREE_BIT_FIXED_REFERENCE_BIT_MASK) >> 26;
 
         // [    ,   x] first node higher order bits
         // [    ,  x ] second node high order bits
@@ -286,7 +287,7 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
         short modifiers = (short) (firstNodeMod | secondNodeMod | firstPrevRelMod | firstNextRelMod |
                                    secondPrevRelMod | secondNextRelMod | nextPropMod);
 
-        cursor.putByte( (byte)modifiers );
+        cursor.putByte( (byte) modifiers );
         cursor.putInt( (int) firstNode );
         cursor.putInt( (int) secondNode );
         cursor.putInt( (int) firstPrevRel );

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -196,11 +196,11 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
            return (isRecordBigEnoughForFixedReferences( recordSize ) &&
                   (record.getFirstNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
                   ((record.getSecondNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
-                  ((record.getFirstPrevRel() != NULL) && ((record.getFirstPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getFirstNextRel() != NULL) && ((record.getFirstNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getSecondPrevRel() != NULL) && ((record.getSecondPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getSecondNextRel() != NULL) && ((record.getSecondNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
-                  ((record.getNextProp() != NULL) && ((record.getNextProp() & THREE_BITS_OVERFLOW_BIT_MASK) == 0));
+                  ((record.getFirstPrevRel() == NULL) || ((record.getFirstPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getFirstNextRel() == NULL) || ((record.getFirstNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getSecondPrevRel() == NULL) || ((record.getSecondPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getSecondNextRel() == NULL) || ((record.getSecondNextRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
+                  ((record.getNextProp() == NULL) || ((record.getNextProp() & THREE_BITS_OVERFLOW_BIT_MASK) == 0));
     }
 
     private boolean isRecordBigEnoughForFixedReferences( int recordSize )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -48,15 +48,15 @@ import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
 class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRecord>
 {
     static final int RECORD_SIZE = 32;
-    private static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
-                                                        Byte.BYTES /* modifiers */ +
-                                                        Integer.BYTES /* first node */ +
-                                                        Integer.BYTES /* second node */ +
-                                                        Integer.BYTES /* first prev rel */ +
-                                                        Integer.BYTES /* first next rel */ +
-                                                        Integer.BYTES /* second prev rel */ +
-                                                        Integer.BYTES /* second next rel */ +
-                                                        Integer.BYTES /* next property */;
+    static final int FIXED_FORMAT_RECORD_SIZE = HEADER_BYTE +
+                                                Byte.BYTES /* modifiers */ +
+                                                Integer.BYTES /* first node */ +
+                                                Integer.BYTES /* second node */ +
+                                                Integer.BYTES /* first prev rel */ +
+                                                Integer.BYTES /* first next rel */ +
+                                                Integer.BYTES /* second prev rel */ +
+                                                Integer.BYTES /* second next rel */ +
+                                                Integer.BYTES /* next property */;
 
     private static final int FIRST_IN_FIRST_CHAIN_BIT = 0b0000_1000;
     private static final int FIRST_IN_SECOND_CHAIN_BIT = 0b0001_0000;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/BaseHighLimitRecordFormatV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/BaseHighLimitRecordFormatV3_0.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.impl.CompositePageCursor;
+import org.neo4j.kernel.impl.store.StoreHeader;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.highlimit.Reference;
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.neo4j.kernel.impl.store.RecordPageLocationCalculator.offsetForId;
+import static org.neo4j.kernel.impl.store.RecordPageLocationCalculator.pageIdForRecord;
+
+/**
+ * Base class for record format which utilizes dynamically sized references to other record IDs and with ability
+ * to use record units, meaning that a record may span two physical records in the store. This to keep store size
+ * low and only have records that have big references occupy double amount of space. This format supports up to
+ * 58-bit IDs, which is roughly 280 quadrillion. With that size the ID limits can be considered highlimit,
+ * hence the format name. The IDs take up between 3-8B depending on the size of the ID where relative ID
+ * references are used as often as possible. See {@link Reference}.
+ *
+ * For consistency, all formats have a one-byte header specifying:
+ *
+ * <ol>
+ * <li>0x1: inUse [0=unused, 1=used]</li>
+ * <li>0x2: record unit [0=single record, 1=multiple records]</li>
+ * <li>0x4: record unit type [1=first, 0=consecutive]
+ * <li>0x8 - 0x80 other flags for this record specific to each type</li>
+ * </ol>
+ *
+ * NOTE to the rest of the flags is that a good use of them is to denote whether or not an ID reference is
+ * null (-1) as to save 3B (smallest compressed size) by not writing a reference at all.
+ *
+ * For records that are the first out of multiple record units, then immediately following the header byte is
+ * the reference (3-8B) to the secondary ID. After that the "statically sized" data and in the end the
+ * dynamically sized data. The general thinking is that the break-off into the secondary record will happen in
+ * the sequence of dynamically sized references and this will allow for crossing the record boundary
+ * in between, but even in the middle of, references quite easily since the {@link CompositePageCursor}
+ * handles the transition seamlessly.
+ *
+ * Assigning secondary record unit IDs is done outside of this format implementation, it is just assumed
+ * that records that gets {@link RecordFormat#write(AbstractBaseRecord, PageCursor, int) written} have already
+ * been assigned all required such data.
+ *
+ * Usually each records are written and read atomically, so this format requires additional logic to be able to
+ * write and read multiple records together atomically. For writing then currently this is guarded by
+ * higher level entity write locks and so the {@link PageCursor} can simply move from the first on to the second
+ * record and continue writing. For reading, which is optimistic and may require retry, one additional
+ * {@link PageCursor} needs to be acquired over the second record, checking {@link PageCursor#shouldRetry()}
+ * on both and potentially re-reading the second or both until a consistent read was had.
+ *
+ * @param <RECORD> type of {@link AbstractBaseRecord}
+ */
+abstract class BaseHighLimitRecordFormatV3_0<RECORD extends AbstractBaseRecord>
+        extends BaseOneByteHeaderRecordFormat<RECORD>
+{
+    private static final int HEADER_BYTE = Byte.BYTES;
+
+    static final long NULL = Record.NULL_REFERENCE.intValue();
+    static final int HEADER_BIT_RECORD_UNIT = 0b0000_0010;
+    static final int HEADER_BIT_FIRST_RECORD_UNIT = 0b0000_0100;
+
+    protected BaseHighLimitRecordFormatV3_0( Function<StoreHeader,Integer> recordSize, int recordHeaderSize )
+    {
+        super( recordSize, recordHeaderSize, IN_USE_BIT, HighLimitV3_0.DEFAULT_MAXIMUM_BITS_PER_ID );
+    }
+
+    public void read( RECORD record, PageCursor primaryCursor, RecordLoad mode, int recordSize )
+            throws IOException
+    {
+        int primaryStartOffset = primaryCursor.getOffset();
+        byte headerByte = primaryCursor.getByte();
+        boolean inUse = isInUse( headerByte );
+        boolean doubleRecordUnit = has( headerByte, HEADER_BIT_RECORD_UNIT );
+        if ( doubleRecordUnit )
+        {
+            boolean firstRecordUnit = has( headerByte, HEADER_BIT_FIRST_RECORD_UNIT );
+            if ( !firstRecordUnit )
+            {
+                // This is a record unit and not even the first one, so you cannot go here directly and read it,
+                // it may only be read as part of reading the primary unit.
+                record.clear();
+                // Return and try again
+                primaryCursor.setCursorException(
+                        "Expected record to be the first unit in the chain, but record header says it's not" );
+                return;
+            }
+
+            // This is a record that is split into multiple record units. We need a bit more clever
+            // data structures here. For the time being this means instantiating one object,
+            // but the trade-off is a great reduction in complexity.
+            long secondaryId = Reference.decode( primaryCursor );
+            long pageId = pageIdForRecord( secondaryId, primaryCursor.getCurrentPageSize(), recordSize );
+            int offset = offsetForId( secondaryId, primaryCursor.getCurrentPageSize(), recordSize );
+            PageCursor secondaryCursor = primaryCursor.openLinkedCursor( pageId );
+            if ( (!secondaryCursor.next()) | offset < 0 )
+            {
+                // We must have made an inconsistent read of the secondary record unit reference.
+                // No point in trying to read this.
+                record.clear();
+                primaryCursor.setCursorException( illegalSecondaryReferenceMessage( pageId ) );
+                return;
+            }
+            secondaryCursor.setOffset( offset + HEADER_BYTE);
+            int primarySize = recordSize - (primaryCursor.getOffset() - primaryStartOffset);
+            // We *could* sanity check the secondary record header byte here, but we won't. If it is wrong, then we most
+            // likely did an inconsistent read, in which case we'll just retry. Otherwise, if the header byte is wrong,
+            // then there is little we can do about it here, since we are not allowed to throw exceptions.
+
+            int secondarySize = recordSize - HEADER_BYTE;
+            PageCursor composite = CompositePageCursor.compose(
+                    primaryCursor, primarySize, secondaryCursor, secondarySize );
+            doReadInternal( record, composite, recordSize, headerByte, inUse );
+            record.setSecondaryUnitId( secondaryId );
+        }
+        else
+        {
+            doReadInternal( record, primaryCursor, recordSize, headerByte, inUse );
+        }
+    }
+
+    private String illegalSecondaryReferenceMessage( long secondaryId )
+    {
+        return "Illegal secondary record reference: " + secondaryId;
+    }
+
+    protected abstract void doReadInternal(
+            RECORD record, PageCursor cursor, int recordSize, long inUseByte, boolean inUse );
+
+    @Override
+    public void write( RECORD record, PageCursor primaryCursor, int recordSize )
+            throws IOException
+    {
+        if ( record.inUse() )
+        {
+            // Let the specific implementation provide the additional header bits and we'll provide the core format bits.
+            byte headerByte = headerBits( record );
+            assert (headerByte & 0x7) == 0 : "Format-specific header bits (" + headerByte +
+                                             ") collides with format-generic header bits";
+            headerByte = set( headerByte, IN_USE_BIT, record.inUse() );
+            headerByte = set( headerByte, HEADER_BIT_RECORD_UNIT, record.requiresSecondaryUnit() );
+            headerByte = set( headerByte, HEADER_BIT_FIRST_RECORD_UNIT, true );
+            primaryCursor.putByte( headerByte );
+
+            if ( record.requiresSecondaryUnit() )
+            {
+                // Write using the normal adapter since the first reference we write cannot really overflow
+                // into the secondary record
+                long secondaryUnitId = record.getSecondaryUnitId();
+                long pageId = pageIdForRecord( secondaryUnitId, primaryCursor.getCurrentPageSize(), recordSize );
+                int offset = offsetForId( secondaryUnitId, primaryCursor.getCurrentPageSize(), recordSize );
+                PageCursor secondaryCursor = primaryCursor.openLinkedCursor( pageId );
+                if ( !secondaryCursor.next() )
+                {
+                    // We are not allowed to write this much data to the file, apparently.
+                    record.clear();
+                    return;
+                }
+                secondaryCursor.setOffset( offset );
+                secondaryCursor.putByte( (byte) (IN_USE_BIT | HEADER_BIT_RECORD_UNIT) );
+                int recordSizeWithoutHeader = recordSize - HEADER_BYTE;
+                PageCursor composite = CompositePageCursor.compose(
+                        primaryCursor, recordSizeWithoutHeader, secondaryCursor, recordSizeWithoutHeader );
+
+                Reference.encode( secondaryUnitId, composite );
+                doWriteInternal( record, composite );
+            }
+            else
+            {
+                doWriteInternal( record, primaryCursor );
+            }
+        }
+        else
+        {
+            markAsUnused( primaryCursor, record, recordSize );
+        }
+    }
+
+    /*
+     * Use this instead of {@link #markFirstByteAsUnused(PageCursor)} to mark both record units,
+     * if record has a reference to a secondary unit.
+     */
+    protected void markAsUnused( PageCursor cursor, RECORD record, int recordSize )
+            throws IOException
+    {
+        markAsUnused( cursor );
+        if ( record.hasSecondaryUnitId() )
+        {
+            long secondaryUnitId = record.getSecondaryUnitId();
+            long pageIdForSecondaryRecord = pageIdForRecord( secondaryUnitId, cursor.getCurrentPageSize(), recordSize );
+            int offsetForSecondaryId = offsetForId( secondaryUnitId, cursor.getCurrentPageSize(), recordSize );
+            if ( !cursor.next( pageIdForSecondaryRecord ) )
+            {
+                throw new UnderlyingStorageException( "Couldn't move to secondary page " + pageIdForSecondaryRecord );
+            }
+            cursor.setOffset( offsetForSecondaryId );
+            markAsUnused( cursor );
+        }
+    }
+
+    protected abstract void doWriteInternal( RECORD record, PageCursor cursor ) throws IOException;
+
+    protected abstract byte headerBits( RECORD record );
+
+    @Override
+    public final void prepare( RECORD record, int recordSize, IdSequence idSequence )
+    {
+        if ( record.inUse() )
+        {
+            int requiredLength = HEADER_BYTE + requiredDataLength( record );
+            boolean requiresSecondaryUnit = requiredLength > recordSize;
+            record.setRequiresSecondaryUnit( requiresSecondaryUnit );
+            if ( record.requiresSecondaryUnit() && !record.hasSecondaryUnitId() )
+            {
+                // Allocate a new id at this point, but this is not the time to free this ID the the case where
+                // this record doesn't need this secondary unit anymore... that needs to be done when applying to store.
+                record.setSecondaryUnitId( idSequence.nextId() );
+            }
+        }
+    }
+
+    /**
+     * Required length of the data in the given record (without the header byte).
+     *
+     * @param record data to check how much space it would require.
+     * @return length required to store the data in the given record.
+     */
+    protected abstract int requiredDataLength( RECORD record );
+
+    protected static int length( long reference )
+    {
+        return Reference.length( reference );
+    }
+
+    protected static int length( long reference, long nullValue )
+    {
+        return reference == nullValue ? 0 : length( reference );
+    }
+
+    protected static long decodeCompressedReference( PageCursor cursor )
+    {
+        return Reference.decode( cursor );
+    }
+
+    protected static long decodeCompressedReference( PageCursor cursor, long headerByte, int headerBitMask, long nullValue )
+    {
+        return has( headerByte, headerBitMask ) ? decodeCompressedReference( cursor ) : nullValue;
+    }
+
+    protected static void encode( PageCursor cursor, long reference ) throws IOException
+    {
+        Reference.encode( reference, cursor );
+    }
+
+    protected static void encode( PageCursor cursor, long reference, long nullValue ) throws IOException
+    {
+        if ( reference != nullValue )
+        {
+            Reference.encode( reference, cursor );
+        }
+    }
+
+    protected static byte set( byte header, int bitMask, long reference, long nullValue )
+    {
+        return set( header, bitMask, reference != nullValue );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/HighLimitV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/HighLimitV3_0.java
@@ -17,13 +17,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.format.highlimit;
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
 
 import org.neo4j.kernel.impl.store.format.BaseRecordFormats;
 import org.neo4j.kernel.impl.store.format.Capability;
 import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.StoreVersion;
+import org.neo4j.kernel.impl.store.format.highlimit.DynamicRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.LabelTokenRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.PropertyKeyTokenRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.RelationshipTypeTokenRecordFormat;
@@ -39,9 +40,9 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 /**
  * Record format with very high limits, 50-bit per ID, while at the same time keeping store size small.
  *
- * @see BaseHighLimitRecordFormat
+ * @see BaseHighLimitRecordFormatV3_0
  */
-public class HighLimit extends BaseRecordFormats
+public class HighLimitV3_0 extends BaseRecordFormats
 {
     /**
      * Default maximum number of bits that can be used to represent id
@@ -49,36 +50,36 @@ public class HighLimit extends BaseRecordFormats
     static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
 
     public static final String STORE_VERSION = StoreVersion.HIGH_LIMIT_V3_0.versionString();
-    public static final RecordFormats RECORD_FORMATS = new HighLimit();
-    public static final String NAME = "high_limit";
+    public static final RecordFormats RECORD_FORMATS = new HighLimitV3_0();
+    public static final String NAME = "high_limitV3_0";
 
-    public HighLimit()
+    public HighLimitV3_0()
     {
-        super( STORE_VERSION, 8, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
+        super( STORE_VERSION, 7, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override
     public RecordFormat<NodeRecord> node()
     {
-        return new NodeRecordFormat();
+        return new NodeRecordFormatV3_0();
     }
 
     @Override
     public RecordFormat<RelationshipRecord> relationship()
     {
-        return new RelationshipRecordFormat();
+        return new RelationshipRecordFormatV3_0();
     }
 
     @Override
     public RecordFormat<RelationshipGroupRecord> relationshipGroup()
     {
-        return new RelationshipGroupRecordFormat();
+        return new RelationshipGroupRecordFormatV3_0();
     }
 
     @Override
     public RecordFormat<PropertyRecord> property()
     {
-        return new PropertyRecordFormat();
+        return new PropertyRecordFormatV3_0();
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/NodeRecordFormatV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/NodeRecordFormatV3_0.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+
+/**
+ * LEGEND:
+ * V: variable between 3B-8B
+ *
+ * Record format:
+ * 1B   header
+ * VB   first relationship
+ * VB   first property
+ * 5B   labels
+ *
+ * => 12B-22B
+ */
+public class NodeRecordFormatV3_0 extends BaseHighLimitRecordFormatV3_0<NodeRecord>
+{
+    public static final int RECORD_SIZE = 16;
+
+    private static final long NULL_LABELS = Record.NO_LABELS_FIELD.intValue();
+    private static final int DENSE_NODE_BIT       = 0b0000_1000;
+    private static final int HAS_RELATIONSHIP_BIT = 0b0001_0000;
+    private static final int HAS_PROPERTY_BIT     = 0b0010_0000;
+    private static final int HAS_LABELS_BIT       = 0b0100_0000;
+
+    public NodeRecordFormatV3_0()
+    {
+        this( RECORD_SIZE );
+    }
+
+    NodeRecordFormatV3_0( int recordSize )
+    {
+        super( fixedRecordSize( recordSize ), 0 );
+    }
+
+    @Override
+    public NodeRecord newRecord()
+    {
+        return new NodeRecord( -1 );
+    }
+
+    @Override
+    protected void doReadInternal( NodeRecord record, PageCursor cursor, int recordSize, long headerByte,
+            boolean inUse )
+    {
+        // Interpret the header byte
+        boolean dense = has( headerByte, DENSE_NODE_BIT );
+
+        // Now read the rest of the data. The adapter will take care of moving the cursor over to the
+        // other unit when we've exhausted the first one.
+        long nextRel = decodeCompressedReference( cursor, headerByte, HAS_RELATIONSHIP_BIT, NULL );
+        long nextProp = decodeCompressedReference( cursor, headerByte, HAS_PROPERTY_BIT, NULL );
+        long labelField = decodeCompressedReference( cursor, headerByte, HAS_LABELS_BIT, NULL_LABELS );
+        record.initialize( inUse, nextProp, dense, nextRel, labelField );
+    }
+
+    @Override
+    public int requiredDataLength( NodeRecord record )
+    {
+        return  length( record.getNextRel(), NULL ) +
+                length( record.getNextProp(), NULL ) +
+                length( record.getLabelField(), NULL_LABELS );
+    }
+
+    @Override
+    protected byte headerBits( NodeRecord record )
+    {
+        byte header = 0;
+        header = set( header, DENSE_NODE_BIT, record.isDense() );
+        header = set( header, HAS_RELATIONSHIP_BIT, record.getNextRel(), NULL );
+        header = set( header, HAS_PROPERTY_BIT, record.getNextProp(), NULL );
+        header = set( header, HAS_LABELS_BIT, record.getLabelField(), NULL_LABELS );
+        return header;
+    }
+
+    @Override
+    protected void doWriteInternal( NodeRecord record, PageCursor cursor )
+            throws IOException
+    {
+        encode( cursor, record.getNextRel(), NULL );
+        encode( cursor, record.getNextProp(), NULL );
+        encode( cursor, record.getLabelField(), NULL_LABELS );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/PropertyRecordFormatV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/PropertyRecordFormatV3_0.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
+import org.neo4j.kernel.impl.store.format.highlimit.Reference;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toAbsolute;
+import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
+
+
+/**
+ * LEGEND:
+ * V: variable between 3B-8B
+ *
+ * Record format:
+ * 1B   header
+ * VB   previous property
+ * VB   next property
+ * 8B   property block
+ * 8B   property block
+ * 8B   property block
+ * 8B   property block
+ *
+ * => 39B-49B
+ */
+public class PropertyRecordFormatV3_0 extends BaseOneByteHeaderRecordFormat<PropertyRecord>
+{
+    public static final int RECORD_SIZE = 48;
+
+    public PropertyRecordFormatV3_0()
+    {
+        super( fixedRecordSize( RECORD_SIZE ), 0, IN_USE_BIT, HighLimitV3_0.DEFAULT_MAXIMUM_BITS_PER_ID );
+    }
+
+    @Override
+    public PropertyRecord newRecord()
+    {
+        return new PropertyRecord( -1 );
+    }
+
+    @Override
+    public void read( PropertyRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
+            throws IOException
+    {
+        int offset = cursor.getOffset();
+        byte headerByte = cursor.getByte();
+        boolean inUse = isInUse( headerByte );
+        if ( mode.shouldLoad( inUse ) )
+        {
+            int blockCount = headerByte >>> 4;
+            long recordId = record.getId();
+            record.initialize( inUse,
+                    toAbsolute( Reference.decode( cursor ), recordId ),
+                    toAbsolute( Reference.decode( cursor ), recordId ) );
+            if ( (blockCount > record.getBlockCapacity()) | (RECORD_SIZE - (cursor.getOffset() - offset) < blockCount * Long.BYTES) )
+            {
+                cursor.setCursorException( "PropertyRecord claims to contain more blocks than can fit in a record" );
+                return;
+            }
+            while ( blockCount-- > 0 )
+            {
+                record.addLoadedBlock( cursor.getLong() );
+            }
+        }
+    }
+
+    @Override
+    public void write( PropertyRecord record, PageCursor cursor, int recordSize )
+            throws IOException
+    {
+        if ( record.inUse() )
+        {
+            cursor.putByte( (byte) ((record.inUse() ? IN_USE_BIT : 0) | numberOfBlocks( record ) << 4) );
+            long recordId = record.getId();
+            Reference.encode( toRelative( record.getPrevProp(), recordId), cursor );
+            Reference.encode( toRelative( record.getNextProp(), recordId), cursor );
+            for ( PropertyBlock block : record )
+            {
+                for ( long propertyBlock : block.getValueBlocks() )
+                {
+                    cursor.putLong( propertyBlock );
+                }
+            }
+        }
+        else
+        {
+            markAsUnused( cursor );
+        }
+    }
+
+    private int numberOfBlocks( PropertyRecord record )
+    {
+        int count = 0;
+        for ( PropertyBlock block : record )
+        {
+            count += block.getValueBlocks().length;
+        }
+        return count;
+    }
+
+    @Override
+    public long getNextRecordReference( PropertyRecord record )
+    {
+        return record.getNextProp();
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/RelationshipGroupRecordFormatV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/RelationshipGroupRecordFormatV3_0.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+
+/**
+ * LEGEND:
+ * V: variable between 3B-8B
+ *
+ * Record format:
+ * 1B   header
+ * 2B   relationship type
+ * VB   first outgoing relationships
+ * VB   first incoming relationships
+ * VB   first loop relationships
+ * VB   owning node
+ * VB   next relationship group record
+ *
+ * => 18B-43B
+ */
+public class RelationshipGroupRecordFormatV3_0 extends BaseHighLimitRecordFormatV3_0<RelationshipGroupRecord>
+{
+    public static final int RECORD_SIZE = 32;
+
+    private static final int HAS_OUTGOING_BIT = 0b0000_1000;
+    private static final int HAS_INCOMING_BIT = 0b0001_0000;
+    private static final int HAS_LOOP_BIT     = 0b0010_0000;
+    private static final int HAS_NEXT_BIT     = 0b0100_0000;
+
+    public RelationshipGroupRecordFormatV3_0()
+    {
+        this( RECORD_SIZE );
+    }
+
+    RelationshipGroupRecordFormatV3_0( int recordSize )
+    {
+        super( fixedRecordSize( recordSize ), 0 );
+    }
+
+    @Override
+    public RelationshipGroupRecord newRecord()
+    {
+        return new RelationshipGroupRecord( -1 );
+    }
+
+    @Override
+    protected void doReadInternal( RelationshipGroupRecord record, PageCursor cursor, int recordSize, long headerByte,
+            boolean inUse )
+    {
+        record.initialize( inUse,
+                cursor.getShort() & 0xFFFF,
+                decodeCompressedReference( cursor, headerByte, HAS_OUTGOING_BIT, NULL ),
+                decodeCompressedReference( cursor, headerByte, HAS_INCOMING_BIT, NULL ),
+                decodeCompressedReference( cursor, headerByte, HAS_LOOP_BIT, NULL ),
+                decodeCompressedReference( cursor ),
+                decodeCompressedReference( cursor, headerByte, HAS_NEXT_BIT, NULL ) );
+    }
+
+    @Override
+    protected byte headerBits( RelationshipGroupRecord record )
+    {
+        byte header = 0;
+        header = set( header, HAS_OUTGOING_BIT, record.getFirstOut(), NULL );
+        header = set( header, HAS_INCOMING_BIT, record.getFirstIn(), NULL );
+        header = set( header, HAS_LOOP_BIT, record.getFirstLoop(), NULL );
+        header = set( header, HAS_NEXT_BIT, record.getNext(), NULL );
+        return header;
+    }
+
+    @Override
+    protected int requiredDataLength( RelationshipGroupRecord record )
+    {
+        return  2 + // type
+                length( record.getFirstOut(), NULL ) +
+                length( record.getFirstIn(), NULL ) +
+                length( record.getFirstLoop(), NULL ) +
+                length( record.getOwningNode() ) +
+                length( record.getNext(), NULL );
+    }
+
+    @Override
+    protected void doWriteInternal( RelationshipGroupRecord record, PageCursor cursor )
+            throws IOException
+    {
+        cursor.putShort( (short) record.getType() );
+        encode( cursor, record.getFirstOut(), NULL );
+        encode( cursor, record.getFirstIn(), NULL );
+        encode( cursor, record.getFirstLoop(), NULL );
+        encode( cursor, record.getOwningNode() );
+        encode( cursor, record.getNext(), NULL );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/RelationshipRecordFormatV3_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v30/RelationshipRecordFormatV3_0.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit.v30;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toAbsolute;
+import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
+
+/**
+ * LEGEND:
+ * V: variable between 3B-8B
+ *
+ * Record format:
+ * 1B   header
+ * 2B   relationship type
+ * VB   first property
+ * VB   start node
+ * VB   end node
+ * VB   start node chain previous relationship
+ * VB   start node chain next relationship
+ * VB   end node chain previous relationship
+ * VB   end node chain next relationship
+ *
+ * => 24B-59B
+ */
+public class RelationshipRecordFormatV3_0 extends BaseHighLimitRecordFormatV3_0<RelationshipRecord>
+{
+    public static final int RECORD_SIZE = 32;
+
+    private static final int FIRST_IN_FIRST_CHAIN_BIT = 0b0000_1000;
+    private static final int FIRST_IN_SECOND_CHAIN_BIT = 0b0001_0000;
+    private static final int HAS_FIRST_CHAIN_NEXT_BIT = 0b0010_0000;
+    private static final int HAS_SECOND_CHAIN_NEXT_BIT = 0b0100_0000;
+    private static final int HAS_PROPERTY_BIT = 0b1000_0000;
+
+    public RelationshipRecordFormatV3_0()
+    {
+        this( RECORD_SIZE );
+    }
+
+    RelationshipRecordFormatV3_0( int recordSize )
+    {
+        super( fixedRecordSize( recordSize ), 0 );
+    }
+
+    @Override
+    public RelationshipRecord newRecord()
+    {
+        return new RelationshipRecord( -1 );
+    }
+
+    @Override
+    protected void doReadInternal(
+            RelationshipRecord record, PageCursor cursor, int recordSize, long headerByte, boolean inUse )
+    {
+        int type = cursor.getShort() & 0xFFFF;
+        long recordId = record.getId();
+        record.initialize( inUse,
+                decodeCompressedReference( cursor, headerByte, HAS_PROPERTY_BIT, NULL ),
+                decodeCompressedReference( cursor ),
+                decodeCompressedReference( cursor ),
+                type,
+                decodeAbsoluteOrRelative( cursor, headerByte, FIRST_IN_FIRST_CHAIN_BIT, recordId ),
+                decodeAbsoluteIfPresent( cursor, headerByte, HAS_FIRST_CHAIN_NEXT_BIT, recordId ),
+                decodeAbsoluteOrRelative( cursor, headerByte, FIRST_IN_SECOND_CHAIN_BIT, recordId ),
+                decodeAbsoluteIfPresent( cursor, headerByte, HAS_SECOND_CHAIN_NEXT_BIT, recordId ),
+                has( headerByte, FIRST_IN_FIRST_CHAIN_BIT ),
+                has( headerByte, FIRST_IN_SECOND_CHAIN_BIT ) );
+    }
+
+    private long decodeAbsoluteOrRelative( PageCursor cursor, long headerByte, int firstInStartBit, long recordId )
+    {
+        return has( headerByte, firstInStartBit ) ?
+               decodeCompressedReference( cursor ) :
+               toAbsolute( decodeCompressedReference( cursor ), recordId );
+    }
+
+    @Override
+    protected byte headerBits( RelationshipRecord record )
+    {
+        byte header = 0;
+        header = set( header, FIRST_IN_FIRST_CHAIN_BIT, record.isFirstInFirstChain() );
+        header = set( header, FIRST_IN_SECOND_CHAIN_BIT, record.isFirstInSecondChain() );
+        header = set( header, HAS_PROPERTY_BIT, record.getNextProp(), NULL );
+        header = set( header, HAS_FIRST_CHAIN_NEXT_BIT, record.getFirstNextRel(), NULL );
+        header = set( header, HAS_SECOND_CHAIN_NEXT_BIT, record.getSecondNextRel(), NULL );
+        return header;
+    }
+
+    @Override
+    protected int requiredDataLength( RelationshipRecord record )
+    {
+        long recordId = record.getId();
+        return Short.BYTES + // type
+               length( record.getNextProp(), NULL ) +
+               length( record.getFirstNode() ) +
+               length( record.getSecondNode() ) +
+               length( getFirstPrevReference( record, recordId ) ) +
+               getRelativeReferenceLength( record.getFirstNextRel(), recordId ) +
+               length( getSecondPrevReference( record, recordId ) ) +
+               getRelativeReferenceLength( record.getSecondNextRel(), recordId );
+    }
+
+    @Override
+    protected void doWriteInternal( RelationshipRecord record, PageCursor cursor )
+            throws IOException
+    {
+        cursor.putShort( (short) record.getType() );
+        long recordId = record.getId();
+        encode( cursor, record.getNextProp(), NULL );
+        encode( cursor, record.getFirstNode() );
+        encode( cursor, record.getSecondNode() );
+
+        encode( cursor, getFirstPrevReference( record, recordId ) );
+        if ( record.getFirstNextRel() != NULL )
+        {
+            encode( cursor, toRelative( record.getFirstNextRel(), recordId ) );
+        }
+        encode( cursor, getSecondPrevReference( record, recordId ) );
+        if ( record.getSecondNextRel() != NULL )
+        {
+            encode( cursor, toRelative( record.getSecondNextRel(), recordId ) );
+        }
+    }
+
+    private long getSecondPrevReference( RelationshipRecord record, long recordId )
+    {
+        return record.isFirstInSecondChain() ? record.getSecondPrevRel() :
+               toRelative( record.getSecondPrevRel(), recordId );
+    }
+
+    private long getFirstPrevReference( RelationshipRecord record, long recordId )
+    {
+        return record.isFirstInFirstChain() ? record.getFirstPrevRel()
+                                            : toRelative( record.getFirstPrevRel(), recordId );
+    }
+
+    private int getRelativeReferenceLength( long absoluteReference, long recordId )
+    {
+        return absoluteReference != NULL ? length( toRelative( absoluteReference, recordId ) ) : 0;
+    }
+
+    private long decodeAbsoluteIfPresent( PageCursor cursor, long headerByte, int conditionBit, long recordId )
+    {
+        return has( headerByte, conditionBit ) ? toAbsolute( decodeCompressedReference( cursor ), recordId ) : NULL;
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
@@ -101,9 +101,6 @@ public class NodeIdReuseStressIT
         long currentHighestNodeId = highestNodeId( db );
 
         assertThat( currentHighestNodeId, lessThan( highestNodeIdWithoutReuse ) );
-
-        System.out.println( "highestNodeIdWithoutReuse = " + highestNodeIdWithoutReuse );
-        System.out.println( "currentHighestNodeId = " + currentHighestNodeId );
     }
 
     private static void createInitialNodes( GraphDatabaseService db )

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -140,7 +140,7 @@ public class BaseHighLimitRecordFormatTest
         }
 
         @Override
-        protected boolean canUseFixedReferences( MyRecord record )
+        protected boolean canUseFixedReferences( MyRecord record, int recordSize )
         {
             return false;
         }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -140,6 +140,12 @@ public class BaseHighLimitRecordFormatTest
         }
 
         @Override
+        protected boolean canUseFixedReferences( MyRecord record )
+        {
+            return false;
+        }
+
+        @Override
         protected int requiredDataLength( MyRecord record )
         {
             return 4;

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ConstantIdSequence.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/ConstantIdSequence.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.neo4j.kernel.impl.store.id.IdSequence;
+
+class ConstantIdSequence implements IdSequence
+{
+    @Override
+    public long nextId()
+    {
+        return 1;
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/FixedLinkedStubPageCursor.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/FixedLinkedStubPageCursor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.StubPageCursor;
+
+class FixedLinkedStubPageCursor extends StubPageCursor
+{
+    FixedLinkedStubPageCursor( int initialPageId, int size )
+    {
+        super( initialPageId, size );
+    }
+
+    @Override
+    public PageCursor openLinkedCursor( long pageId )
+    {
+        // Since we always assume here that test data will be small enough for one page it's safe
+        // to assume that all cursors will be be positioned into that one page.
+        // And since stub cursors use byte buffers to store data we want to prevent data loss and keep already
+        // created linked cursors
+        if ( linkedCursor == null )
+        {
+            return super.openLinkedCursor( pageId );
+        }
+        return linkedCursor;
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
@@ -1,0 +1,135 @@
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NodeRecordFormatTest
+{
+
+    private NodeRecordFormat recordFormat;
+    private StubPageCursor pageCursor;
+    private TestIdSequence idSequence;
+
+    @Before
+    public void setUp()
+    {
+        recordFormat = new NodeRecordFormat();
+        pageCursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 8 ) );
+        idSequence = new TestIdSequence();
+    }
+
+    @After
+    public void tearDown()
+    {
+        pageCursor.close();
+    }
+
+    @Test
+    public void readWriteFixedReferencesRecord() throws Exception
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, randomFixedReference(), true, randomFixedReference(), 0L );
+
+        writeReadRecord( source, target );
+
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
+        assertEquals("Records should be equal.", source, target);
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenRelationshipIsMissing() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, randomFixedReference(), true, Record.NULL_REFERENCE.byteValue(), 0L );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertEquals("Records should be equal.", source, target);
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenPropertyIsMissing() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, Record.NULL_REFERENCE.intValue(), true, randomFixedReference(), 0L );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertEquals("Records should be equal.", source, target);
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenRelationshipReferenceTooBig() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, 1L << 37, true, randomFixedReference(), 0L );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertEquals("Records should be equal.", source, target);
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenPropertyReferenceTooBig() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, randomFixedReference(), true, 1L << 37, 0L );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertEquals("Records should be equal.", source, target);
+    }
+
+    private void writeReadRecord( NodeRecord source, NodeRecord target ) throws java.io.IOException
+    {
+        int recordSize = NodeRecordFormat.RECORD_SIZE;
+        recordFormat.prepare( source, recordSize, idSequence );
+        recordFormat.write( source, pageCursor, recordSize );
+        pageCursor.setOffset( 0 );
+        recordFormat.read( target, pageCursor, RecordLoad.NORMAL, recordSize );
+    }
+
+    private long randomFixedReference()
+    {
+        return randomReference( 1L << (Integer.SIZE + (Byte.SIZE / 2)) );
+    }
+
+    private long randomReference( long maxValue )
+    {
+        return ThreadLocalRandom.current().nextLong( maxValue );
+    }
+
+    private static class TestIdSequence implements IdSequence
+    {
+        @Override
+        public long nextId()
+        {
+            return -1;
+        }
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.kernel.impl.store.format.highlimit;
 
 
@@ -10,7 +29,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.pagecache.StubPageCursor;
-import org.neo4j.kernel.impl.store.id.IdSequence;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
@@ -24,14 +42,14 @@ public class NodeRecordFormatTest
 
     private NodeRecordFormat recordFormat;
     private StubPageCursor pageCursor;
-    private TestIdSequence idSequence;
+    private ConstantIdSequence idSequence;
 
     @Before
     public void setUp()
     {
         recordFormat = new NodeRecordFormat();
         pageCursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 8 ) );
-        idSequence = new TestIdSequence();
+        idSequence = new ConstantIdSequence();
     }
 
     @After
@@ -50,7 +68,7 @@ public class NodeRecordFormatTest
         writeReadRecord( source, target );
 
         assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
-        assertEquals("Records should be equal.", source, target);
+        verifySameReferences( source, target);
     }
 
     @Test
@@ -63,7 +81,7 @@ public class NodeRecordFormatTest
         writeReadRecord( source, target );
 
         assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
-        assertEquals("Records should be equal.", source, target);
+        verifySameReferences( source, target);
     }
 
     @Test
@@ -76,7 +94,7 @@ public class NodeRecordFormatTest
         writeReadRecord( source, target );
 
         assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
-        assertEquals("Records should be equal.", source, target);
+        verifySameReferences( source, target);
     }
 
     @Test
@@ -89,7 +107,7 @@ public class NodeRecordFormatTest
         writeReadRecord( source, target );
 
         assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
-        assertEquals("Records should be equal.", source, target);
+        verifySameReferences( source, target);
     }
 
     @Test
@@ -102,7 +120,14 @@ public class NodeRecordFormatTest
         writeReadRecord( source, target );
 
         assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
-        assertEquals("Records should be equal.", source, target);
+        verifySameReferences( source, target);
+    }
+
+    private void verifySameReferences( NodeRecord recordA, NodeRecord recordB )
+    {
+        assertEquals( recordA.getNextProp(), recordB.getNextProp() );
+        assertEquals( recordA.getNextRel(), recordB.getNextRel() );
+        assertEquals( recordA.getLabelField(), recordB.getLabelField() );
     }
 
     private void writeReadRecord( NodeRecord source, NodeRecord target ) throws java.io.IOException
@@ -124,12 +149,4 @@ public class NodeRecordFormatTest
         return ThreadLocalRandom.current().nextLong( maxValue );
     }
 
-    private static class TestIdSequence implements IdSequence
-    {
-        @Override
-        public long nextId()
-        {
-            return -1;
-        }
-    }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
@@ -123,6 +123,32 @@ public class NodeRecordFormatTest
         verifySameReferences( source, target);
     }
 
+    @Test
+    public void useVariableLengthFormatWhenRecordSizeIsTooSmall() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, randomFixedReference(), true, randomFixedReference(), 0L );
+
+        writeReadRecord( source, target, NodeRecordFormat.FIXED_FORMAT_RECORD_SIZE - 1 );
+
+        assertFalse( "Record should use variable length reference if format record is too small.", target.isUseFixedReferences() );
+        verifySameReferences( source, target);
+    }
+
+    @Test
+    public void useFixedReferenceFormatWhenRecordCanFitInRecordSizeRecord() throws IOException
+    {
+        NodeRecord source = new NodeRecord( 1 );
+        NodeRecord target = new NodeRecord( 1 );
+        source.initialize( true, randomFixedReference(), true, randomFixedReference(), 0L );
+
+        writeReadRecord( source, target, NodeRecordFormat.FIXED_FORMAT_RECORD_SIZE );
+
+        assertTrue( "Record should use fixed reference if can fit in format record.", target.isUseFixedReferences() );
+        verifySameReferences( source, target);
+    }
+
     private void verifySameReferences( NodeRecord recordA, NodeRecord recordB )
     {
         assertEquals( recordA.getNextProp(), recordB.getNextProp() );
@@ -132,7 +158,11 @@ public class NodeRecordFormatTest
 
     private void writeReadRecord( NodeRecord source, NodeRecord target ) throws java.io.IOException
     {
-        int recordSize = NodeRecordFormat.RECORD_SIZE;
+        writeReadRecord( source, target, NodeRecordFormat.RECORD_SIZE );
+    }
+
+    private void writeReadRecord( NodeRecord source, NodeRecord target, int recordSize ) throws java.io.IOException
+    {
         recordFormat.prepare( source, recordSize, idSequence );
         recordFormat.write( source, pageCursor, recordSize );
         pageCursor.setOffset( 0 );
@@ -148,5 +178,4 @@ public class NodeRecordFormatTest
     {
         return ThreadLocalRandom.current().nextLong( maxValue );
     }
-
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormatTest.java
@@ -72,7 +72,7 @@ public class NodeRecordFormatTest
     }
 
     @Test
-    public void useVariableLengthFormatWhenRelationshipIsMissing() throws IOException
+    public void useFixedReferencesFormatWhenRelationshipIsMissing() throws IOException
     {
         NodeRecord source = new NodeRecord( 1 );
         NodeRecord target = new NodeRecord( 1 );
@@ -80,12 +80,12 @@ public class NodeRecordFormatTest
 
         writeReadRecord( source, target );
 
-        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
         verifySameReferences( source, target );
     }
 
     @Test
-    public void useVariableLengthFormatWhenPropertyIsMissing() throws IOException
+    public void useFixedReferencesFormatWhenPropertyIsMissing() throws IOException
     {
         NodeRecord source = new NodeRecord( 1 );
         NodeRecord target = new NodeRecord( 1 );
@@ -93,7 +93,7 @@ public class NodeRecordFormatTest
 
         writeReadRecord( source, target );
 
-        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
         verifySameReferences( source, target );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -78,7 +78,7 @@ public class PropertyRecordFormatTest
         record.setInUse( true );
         record.setId( recordId );
         record.setNextProp( 1L );
-        record.setPrevProp( 3L );
+        record.setPrevProp( (Integer.MAX_VALUE + 1L) << 3 );
         return record;
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -154,6 +154,32 @@ public class PropertyRecordFormatTest
         verifySameReferences( source, target );
     }
 
+    @Test
+    public void useVariableLengthFormatWhenRecordSizeIsTooSmall() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, randomFixedReference(), randomFixedReference() );
+
+        writeReadRecord( source, target, PropertyRecordFormat.FIXED_FORMAT_RECORD_SIZE - 1 );
+
+        assertFalse( "Record should use variable length reference if format record is too small.", target.isUseFixedReferences() );
+        verifySameReferences( source, target);
+    }
+
+    @Test
+    public void useFixedReferenceFormatWhenRecordCanFitInRecordSizeRecord() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, randomFixedReference(), randomFixedReference() );
+
+        writeReadRecord( source, target, PropertyRecordFormat.FIXED_FORMAT_RECORD_SIZE );
+
+        assertTrue( "Record should use fixed reference if can fit in format record.", target.isUseFixedReferences() );
+        verifySameReferences( source, target);
+    }
+
     private void verifySameReferences( PropertyRecord recordA, PropertyRecord recordB )
     {
         assertEquals( recordA.getNextProp(), recordB.getNextProp() );
@@ -168,7 +194,12 @@ public class PropertyRecordFormatTest
 
     private void writeReadRecord( PropertyRecord source, PropertyRecord target ) throws java.io.IOException
     {
-        int recordSize = PropertyRecordFormat.RECORD_SIZE;
+        writeReadRecord( source, target, PropertyRecordFormat.RECORD_SIZE );
+    }
+
+    private void writeReadRecord( PropertyRecord source, PropertyRecord target, int recordSize )
+            throws java.io.IOException
+    {
         recordFormat.prepare( source, recordSize, idSequence );
         recordFormat.write( source, pageCursor, recordSize );
         pageCursor.setOffset( 0 );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -19,52 +19,170 @@
  */
 package org.neo4j.kernel.impl.store.format.highlimit;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.pagecache.StubPageCursor;
 import org.neo4j.kernel.impl.store.IntStoreHeader;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PropertyRecordFormatTest
 {
     private static final int DATA_SIZE = 100;
+    private static final long TOO_BIG_REFERENCE = 1L << (Integer.SIZE + (Byte.SIZE * 3));
+
+    private PropertyRecordFormat recordFormat;
+    private StubPageCursor pageCursor;
+    private ConstantIdSequence idSequence;
+
+    @Before
+    public void setUp()
+    {
+        recordFormat = new PropertyRecordFormat();
+        pageCursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 8 ) );
+        idSequence = new ConstantIdSequence();
+    }
+
+    @After
+    public void tearDown()
+    {
+        pageCursor.close();
+    }
 
     @Test
     public void writeAndReadRecordWithRelativeReferences() throws IOException
     {
-        PropertyRecordFormat format = new PropertyRecordFormat();
-        int recordSize = format.getRecordSize( new IntStoreHeader( DATA_SIZE ) );
-        StubPageCursor cursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 4 ) );
+        int recordSize = recordFormat.getRecordSize( new IntStoreHeader( DATA_SIZE ) );
         long recordId = 0xF1F1F1F1F1F1L;
-        int recordOffset = cursor.getOffset();
+        int recordOffset = pageCursor.getOffset();
 
-        PropertyRecord record = createRecord( format, recordId );
-        format.write( record, cursor, recordSize );
+        PropertyRecord record = createRecord( recordFormat, recordId );
+        recordFormat.write( record, pageCursor, recordSize );
 
-        PropertyRecord recordFromStore = format.newRecord();
+        PropertyRecord recordFromStore = recordFormat.newRecord();
         recordFromStore.setId( recordId  );
-        resetCursor( cursor, recordOffset );
-        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize );
+        resetCursor( pageCursor, recordOffset );
+        recordFormat.read( recordFromStore, pageCursor, RecordLoad.NORMAL, recordSize );
 
         // records should be the same
         assertEquals( record.getNextProp(), recordFromStore.getNextProp() );
         assertEquals( record.getPrevProp(), recordFromStore.getPrevProp() );
 
         // now lets try to read same data into a record with different id - we should get different absolute references
-        resetCursor( cursor, recordOffset );
-        PropertyRecord recordWithOtherId = format.newRecord();
+        resetCursor( pageCursor, recordOffset );
+        PropertyRecord recordWithOtherId = recordFormat.newRecord();
         recordWithOtherId.setId( 1L  );
-        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize );
+        recordFormat.read( recordWithOtherId, pageCursor, RecordLoad.NORMAL, recordSize );
 
-        assertNotEquals( record.getNextProp(), recordWithOtherId.getNextProp() );
-        assertNotEquals( record.getPrevProp(), recordWithOtherId.getPrevProp() );
+        verifyDifferentReferences(record, recordWithOtherId);
+    }
+
+    @Test
+    public void readWriteFixedReferencesRecord() throws Exception
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, randomFixedReference(), randomFixedReference() );
+
+        writeReadRecord( source, target );
+
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target );
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenNextPropertyIsMissing() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, randomFixedReference(), Record.NULL_REFERENCE.byteValue() );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target );
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenPreviousPropertyIsMissing() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, Record.NULL_REFERENCE.intValue(), randomFixedReference() );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target );
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenPreviousPropertyReferenceTooBig() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, TOO_BIG_REFERENCE, randomFixedReference() );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target );
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenNextPropertyReferenceTooBig() throws IOException
+    {
+        PropertyRecord source = new PropertyRecord( 1 );
+        PropertyRecord target = new PropertyRecord( 1 );
+        source.initialize( true, randomFixedReference(), TOO_BIG_REFERENCE );
+
+        writeReadRecord( source, target );
+
+        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target );
+    }
+
+    private void verifySameReferences( PropertyRecord recordA, PropertyRecord recordB )
+    {
+        assertEquals( recordA.getNextProp(), recordB.getNextProp() );
+        assertEquals( recordA.getPrevProp(), recordB.getPrevProp() );
+    }
+
+    private void verifyDifferentReferences(PropertyRecord recordA, PropertyRecord recordB)
+    {
+        assertNotEquals( recordA.getNextProp(), recordB.getNextProp() );
+        assertNotEquals( recordA.getPrevProp(), recordB.getPrevProp() );
+    }
+
+    private void writeReadRecord( PropertyRecord source, PropertyRecord target ) throws java.io.IOException
+    {
+        int recordSize = PropertyRecordFormat.RECORD_SIZE;
+        recordFormat.prepare( source, recordSize, idSequence );
+        recordFormat.write( source, pageCursor, recordSize );
+        pageCursor.setOffset( 0 );
+        recordFormat.read( target, pageCursor, RecordLoad.NORMAL, recordSize );
+    }
+
+    private long randomFixedReference()
+    {
+        return randomReference( 1L << (Integer.SIZE + (Byte.SIZE * 2)) );
+    }
+
+    private long randomReference( long maxValue )
+    {
+        return ThreadLocalRandom.current().nextLong( maxValue );
     }
 
     private void resetCursor( StubPageCursor cursor, int recordOffset )
@@ -78,7 +196,7 @@ public class PropertyRecordFormatTest
         record.setInUse( true );
         record.setId( recordId );
         record.setNextProp( 1L );
-        record.setPrevProp( (Integer.MAX_VALUE + 1L) << 3 );
+        record.setPrevProp( (Integer.MAX_VALUE + 1L) << Byte.SIZE * 3 );
         return record;
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -104,7 +104,7 @@ public class PropertyRecordFormatTest
     }
 
     @Test
-    public void useVariableLengthFormatWhenNextPropertyIsMissing() throws IOException
+    public void useFixedReferenceFormatWhenNextPropertyIsMissing() throws IOException
     {
         PropertyRecord source = new PropertyRecord( 1 );
         PropertyRecord target = new PropertyRecord( 1 );
@@ -112,12 +112,12 @@ public class PropertyRecordFormatTest
 
         writeReadRecord( source, target );
 
-        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
         verifySameReferences( source, target );
     }
 
     @Test
-    public void useVariableLengthFormatWhenPreviousPropertyIsMissing() throws IOException
+    public void useFixedReferenceFormatWhenPreviousPropertyIsMissing() throws IOException
     {
         PropertyRecord source = new PropertyRecord( 1 );
         PropertyRecord target = new PropertyRecord( 1 );
@@ -125,7 +125,7 @@ public class PropertyRecordFormatTest
 
         writeReadRecord( source, target );
 
-        assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
         verifySameReferences( source, target );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.kernel.impl.store.format.highlimit.BaseHighLimitRecordFormat.NULL;
+
+public class RelationshipGroupRecordFormatTest
+{
+
+    private RelationshipGroupRecordFormat recordFormat;
+    private StubPageCursor pageCursor;
+    private ConstantIdSequence idSequence;
+
+    @Before
+    public void setUp()
+    {
+        recordFormat = new RelationshipGroupRecordFormat();
+        pageCursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 8 ) );
+        idSequence = new ConstantIdSequence();
+    }
+
+    @After
+    public void tearDown()
+    {
+        pageCursor.close();
+    }
+
+    @Test
+    public void readWriteFixedReferencesRecord() throws Exception
+    {
+        RelationshipGroupRecord source = new RelationshipGroupRecord( 1 );
+        RelationshipGroupRecord target = new RelationshipGroupRecord( 1 );
+        source.initialize( true, 0, randomFixedReference(), randomFixedReference(),
+                randomFixedReference(), randomFixedReference(), randomFixedReference());
+
+        writeReadRecord( source, target );
+
+        assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
+        verifySameReferences( source, target);
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenOneOfTheReferencesIsMissing() throws IOException
+    {
+        RelationshipGroupRecord source = new RelationshipGroupRecord( 1 );
+        RelationshipGroupRecord target = new RelationshipGroupRecord( 1 );
+
+        verifyRecordsWithPoisonedReference( source, target, NULL );
+    }
+
+    @Test
+    public void useVariableLengthFormatWhenOneOfTheReferencesReferenceTooBig() throws IOException
+    {
+        RelationshipGroupRecord source = new RelationshipGroupRecord( 1 );
+        RelationshipGroupRecord target = new RelationshipGroupRecord( 1 );
+
+        verifyRecordsWithPoisonedReference( source, target, 1L << (Integer.SIZE + 2) );
+    }
+
+    private void verifyRecordsWithPoisonedReference( RelationshipGroupRecord source, RelationshipGroupRecord target,
+            long poisonedReference ) throws IOException
+    {
+        int differentReferences = 5;
+        List<Long> references = buildReferenceList( differentReferences, poisonedReference );
+        for ( int i = 0; i < differentReferences; i++ )
+        {
+            pageCursor.setOffset( 0 );
+            Iterator<Long> iterator = references.iterator();
+
+            source.initialize( true, 0, iterator.next(), iterator.next(), iterator.next(), iterator.next(),
+                    iterator.next() );
+
+            writeReadRecord( source, target );
+
+            assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+            verifySameReferences( source, target );
+            Collections.rotate( references, 1 );
+        }
+    }
+
+    private List<Long> buildReferenceList( int differentReferences, long poison )
+    {
+        List<Long> references = new ArrayList<>( differentReferences );
+        references.add( poison );
+        for ( int i = 1; i < differentReferences; i++ )
+        {
+            references.add( randomFixedReference() );
+        }
+        return references;
+    }
+
+    private void verifySameReferences( RelationshipGroupRecord recordA, RelationshipGroupRecord recordB )
+    {
+        assertEquals( "First In references should be equal.", recordA.getFirstIn(), recordB.getFirstIn() );
+        assertEquals( "First Loop references should be equal.", recordA.getFirstLoop(), recordB.getFirstLoop() );
+        assertEquals( "First Out references should be equal.", recordA.getFirstOut(), recordB.getFirstOut() );
+        assertEquals( "Next references should be equal.", recordA.getNext(), recordB.getNext() );
+        assertEquals( "Prev references should be equal.", recordA.getPrev(), recordB.getPrev() );
+        assertEquals( "Owning node references should be equal.", recordA.getOwningNode(), recordB.getOwningNode() );
+    }
+
+    private void writeReadRecord( RelationshipGroupRecord source, RelationshipGroupRecord target ) throws java.io.IOException
+    {
+        int recordSize = RelationshipGroupRecordFormat.RECORD_SIZE;
+        recordFormat.prepare( source, recordSize, idSequence );
+        recordFormat.write( source, pageCursor, recordSize );
+        pageCursor.setOffset( 0 );
+        recordFormat.read( target, pageCursor, RecordLoad.NORMAL, recordSize );
+    }
+
+    private long randomFixedReference()
+    {
+        return randomReference( 1L << (Integer.SIZE + 1) );
+    }
+
+    private long randomReference( long maxValue )
+    {
+        return ThreadLocalRandom.current().nextLong( maxValue );
+    }
+
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormatTest.java
@@ -76,7 +76,7 @@ public class RelationshipGroupRecordFormatTest
     }
 
     @Test
-    public void useVariableLengthFormatWhenOneOfTheReferencesIsMissing() throws IOException
+    public void useFixedReferenceFormatWhenOneOfTheReferencesIsMissing() throws IOException
     {
         RelationshipGroupRecord source = new RelationshipGroupRecord( 1 );
         RelationshipGroupRecord target = new RelationshipGroupRecord( 1 );
@@ -167,6 +167,7 @@ public class RelationshipGroupRecordFormatTest
     private void verifyRecordsWithPoisonedReference( RelationshipGroupRecord source, RelationshipGroupRecord target,
             long poisonedReference ) throws IOException
     {
+        boolean nullPoisoned = poisonedReference == BaseHighLimitRecordFormat.NULL;
         int differentReferences = 5;
         List<Long> references = buildReferenceList( differentReferences, poisonedReference );
         for ( int i = 0; i < differentReferences; i++ )
@@ -179,7 +180,14 @@ public class RelationshipGroupRecordFormatTest
 
             writeReadRecord( source, target );
 
-            assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+            if ( nullPoisoned )
+            {
+                assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
+            }
+            else
+            {
+                assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+            }
             verifySameReferences( source, target );
             Collections.rotate( references, 1 );
         }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
@@ -129,7 +129,7 @@ public class RelationshipRecordFormatTest
     }
 
     @Test
-    public void useVariableLengthFormatWhenAtLeastOneOfTheReferencesIsMissing() throws IOException
+    public void useFixedRecordFormatWhenAtLeastOneOfTheReferencesIsMissing() throws IOException
     {
         RelationshipRecord source = new RelationshipRecord( 1 );
         RelationshipRecord target = new RelationshipRecord( 1 );
@@ -238,7 +238,14 @@ public class RelationshipRecordFormatTest
 
             writeReadRecord( source, target );
 
-            assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+            if ( nullPoison )
+            {
+                assertTrue( "Record should use fixed reference format.", target.isUseFixedReferences() );
+            }
+            else
+            {
+                assertFalse( "Record should use variable length reference format.", target.isUseFixedReferences() );
+            }
             verifySameReferences( source, target );
             Collections.rotate( references, 1 );
         }

--- a/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueEnterpriseConcurrencyIT.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueEnterpriseConcurrencyIT.scala
@@ -71,8 +71,6 @@ class CreateUniqueEnterpriseConcurrencyIT extends ExecutionEngineFunSuite with E
 
     threads.foreach(_.start())
     threads.foreach(_.join)
-    if (deadlockCounter.get() > 0)
-      println(s"Deadlocks found: ${deadlockCounter.get()}")
     counter.get()
   }
 


### PR DESCRIPTION
Variable length encoding of references decoding and encoding or records in enterprise format takes some additional time.
To minimise damage for common case (small records) possibility of fixed records introduced.
From now on in case if record can be encoded in a fixed reference format (criteria based on references that are used in record) it will be used instead of variable-length format.
In case if record can't be encoded in fixed references format - default variable-length format will be selected and used.

changelog:
Speeding up enterprise 'high limit' record format by adding possibility to store small records in a fixed references form to avoid variable length encoding/decoding costs
