### PR TITLE
Support returned point types as params to later queries

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -643,6 +643,13 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
     assert(error.getMessage.contains("Type mismatch: expected Map, Node or Relationship but was Integer"))
   }
 
+  test("point results should be usable as parameters to subsequent queries") {
+    val p = executeWithAllPlanners("RETURN point({latitude: 12.78, longitude: 56.7}) as point").columnAs("point").next().asInstanceOf[GeographicPoint]
+    List(p) should equal(List(GeographicPoint(56.7, 12.78, CRS.WGS84)))
+    val result = executeWithAllPlanners("RETURN distance(point({latitude: 12.18, longitude: 56.2}),{point}) as dist", "point" -> p)
+    Math.round(result.columnAs("dist").next().asInstanceOf[Double]) should equal(86107)
+  }
+
   ignore("point function should be assignable to node property") {
     // Given
     createLabeledNode("Place")

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -594,7 +594,7 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
 
   test("distance function should fail on wrong type") {
     val error = intercept[SyntaxException](executeWithAllPlanners("RETURN distance(1, 2) as dist"))
-    assert(error.getMessage.contains("Type mismatch: expected Point but was Integer"))
+    assert(error.getMessage.contains("Type mismatch: expected Point or Geometry but was Integer"))
   }
 
   test("point function should work with node properties") {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
@@ -22,14 +22,19 @@ package org.neo4j.cypher.internal.compiler.v3_0
 import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InvalidArgumentException}
 
 trait Geometry {
-  def coordinates: Seq[Double]
+  def geometryType: String
+  def coordinates: Array[Coordinate]
   def crs: CRS
 }
 
+case class Coordinate(values:Double*)
+
 trait Point extends Geometry {
+  def geometryType = "Point"
   def x: Double
   def y: Double
-  def coordinates = Vector(x, y)
+  def coordinate = Coordinate(x, y)
+  def coordinates = Array(coordinate)
 }
 
 case class CartesianPoint(x: Double, y: Double, crs: CRS) extends Point

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
-import org.neo4j.cypher.internal.frontend.v3_0.InvalidArgumentException
+import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InvalidArgumentException}
 
 trait Geometry {
   def coordinates: Seq[Double]
@@ -61,5 +61,32 @@ object CRS {
     case Cartesian.url => Cartesian
     case WGS84.url => WGS84
     case _ => throw new InvalidArgumentException(s"HREF '$url' does not match any supported coordinate reference system for points, supported CRS are: '${WGS84.url}', '${Cartesian.url}'")
+  }
+}
+
+object Points {
+  def fromMap(map: collection.Map[String, Any]): Point = {
+    if (map.contains("x") && map.contains("y")) {
+      val x = safeToDouble(map("x"))
+      val y = safeToDouble(map("y"))
+      val crsName = map.getOrElse("crs", CRS.Cartesian.name).asInstanceOf[String]
+      val crs = CRS.fromName(crsName)
+      crs match {
+        case CRS.WGS84 => GeographicPoint(x, y, crs)
+        case _ => CartesianPoint(x, y, crs)
+      }
+    } else if (map.contains("latitude") && map.contains("longitude")) {
+      val crsName = map.getOrElse("crs", CRS.WGS84.name).asInstanceOf[String]
+      if (crsName != CRS.WGS84.name) throw new InvalidArgumentException(s"'$crsName' is not a supported coordinate reference system for geographic points, supported CRS are: '${CRS.WGS84.name}'")
+      val latitude = safeToDouble(map("latitude"))
+      val longitude = safeToDouble(map("longitude"))
+      GeographicPoint(longitude, latitude, CRS.fromName(crsName))
+    } else {
+      throw new InvalidArgumentException("A point must contain either 'x' and 'y' or 'latitude' and 'longitude'")
+    }
+  }
+  private def safeToDouble(value: Any) = value match {
+    case n: Number => n.doubleValue()
+    case other => throw new CypherTypeException(other.getClass.getSimpleName + " is not a valid coordinate type.")
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/PipeExecutionResult.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/PipeExecutionResult.scala
@@ -45,7 +45,7 @@ class PipeExecutionResult(val result: ResultIterator,
 
   self =>
 
-  val javaValues = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.publicTypeConverter)
+  val javaValues = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.typeConverter.asPublicType)
   lazy val dumpToString = withDumper(dumper => dumper.dumpToString(_))
 
   def dumpToString(writer: PrintWriter) { withDumper(dumper => dumper.dumpToString(writer)(_)) }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -62,8 +62,7 @@ case class InterpretedRuntimeBuilder(interpretedProducer: InterpretedPlanBuilder
 
 }
 
-case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeConverter: Any => Any,
-                                  privateTypeConverter: Any => Any) {
+case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, typeConverter: RuntimeTypeConverter) {
 
   def apply(periodicCommit: Option[PeriodicCommit], logicalPlan: LogicalPlan,
             pipeBuildContext: PipeExecutionBuilderContext,
@@ -73,7 +72,6 @@ case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeCo
     closing(tracer.beginPhase(PIPE_BUILDING)) {
       interpretedToExecutionPlan(new PipeExecutionPlanBuilder(clock, monitors)
         .build(periodicCommit, logicalPlan)(pipeBuildContext, planContext),
-        planContext, preparedQuery, createFingerprintReference, config,
-        publicTypeConverter, privateTypeConverter)
+        planContext, preparedQuery, createFingerprintReference, config, typeConverter)
     }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -62,7 +62,8 @@ case class InterpretedRuntimeBuilder(interpretedProducer: InterpretedPlanBuilder
 
 }
 
-case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeConverter: Any => Any) {
+case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeConverter: Any => Any,
+                                  privateTypeConverter: Any => Any) {
 
   def apply(periodicCommit: Option[PeriodicCommit], logicalPlan: LogicalPlan,
             pipeBuildContext: PipeExecutionBuilderContext,
@@ -71,7 +72,8 @@ case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeCo
             config: CypherCompilerConfiguration) =
     closing(tracer.beginPhase(PIPE_BUILDING)) {
       interpretedToExecutionPlan(new PipeExecutionPlanBuilder(clock, monitors)
-                                   .build(periodicCommit, logicalPlan)(pipeBuildContext, planContext),
-                                 planContext, preparedQuery, createFingerprintReference, config, publicTypeConverter)
+        .build(periodicCommit, logicalPlan)(pipeBuildContext, planContext),
+        planContext, preparedQuery, createFingerprintReference, config,
+        publicTypeConverter, privateTypeConverter)
     }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/coerce.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/coerce.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.commands
 
