### PR TITLE
Record failure to open index

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -99,7 +99,7 @@ public interface IndexPopulator
 
     /**
      * Called then a population failed. The failure string should be stored for future retrieval by
-     * {@link SchemaIndexProvider#getPopulationFailure(long)}. Called before {@link #close(boolean)}
+     * {@link SchemaIndexProvider#getIndexFailure(long)}. Called before {@link #close(boolean)}
      * if there was a failure during population.
      *
      * @param failure the description of the failure.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
@@ -131,9 +131,15 @@ public abstract class SchemaIndexProvider extends LifecycleAdapter implements Co
                 }
 
                 @Override
-                public String getPopulationFailure( long indexId ) throws IllegalStateException
+                public String getIndexFailure( long indexId ) throws IllegalStateException
                 {
                     throw new IllegalStateException();
+                }
+
+                @Override
+                public void storeIndexFailure( long indexId, String failure )
+                {
+                    throw new UnsupportedOperationException();
                 }
             };
 
@@ -183,11 +189,13 @@ public abstract class SchemaIndexProvider extends LifecycleAdapter implements Co
      * Implementations are expected to persist this failure and may elect to make use of
      * {@link org.neo4j.kernel.api.index.util.FailureStorage} for this purpose
      */
-    public abstract String getPopulationFailure( long indexId ) throws IllegalStateException;
+    public abstract String getIndexFailure( long indexId ) throws IllegalStateException;
+
+    public abstract void storeIndexFailure( long indexId, String failure ) throws IOException;
 
     /**
      * Called during startup to find out which state an index is in. If {@link InternalIndexState#FAILED}
-     * is returned then a further call to {@link #getPopulationFailure(long)} is expected and should return
+     * is returned then a further call to {@link #getIndexFailure(long)} is expected and should return
      * the failure accepted by any call to {@link IndexPopulator#markAsFailed(String)} call at the time
      * of failure.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/util/FailureStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/util/FailureStorage.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.index.util;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -122,6 +123,18 @@ public class FailureStorage
 
             channel.force( true );
             channel.close();
+        }
+        catch ( FileNotFoundException fnf )
+        {
+            fs.mkdirs( failureFile.getParentFile() );
+            try ( StoreChannel channel = fs.open( failureFile, "rw" ) )
+            {
+                byte[] data = failure.getBytes( "utf-8" );
+                channel.write( ByteBuffer.wrap( data, 0, Math.min( data.length, MAX_FAILURE_SIZE ) ) );
+
+                channel.force( true );
+                channel.close();
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FailedPopulatingIndexProxyFactory.java
@@ -57,6 +57,16 @@ public class FailedPopulatingIndexProxyFactory implements FailedIndexProxyFactor
     @Override
     public IndexProxy create( Throwable failure )
     {
+        IndexPopulationFailure populationFailure = failure( failure );
+        try
+        {
+            populator.markAsFailed( populationFailure.asString() );
+        }
+        catch ( Exception e )
+        {
+            // we're already in a hole, stop digging
+        }
+        logProvider.getLog( FailedIndexProxy.class ).error( "Index failed " + indexUserDescription, failure );
         return
             new FailedIndexProxy(
                 descriptor, configuration, providerDescriptor,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelExceptio
 import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -238,7 +239,7 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
                     indexProxy = proxySetup.createRecoveringIndexProxy( descriptor, providerDescriptor, constraint );
                     break;
                 case FAILED:
-                    IndexPopulationFailure failure = failure( provider.getPopulationFailure( indexId ) );
+                    IndexPopulationFailure failure = failure( provider.getIndexFailure( indexId ) );
                     indexProxy = proxySetup.createFailedIndexProxy( indexId, descriptor, providerDescriptor, constraint, failure );
                     break;
                 default:

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexPopulatorCompatibility.java
@@ -82,7 +82,7 @@ public class NonUniqueIndexPopulatorCompatibility extends IndexProviderCompatibi
         populator.markAsFailed( failure );
 
         // THEN
-        assertEquals( failure, indexProvider.getPopulationFailure( 17 ) );
+        assertEquals( failure, indexProvider.getIndexFailure( 17 ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationSchemaIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationSchemaIndexProvider.java
@@ -117,9 +117,15 @@ public class ControlledPopulationSchemaIndexProvider extends SchemaIndexProvider
     }
 
     @Override
-    public String getPopulationFailure( long indexId ) throws IllegalStateException
+    public String getIndexFailure( long indexId ) throws IllegalStateException
     {
         throw new IllegalStateException();
+    }
+
+    @Override
+    public void storeIndexFailure( long indexId, String failure ) throws IOException
+    {
+        throw new UnsupportedOperationException( "should never have to record failure" );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
@@ -95,7 +95,7 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
     }
 
     @Override
-    public String getPopulationFailure( long indexId ) throws IllegalStateException
+    public String getIndexFailure( long indexId ) throws IllegalStateException
     {
         String failure = indexes.get( indexId ).failure;
         if ( failure == null )
@@ -103,6 +103,12 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
             throw new IllegalStateException();
         }
         return failure;
+    }
+
+    @Override
+    public void storeIndexFailure( long indexId, String failure )
+    {
+        indexes.get( indexId ).failure = failure;
     }
 
     public InMemoryIndexProvider snapshot()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexCorruptionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexCorruptionTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.impl.index;
 
 import org.apache.lucene.index.CorruptIndexException;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -33,6 +34,7 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.udc.UsageDataKeys.OperationalMode;
 
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertTrue;
@@ -81,7 +83,7 @@ public class LuceneSchemaIndexCorruptionTest
 
         // Then
         assertThat( initialState, equalTo(InternalIndexState.FAILED) );
-        assertThat( p.getPopulationFailure( 1l ), equalTo( "File not found: " + toThrow.getMessage() ) );
+        assertThat( p.getIndexFailure( 1l ), startsWith( FileNotFoundException.class.getName() + ": " + toThrow.getMessage() ) );
     }
 
     @Test
@@ -101,7 +103,7 @@ public class LuceneSchemaIndexCorruptionTest
 
         // Then
         assertThat( initialState, equalTo(InternalIndexState.FAILED) );
-        assertThat( p.getPopulationFailure( 1l ), equalTo( "EOF encountered: " + toThrow.getMessage() ) );
+        assertThat( p.getIndexFailure( 1l ), startsWith( EOFException.class.getName() + ": " + toThrow.getMessage() ) );
     }
 
     @Test
@@ -125,7 +127,7 @@ public class LuceneSchemaIndexCorruptionTest
         boolean exceptionOnOtherIndexThrown = false;
         try
         {
-            p.getPopulationFailure( 2l );
+            p.getIndexFailure( 2l );
         }
         catch( IllegalStateException e )
         {

--- a/community/neo4j/src/test/java/org/neo4j/index/TransientIndexFailureOnStartupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/TransientIndexFailureOnStartupTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.EmbeddedDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.schema.Schema.IndexState.FAILED;
+
+public class TransientIndexFailureOnStartupTest
+{
+    @Rule
+    public final DatabaseRule db = new EmbeddedDatabaseRule();
+
+    @Test
+    public void failedIndexShouldNotBecomeOperationalAgain() throws Exception
+    {
+        // given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().indexFor( label( "Person" ) ).on( "name" ).create();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "Person" ) ).setProperty( "name", "Johan" );
+            tx.success();
+        }
+        // when - we restart the database in a state where the index is not operational
+        db.restartDatabase( new DatabaseRule.RestartAction()
+        {
+            @Override
+            public void run( FileSystemAbstraction fs, File path ) throws IOException
+            {
+                fs.renameFile(
+                        new File( path, "schema/index/lucene/1/_0.cfs" ),
+                        new File( path, "schema/index/lucene/1/sneaky" ) );
+            }
+        } );
+        // then - the database should still be operational
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "Person" ) ).setProperty( "name", "Lars" );
+            tx.success();
+        }
+        // when - we restart the database in a state where the index is operational again
+        db.restartDatabase( new DatabaseRule.RestartAction()
+        {
+            @Override
+            public void run( FileSystemAbstraction fs, File path ) throws IOException
+            {
+                fs.renameFile(
+                        new File( path, "schema/index/lucene/1/sneaky" ),
+                        new File( path, "schema/index/lucene/1/_0.cfs" ) );
+            }
+        } );
+        // then - an index once failed must remain failed
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertNotNull(
+                    "Must be able to find node created while index was offline",
+                    db.findNode( label( "Person" ), "name", "Lars" ) );
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( IndexDefinition index : db.schema().getIndexes() )
+            {
+                assertEquals( FAILED, db.schema().getIndexState( index ) );
+            }
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldNotBeAbleToViolateConstraintWhenBackingIndexIsFailed() throws Exception
+    {
+        // given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( label( "Person" ) ).assertPropertyIsUnique( "name" ).create();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "Person" ) ).setProperty( "name", "Lars" );
+            tx.success();
+        }
+        // when - we restart the database in a state where the index is not operational
+        db.restartDatabase( new DatabaseRule.RestartAction()
+        {
+            @Override
+            public void run( FileSystemAbstraction fs, File path ) throws IOException
+            {
+                fs.renameFile(
+                        new File( path, "schema/index/lucene/1/_0.cfs" ),
+                        new File( path, "schema/index/lucene/1/sneaky" ) );
+            }
+        } );
+        // then - we must not be able to violate the constraint
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "Person" ) ).setProperty( "name", "Johan" );
+            tx.success();
+        }
+        catch ( Throwable e )
+        {
+            // we accept failure here, but we don't require it
+        }
+        Throwable failure = null;
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "Person" ) ).setProperty( "name", "Lars" );
+            tx.success();
+        }
+        catch ( Throwable e )
+        {
+            // this must fail, otherwise we have violated the constraint
+            failure = e;
+        }
+        assertNotNull( failure );
+        // when - we restart the database in a state where the index is operational again
+        db.restartDatabase( new DatabaseRule.RestartAction()
+        {
+            @Override
+            public void run( FileSystemAbstraction fs, File path ) throws IOException
+            {
+                fs.renameFile(
+                        new File( path, "schema/index/lucene/1/sneaky" ),
+                        new File( path, "schema/index/lucene/1/_0.cfs" ) );
+            }
+        } );
+        // then - an index once failed must remain failed
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( IndexDefinition index : db.schema().getIndexes() )
+            {
+                assertEquals( FAILED, db.schema().getIndexState( index ) );
+            }
+            tx.success();
+        }
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -524,9 +524,15 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public String getPopulationFailure( long indexId ) throws IllegalStateException
+        public String getIndexFailure( long indexId ) throws IllegalStateException
         {
-            return delegate.getPopulationFailure( indexId );
+            return delegate.getIndexFailure( indexId );
+        }
+
+        @Override
+        public void storeIndexFailure( long indexId, String failure ) throws IOException
+        {
+            delegate.storeIndexFailure( indexId, failure );
         }
     }
 


### PR DESCRIPTION
If an index fails to open it will be in a failed state for the lifespan of the database. This means that no updates will be applied to that index (and how could they, the index could not be opened). If the database is then restarted the index must remain in a failed state, since otherwise it would now be inconsistent with the data.

Previously failures to open an index were not durably recorded in the failure store (where we recorded failure to completely populate the index), so if the failure to open turned out to be transient, the index would come back online at next startup but now be inconsistent with the data. This is fixed by recording the failure durably in all (known) cases where the index can enter the FAILED state.
