### PR TITLE
All instances in ha.inital_cluster must be up

### DIFF
--- a/enterprise/ha/src/docs/dev/ha-setup-tutorial.asciidoc
+++ b/enterprise/ha/src/docs/dev/ha-setup-tutorial.asciidoc
@@ -31,18 +31,18 @@ It must be a positive integer and must be unique among all Neo4j instances in th
 
 For example, +ha.server_id=1+.
 
-=== ha.cluster_server
+=== ha.host.coordination
 
-+ha.cluster_server+ is an address/port setting that specifies where the Neo4j instance will listen for cluster communications (like hearbeat messages).
++ha.host.coordination+ is an address/port setting that specifies where the Neo4j instance will listen for cluster communications (like hearbeat messages).
 The default port is +5001+.
 In the absence of a specified IP address, Neo4j will attempt to find a valid interface for binding.
 While this behavior typically results in a well-behaved server, it is _strongly recommended_ that users explicitly choose an IP address bound to the network interface of their choosing to ensure a coherent cluster deployment.
 
-For example, +ha.cluster_server=192.168.33.22:5001+ will listen for cluster communications on the network interface bound to the 192.168.33.0 subnet on port 5001.
+For example, +ha.host.coordination=192.168.33.22:5001+ will listen for cluster communications on the network interface bound to the 192.168.33.0 subnet on port 5001.
 
 === ha.initial_hosts
 
-+ha.initial_hosts+ is a comma separated list of address/port pairs, which specify how to reach other Neo4j instances in the cluster (as configured via their +ha.cluster_server+ option).
++ha.initial_hosts+ is a comma separated list of address/port pairs, which specify how to reach other Neo4j instances in the cluster (as configured via their +ha.host.coordination+ option).
 These hostname/ports will be used when the Neo4j instances start, to allow them to find and join the cluster.
 Specifying an instance's own address is permitted.
 
@@ -54,25 +54,25 @@ Do _not_ use any whitespace in this configuration option.
 For example, +ha.initial_hosts=192.168.33.22:5001,192.168.33.21:5001+ will attempt to reach Neo4j instances listening on
 192.168.33.22 on port 5001 and 192.168.33.21 on port 5001 on the 192.168.33.0 subnet.
 
-=== ha.server
+=== ha.host.data
 
-+ha.server+ is an address/port setting that specifies where the Neo4j instance will listen for transactions (changes to the graph data) from the cluster master.
++ha.host.data+ is an address/port setting that specifies where the Neo4j instance will listen for transactions (changes to the graph data) from the cluster master.
 The default port is +6001+.
 In the absence of a specified IP address, Neo4j will attempt to find a valid interface for binding.
 While this behavior typically results in a well-behaved server, it is _strongly recommended_ that users explicitly choose an IP address bound to the network interface of their choosing to ensure a coherent cluster topology.
 
-+ha.server+ must user a different port to +ha.cluster_server+.
++ha.host.data+ must use a different port to +ha.host.coordination+.
 
-For example, +ha.server=192.168.33.22:6001+ will listen for cluster communications on the network interface bound to the 192.168.33.0 subnet on port 6001.
+For example, +ha.host.data=192.168.33.22:6001+ will listen for cluster communications on the network interface bound to the 192.168.33.0 subnet on port 6001.
 
 [TIP]
 .Address/port format
 ====
-The +ha.cluster_server+ and +ha.server+ configuration options are specified as +<IP address>:<port>+.
+The +ha.host.coordination+ and +ha.host.data+ configuration options are specified as +<IP address>:<port>+.
 
-For +ha.server+ the IP address _must be_ the address assigned to one of the host's network interfaces.
+For +ha.host.data+ the IP address _must be_ the address assigned to one of the host's network interfaces.
 
-For +ha.cluster_server+ the IP address _must be_ the address assigned to one of the host's network interfaces, or the value +0.0.0.0+, which will cause Neo4j to listen on every network interface.
+For +ha.host.coordination+ the IP address _must be_ the address assigned to one of the host's network interfaces, or the value +0.0.0.0+, which will cause Neo4j to listen on every network interface.
 
 Either the address or the port can be omitted, in which case the default for that part will be used.
 If the address is omitted, then the port must be preceded with a colon (eg. +:5001+).
@@ -95,7 +95,7 @@ Note that this usage is not permitted when the hostname is specified as +0.0.0.0
 Neo4j instance #1 -- neo4j-01.local::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -105,23 +105,20 @@ ha.server_id = 1
 ha.initial_hosts = neo4j-01.local:5001,neo4j-02.local:5001,neo4j-03.local:5001
 # Alternatively, use IP addresses:
 #ha.initial_hosts = 192.168.0.20:5001,192.168.0.21:5001,192.168.0.22:5001
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# Let the webserver only listen on the specified IP.
-org.neo4j.server.webserver.address=0.0.0.0
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7474
 ----
 
 Neo4j instance #2 -- neo4j-02.local::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -131,23 +128,20 @@ ha.server_id = 2
 ha.initial_hosts = neo4j-01.local:5001,neo4j-02.local:5001,neo4j-03.local:5001
 # Alternatively, use IP addresses:
 #ha.initial_hosts = 192.168.0.20:5001,192.168.0.21:5001,192.168.0.22:5001
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# Let the webserver only listen on the specified IP.
-org.neo4j.server.webserver.address=0.0.0.0
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7474
 ----
 
 Neo4j instance #3 -- neo4j-03.local::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -157,17 +151,14 @@ ha.server_id = 3
 ha.initial_hosts = neo4j-01.local:5001,neo4j-02.local:5001,neo4j-03.local:5001
 # Alternatively, use IP addresses:
 #ha.initial_hosts = 192.168.0.20:5001,192.168.0.21:5001,192.168.0.22:5001
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# Let the webserver only listen on the specified IP.
-org.neo4j.server.webserver.address=0.0.0.0
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7474
 ----
 
 === Start the Neo4j Servers