-import org.neo4j.cypher.internal.compiler.v3_0.Point
+import org.neo4j.cypher.internal.compiler.v3_0.{Geometry, Point}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.{IsCollection, IsMap}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
@@ -52,6 +52,7 @@ object coerce {
         case CTBoolean => value.asInstanceOf[Boolean]
         case CTNumber => value.asInstanceOf[Number]
         case CTPoint => value.asInstanceOf[Point]
+        case CTGeometry => value.asInstanceOf[Geometry]
         case _ => throw cantCoerce(value, typ)
       }
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/DistanceFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/DistanceFunction.scala
@@ -23,7 +23,7 @@ import java.lang.Math._
 
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.compiler.v3_0.{CRS, ExecutionContext, Geometry}
+import org.neo4j.cypher.internal.compiler.v3_0.{Geometry, CRS, ExecutionContext, Point}
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 
@@ -35,18 +35,36 @@ case class DistanceFunction(p1: Expression, p2: Expression) extends Expression {
     (p1(ctx), p2(ctx)) match {
       case (null, _) => null
       case (_, null) => null
-      case (geometry1: Geometry, geometry2: Geometry) =>
-        Seq(
-          HaversinCalculator,
-          CartesianCalculator
-        ).collectFirst {
-          case distance: DistanceCalculator if distance.isDefinedAt(geometry1, geometry2) =>
-            distance(geometry1, geometry2)
-        }.getOrElse(
-            throw new IllegalArgumentException(s"Invalid points passed to distance($p1, $p2)")
-          ).get
+      case (geometry1: Point, geometry2: Point) => calculateDistance(geometry1, geometry2)
+      case (geometry1: Geometry, geometry2: Geometry) => calculateDistance(geometry1, geometry2)
       case (x, y) => throw new CypherTypeException(s"Expected two Points, but got $x and $y")
     }
+  }
+
+  implicit def coerceToPoint(geometry: Geometry): Point = geometry match {
+    case point: Point => point
+    case _ if(geometry.geometryType == "Point") => new Point {
+      override def coordinate = geometry.coordinates(0)
+
+      override def y: Double = coordinate.values(0)
+
+      override def x: Double = coordinate.values(1)
+
+      override def crs: CRS = geometry.crs
+    }
+    case _ => throw new CypherTypeException(s"Expected Point, but got $geometry")
+  }
+
+  def calculateDistance(geometry1: Point, geometry2: Point) = {
+    Seq(
+      HaversinCalculator,
+      CartesianCalculator
+    ).collectFirst {
+      case distance: DistanceCalculator if distance.isDefinedAt(geometry1, geometry2) =>
+        distance(geometry1, geometry2)
+    }.getOrElse(
+      throw new IllegalArgumentException(s"Invalid points passed to distance($p1, $p2)")
+    ).get
   }
 
   override def rewrite(f: (Expression) => Expression) = f(DistanceFunction(p1.rewrite(f), p2.rewrite(f)))
