### PR TITLE
LocalDatabase is now the sole manager of DSM lifecycle in edges

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EdgeStartupProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EdgeStartupProcess.java
@@ -19,29 +19,27 @@
  */
 package org.neo4j.coreedge.edge;
 
+import static org.neo4j.coreedge.edge.EnterpriseEdgeEditionModule.extractBoltAddress;
+
 import java.util.concurrent.locks.LockSupport;
 
 import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
 import org.neo4j.coreedge.catchup.storecopy.StoreFetcher;
-import org.neo4j.coreedge.messaging.routing.CoreMemberSelectionException;
-import org.neo4j.coreedge.discovery.EdgeTopologyService;
-import org.neo4j.coreedge.messaging.routing.CoreMemberSelectionStrategy;
 import org.neo4j.coreedge.core.state.machines.tx.RetryStrategy;
+import org.neo4j.coreedge.discovery.EdgeTopologyService;
 import org.neo4j.coreedge.identity.MemberId;
+import org.neo4j.coreedge.messaging.routing.CoreMemberSelectionException;
+import org.neo4j.coreedge.messaging.routing.CoreMemberSelectionStrategy;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
-
-import static org.neo4j.coreedge.edge.EnterpriseEdgeEditionModule.extractBoltAddress;
 
 public class EdgeStartupProcess implements Lifecycle
 {
     private final StoreFetcher storeFetcher;
     private final LocalDatabase localDatabase;
     private final Lifecycle txPulling;
-    private final DataSourceManager dataSourceManager;
     private final CoreMemberSelectionStrategy connectionStrategy;
     private final Log log;
     private final EdgeTopologyService discoveryService;
@@ -52,7 +50,6 @@ public class EdgeStartupProcess implements Lifecycle
             StoreFetcher storeFetcher,
             LocalDatabase localDatabase,
             Lifecycle txPulling,
-            DataSourceManager dataSourceManager,
             CoreMemberSelectionStrategy connectionStrategy,
             RetryStrategy retryStrategy,
             LogProvider logProvider, EdgeTopologyService discoveryService, Config config )
@@ -60,7 +57,6 @@ public class EdgeStartupProcess implements Lifecycle
         this.storeFetcher = storeFetcher;
         this.localDatabase = localDatabase;
         this.txPulling = txPulling;
-        this.dataSourceManager = dataSourceManager;
         this.connectionStrategy = connectionStrategy;
         this.timeout = retryStrategy.newTimeout();
         this.log = logProvider.getLog( getClass() );
@@ -71,14 +67,14 @@ public class EdgeStartupProcess implements Lifecycle
     @Override
     public void init() throws Throwable
     {
-        dataSourceManager.init();
+        localDatabase.init();
         txPulling.init();
     }
 
     @Override
     public void start() throws Throwable
     {
-        dataSourceManager.start();
+        localDatabase.start();
 
         MemberId memberId = findCoreMemberToCopyFrom();
         if ( localDatabase.isEmpty() )
@@ -120,13 +116,13 @@ public class EdgeStartupProcess implements Lifecycle
     public void stop() throws Throwable
     {
         txPulling.stop();
-        dataSourceManager.stop();
+        localDatabase.stop();
     }
 
     @Override
     public void shutdown() throws Throwable
     {
         txPulling.shutdown();
-        dataSourceManager.shutdown();
+        localDatabase.shutdown();
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -218,7 +218,7 @@ public class EnterpriseEdgeEditionModule extends EditionModule
                         platformModule.dataSourceManager,
                         dependencies.provideDependency( TransactionIdStore.class ),
                         databaseHealthSupplier, logProvider ),
-                txPulling, platformModule.dataSourceManager, new ConnectToRandomCoreMember( discoveryService ),
+                txPulling, new ConnectToRandomCoreMember( discoveryService ),
                 new ExponentialBackoffStrategy( 1, TimeUnit.SECONDS ), logProvider, discoveryService, config ) );
 
         dependencies.satisfyDependency( createSessionTracker() );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
@@ -85,7 +85,6 @@ public class HazelcastClusterTopologyTest
         final EdgeStartupProcess startupProcess = new EdgeStartupProcess( null,
                 localDatabase,
                 mock( Lifecycle.class ),
-                mock( DataSourceManager.class ),
                 connectionStrategy,
                 new ConstantTimeRetryStrategy( 1, TimeUnit.MILLISECONDS ),
                 NullLogProvider.getInstance(), topology, config );


### PR DESCRIPTION
DataSourceManager lifecycle was controlled both directly and through
 LocalDatabase. This caused some confusion, which is now solved.

Effectively this is an implementation of 436737a077cc17c6a66e52df6d5d6a5bb7d3cae3
 for edges.
