### PR TITLE
Log election timeout only in the relevant role handlers.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/RaftMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/RaftMachine.java
@@ -26,25 +26,25 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
-import org.neo4j.coreedge.helper.VolatileFuture;
 import org.neo4j.coreedge.core.consensus.log.RaftLog;
 import org.neo4j.coreedge.core.consensus.log.RaftLogEntry;
 import org.neo4j.coreedge.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.coreedge.core.consensus.membership.RaftGroup;
 import org.neo4j.coreedge.core.consensus.membership.RaftMembershipManager;
-import org.neo4j.coreedge.messaging.Outbound;
 import org.neo4j.coreedge.core.consensus.outcome.AppendLogEntry;
 import org.neo4j.coreedge.core.consensus.outcome.ConsensusOutcome;
 import org.neo4j.coreedge.core.consensus.outcome.Outcome;
+import org.neo4j.coreedge.core.consensus.roles.Role;
 import org.neo4j.coreedge.core.consensus.schedule.RenewableTimeoutService;
 import org.neo4j.coreedge.core.consensus.shipping.RaftLogShippingManager;
-import org.neo4j.coreedge.core.consensus.roles.Role;
 import org.neo4j.coreedge.core.consensus.state.RaftState;
 import org.neo4j.coreedge.core.consensus.state.ReadableRaftState;
-import org.neo4j.coreedge.core.state.storage.StateStorage;
 import org.neo4j.coreedge.core.consensus.term.TermState;
 import org.neo4j.coreedge.core.consensus.vote.VoteState;
+import org.neo4j.coreedge.core.state.storage.StateStorage;
+import org.neo4j.coreedge.helper.VolatileFuture;
 import org.neo4j.coreedge.identity.MemberId;
+import org.neo4j.coreedge.messaging.Outbound;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
@@ -122,7 +122,6 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
     {
         electionTimer = renewableTimeoutService.create( Timeouts.ELECTION, electionTimeout, randomTimeoutRange(),
                 timeout -> {
-                    log.info( "Election timeout triggered, base timeout value is %d", electionTimeout );
                     try
                     {
                         handle( new RaftMessages.Timeout.Election( myself ) );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Candidate.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Candidate.java
@@ -28,6 +28,7 @@ import org.neo4j.coreedge.core.consensus.outcome.Outcome;
 import org.neo4j.coreedge.core.consensus.state.ReadableRaftState;
 import org.neo4j.logging.Log;
 
+import static org.neo4j.cluster.protocol.election.ElectionMessage.electionTimeout;
 import static org.neo4j.coreedge.core.consensus.MajorityIncludingSelfQuorum.isQuorum;
 import static org.neo4j.coreedge.core.consensus.roles.Role.CANDIDATE;
 import static org.neo4j.coreedge.core.consensus.roles.Role.FOLLOWER;
@@ -136,6 +137,7 @@ class Candidate implements RaftMessageHandler
 
             case ELECTION_TIMEOUT:
             {
+                log.info( "Election timeout triggered, base timeout value is %d", electionTimeout );
                 if ( !Election.start( ctx, outcome, log ) )
                 {
                     log.info( "Moving to FOLLOWER state after failing to start election" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Follower.java
@@ -30,6 +30,7 @@ import org.neo4j.coreedge.core.consensus.state.ReadableRaftState;
 import org.neo4j.logging.Log;
 
 import static java.lang.Long.min;
+import static org.neo4j.cluster.protocol.election.ElectionMessage.electionTimeout;
 import static org.neo4j.coreedge.core.consensus.roles.Role.CANDIDATE;
 import static org.neo4j.coreedge.core.consensus.roles.Role.FOLLOWER;
 
@@ -114,6 +115,7 @@ class Follower implements RaftMessageHandler
 
             case ELECTION_TIMEOUT:
             {
+                log.info( "Election timeout triggered, base timeout value is %d", electionTimeout );
                 if ( Election.start( ctx, outcome, log ) )
                 {
                     outcome.setNextRole( CANDIDATE );


### PR DESCRIPTION
Otherwise the leader, who does not act on an election timeout, will
spam debug.log with these messages.
