### PR TITLE
neo4j-admin: add check-consistency command.

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/community/consistency-check/LICENSES.txt
+++ b/community/consistency-check/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene codecs
   Lucene Common Analyzers

--- a/community/consistency-check/NOTICE.txt
+++ b/community/consistency-check/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene codecs
   Lucene Common Analyzers

--- a/community/consistency-check/pom.xml
+++ b/community/consistency-check/pom.xml
@@ -111,5 +111,20 @@ the relevant Commercial Agreement.
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-command-line</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-dbms</artifactId>
+      <version>${neo4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-io</artifactId>
+      <version>${neo4j.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.Converters;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.server.configuration.ConfigLoader;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+
+public class CheckConsistencyCommand implements AdminCommand
+{
+    public static class Provider extends AdminCommand.Provider
+    {
+        public Provider()
+        {
+            super( "check-consistency" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "--database=<database> [--tuning-config=<file>] [--verbose]" );
+        }
+
+        @Override
+        public String description()
+        {
+            return "Check the consistency of a database.";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new CheckConsistencyCommand( homeDir, configDir );
+        }
+    }
+
+    private final Path homeDir;
+    private final Path configDir;
+    private final ConsistencyCheckService consistencyCheckService;
+    private final LogProvider logProvider;
+    private final FileSystemAbstraction fileSystemAbstraction;
+
+    public CheckConsistencyCommand( Path homeDir, Path configDir )
+    {
+        this( homeDir, configDir, new ConsistencyCheckService() );
+    }
+
+    public CheckConsistencyCommand( Path homeDir, Path configDir, ConsistencyCheckService consistencyCheckService )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+        this.consistencyCheckService = consistencyCheckService;
+        this.logProvider = FormattedLogProvider.toOutputStream( System.out );
+        this.fileSystemAbstraction = new DefaultFileSystemAbstraction();
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        String database;
+        Boolean verbose;
+        File tuningConfigFile;
+
+        Args parsedArgs = Args.parse( args );
+        try
+        {
+            database = parsedArgs.interpretOption( "database", Converters.mandatory(), s -> s );
+            verbose = parsedArgs.getBoolean( "verbose" );
+            tuningConfigFile =
+                    parsedArgs.interpretOption( "tuning-confing", Converters.optional(), Converters.toFile() );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+
+        Config config = loadNeo4jConfig( homeDir, configDir, database, loadTuningConfig( tuningConfigFile ) );
+
+        try
+        {
+            consistencyCheckService.runFullConsistencyCheck( config.get( database_path ), config,
+                    ProgressMonitorFactory.textual( System.err ), logProvider, fileSystemAbstraction, verbose );
+        }
+        catch ( ConsistencyCheckIncompleteException | IOException e )
+        {
+            throw new CommandFailed( "Consistency checking failed.", e );
+        }
+    }
+
+    private Map<String,String> loadTuningConfig( File tuningConfigFile )
+    {
+        if ( tuningConfigFile == null )
+        {
+            return new HashMap<>();
+        }
+
+        try
+        {
+            return MapUtil.load( tuningConfigFile );
+        }
+        catch ( IOException e )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Could not read configuration file [%s]", tuningConfigFile ), e );
+        }
+    }
+
+    private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName,
+            Map<String,String> additionalConfig )
+    {
+        ConfigLoader configLoader = new ConfigLoader( settings() );
+        Config config = configLoader.loadConfig( Optional.of( homeDir.toFile() ),
+                Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) );
+        additionalConfig.put( DatabaseManagementSystemSettings.active_database.name(), databaseName );
+        return config.with( additionalConfig );
+    }
+
+    private static List<Class<?>> settings()
+    {
+        List<Class<?>> settings = new ArrayList<>();
+        settings.add( GraphDatabaseSettings.class );
+        settings.add( DatabaseManagementSystemSettings.class );
+        settings.add( ConsistencyCheckSettings.class );
+        return settings;
+    }
+}

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -198,7 +198,7 @@ public class ConsistencyCheckService
         return Result.SUCCESS;
     }
 