@@ -61,11 +79,11 @@ case class DistanceFunction(p1: Expression, p2: Expression) extends Expression {
 }
 
 trait DistanceCalculator {
-  def isDefinedAt(p1: Geometry, p2: Geometry): Boolean
+  def isDefinedAt(p1: Point, p2: Point): Boolean
 
-  def calculateDistance(p1: Geometry, p2: Geometry): Double
+  def calculateDistance(p1: Point, p2: Point): Double
 
-  def apply(p1: Geometry, p2: Geometry): Option[Double] =
+  def apply(p1: Point, p2: Point): Option[Double] =
     if (isDefinedAt(p1, p2))
       Some(calculateDistance(p1, p2))
     else
@@ -73,11 +91,11 @@ trait DistanceCalculator {
 }
 
 object CartesianCalculator extends DistanceCalculator {
-  override def isDefinedAt(p1: Geometry, p2: Geometry) =
+  override def isDefinedAt(p1: Point, p2: Point) =
     p1.crs == CRS.Cartesian && p2.crs == CRS.Cartesian
 
-  override def calculateDistance(p1: Geometry, p2: Geometry): Double = {
-    val d2: Seq[Double] = (p1.coordinates zip p2.coordinates).map(x => pow(x._2 - x._1, 2))
+  override def calculateDistance(p1: Point, p2: Point): Double = {
+    val d2: Seq[Double] = (p1.coordinate.values zip p2.coordinate.values).map(x => pow(x._2 - x._1, 2))
     val sum = d2.foldLeft(0.0)((a, v) => a + v)
     sqrt(sum)
   }
@@ -87,12 +105,12 @@ object HaversinCalculator extends DistanceCalculator {
 
   private val EARTH_RADIUS_METERS = 6378140.0
 
-  override def isDefinedAt(p1: Geometry, p2: Geometry): Boolean =
+  override def isDefinedAt(p1: Point, p2: Point): Boolean =
     p1.crs == CRS.WGS84 && p2.crs == CRS.WGS84
 
-  override def calculateDistance(p1: Geometry, p2: Geometry): Double = {
-    val c1: Seq[Double] = p1.coordinates.map(toRadians)
-    val c2: Seq[Double] = p2.coordinates.map(toRadians)
+  override def calculateDistance(p1: Point, p2: Point): Double = {
+    val c1: Seq[Double] = p1.coordinate.values.map(toRadians)
+    val c2: Seq[Double] = p2.coordinate.values.map(toRadians)
     val dx = c2(0) - c1(0)
     val dy = c2(1) - c1(1)
     val a = pow(sin(dy / 2), 2.0) + cos(c1(1)) * cos(c2(1)) * pow(sin(dx / 2.0), 2.0)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/PointFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/PointFunction.scala
@@ -22,33 +22,15 @@ package org.neo4j.cypher.internal.compiler.v3_0.commands.expressions
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.IsMap
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.compiler.v3_0.{CRS, CartesianPoint, ExecutionContext, GeographicPoint}
+import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
-import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InvalidArgumentException, SyntaxException}
+import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 
 case class PointFunction(data: Expression) extends NullInNullOutExpression(data) {
 
   override def compute(value: Any, ctx: ExecutionContext)(implicit state: QueryState): Any = value match {
     case IsMap(mapCreator) =>
-      val map = mapCreator(state.query)
-      if (map.contains("x") && map.contains("y")) {
-        val x = safeToDouble(map("x"))
-        val y = safeToDouble(map("y"))
-        val crsName = map.getOrElse("crs", CRS.Cartesian.name).asInstanceOf[String]
-        val crs = CRS.fromName(crsName)
-        crs match {
-          case CRS.WGS84 => GeographicPoint(x, y, crs)
-          case _ => CartesianPoint(x, y, crs)
-        }
-      } else if (map.contains("latitude") && map.contains("longitude")) {
-        val crsName = map.getOrElse("crs", CRS.WGS84.name).asInstanceOf[String]
-        if (crsName != CRS.WGS84.name) throw new InvalidArgumentException(s"'$crsName' is not a supported coordinate reference system for geographic points, supported CRS are: '${CRS.WGS84.name}'")
-        val latitude = safeToDouble(map("latitude"))
-        val longitude = safeToDouble(map("longitude"))
-        GeographicPoint(longitude, latitude, CRS.fromName(crsName))
-      } else {
-        throw new InvalidArgumentException("A point must contain either 'x' and 'y' or 'latitude' and 'longitude'")
-      }
+      Points.fromMap(mapCreator(state.query))
     case x => throw new CypherTypeException(s"Expected a map but got $x")
   }
 
@@ -61,9 +43,4 @@ case class PointFunction(data: Expression) extends NullInNullOutExpression(data)
   override def symbolTableDependencies = data.symbolTableDependencies
 
   override def toString = "Point(" + data + ")"
-
-  private def safeToDouble(value: Any) = value match {
-    case n: Number => n.doubleValue()
-    case other => throw new CypherTypeException(other.getClass.getSimpleName + " is not a valid coordinate type.")
-  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{CSVResources, QueryContext}
@@ -28,8 +29,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.CypherException
 import scala.collection.mutable
 
 case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: List[String],
-                                                publicTypeConverter: Any => Any,
-                                                privateTypeConverter: Any => Any) extends ExecutionResultBuilderFactory {
+                                                typeConverter: RuntimeTypeConverter) extends ExecutionResultBuilderFactory {
   def create(): ExecutionResultBuilder =
     ExecutionWorkflowBuilder()
 
@@ -62,7 +62,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
       taskCloser.addTask(queryContext.transactionalContext.close)
       val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId,
                                  triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty,
-                                 publicTypeConverter = publicTypeConverter, privateTypeConverter = privateTypeConverter)
+                                 typeConverter = typeConverter)
       try {
         try {
           createResults(state, planType, notificationLogger)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -27,7 +27,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.CypherException
 
 import scala.collection.mutable
 
-case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: List[String], publicTypeConverter: Any => Any) extends ExecutionResultBuilderFactory {
+case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: List[String],
+                                                publicTypeConverter: Any => Any,
+                                                privateTypeConverter: Any => Any) extends ExecutionResultBuilderFactory {
   def create(): ExecutionResultBuilder =
     ExecutionWorkflowBuilder()
 
@@ -60,7 +62,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
       taskCloser.addTask(queryContext.transactionalContext.close)
       val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId,
                                  triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty,
-                                 publicTypeConverter = publicTypeConverter)
+                                 publicTypeConverter = publicTypeConverter, privateTypeConverter = privateTypeConverter)
       try {
         try {
           createResults(state, planType, notificationLogger)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 import java.time.Clock
 
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders._
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CantCompileQueryException, CantHandleQueryException}
@@ -88,11 +89,10 @@ object InterpretedExecutionPlanBuilder {
   def interpretedToExecutionPlan(pipeInfo: PipeInfo, planContext: PlanContext, inputQuery: PreparedQuerySemantics,
                                  createFingerprintReference:Option[PlanFingerprint]=>PlanFingerprintReference,
                                  config: CypherCompilerConfiguration,
-                                 publicTypeConverter: Any => Any,
-                                 privateTypeConverter: Any => Any) = {
+                                 typeConverter: RuntimeTypeConverter) = {
     val PipeInfo(pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
     val columns = inputQuery.statement.returnColumns
-    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, publicTypeConverter, privateTypeConverter)
+    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, typeConverter)
     val func = getExecutionPlanFunction(periodicCommitInfo, inputQuery.queryText, updating, resultBuilderFactory, inputQuery
       .notificationLogger)
     new ExecutionPlan {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -88,10 +88,11 @@ object InterpretedExecutionPlanBuilder {
   def interpretedToExecutionPlan(pipeInfo: PipeInfo, planContext: PlanContext, inputQuery: PreparedQuerySemantics,
                                  createFingerprintReference:Option[PlanFingerprint]=>PlanFingerprintReference,
                                  config: CypherCompilerConfiguration,
-                                 publicTypeConverter: Any => Any) = {
+                                 publicTypeConverter: Any => Any,
+                                 privateTypeConverter: Any => Any) = {
     val PipeInfo(pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
     val columns = inputQuery.statement.returnColumns
-    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, publicTypeConverter = publicTypeConverter)
+    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, publicTypeConverter, privateTypeConverter)
     val func = getExecutionPlanFunction(periodicCommitInfo, inputQuery.queryText, updating, resultBuilderFactory, inputQuery
       .notificationLogger)
     new ExecutionPlan {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenT
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InterpretedExecutionPlanBuilder.interpretedToExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.{DisconnectedShortestPathEndPointsBuilder, _}
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
@@ -40,8 +41,7 @@ trait ExecutionPlanInProgressRewriter {
 class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConfiguration,
                                   rewriterSequencer: (String) => RewriterStepSequencer,
                                   eagernessRewriter: Pipe => Pipe = addEagernessIfNecessary,
-                                  publicTypeConverter: Any => Any,
-                                  privateTypeConverter: Any => Any)
+                                  typeConverter: RuntimeTypeConverter)
   extends PatternGraphBuilder with ExecutablePlanBuilder with GraphQueryBuilder {
 
   private implicit val pipeMonitor: PipeMonitor = monitors.newMonitor[PipeMonitor]()
@@ -49,7 +49,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConf
   override def producePlan(inputQuery: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING,
                            createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan =
     interpretedToExecutionPlan(producePipe(inputQuery, planContext, tracer), planContext, inputQuery,
-                               createFingerprintReference, config, publicTypeConverter, privateTypeConverter)
+                               createFingerprintReference, config, typeConverter)
 
   def producePipe(in: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer): PipeInfo = {
     val rewriter = rewriterSequencer("LegacyPipeBuilder")(reattachAliasedExpressions).rewriter

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
@@ -40,7 +40,8 @@ trait ExecutionPlanInProgressRewriter {
 class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConfiguration,
                                   rewriterSequencer: (String) => RewriterStepSequencer,
                                   eagernessRewriter: Pipe => Pipe = addEagernessIfNecessary,
-                                  publicTypeConverter: Any => Any)
+                                  publicTypeConverter: Any => Any,
+                                  privateTypeConverter: Any => Any)
   extends PatternGraphBuilder with ExecutablePlanBuilder with GraphQueryBuilder {
 
   private implicit val pipeMonitor: PipeMonitor = monitors.newMonitor[PipeMonitor]()
@@ -48,7 +49,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConf
   override def producePlan(inputQuery: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING,
                            createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan =
     interpretedToExecutionPlan(producePipe(inputQuery, planContext, tracer), planContext, inputQuery,
-                               createFingerprintReference, config, publicTypeConverter)
+                               createFingerprintReference, config, publicTypeConverter, privateTypeConverter)
 
   def producePipe(in: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer): PipeInfo = {
     val rewriter = rewriterSequencer("LegacyPipeBuilder")(reattachAliasedExpressions).rewriter

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/StandardInternalExecutionResult.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/StandardInternalExecutionResult.scala
@@ -44,7 +44,7 @@ abstract class StandardInternalExecutionResult(context: QueryContext,
   import scala.collection.JavaConverters._
 
   protected val isGraphKernelResultValue = context.isGraphKernelResultValue _
-  private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue)
+  private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue, identity)
 
   private var successful = false
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeScalaValueConverter.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeScalaValueConverter.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable
 //
 // Main use: Converting results when using ExecutionEngine from scala
 //
-class RuntimeScalaValueConverter(skip: Any => Boolean) {
+class RuntimeScalaValueConverter(skip: Any => Boolean, converter: Any => Any) {
 
   final def asDeepScalaMap[A, B](map: JavaMap[A, B]): immutable.Map[A, Any] =
     if (map == null) null else immutableMapValues(map.asScala, asDeepScalaValue): immutable.Map[A, Any]
@@ -45,7 +45,7 @@ class RuntimeScalaValueConverter(skip: Any => Boolean) {
     case javaIterable: JavaIterable[_] => javaIterable.asScala.map(asDeepScalaValue).toList: List[_]
     case map: collection.Map[_, _] => immutableMapValues(map, asDeepScalaValue): immutable.Map[_, _]
     case traversable: TraversableOnce[_] => traversable.map(asDeepScalaValue).toList: List[_]
-    case anything => anything
+    case anything => converter(anything)
   }
 
   def asShallowScalaValue(value: Any): Any = value match {
@@ -53,6 +53,6 @@ class RuntimeScalaValueConverter(skip: Any => Boolean) {
     case javaMap: JavaMap[_, _] => javaMap.asScala.toMap: immutable.Map[_, _]
     case javaIterable: JavaIterable[_] => javaIterable.asScala.toList: List[_]
     case map: collection.Map[_, _] => map.toMap: immutable.Map[_, _]
-    case anything => anything
+    case anything => converter(anything)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeTypeConverter.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeTypeConverter.scala
@@ -17,18 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
+package org.neo4j.cypher.internal.compiler.v3_0.helpers
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Function, SimpleTypedFunction}
-import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+trait RuntimeTypeConverter {
+  def asPublicType: Any => Any
 
-case object Distance extends Function with SimpleTypedFunction {
-  def name = "distance"
+  def asPrivateType: Any => Any
+}
 
-  val signatures = Vector(
-    Signature(argumentTypes = Vector(CTGeometry, CTGeometry), outputType = CTFloat),
-    Signature(argumentTypes = Vector(CTPoint, CTGeometry), outputType = CTFloat),
-    Signature(argumentTypes = Vector(CTGeometry, CTPoint), outputType = CTFloat),
-    Signature(argumentTypes = Vector(CTPoint, CTPoint), outputType = CTFloat)
-  )
+object IdentityTypeConverter extends RuntimeTypeConverter {
+  override val asPublicType: Any => Any = identity
+
+  override def asPrivateType: Any => Any = identity
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
@@ -68,7 +68,7 @@ case class ProcedureCallPipe(source: Pipe,
     builder.sizeHint(resultIndices.length)
 
     val isGraphKernelResultValue = qtx.isGraphKernelResultValue _
-    val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue)
+    val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue, state.privateTypeConverter)
 
     input flatMap { input =>
       val argValues = argExprs.map(arg => converter.asDeepJavaValue(arg(input)(state)))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
@@ -57,18 +57,19 @@ case class ProcedureCallPipe(source: Pipe,
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
-    val converter = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.publicTypeConverter)
+    val converter = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.typeConverter.asPublicType)
 
     rowProcessor(input, state, converter)
   }
 
-  private def internalCreateResultsByAppending(input: Iterator[ExecutionContext], state: QueryState, converter: RuntimeJavaValueConverter): Iterator[ExecutionContext] = {
+  private def internalCreateResultsByAppending(input: Iterator[ExecutionContext], state: QueryState,
+                                               converter: RuntimeJavaValueConverter): Iterator[ExecutionContext] = {
     val qtx = state.query
     val builder = Seq.newBuilder[(String, Any)]
     builder.sizeHint(resultIndices.length)
 
     val isGraphKernelResultValue = qtx.isGraphKernelResultValue _
-    val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue, state.privateTypeConverter)
+    val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue, state.typeConverter.asPrivateType)
 
     input flatMap { input =>
       val argValues = argExprs.map(arg => converter.asDeepJavaValue(arg(input)(state)))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
@@ -40,6 +40,7 @@ class QueryState(val query: QueryContext,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
                  val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
                  val publicTypeConverter: Any => Any = identity,
+                 val privateTypeConverter: Any => Any = identity,
                  val cachedIn: SingleThreadedLRUCache[Any, InCheckContainer] =
                    new SingleThreadedLRUCache(maxSize = 16)) {
   private var _pathValueBuilder: PathValueBuilder = null
@@ -59,13 +60,13 @@ class QueryState(val query: QueryContext,
   def getStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
   def withDecorator(decorator: PipeDecorator) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
 
   def withInitialContext(initialContext: ExecutionContext) =
-    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, publicTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
 
   def withQueryContext(query: QueryContext) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.PathValueBuilder
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{InCheckContainer, SingleThreadedLRUCache}
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.{IdentityTypeConverter, RuntimeTypeConverter}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.ParameterNotFoundException
 import org.neo4j.collection.primitive.PrimitiveLongSet
@@ -39,8 +40,7 @@ class QueryState(val query: QueryContext,
                  val queryId: AnyRef = UUID.randomUUID().toString,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
                  val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
-                 val publicTypeConverter: Any => Any = identity,
-                 val privateTypeConverter: Any => Any = identity,
+                 val typeConverter: RuntimeTypeConverter = IdentityTypeConverter,
                  val cachedIn: SingleThreadedLRUCache[Any, InCheckContainer] =
                    new SingleThreadedLRUCache(maxSize = 16)) {
   private var _pathValueBuilder: PathValueBuilder = null
@@ -60,13 +60,13 @@ class QueryState(val query: QueryContext,
   def getStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
   def withDecorator(decorator: PipeDecorator) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, typeConverter, cachedIn)
 
   def withInitialContext(initialContext: ExecutionContext) =
-    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, typeConverter, cachedIn)
 
   def withQueryContext(query: QueryContext) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, privateTypeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, typeConverter, cachedIn)
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/CoerceToTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/CoerceToTest.scala
@@ -24,7 +24,7 @@ import java.util.{ArrayList => JavaList, HashMap => JavaMap}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.Counter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
-import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, Point}
+import org.neo4j.cypher.internal.compiler.v3_0.{Geometry, ExecutionContext, Point}
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -58,6 +58,14 @@ class CoerceToTest extends CypherFunSuite {
       .coerce(mock[Point])
       .to(CTAny).unchanged
       .to(CTPoint).unchanged
+      .forRemainingTypes { typ => _.notTo(typ) }
+  }
+
+  test("GEOMETRY") {
+    testedTypes
+      .coerce(mock[Geometry])
+      .to(CTAny).unchanged
+      .to(CTGeometry).unchanged
       .forRemainingTypes { typ => _.notTo(typ) }
   }
 
@@ -168,6 +176,8 @@ class CoerceToTest extends CypherFunSuite {
         .to(CTList(CTNumber)).changedTo(List.empty)
         .to(CTList(CTList(CTPoint))).changedTo(List.empty)
         .to(CTList(CTPoint)).changedTo(List.empty)
+        .to(CTList(CTList(CTGeometry))).changedTo(List.empty)
+        .to(CTList(CTGeometry)).changedTo(List.empty)
         .to(CTList(CTList(CTNode))).changedTo(List.empty)
         .to(CTList(CTNode)).changedTo(List.empty)
         .to(CTList(CTList(CTRelationship))).changedTo(List.empty)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -35,7 +35,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty, identity, identity)
 
     // WHEN
     val builder = builderFactory.create()
@@ -52,7 +52,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     val pipe = mock[Pipe]
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity, identity)
 
     // WHEN
     val builder = builderFactory.create()
@@ -70,7 +70,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity, identity)
 
     // WHEN
     val builder = builderFactory.create()

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.Pipe
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{QueryContext, QueryTransactionalContext}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -35,7 +36,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty, identity, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty, IdentityTypeConverter)
 
     // WHEN
     val builder = builderFactory.create()
@@ -52,7 +53,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     val pipe = mock[Pipe]
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, IdentityTypeConverter)
 
     // WHEN
     val builder = builderFactory.create()
@@ -70,7 +71,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity, identity)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, IdentityTypeConverter)
 
     // WHEN
     val builder = builderFactory.create()

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -43,7 +43,8 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false
   )
-  val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating, publicTypeConverter = identity)
+  val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating,
+    publicTypeConverter = identity, privateTypeConverter = identity)
 
   test("should_use_distinct_pipe_for_distinct") {
     val pipe = buildExecutionPipe("MATCH n RETURN DISTINCT n")

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.DefaultIDPSolverConfig
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
@@ -44,7 +45,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     errorIfShortestPathFallbackUsedAtRuntime = false
   )
   val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating,
-    publicTypeConverter = identity, privateTypeConverter = identity)
+    typeConverter = IdentityTypeConverter)
 
   test("should_use_distinct_pipe_for_distinct") {
     val pipe = buildExecutionPipe("MATCH n RETURN DISTINCT n")

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeScalaValueConverterTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeScalaValueConverterTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class RuntimeScalaValueConverterTest extends CypherFunSuite {
 
-  val converter = new RuntimeScalaValueConverter(_ => false)
+  val converter = new RuntimeScalaValueConverter(_ => false, identity)
 
   test("should convert hash map") {
     val it = new util.HashMap[String, Any]()

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -26,6 +26,7 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.{namePatternPredicatePatternElements, normalizeReturnClauses, normalizeWithClauses}
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -167,7 +168,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       queryPlanner = queryPlanner,
       rewriterSequencer = rewriterSequencer,
       plannerName = None,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors, identity, identity)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors, IdentityTypeConverter)),
       semanticChecker = semanticChecker,
       updateStrategy = None,
       config = config,

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -167,7 +167,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       queryPlanner = queryPlanner,
       rewriterSequencer = rewriterSequencer,
       plannerName = None,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors, identity)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors, identity, identity)),
       semanticChecker = semanticChecker,
       updateStrategy = None,
       config = config,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -77,7 +77,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
   private val parsedQueries = new LRUCachev3_0[String, ParsedQuery](getPlanCacheSize)
 
   private val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue, identity)
