### PR TITLE
Update compatibility docs to reflect reality

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
@@ -1,7 +1,7 @@
 [[cypher-compatibility]]
 = Compatibility
 
-Cypher is not a static language. New versions introduces new features and sometimes old features get dropped.
+Cypher is not a static language. New versions introduce new features and sometimes old features get dropped.
 Older versions of the language can still be accessed if required.
 There are two ways to select which version to use in queries.
 

--- a/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
@@ -1,24 +1,19 @@
 [[cypher-compatibility]]
 = Compatibility
 
-Cypher is still changing rather rapidly.
-Parts of the changes are internal -- we add new pattern matchers, aggregators and optimizations or write new <<query-tuning,query planners>>, which hopefully makes your queries run faster.
-
-Other changes are directly visible to our users -- the syntax is still changing.
-New concepts are being added and old ones changed to fit into new possibilities.
-To guard you from having to keep up with our syntax changes, Neo4j allows you to use an older parser, but still gain speed from new optimizations.
-
-There are two ways you can select which parser to use.
-You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which parser you'd like to use (see <<cypher-versions>>)).
-Any Cypher query that doesn't explicitly say anything else, will get the parser you have configured, or the latest parser if none is configured.
+Cypher is not a static language - every new version brings new features and sometimes old features get dropped.
+It is possible to access older language versions if that is needed.
+There are two ways you can select which version to use.
+You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>)).
+Any Cypher query that doesn't explicitly say anything else, will use the version you have configured, or the latest version if none is configured.
 
 The other way is on a query by query basis.
-By simply putting `CYPHER 2.2` at the beginning, that particular query will be parsed with the 2.2 version of the parser.
+By simply putting `CYPHER 2.3` at the beginning, that particular query will be executed with the version of Cypher included in Neo4j 2.3.
 Below is an example using the `START` clause to access a legacy index:
 
 [source,cypher]
 ----
-CYPHER 2.2
+CYPHER 2.3
 START n=node:nodes(name = "A")
 RETURN n
 ----

--- a/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
@@ -1,14 +1,18 @@
 [[cypher-compatibility]]
 = Compatibility
 
-Cypher is not a static language - every new version brings new features and sometimes old features get dropped.
-It is possible to access older language versions if that is needed.
-There are two ways you can select which version to use.
-You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>)).
-Any Cypher query that doesn't explicitly say anything else, will use the version you have configured, or the latest version if none is configured.
+Cypher is not a static language. New versions brings new features and sometimes old features get dropped.
+Older versions of the language can still be accessed if required.
+There are two ways to select which version to use in queries.
 
+1 - Setting a version for all queries
+You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>)).
+Every Cypher query will use this version, provided the query hasn't explicitly been configured as described in the next item below.
+
+2 - Setting a version on a query by query basis
 The other way is on a query by query basis.
 By simply putting `CYPHER 2.3` at the beginning, that particular query will be executed with the version of Cypher included in Neo4j 2.3.
+
 Below is an example using the `START` clause to access a legacy index:
 
 [source,cypher]

--- a/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general/compatibility.asciidoc
@@ -1,12 +1,12 @@
 [[cypher-compatibility]]
 = Compatibility
 
-Cypher is not a static language. New versions brings new features and sometimes old features get dropped.
+Cypher is not a static language. New versions introduces new features and sometimes old features get dropped.
 Older versions of the language can still be accessed if required.
 There are two ways to select which version to use in queries.
 
 1 - Setting a version for all queries
-You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>)).
+You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>).
 Every Cypher query will use this version, provided the query hasn't explicitly been configured as described in the next item below.
 
 2 - Setting a version on a query by query basis

--- a/manual/cypher/cypher-docs/src/docs/dev/general/versions.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general/versions.asciidoc
@@ -1,14 +1,12 @@
 [[cypher-versions]]
 = Supported Language Versions
 
-Neo4j 2.3 supports the following versions of the Cypher language:
+Neo4j 3.0 supports the following versions of the Cypher language:
 
+* Neo4j Cypher 3.0
 * Neo4j Cypher 2.3
-* Neo4j Cypher 2.2
-* Neo4j Cypher 1.9
 
 [TIP]
 Each release of Neo4j supports a limited number of old Cypher Language Versions.
 When you upgrade to a new release of Neo4j, please make sure that it supports the Cypher language version you need.
 If not, you may need to modify your queries to work with a newer Cypher language version.
-


### PR DESCRIPTION
When forward merging this, `versions.asciidoc` should be updated to list 3.1, 3.0 and 2.3 as the possible language versions.