-    private File chooseReportPath( Config tuningConfiguration, File storeDir )
+    public File chooseReportPath( Config tuningConfiguration, File storeDir )
     {
         if ( tuningConfiguration.get( GraphDatabaseSettings.neo4j_home ) == null )
         {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -53,6 +53,8 @@ public class ConsistencyCheckTool
     {
         try
         {
+            System.err.println("WARNING: ConsistencyCheckTool is deprecated and support for it will be" +
+                    "removed in a future version of Neo4j. Please use neo4j-admin check-consistency.");
             runConsistencyCheckTool( args );
         }
         catch ( ToolFailureException e )

--- a/community/consistency-check/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/consistency-check/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,0 +1,1 @@
+org.neo4j.consistency.CheckConsistencyCommand$Provider

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CheckConsistencyCommandTest
+{
+    private TestDirectory testDir = TestDirectory.testDirectory( getClass() );
+
+    @Rule
+    public final DatabaseRule db = new EmbeddedDatabaseRule();
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( testDir );
+
+    @Test
+    public void requiresDatabaseArgument() throws Exception
+    {
+        CheckConsistencyCommand checkConsistencyCommand =
+                new CheckConsistencyCommand( testDir.directory( "home" ).toPath(),
+                        testDir.directory( "conf" ).toPath() );
+
+        String[] arguments = {""};
+        try
+        {
+            checkConsistencyCommand.execute( arguments );
+            fail( "Should have thrown an exception." );
+        }
+        catch ( IncorrectUsage e )
+        {
+            assertThat( e.getMessage(), containsString( "database" ) );
+        }
+    }
+
+    @Test
+    public void runsConsistencyChecker() throws Exception
+    {
+        ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
+
+        Path homeDir = testDir.directory( "home" ).toPath();
+        CheckConsistencyCommand checkConsistencyCommand =
+                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), consistencyCheckService );
+
+        File databasePath = new File( homeDir.toFile(), "data/databases/mydb" );
+        checkConsistencyCommand.execute( new String[]{"--database=mydb"} );
+
+        verify( consistencyCheckService )
+                .runFullConsistencyCheck( eq( databasePath ), any( Config.class ), any( ProgressMonitorFactory.class ),
+                        any( LogProvider.class ), any( FileSystemAbstraction.class ), eq( false ) );
+    }
+
+    @Test
+    public void enablesVerbosity() throws Exception
+    {
+        ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
+
+        Path homeDir = testDir.directory( "home" ).toPath();
+        CheckConsistencyCommand checkConsistencyCommand =
+                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), consistencyCheckService );
+
+        File databasePath = new File( homeDir.toFile(), "data/databases/mydb" );
+
+        checkConsistencyCommand.execute( new String[]{"--database=mydb", "--verbose"} );
+
+        verify( consistencyCheckService )
+                .runFullConsistencyCheck( eq( databasePath ), any( Config.class ), any( ProgressMonitorFactory.class ),
+                        any( LogProvider.class ), any( FileSystemAbstraction.class ), eq( true ) );
+    }
+}

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.nio.file.Path;
 
 import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -56,9 +57,10 @@ public class CheckConsistencyCommandTest
     @Test
     public void requiresDatabaseArgument() throws Exception
     {
+        OutsideWorld outsideWorld = mock( OutsideWorld.class );
         CheckConsistencyCommand checkConsistencyCommand =
                 new CheckConsistencyCommand( testDir.directory( "home" ).toPath(),
-                        testDir.directory( "conf" ).toPath() );
+                        testDir.directory( "conf" ).toPath(), outsideWorld );
 
         String[] arguments = {""};
         try
@@ -78,8 +80,10 @@ public class CheckConsistencyCommandTest
         ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
 
         Path homeDir = testDir.directory( "home" ).toPath();
+        OutsideWorld outsideWorld = mock( OutsideWorld.class );
         CheckConsistencyCommand checkConsistencyCommand =
-                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), consistencyCheckService );
+                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
+                        consistencyCheckService );
 
         File databasePath = new File( homeDir.toFile(), "data/databases/mydb" );
         checkConsistencyCommand.execute( new String[]{"--database=mydb"} );
@@ -95,8 +99,10 @@ public class CheckConsistencyCommandTest
         ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
 
         Path homeDir = testDir.directory( "home" ).toPath();
+        OutsideWorld outsideWorld = mock( OutsideWorld.class );
         CheckConsistencyCommand checkConsistencyCommand =
-                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), consistencyCheckService );
+                new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
+                        consistencyCheckService );
 
         File databasePath = new File( homeDir.toFile(), "data/databases/mydb" );
 

--- a/community/neo4j/LICENSES.txt
+++ b/community/neo4j/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/manual/cypher/graphgist/LICENSES.txt
+++ b/manual/cypher/graphgist/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Commons IO
   ConcurrentLinkedHashMap

--- a/manual/cypher/graphgist/NOTICE.txt
+++ b/manual/cypher/graphgist/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Commons IO
   ConcurrentLinkedHashMap

--- a/manual/embedded-examples/LICENSES.txt
+++ b/manual/embedded-examples/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/manual/embedded-examples/NOTICE.txt
+++ b/manual/embedded-examples/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/tools/LICENSES.txt
+++ b/tools/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   airline
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Guava: Google Core Libraries for Java

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   airline
+  Apache Commons Compress
   Apache Commons Lang
   ConcurrentLinkedHashMap
   Guava: Google Core Libraries for Java


### PR DESCRIPTION
changelog [tools] Added `check-consistency` command to `neo4j-admin`
The previous method of invoking the consistency checker manually via `org.neo4j.consistency.ConsistencyCheckTool` is deprecated and will be removed in a future release.
