### PR TITLE
Defaults REST traversal expander to all relationships

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilder.java
@@ -32,7 +32,7 @@ public class RelationshipExpanderBuilder
     @SuppressWarnings( "unchecked" )
     public static PathExpander describeRelationships( Map<String, Object> description )
     {
-        PathExpanderBuilder expander = PathExpanderBuilder.empty();
+        PathExpanderBuilder expander = PathExpanderBuilder.allTypesAndDirections();
 
         Object relationshipsDescription = description.get( "relationships" );
         if ( relationshipsDescription != null )

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/RelationshipExpanderBuilderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.domain;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Set;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.graphdb.traversal.BranchState.NO_STATE;
+import static org.neo4j.graphdb.traversal.Paths.singleNodePath;
+import static org.neo4j.helpers.collection.Iterables.asSet;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class RelationshipExpanderBuilderTest
+{
+    @ClassRule
+    public static final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldInterpretNoSpecifiedRelationshipsAsAll() throws Exception
+    {
+        // GIVEN
+        Node node = createSomeData();
+        PathExpander expander = RelationshipExpanderBuilder.describeRelationships( map() );
+
+        // WHEN
+        Set<Relationship> expanded;
+        try ( Transaction tx = db.beginTx() )
+        {
+            expanded = asSet( expander.expand( singleNodePath( node ), NO_STATE ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            // THEN
+            assertEquals( asSet( node.getRelationships() ), expanded );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldInterpretSomeSpecifiedRelationships() throws Exception
+    {
+        // GIVEN
+        Node node = createSomeData();
+        PathExpander expander = RelationshipExpanderBuilder.describeRelationships(
+                map( "relationships", map(
+                        "type", MyRelTypes.TEST.name(),
+                        "direction", RelationshipDirection.out.name() ) ) );
+
+        // WHEN
+        Set<Relationship> expanded;
+        try ( Transaction tx = db.beginTx() )
+        {
+            expanded = asSet( expander.expand( singleNodePath( node ), NO_STATE ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            // THEN
+            assertEquals( asSet( node.getRelationships( MyRelTypes.TEST ) ), expanded );
+            tx.success();
+        }
+    }
+
+    private Node createSomeData()
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            node.createRelationshipTo( db.createNode(), MyRelTypes.TEST );
+            node.createRelationshipTo( db.createNode(), MyRelTypes.TEST2 );
+            tx.success();
+            return node;
+        }
+    }
+}


### PR DESCRIPTION
which is the case in previous versions. There was a recent mistake in
a refactoring making the default be empty instead.

changelog: [3.0, server] Fixes #7497