-  private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue)
+  private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue, identity)
 
   @throws(classOf[SyntaxException])
   def profile(query: String, scalaParams: Map[String, Any], session: QuerySession): ExtendedExecutionResult = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -66,17 +66,15 @@ object typeConversionsFor3_0 {
 
   def asPrivateType(obj: Any): Any = obj match {
     case map: Map[String, Any] => asPrivateMap(map)
-    case seq: Seq[Any] => seq.foldLeft(Seq.empty[Any]) { (s, v: Any) => s :+ asPrivateType(v) }
-    case arr: Array[Any] => arr.foldLeft(Array.empty[Any]) { (a, v: Any) => a :+ asPrivateType(v) }
+    case seq: Seq[Any] => seq.map(asPrivateType)
+    case arr: Array[Any] => arr.map(asPrivateType)
     case point: graphdb.spatial.Point => asPrivatePoint(point)
     case geometry: graphdb.spatial.Geometry => asPrivateGeometry(geometry)
     case value => value
   }
 
   def asPrivateMap(incoming: Map[String, Any]): Map[String, Any] =
-    incoming.foldLeft(Map.empty[String, Any]) { (params, v: (String, Any)) =>
-      params + (v._1 -> asPrivateType(v._2))
-    }
+    incoming.mapValues(asPrivateType)
 
   private def asPublicPoint(point: Point) = new graphdb.spatial.Point {
     override def getGeometryType = "Point"

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -571,8 +571,8 @@ case class CompatibilityFor3_0Cost(graph: GraphDatabaseQueryService,
     val logger = new StringInfoLogger3_0(log)
     val monitors = new WrappedMonitors3_0(kernelMonitors)
     CypherCompilerFactory.costBasedCompiler(graph, config, clock,
-                                            monitors, logger, rewriterSequencer, plannerName, runtimeName,
-                                            updateStrategy, typeConversionsFor3_0.asPublicType)
+      monitors, logger, rewriterSequencer, plannerName, runtimeName, updateStrategy,
+      typeConversionsFor3_0.asPublicType, typeConversionsFor3_0.asPrivateType)
   }
 
   override val queryCacheSize: Int = config.queryCacheSize
@@ -585,7 +585,8 @@ case class CompatibilityFor3_0Rule(graph: GraphDatabaseQueryService,
                                    kernelAPI: KernelAPI) extends CompatibilityFor3_0 {
   protected val compiler = {
     val monitors = new WrappedMonitors3_0(kernelMonitors)
-    CypherCompilerFactory.ruleBasedCompiler(graph, config, clock, monitors, rewriterSequencer, typeConversionsFor3_0.asPublicType)
+    CypherCompilerFactory.ruleBasedCompiler(graph, config, clock, monitors, rewriterSequencer,
+      typeConversionsFor3_0.asPublicType, typeConversionsFor3_0.asPrivateType)
   }
 
   override val queryCacheSize: Int = config.queryCacheSize

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -69,6 +69,7 @@ object typeConversionsFor3_0 {
     case seq: Seq[Any] => seq.foldLeft(Seq.empty[Any]) { (s, v: Any) => s :+ asPrivateType(v) }
     case arr: Array[Any] => arr.foldLeft(Array.empty[Any]) { (a, v: Any) => a :+ asPrivateType(v) }
     case point: graphdb.spatial.Point => asPrivatePoint(point)
+    case geometry: graphdb.spatial.Geometry => asPrivateGeometry(geometry)
     case value => value
   }
 
@@ -90,7 +91,7 @@ object typeConversionsFor3_0 {
     }
 
     override def getCoordinates: java.util.List[graphdb.spatial.Coordinate] = Collections
-      .singletonList(new graphdb.spatial.Coordinate(point.coordinates:_*))
+      .singletonList(new graphdb.spatial.Coordinate(point.coordinate.values: _*))
   }
 
   private def asPrivatePoint(point: graphdb.spatial.Point) = new Point {
@@ -99,6 +100,17 @@ object typeConversionsFor3_0 {
     override def y: Double = point.getCoordinate.getCoordinate.get(1)
 
     override def crs: CRS = CRS.fromURL(point.getCRS.getHref)
+  }
+
+  private def asPrivateCoordinate(coordinate: graphdb.spatial.Coordinate) =
+    Coordinate(coordinate.getCoordinate.asScala.toSeq.map(v=>v.doubleValue()):_*)
+
+  private def asPrivateGeometry(geometry: graphdb.spatial.Geometry) = new Geometry {
+    override def coordinates: Array[Coordinate] = geometry.getCoordinates.asScala.toArray.map(asPrivateCoordinate)
+
+    override def crs: CRS = CRS.fromURL(geometry.getCRS.getHref)
+
+    override def geometryType: String = geometry.getGeometryType
   }
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
@@ -156,6 +156,8 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper)
     case Neo4jTypes.NTNode => symbols.CTNode
     case Neo4jTypes.NTRelationship => symbols.CTRelationship
     case Neo4jTypes.NTPath => symbols.CTPath
+    case Neo4jTypes.NTPoint => symbols.CTPoint
+    case Neo4jTypes.NTGeometry => symbols.CTGeometry
     case Neo4jTypes.NTAny => symbols.CTAny
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -119,7 +119,8 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
       rewriterSequencer = RewriterStepSequencer.newValidating,
-      publicTypeConverter = identity
+      publicTypeConverter = identity,
+      privateTypeConverter = identity
     )
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -25,6 +25,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.{verify, _}
 import org.neo4j.cypher.internal.compatibility._
 import org.neo4j.cypher.internal.compiler.v3_0._
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_0.notification.CartesianProductNotification
@@ -119,8 +120,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
       rewriterSequencer = RewriterStepSequencer.newValidating,
