### PR TITLE
Do not run ITs in Bolt by default

### DIFF
--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -111,22 +111,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
ITs should be run when -DrunITs is specified like for all the other modules.
