### PR TITLE
Make CoreState.downloadSnapshot() private and non synchronized

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/CoreState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/CoreState.java
@@ -90,7 +90,6 @@ public class CoreState implements MessageHandler<RaftMessages.StoreIdAwareMessag
                 raftMachine.stopTimers();
                 localDatabase.panic( e );
             }
-
         }
         else
         {
@@ -141,7 +140,7 @@ public class CoreState implements MessageHandler<RaftMessages.StoreIdAwareMessag
 
     public void addMismatchedStoreListener( MismatchedStoreListener listener )
     {
-        listeners.add(listener);
+        listeners.add( listener );
     }
 
     private synchronized void notifyCommitted( long commitIndex )
@@ -166,7 +165,7 @@ public class CoreState implements MessageHandler<RaftMessages.StoreIdAwareMessag
      *
      * @param source The source address to attempt a download of a snapshot from.
      */
-    public synchronized void downloadSnapshot( MemberId source )
+    private void downloadSnapshot( MemberId source )
     {
         try
         {


### PR DESCRIPTION
That particular method was public to be used from
 CoreToCoreCopySnapshotIT and that was also the reason it was declared
 as synchronized. Nevertheless, its usage still caused exceptions
 to be thrown because of race conditions and besides, the test
 was not testing something valuable.
The test has now been rewritten to test behaviour of cluster
 member snapshot copy after the store has been deleted. This
 also removes all non private usage of the method, so it's made
 private. Synchronization is no longer needed, because it is
 guaranteed by the queue in front of CoreState.handle().