-      publicTypeConverter = identity,
-      privateTypeConverter = identity
+      typeConverter = IdentityTypeConverter
     )
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD}
 import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_0.{CypherCompilerFactory, InfoLogger, _}
 
@@ -200,8 +201,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
       plannerName = Some(IDPPlannerName),
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
-      publicTypeConverter = identity,
-      privateTypeConverter = identity
+      typeConverter = IdentityTypeConverter
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -200,7 +200,8 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
       plannerName = Some(IDPPlannerName),
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
-      publicTypeConverter = identity
+      publicTypeConverter = identity,
+      privateTypeConverter = identity
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -304,15 +304,15 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
       plannerName = Some(plannerName),
       rewriterSequencer = rewriterSequencer,
       queryPlanner = queryPlanner,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(clock, monitors, identity)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(clock, monitors, identity, identity)),
       semanticChecker = checker,
       config = config,
       updateStrategy = None,
       publicTypeConverter = identity
     )
-    val pipeBuilder = new SilentFallbackPlanBuilder(new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
-                                                                                    publicTypeConverter = identity), planner,
-                                                    planBuilderMonitor)
+    val pipeBuilder = new SilentFallbackPlanBuilder(
+      new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
+        publicTypeConverter = identity, privateTypeConverter = identity), planner, planBuilderMonitor)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)
@@ -330,7 +330,8 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val parser = new CypherParser
     val checker = new SemanticChecker
     val rewriter = new ASTRewriter(rewriterSequencer)
