### PR TITLE
3.1 Fixed neo4j-admin set-password

### DIFF
--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -93,7 +93,9 @@ public class SetPasswordCommand implements AdminCommand
 
         String username = parsedArgs.orphans().get( 0 );
         String password = parsedArgs.orphans().get( 1 );
-        boolean shouldCreate = parsedArgs.asMap().containsKey( "create" );
+        boolean shouldCreate = parsedArgs.asMap().containsKey( "create" ) && (
+                parsedArgs.asMap().get( "create" ) == null ||   // support trailing --create
+                parsedArgs.asMap().get( "create" ).toLowerCase().equals( "true" )); // support --create=true
         try
         {
             Config config = loadNeo4jConfig( homeDir, configDir );

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -114,7 +114,7 @@ public class SetPasswordCommand implements AdminCommand
             }
             catch ( InvalidArgumentsException e )
             {
-                if ( shouldCreate )
+                if ( shouldCreate  && e.getMessage().contains( "does not exist" ))
                 {
                     authManager.getUserManager().newUser( username, password, false );
                     outsideWorld.stdOutLine( "Created new user '" + username + "'" );

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -57,13 +57,14 @@ public class SetPasswordCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "--create=<true|false> <username> <password>" );
+            return Optional.of( "[--create=<true|false>] <username> <password>" );
         }
 
         @Override
         public String description()
         {
-            return "Sets the password for the specified user and removes the password change requirement";
+            return "Sets the password for the specified user and removes the password change requirement. If the user " +
+                   "does not exist an error message will be shown, unless you specify the option --create=true.";
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -57,7 +57,7 @@ public class SetPasswordCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "--create <username> <password>" );
+            return Optional.of( "--create=<true|false> <username> <password>" );
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -69,17 +69,19 @@ public class SetPasswordCommand implements AdminCommand
         @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
-            return new SetPasswordCommand( homeDir, configDir );
+            return new SetPasswordCommand( homeDir, configDir, outsideWorld );
         }
     }
 
     private final Path homeDir;
     private final Path configDir;
+    private OutsideWorld outsideWorld;
 
-    public SetPasswordCommand( Path homeDir, Path configDir )
+    public SetPasswordCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
         this.homeDir = homeDir;
         this.configDir = configDir;
+        this.outsideWorld = outsideWorld;
     }
 
     @Override
@@ -108,12 +110,14 @@ public class SetPasswordCommand implements AdminCommand
             try
             {
                 authManager.setUserPassword( username, password );
+                outsideWorld.stdOutLine( "Changed password for user '" + username + "'" );
             }
             catch ( InvalidArgumentsException e )
             {
                 if ( shouldCreate )
                 {
                     authManager.getUserManager().newUser( username, password, false );
+                    outsideWorld.stdOutLine( "Created new user '" + username + "'" );
                 } else {
                     throw e;
                 }

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -44,10 +44,10 @@ import static org.neo4j.dbms.DatabaseManagementSystemSettings.auth_store_directo
 
 public class SetPasswordCommand implements AdminCommand
 {
-    public class Provider extends AdminCommand.Provider
+    public static class Provider extends AdminCommand.Provider
     {
 
-        protected Provider()
+        public Provider()
         {
             super( "set-password" );
         }

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetPasswordCommand.java
@@ -31,6 +31,8 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.configuration.ConfigLoader;
@@ -55,7 +57,7 @@ public class SetPasswordCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "<username> <password>" );
+            return Optional.of( "--create <username> <password>" );
         }
 
         @Override
@@ -83,12 +85,15 @@ public class SetPasswordCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        if ( args.length < 2 )
+        Args parsedArgs = Args.parse( args );
+        if ( parsedArgs.orphans().size() < 2 )
         {
             throw new IncorrectUsage( "Missing arguments: expected username and password" );
         }
-        String username = args[0];
-        String password = args[1];
+
+        String username = parsedArgs.orphans().get( 0 );
+        String password = parsedArgs.orphans().get( 1 );
+        boolean shouldCreate = parsedArgs.asMap().containsKey( "create" );
         try
         {
             Config config = loadNeo4jConfig( homeDir, configDir );
@@ -98,7 +103,19 @@ public class SetPasswordCommand implements AdminCommand
             userRepository.start();
             PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
             BasicAuthManager authManager = new BasicAuthManager( userRepository, passwordPolicy, systemUTC() );
-            authManager.setUserPassword( username, password );
+            try
+            {
+                authManager.setUserPassword( username, password );
+            }
+            catch ( InvalidArgumentsException e )
+            {
+                if ( shouldCreate )
+                {
+                    authManager.getUserManager().newUser( username, password, false );
+                } else {
+                    throw e;
+                }
+            }
         }
         catch ( Exception e )
         {
@@ -106,7 +123,8 @@ public class SetPasswordCommand implements AdminCommand
         }
         catch ( Throwable t )
         {
-            throw new CommandFailed( "Failed to set password for '" + username + "': " + t.getMessage(), new RuntimeException(t.getMessage()) );
+            throw new CommandFailed( "Failed to set password for '" + username + "': " + t.getMessage(),
+                    new RuntimeException( t.getMessage() ) );
         }
     }
 

