### PR TITLE
Update debian java dependency

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/control
@@ -8,8 +8,8 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-advanced
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, java7-runtime | j2re1.7
-Conflicts: 
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Conflicts:
 Replaces: neo4j-enterprise, neo4j
 Description: graph database server
  Neo4j server is a database that stores data as graphs rather than tables.

--- a/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/advanced/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-advanced
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre | openjdk-8-jre | java7-runtime
 Conflicts:
 Replaces: neo4j-enterprise, neo4j
 Description: graph database server

--- a/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/control
@@ -8,9 +8,8 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-arbiter
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, java7-runtime | j2re1.7
-Conflicts: 
-Replaces: 
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, openjdk-7-jre-headless | java7-runtime-headless
+Conflicts:
+Replaces:
 Description: Arbiter service for Neo4j clusters.
  The arbiter service is used to break ties in Neo4j clusters that have an even number of cluster members.
-

--- a/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/arbiter/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-arbiter
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, openjdk-7-jre-headless | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, openjdk-7-jre | openjdk-8-jre | java7-runtime
 Conflicts:
 Replaces:
 Description: Arbiter service for Neo4j clusters.

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre | openjdk-8-jre | java7-runtime
 Conflicts:
 Replaces: neo4j-enterprise, neo4j-advanced
 Description: graph database server

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
@@ -8,8 +8,8 @@ Homepage: http://neo4j.org/
 
 Package: neo4j
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, java7-runtime | j2re1.7
-Conflicts: 
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Conflicts:
 Replaces: neo4j-enterprise, neo4j-advanced
 Description: graph database server
  Neo4j server is a database that stores data as graphs rather than tables.

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-enterprise
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre | openjdk-8-jre | java7-runtime
 Conflicts:
 Replaces: neo4j, neo4j-advanced
 Description: graph database server

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
@@ -8,8 +8,8 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-enterprise
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, java7-runtime | j2re1.7
-Conflicts: 
+Depends: ${misc:Depends}, daemon, adduser, psmisc, lsof, lsb-base, openjdk-7-jre-headless | java7-runtime-headless
+Conflicts:
 Replaces: neo4j, neo4j-advanced
 Description: graph database server
  Neo4j server is a database that stores data as graphs rather than tables.


### PR DESCRIPTION
This is a backport and update of the fix for #7188

It does not use the `Conflicts` line we previously added to prevent the
installation of openjdk-9 on Ubuntu 16.04. (when forward merging should
take care to remove that line from the 3.x branches, and update version
to java-8 as well).

The relevant part of `Depends:` is:

```
openjdk-N-jre | javaN-runtime
```

(where N will be 7 for 2.x and 8 for 3.x)

`javaN-runtime` is a virtual package which for example `openjdk-N-jre`
provides. Installing for example an Oracle JRE from webupd8 will also
provide it.

The line has the following effect:
- If neither package is found/provided on the system, it will install
  `openjdk-N-jre`
- If either of the packages is found/provided on the system, no
  additional JRE will be installed.
## Tests to be verified:
### Neo4j 2.x
- [x] debian 7/8
- [x] ubuntu 14.04
- [x] ubuntu 16.04
- [x] ubuntu 14.04 (with pre installed jre)
- [x] ubuntu 16.04 (with pre installed jre)
### Upgrade Neo4j from 2.x to 3.0
- [x] debian 8
- [x] ubuntu 14.04
- [x] ubuntu 16.04
## Some simple testing of this behavior on a fresh Ubuntu 16.04 docker instance follows.

First setup the webupd8 ppa to be able to test with another JRE:

```
apt-get update && \
  apt-get install -y software-properties-common && \
  add-apt-repository ppa:webupd8team/java && \
  apt-get update
```

Then, install neo4j (example uses this change but built for 3.1)

```
dpkg -i neo4j_3.1.0.SNAPSHOT_all.deb
```

dpkg will complain about missing packages

```
Selecting previously unselected package neo4j.
(Reading database ... 10127 files and directories currently installed.)
Preparing to unpack neo4j_3.1.0.SNAPSHOT_all.deb ...
Unpacking neo4j (3.1.0.SNAPSHOT) ...
dpkg: dependency problems prevent configuration of neo4j:
 neo4j depends on daemon; however:
  Package daemon is not installed.
 neo4j depends on psmisc; however:
  Package psmisc is not installed.
 neo4j depends on openjdk-8-jre-headless | java8-runtime; however:
  Package openjdk-8-jre-headless is not installed.
  Package java8-runtime is not installed.

dpkg: error processing package neo4j (--install):
 dependency problems - leaving unconfigured
Processing triggers for systemd (229-4ubuntu4) ...
Errors were encountered while processing:
 neo4j
```

Fix them and see that
openjdk-9 is NOT installed

```
apt-get install -f
```

```
The following NEW packages will be installed:
  ca-certificates-java daemon fontconfig-config fonts-dejavu-core java-common libavahi-client3 libavahi-common-data
  libavahi-common3 libcups2 libfontconfig1 libfreetype6 libjpeg-turbo8 libjpeg8 liblcms2-2 libnspr4 libnss3 libnss3-nssdb
  libpcsclite1 libpng12-0 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxrender1 libxtst6
  openjdk-8-jre-headless psmisc x11-common
```

Now, we try with Oracle JRE instead

Uninstall neo4j and java again

```
apt-get purge neo4j openjdk-8-jre-headless
```

Install Oracle JRE

```
apt-get install oracle-java8-installer
```

and install neo4j and notice that nothing is missing and nothing more is
installed

```
dpkg -i neo4j_3.1.0.SNAPSHOT_all.deb
```

```
Selecting previously unselected package neo4j.
(Reading database ... 11232 files and directories currently installed.)
Preparing to unpack neo4j_3.1.0.SNAPSHOT_all.deb ...
Unpacking neo4j (3.1.0.SNAPSHOT) ...
Setting up neo4j (3.1.0.SNAPSHOT) ...
invoke-rc.d: policy-rc.d denied execution of start.
Processing triggers for systemd (229-4ubuntu4) ...
```