-    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer, publicTypeConverter = identity)
+    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
+      publicTypeConverter = identity, privateTypeConverter = identity)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -26,6 +26,7 @@ import java.util.{Date, Locale}
 
 import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan._
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -304,15 +305,15 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
       plannerName = Some(plannerName),
       rewriterSequencer = rewriterSequencer,
       queryPlanner = queryPlanner,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(clock, monitors, identity, identity)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(clock, monitors, IdentityTypeConverter)),
       semanticChecker = checker,
       config = config,
       updateStrategy = None,
       publicTypeConverter = identity
     )
     val pipeBuilder = new SilentFallbackPlanBuilder(
-      new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
-        publicTypeConverter = identity, privateTypeConverter = identity), planner, planBuilderMonitor)
+      new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer, typeConverter = IdentityTypeConverter),
+      planner, planBuilderMonitor)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)
@@ -330,8 +331,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val parser = new CypherParser
     val checker = new SemanticChecker
     val rewriter = new ASTRewriter(rewriterSequencer)
-    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
-      publicTypeConverter = identity, privateTypeConverter = identity)
+    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer, typeConverter = IdentityTypeConverter)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -24,6 +24,7 @@ import java.time.{Clock, Instant, ZoneOffset}
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.{StringInfoLogger3_0, WrappedMonitors3_0}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlan
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -57,8 +58,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
       rewriterSequencer = RewriterStepSequencer.newValidating,
