### PR TITLE
Dual guava dependency cleanup

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -244,8 +244,6 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/community/security/pom.xml
+++ b/community/security/pom.xml
@@ -106,8 +106,6 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -151,8 +151,6 @@
     <dependency>
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -171,8 +171,6 @@ public class MultiRealmAuthManagerTest
     @Test
     public void shouldDeleteUser() throws Throwable
     {
-        System.out.println("shouldDeleteUser");
-
         // Given
         final User user = newUser( "jake", "abc123" , true );
         final User user2 = newUser( "craig", "321cba" , true );

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,13 @@
         <version>${pico.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.jimfs</groupId>
+        <artifactId>jimfs</artifactId>
+        <version>1.1</version>
+        <scope>test</scope>
+      </dependency>
+
 
       <!-- The JUnit-Hamcrest-Mockito combo -->
       <dependency>


### PR DESCRIPTION
Update jimfs version (to 1.1) to avoid usage of several guava versions. (airline already using 18.0)
Extract dependency definition into parent pom.