@@ -192,9 +183,9 @@ neo4j-03$ ./bin/neo4j start
 .Startup Time
 ====
 When running in HA mode, the startup script returns immediately instead of waiting for the server to become available.
-This is because the instance does not accept any requests until a cluster has been formed.
-In the example above this happens when you start the second instance.
-To keep track of the startup state you can follow the messages in _console.log_ -- the path is printed before the startup script returns.
+This is because the instance does not accept any requests until a cluster has been formed, which is when _all_ the servers in +ha.initial_hosts+ are running and have joined the cluster.
+In the example above this happens when you have started all three instances.
+To keep track of the startup state you can follow the messages in _neo4j.log_ -- the path is printed before the startup script returns.
 ====
 
 Now, you should be able to access the three servers and check their HA status.
@@ -218,7 +209,7 @@ For more HA related configuration options take a look at <<ha-configuration>>.
 
 If you want to start a cluster similar to the one described above, but for development and testing purposes, it is convenient to run all Neo4j instances on the same machine.
 This is easy to achieve, although it requires some additional configuration as the defaults will conflict with each other.
-Furthermore, the default `dbms.pagecache.memory` assumes that Neo4j has the machine to itself.
+Furthermore, the default `dbms.memory.pagecache.size` assumes that Neo4j has the machine to itself.
 If we in this example assume that the machine has 4 gigabytes of memory, and that each JVM consumes 500 megabytes of memory, then we can allocate 500 megabytes of memory to the page cache of each server.
 
 === Download and configure
@@ -231,13 +222,13 @@ If we in this example assume that the machine has 4 gigabytes of memory, and tha
 Neo4j instance #1 -- ~/neo4j-01::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Reduce the default page cache memory allocation
-dbms.pagecache.memory=500m
+dbms.memory.pagecache.size=500m
 
 # Port to listen to for incoming backup requests.
-online_backup_server = 127.0.0.1:6366
+dbms.backup.address = 127.0.0.1:6366
 
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -248,37 +239,31 @@ ha.initial_hosts = 127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
 
 # IP and port for this instance to bind to for communicating cluster information
 # with the other neo4j instances in the cluster.
-ha.cluster_server = 127.0.0.1:5001
+ha.host.coordination = 127.0.0.1:5001
 
 # IP and port for this instance to bind to for communicating data with the
 # other neo4j instances in the cluster.
-ha.server = 127.0.0.1:6363
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+ha.host.data = 127.0.0.1:6363
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=7474
-
-# https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=7484
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7474
 ----
 
 Neo4j instance #2 -- ~/neo4j-02::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Reduce the default page cache memory allocation
-dbms.pagecache.memory=500m
+dbms.memory.pagecache.size=500m
 
 # Port to listen to for incoming backup requests.
-online_backup_server = 127.0.0.1:6367
+dbms.backup.address = 127.0.0.1:6367
 
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -289,37 +274,31 @@ ha.initial_hosts = 127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
 
 # IP and port for this instance to bind to for communicating cluster information
 # with the other neo4j instances in the cluster.
-ha.cluster_server = 127.0.0.1:5002
+ha.host.coordination = 127.0.0.1:5002
 
 # IP and port for this instance to bind to for communicating data with the
 # other neo4j instances in the cluster.
-ha.server = 127.0.0.1:6364
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+ha.host.data = 127.0.0.1:6364
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=7475
-
-# https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=7485
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7475
 ----
 
 Neo4j instance #3 -- ~/neo4j-03::
 +
 [source, properties]
-.conf/neo4j.properties
+.conf/neo4j.conf
 ----
 # Reduce the default page cache memory allocation
-dbms.pagecache.memory=500m
+dbms.memory.pagecache.size=500m
 
 # Port to listen to for incoming backup requests.
-online_backup_server = 127.0.0.1:6368
+dbms.backup.address = 127.0.0.1:6368
 
 # Unique server id for this Neo4j instance
 # can not be negative id and must be unique
@@ -330,25 +309,19 @@ ha.initial_hosts = 127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
 
 # IP and port for this instance to bind to for communicating cluster information
 # with the other neo4j instances in the cluster.
-ha.cluster_server = 127.0.0.1:5003
+ha.host.coordination = 127.0.0.1:5003
 
 # IP and port for this instance to bind to for communicating data with the
 # other neo4j instances in the cluster.
-ha.server = 127.0.0.1:6365
-----
-+
-[source, properties]
-.conf/neo4j-server.properties
-----
+ha.host.data = 127.0.0.1:6365
+
 # HA - High Availability
 # SINGLE - Single mode, default.
-org.neo4j.server.database.mode=HA
+dbms.mode=HA
 
-# http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=7476
-
-# https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=7486
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+dbms.connector.http.address=0.0.0.0:7476
 ----
 
 === Start the Neo4j Servers


### PR DESCRIPTION
Clarify in ha tutorial that all instances in ha.initial_cluster must be up in order for
the cluster to be functional.
