### PR TITLE
Debian package now depends on headless java runtime

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
@@ -9,7 +9,7 @@ Homepage: http://neo4j.org/
 Package: neo4j
 Architecture: all
 Pre-Depends: dpkg (>= 1.15.7.2)
-Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, openjdk-8-jre | java8-runtime
+Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, openjdk-8-jre-headless | java8-runtime-headless
 Conflicts:
 Replaces: neo4j-enterprise, neo4j-advanced
 Description: graph database server

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
@@ -9,7 +9,7 @@ Homepage: http://neo4j.org/
 Package: neo4j-enterprise
 Architecture: all
 Pre-Depends: dpkg (>= 1.15.7.2)
-Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, openjdk-8-jre | java8-runtime
+Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, openjdk-8-jre-headless | java8-runtime-headless
 Conflicts:
 Replaces: neo4j, neo4j-advanced
 Description: graph database server


### PR DESCRIPTION
A continuation from #7728
## Manual tests:
### Install
- [x] Debian 8 with backports enabled
- [x] Ubuntu 14.04 with Oracle java from webupd8 preinstalled
- [x] Ubuntu 16.04 (verify no java9 is pulled in)
### Upgrades
- [x] From already installed 3.0 package (which required non-headless) to this

changelog: [packaging]