--- a/community/security/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/security/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,0 +1,1 @@
+org.neo4j.commandline.admin.security.SetPasswordCommand$Provider

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -179,7 +179,7 @@ public class SetPasswordCommandTest
 
         // Then we get error output and user still requires password change
         verify( out, times( 0 ) ).stdOutLine( anyString() );
-        verify( out ).stdErrLine( "neo4j-admin set-password --create <username> <password>" );
+        verify( out ).stdErrLine( "neo4j-admin set-password --create=<true|false> <username> <password>" );
         verify( out ).stdErrLine( "    Sets the password for the specified user and removes the password change " );
         verify( out ).stdErrLine( "    requirement" );
         verify( out ).stdErrLine( "Missing arguments: expected username and password" );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -204,6 +204,23 @@ public class SetPasswordCommandTest
     }
 
     @Test
+    public void shouldRunAdminToolWithSetPasswordCommandAndArgsButNoUserAndCreateFalse() throws Throwable
+    {
+        // Given no existing user
+
+        // When running the neo4j-admin tool without --create parameter
+        Path homeDir = testDir.graphDbDir().toPath();
+        Path configDir = testDir.directory( "conf" ).toPath();
+        OutsideWorld out = mock( OutsideWorld.class );
+        AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
+        tool.execute( homeDir, configDir, "set-password", "neo4j", "abc", "--create=false" );
+
+        // Then we get error output and user still requires password change
+        verify( out, times( 0 ) ).stdOutLine( anyString() );
+        verify( out ).stdErrLine( "command failed: Failed to set password for 'neo4j': User 'neo4j' does not exist" );
+    }
+
+    @Test
     public void shouldRunAdminToolWithSetPasswordCommandAndExistingUser() throws Throwable
     {
         // Given a user that requires password change

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -183,9 +183,10 @@ public class SetPasswordCommandTest
 
         // Then we get error output and user still requires password change
         verify( out, times( 0 ) ).stdOutLine( anyString() );
-        verify( out ).stdErrLine( "neo4j-admin set-password --create=<true|false> <username> <password>" );
+        verify( out ).stdErrLine( "neo4j-admin set-password [--create=<true|false>] <username> <password>" );
         verify( out ).stdErrLine( "    Sets the password for the specified user and removes the password change " );
-        verify( out ).stdErrLine( "    requirement" );
+        verify( out ).stdErrLine( "    requirement. If the user does not exist an error message will be shown, unless " );
+        verify( out ).stdErrLine( "    you specify the option --create=true." );
         verify( out ).stdErrLine( "Missing arguments: expected username and password" );
         verify( out ).exit( 1 );
         assertUserRequiresPasswordChange( "neo4j" );


### PR DESCRIPTION
The set password command did not work in packaged deployments. There were several issues addressed as well as addition of integration tests.
- Corrected provider specification (needed static inner class and public constructor)
- Re-added missing services file (lost in a rebase)
- Added support for --create=true to enable creation of missing user
- Added integration tests that actually create and run AdminTool

changelog: Fixed set-password command and added --create=true for first time use