-      publicTypeConverter = identity,
-      privateTypeConverter = identity
+      typeConverter = IdentityTypeConverter
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -57,7 +57,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
       runtimeName = Some(InterpretedRuntimeName),
       updateStrategy = None,
       rewriterSequencer = RewriterStepSequencer.newValidating,
-      publicTypeConverter = identity
+      publicTypeConverter = identity,
+      privateTypeConverter = identity
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.HasLabel
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.TokenType.{Label, PropertyKey}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.{ReturnItem, _}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutionPlanInProgress, _}
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.mutation.{CreateNode, DeletePropertyAction}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
@@ -70,7 +71,7 @@ class RuleExecutablePlanBuilderTest
     queryPlanner = queryPlanner,
     rewriterSequencer = rewriterSequencer,
     plannerName = None,
-    runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors], identity, identity)),
+    runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors], IdentityTypeConverter)),
     semanticChecker = mock[SemanticChecker],
     updateStrategy = None,
     config = config,
@@ -115,8 +116,8 @@ class RuleExecutablePlanBuilderTest
         .updates(DeletePropertyAction(variable, PropertyKey("foo")))
         .returns(ReturnItem(Variable("x"), "x"))
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity, privateTypeConverter = identity)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
 
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
@@ -145,7 +146,7 @@ class RuleExecutablePlanBuilderTest
         .returns(ReturnItem(Variable("x"), "x"))
 
       val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
-        RewriterStepSequencer.newValidating, publicTypeConverter = identity, privateTypeConverter = identity)
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
       val labelId = queryContext.getLabelId("Person")
@@ -176,8 +177,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity, privateTypeConverter = identity)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -205,8 +206,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity, privateTypeConverter = identity)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -233,8 +234,8 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedSemanticQuery(q)
 
 
-      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                            publicTypeConverter = identity, privateTypeConverter = identity)
+      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
       val pipe = execPlanBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -258,8 +259,8 @@ class RuleExecutablePlanBuilderTest
       )
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity, privateTypeConverter = identity)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+        RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter)
 
       // when
       val periodicCommit = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).periodicCommit
@@ -271,9 +272,8 @@ class RuleExecutablePlanBuilderTest
   }
 }
 
-class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors, config: CypherCompilerConfiguration)
-  extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating,
-    publicTypeConverter = identity, privateTypeConverter = identity) {
+class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors: Monitors, config: CypherCompilerConfiguration)
+  extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating, typeConverter = IdentityTypeConverter) {
   override val phases = new Phase { def myBuilders: Seq[PlanBuilder] = innerBuilders }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -70,7 +70,7 @@ class RuleExecutablePlanBuilderTest
     queryPlanner = queryPlanner,
     rewriterSequencer = rewriterSequencer,
     plannerName = None,
-    runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors], identity)),
+    runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors], identity, identity)),
     semanticChecker = mock[SemanticChecker],
     updateStrategy = None,
     config = config,
@@ -116,7 +116,7 @@ class RuleExecutablePlanBuilderTest
         .returns(ReturnItem(Variable("x"), "x"))
 
       val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity)
+                                                        publicTypeConverter = identity, privateTypeConverter = identity)
 
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
@@ -145,7 +145,7 @@ class RuleExecutablePlanBuilderTest
         .returns(ReturnItem(Variable("x"), "x"))
 
       val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
-                                                            RewriterStepSequencer.newValidating, publicTypeConverter = identity)
+        RewriterStepSequencer.newValidating, publicTypeConverter = identity, privateTypeConverter = identity)
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
       val labelId = queryContext.getLabelId("Person")
