### PR TITLE
Fixing BatchEndpoint Logging Problem

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.server.rest.batch;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -29,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
 
 import org.neo4j.server.rest.web.InternalJettyServletRequest;
 import org.neo4j.server.rest.web.InternalJettyServletResponse;
@@ -59,7 +59,7 @@ public class BatchOperationsTest {
     public void testSchemeInInternalJettyServletRequestForHttp() throws UnsupportedEncodingException
     {
         // when
-        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "http://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse() );
+        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "http://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse(), mock( HttpServletRequest.class ) );
 
         // then
         assertEquals("http",req.getScheme());
@@ -69,7 +69,7 @@ public class BatchOperationsTest {
     public void testSchemeInInternalJettyServletRequestForHttps() throws UnsupportedEncodingException
     {
         // when
-        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "https://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse() );
+        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "https://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse(), mock( HttpServletRequest.class ) );
 
         // then
         assertEquals("https",req.getScheme());

--- a/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.server;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -28,6 +27,7 @@ import org.neo4j.harness.junit.Neo4jRule;
 import org.neo4j.server.configuration.ServerSettings;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.server.ServerTestUtils.getRelativePath;
 import static org.neo4j.server.ServerTestUtils.getSharedTestTemporaryFolder;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
@@ -41,17 +41,15 @@ public class BatchEndpointIT
             .withConfig( ServerSettings.http_logging_enabled, "true" )
             .withConfig( ServerSettings.certificates_directory.name(),
                     getRelativePath( getSharedTestTemporaryFolder(), ServerSettings.certificates_directory ) )
+            .withConfig( ServerSettings.http_logging_enabled, "true" )
             .withConfig( GraphDatabaseSettings.auth_enabled, "false" );
 
     @Test
-    @Ignore("This test is wrong; the reflected Request doesn't like some method calls in logging.")
     public void requestsShouldNotFailWhenHttpLoggingIsOn()
     {
         // Given
         String body = "[" +
-                      "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1}," +
-                      "{'method': 'POST', 'to': '/node', 'body': {'age': 2}, 'id': 2}" +
-                      "]";
+                "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1} ]";
 
         // When
         Response response = withBaseUri( neo4j.httpURI().toString() )


### PR DESCRIPTION
The batch endpoint developed a sublte bug when used with HTTP logging
that causes 500 responses instead of 2xx. This fixes the issue by swallowing
 any exceptions thrown as the batch processor does its work, allowing it to
  complete.
