### PR TITLE
Fixing BatchEndpoint Logging Problem

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/InternalJettyServletRequest.java
@@ -345,12 +345,12 @@ public class InternalJettyServletRequest extends Request
     }
 
     @Override
-	public Response getResponse()
+    public Response getResponse()
     {
-		return response;
-	}
+        return response;
+    }
 
-	@Override
+    @Override
     public String toString()
     {
         return String.format( "%s %s %s\n%s", getMethod(), getUri(), getProtocol(), getHttpFields() );

--- a/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
+++ b/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
@@ -19,17 +19,20 @@
  */
 package org.neo4j.server.web;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.servlet.http.HttpServletRequest;
+
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-
-import java.io.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.neo4j.concurrent.AsyncEvents;
 import org.neo4j.helpers.NamedThreadFactory;
@@ -48,7 +51,8 @@ public class AsyncRequestLog
     private final ExecutorService asyncLogProcessingExecutor;
     private final AsyncEvents<AsyncLogEvent> asyncEventProcessor;
 
-    public AsyncRequestLog( FileSystemAbstraction fs, String logFile, long rotationSize, int rotationKeepNumber ) throws IOException
+    public AsyncRequestLog( FileSystemAbstraction fs, String logFile, long rotationSize, int rotationKeepNumber )
+            throws IOException
     {
         NamedThreadFactory threadFactory = new NamedThreadFactory( "HTTP-Log-Rotator", true );
         ExecutorService rotationExecutor = Executors.newCachedThreadPool( threadFactory );
@@ -66,13 +70,14 @@ public class AsyncRequestLog
     {
         // Trying to replicate this logback pattern:
         // %h %l %user [%t{dd/MMM/yyyy:HH:mm:ss Z}] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D
-        String remoteHost = request.getRemoteHost();
-        String user = request.getRemoteUser();
-        String requestURL = request.getRequestURI() + "?" + request.getQueryString();
+        String remoteHost = swallowExceptions( request, HttpServletRequest::getRemoteHost );
+        String user = swallowExceptions( request, HttpServletRequest::getRemoteUser );
+        String requestURL = swallowExceptions( request, HttpServletRequest::getRequestURI ) + "?" + swallowExceptions
+                ( request, HttpServletRequest::getQueryString );
         int statusCode = response.getStatus();
         long length = response.getContentLength();
-        String referer = request.getHeader( "Referer" );
-        String userAgent = request.getHeader( "User-Agent" );
+        String referer = swallowExceptions( request, ( HttpServletRequest r ) -> (r.getHeader( "Referer" )) );
+        String userAgent = swallowExceptions( request, ( HttpServletRequest r ) -> (r.getHeader( "User-Agent" )) );
         long requestTimeStamp = request.getTimeStamp();
         long now = System.currentTimeMillis();
         long serviceTime = requestTimeStamp < 0 ? -1 : now - requestTimeStamp;
@@ -80,6 +85,19 @@ public class AsyncRequestLog
         log.info( "%s - %s [%tc] \"%s\" %s %s \"%s\" \"%s\" %s",
                 remoteHost, user, now, requestURL, statusCode, length, referer, userAgent, serviceTime );
     }
+
+    private <T> T swallowExceptions( HttpServletRequest outerRequest, Function<HttpServletRequest, T> function )
+    {
+        try
+        {
+            return outerRequest == null ? null : function.apply( outerRequest );
+        }
+        catch ( Throwable t )
+        {
+            return null;
+        }
+    }
+
 
     @Override
     protected synchronized void doStart() throws Exception

--- a/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/batch/BatchOperationsTest.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.server.rest.batch;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -29,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
 
 import org.neo4j.server.rest.web.InternalJettyServletRequest;
 import org.neo4j.server.rest.web.InternalJettyServletResponse;
@@ -59,7 +59,7 @@ public class BatchOperationsTest {
     public void testSchemeInInternalJettyServletRequestForHttp() throws UnsupportedEncodingException
     {
         // when
-        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "http://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse() );
+        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "http://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse(), mock( HttpServletRequest.class ) );
 
         // then
         assertEquals("http",req.getScheme());
@@ -69,7 +69,7 @@ public class BatchOperationsTest {
     public void testSchemeInInternalJettyServletRequestForHttps() throws UnsupportedEncodingException
     {
         // when
-        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "https://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse() );
+        InternalJettyServletRequest req = new InternalJettyServletRequest( "POST", "https://localhost:7473/db/data/node", "{'name':'node1'}", new InternalJettyServletResponse(), mock( HttpServletRequest.class ) );
 
         // then
         assertEquals("https",req.getScheme());

--- a/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.server;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -28,6 +27,7 @@ import org.neo4j.harness.junit.Neo4jRule;
 import org.neo4j.server.configuration.ServerSettings;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.server.ServerTestUtils.getRelativePath;
 import static org.neo4j.server.ServerTestUtils.getSharedTestTemporaryFolder;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
@@ -41,17 +41,15 @@ public class BatchEndpointIT
             .withConfig( ServerSettings.http_logging_enabled, "true" )
             .withConfig( ServerSettings.certificates_directory.name(),
                     getRelativePath( getSharedTestTemporaryFolder(), ServerSettings.certificates_directory ) )
+            .withConfig( ServerSettings.http_logging_enabled, "true" )
             .withConfig( GraphDatabaseSettings.auth_enabled, "false" );
 
     @Test
-    @Ignore("This test is wrong; the reflected Request doesn't like some method calls in logging.")
     public void requestsShouldNotFailWhenHttpLoggingIsOn()
     {
         // Given
         String body = "[" +
-                      "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1}," +
-                      "{'method': 'POST', 'to': '/node', 'body': {'age': 2}, 'id': 2}" +
-                      "]";
+                "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1} ]";
 
         // When
         Response response = withBaseUri( neo4j.httpURI().toString() )


### PR DESCRIPTION
The batch endpoint developed a sublte bug when used with HTTP logging
that causes 500 responses instead of 2xx. This fixes the issue by swallowing
 any exceptions thrown as the batch processor does its work, allowing it to
  complete.