@@ -177,7 +177,7 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedSemanticQuery(q)
 
       val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity)
+                                                        publicTypeConverter = identity, privateTypeConverter = identity)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -206,7 +206,7 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedSemanticQuery(q)
 
       val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity)
+                                                        publicTypeConverter = identity, privateTypeConverter = identity)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -234,7 +234,7 @@ class RuleExecutablePlanBuilderTest
 
 
       val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                            publicTypeConverter = identity)
+                                                            publicTypeConverter = identity, privateTypeConverter = identity)
       val pipe = execPlanBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -259,7 +259,7 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedSemanticQuery(q)
 
       val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
-                                                        publicTypeConverter = identity)
+                                                        publicTypeConverter = identity, privateTypeConverter = identity)
 
       // when
       val periodicCommit = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).periodicCommit
@@ -272,7 +272,8 @@ class RuleExecutablePlanBuilderTest
 }
 
 class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors, config: CypherCompilerConfiguration)
-  extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating, publicTypeConverter = identity) {
+  extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating,
+    publicTypeConverter = identity, privateTypeConverter = identity) {
   override val phases = new Phase { def myBuilders: Seq[PlanBuilder] = innerBuilders }
 }
 

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/GeometryType.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/GeometryType.scala
@@ -17,22 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.frontend.v3_0
+package org.neo4j.cypher.internal.frontend.v3_0.symbols
 
-package object symbols {
-  val CTAny: AnyType = AnyType.instance
-  val CTBoolean: BooleanType = BooleanType.instance
-  val CTString: StringType = StringType.instance
-  val CTNumber: NumberType = NumberType.instance
-  val CTFloat: FloatType = FloatType.instance
-  val CTInteger: IntegerType = IntegerType.instance
-  val CTMap: MapType = MapType.instance
-  val CTNode: NodeType = NodeType.instance
-  val CTRelationship: RelationshipType = RelationshipType.instance
-  val CTPoint: PointType = PointType.instance
-  val CTGeometry: GeometryType = GeometryType.instance
-  val CTPath: PathType = PathType.instance
-  def CTList(inner: CypherType): ListType = ListType(inner)
-
-  implicit def invariantTypeSpec(that: CypherType): TypeSpec = that.invariant
+object GeometryType {
+  val instance = new GeometryType() {
+    val parentType = CTAny
+    override val toString = "Geometry"
+  }
 }
+
+sealed abstract class GeometryType extends CypherType

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/TypeSpec.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/TypeSpec.scala
@@ -37,6 +37,7 @@ object TypeSpec {
     CTPath,
     CTRelationship,
     CTPoint,
+    CTGeometry,
     CTString
   )
 

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/DistanceTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/DistanceTest.scala
@@ -24,16 +24,18 @@ import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 class DistanceTest extends FunctionTestBase("distance")  {
 
   test("should accept correct types") {
-    val t1 = CTPoint
-    testValidTypes(t1, CTPoint)(CTFloat)
+    testValidTypes(CTGeometry, CTGeometry)(CTFloat)
+    testValidTypes(CTPoint, CTGeometry)(CTFloat)
+    testValidTypes(CTGeometry, CTPoint)(CTFloat)
+    testValidTypes(CTPoint, CTPoint)(CTFloat)
   }
 
   test("should fail type check for incompatible arguments") {
     testInvalidApplication(CTList(CTAny), CTList(CTAny))(
-      "Type mismatch: expected Point but was Collection<Any>"
+      "Type mismatch: expected Point or Geometry but was Collection<Any>"
     )
     testInvalidApplication(CTString, CTString)(
-      "Type mismatch: expected Point but was String"
+      "Type mismatch: expected Point or Geometry but was String"
     )
   }
 
@@ -44,7 +46,7 @@ class DistanceTest extends FunctionTestBase("distance")  {
     testInvalidApplication(CTMap)(
       "Insufficient parameters for function 'distance'"
     )
-    testInvalidApplication(CTPoint, CTPoint, CTPoint)(
+    testInvalidApplication(CTGeometry, CTGeometry, CTGeometry)(
       "Too many parameters for function 'distance'"
     )
   }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
@@ -38,6 +38,8 @@ public class Neo4jTypes
     public static final NodeType NTNode = new NodeType();
     public static final RelationshipType NTRelationship = new RelationshipType();
     public static final PathType NTPath = new PathType();
+    public static final GeometryType NTGeometry = new GeometryType();
+    public static final PointType NTPoint = new PointType();
     public static ListType NTList( AnyType innerType ) { return new ListType( innerType ); }
 
     public static class AnyType
@@ -172,6 +174,22 @@ public class Neo4jTypes
         public PathType()
         {
             super( "PATH?" );
+        }
+    }
+
+    public static class GeometryType extends AnyType
+    {
+        public GeometryType()
+        {
+            super( "GEOMETRY?" );
+        }
+    }
+
+    public static class PointType extends AnyType
+    {
+        public PointType()
+        {
+            super( "POINT?" );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -32,6 +32,8 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.spatial.Geometry;
+import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.AvailabilityGuard;
@@ -86,6 +88,8 @@ import static org.neo4j.kernel.api.proc.CallableProcedure.Context.KERNEL_TRANSAC
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTGeometry;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPoint;
 
 /**
  * Datasource module for {@link GraphDatabaseFacadeFactory}. This implements all the
@@ -380,6 +384,8 @@ public class DataSourceModule
         procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class ) );
         procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class ) );
         procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class ) );
+        procedures.registerType( Geometry.class, new SimpleConverter( NTGeometry, Geometry.class ) );
+        procedures.registerType( Point.class, new SimpleConverter( NTPoint, Point.class ) );
 
         // Register injected public API components
         Log proceduresLog = platform.logging.getUserLog( Procedures.class  );


### PR DESCRIPTION
The public types created earlier this year made it impossible to return point objects as parameters to other queries. This code fixes that by adding the reverse conversion of public types back to private when executing cypher. The code for converting in both directions is isolated to the same conversion object for future use when working on separating Cypher and kernel more.

changelog: Fixed inability to use returned point types as parameters to later queries
