### PR TITLE
Built in schema procedure

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -58,6 +59,9 @@ public class BuiltInProcedures
 
     @Context
     public DependencyResolver resolver;
+
+    @Context
+    public GraphDatabaseAPI graphDatabaseAPI;
 
     @Description( "List all labels in the database." )
     @Procedure( name = "db.labels", mode = READ )
@@ -155,6 +159,13 @@ public class BuiltInProcedures
         {
             indexProcedures.resampleOutdatedIndexes();
         }
+    }
+
+    @Description( "Show the schema of the data." )
+    @Procedure(name = "db.schema", mode = READ)
+    public Stream<SchemaProcedure.GraphResult> metaGraph() throws ProcedureException
+    {
+        return Stream.of(new SchemaProcedure(graphDatabaseAPI, tx).buildSchemaGraph());
     }
 
     @Description( "List all constraints in the database." )

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.StatementTokenNameLookup;
+import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+public class SchemaProcedure
+{
+
+    private final GraphDatabaseAPI graphDatabaseAPI;
+    private final KernelTransaction kernelTransaction;
+
+    public SchemaProcedure( final GraphDatabaseAPI graphDatabaseAPI, final KernelTransaction kernelTransaction )
+    {
+        this.graphDatabaseAPI = graphDatabaseAPI;
+        this.kernelTransaction = kernelTransaction;
+    }
+
+    public GraphResult buildSchemaGraph()
+    {
+        final Map<String,NodeImpl> vertices = new HashMap<>();
+        final Map<String,Set<RelationshipImpl>> edges = new HashMap<>();
+
+        ReadOperations readOperations = kernelTransaction.acquireStatement().readOperations();
+        StatementTokenNameLookup statementTokenNameLookup = new StatementTokenNameLookup( readOperations );
+
+        try ( Transaction transaction = graphDatabaseAPI.beginTx(); )
+        {
+            // add all labelsInDatabase
+            ResourceIterator<Label> labelsInDatabase = graphDatabaseAPI.getAllLabelsInUse().iterator();
+            while ( labelsInDatabase.hasNext() )
+            {
+                Label label = labelsInDatabase.next();
+                Map<String,Object> properties = new HashMap<>();
+
+                Iterator<IndexDescriptor> indexDescriptorIterator =
+                        readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
+                ArrayList<String> indexes = new ArrayList<>();
+                while ( indexDescriptorIterator.hasNext() )
+                {
+                    indexes.add( statementTokenNameLookup
+                            .propertyKeyGetName( indexDescriptorIterator.next().getPropertyKeyId() ) );
+                }
+                properties.put( "indexes", indexes );
+
+                Iterator<NodePropertyConstraint> nodePropertyConstraintIterator =
+                        readOperations.constraintsGetForLabel( readOperations.labelGetForName( label.name() ) );
+                ArrayList<String> constraints = new ArrayList<>();
+                while ( nodePropertyConstraintIterator.hasNext() )
+                {
+                    constraints
+                            .add( nodePropertyConstraintIterator.next().userDescription( statementTokenNameLookup ) );
+                }
+                properties.put( "constraints", constraints );
+
+                getOrCreateLabel( label.name(), properties, vertices );
+            }
+
+            //add all relationships
+
+            Iterator<RelationshipType> relationshipTypeIterator =
+                    graphDatabaseAPI.getAllRelationshipTypesInUse().iterator();
+            while ( relationshipTypeIterator.hasNext() )
+            {
+                RelationshipType relationshipType = relationshipTypeIterator.next();
+                String relationshipTypeGetName = relationshipType.name();
+                int relId = readOperations.relationshipTypeGetForName( relationshipTypeGetName );
+                ResourceIterator<Label> labelsInUse = graphDatabaseAPI.getAllLabelsInUse().iterator();
+
+                List<NodeImpl> startVertices = new LinkedList<>();
+                List<NodeImpl> endVertices = new LinkedList<>();
+
+                while ( labelsInUse.hasNext() )
+                {
+                    Label labelToken = labelsInUse.next();
+                    String labelName = labelToken.name();
+                    Map<String,Object> properties = new HashMap<>();
+                    NodeImpl vertex = getOrCreateLabel( labelName, properties, vertices );
+                    int labelId = readOperations.labelGetForName( labelName );
+
+                    if ( readOperations.countsForRelationship( labelId, relId, ReadOperations.ANY_LABEL ) > 0 )
+                    {
+                        startVertices.add( vertex );
+                    }
+                    if ( readOperations.countsForRelationship( ReadOperations.ANY_LABEL, relId, labelId ) > 0 )
+                    {
+                        endVertices.add( vertex );
+                    }
+                }
+                for ( NodeImpl startVertex : startVertices )
+                {
+                    for ( NodeImpl endVertex : endVertices )
+                    {
+                        RelationshipImpl edge = addEdge( startVertex, endVertex, relationshipTypeGetName, edges );
+                    }
+                }
+            }
+            transaction.success();
+            return getGraphResult( vertices, edges );
+        }
+    }
+
+    public static class GraphResult
+    {
+        public final List<Node> nodes;
+        public final List<Relationship> relationships;
+
+        public GraphResult( List<Node> nodes, List<Relationship> relationships )
+        {
+            this.nodes = nodes;
+            this.relationships = relationships;
+        }
+    }
+
+    private NodeImpl getOrCreateLabel( String label, Map<String,Object> properties,
+            final Map<String,NodeImpl> vertices )
+    {
+        if ( vertices.containsKey( label ) )
+        {
+            return vertices.get( label );
+        }
+        NodeImpl vertex = new NodeImpl( label, properties );
+        vertices.put( label, vertex );
+        return vertex;
+    }
+
+    private RelationshipImpl addEdge( NodeImpl startVertex, NodeImpl endVertex, String relType,
+            final Map<String,Set<RelationshipImpl>> edges )
+    {
+        Set<RelationshipImpl> edgesForRel;
+        if ( !edges.containsKey( relType ) )
+        {
+            edgesForRel = new HashSet<>();
+            edges.put( relType, edgesForRel );
+        }
+        else
+        {
+            edgesForRel = edges.get( relType );
+        }
+        RelationshipImpl edge = new RelationshipImpl( startVertex, endVertex, relType );
+        if ( !edgesForRel.contains( edge ) )
+        {
+            edgesForRel.add( edge );
+        }
+        return edge;
+    }
+
+    private GraphResult getGraphResult( final Map<String,NodeImpl> vertices,
+            final Map<String,Set<RelationshipImpl>> edges )
+    {
+        List<Relationship> relationships = new LinkedList<>();
+        for ( Set<RelationshipImpl> edge : edges.values() )
+        {
+            relationships.addAll( edge );
+        }
+
+        GraphResult graphResult;
+        graphResult = new GraphResult( new ArrayList<Node>( vertices.values() ), relationships );
+
+        return graphResult;
+    }
+
+    private static class RelationshipImpl implements Relationship
+    {
+
+        private static AtomicLong MIN_ID = new AtomicLong( -1 );
+
+        private final long id;
+        private final Node startNode;
+        private final Node endNode;
+        private final RelationshipType relationshipType;
+
+        public RelationshipImpl( final NodeImpl startNode, final NodeImpl endNode, final String type )
+        {
+            this.id = MIN_ID.getAndDecrement();
+            this.startNode = startNode;
+            this.endNode = endNode;
+            relationshipType = new RelationshipType()
+            {
+                @Override
+                public String name()
+                {
+                    return type;
+                }
+            };
+        }
+
+        @Override
+        public long getId()
+        {
+            return id;
+        }
+
+        @Override
+        public Node getStartNode()
+        {
+            return startNode;
+        }
+
+        @Override
+        public Node getEndNode()
+        {
+            return endNode;
+        }
+
+        @Override
+        public RelationshipType getType()
+        {
+            return relationshipType;
+        }
+
+        @Override
+        public Map<String,Object> getAllProperties()
+        {
+            return new HashMap<String,Object>();
+        }
+
+        @Override
+        public void delete()
+        {
+
+        }
+
+        @Override
+        public Node getOtherNode( Node node )
+        {
+            return null;
+        }
+
+        @Override
+        public Node[] getNodes()
+        {
+            return new Node[0];
+        }
+
+        @Override
+        public boolean isType( RelationshipType type )
+        {
+            return false;
+        }
+
+        @Override
+        public GraphDatabaseService getGraphDatabase()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean hasProperty( String key )
+        {
+            return false;
+        }
+
+        @Override
+        public Object getProperty( String key )
+        {
+            return null;
+        }
+
+        @Override
+        public Object getProperty( String key, Object defaultValue )
+        {
+            return null;
+        }
+
+        @Override
+        public void setProperty( String key, Object value )
+        {
+
+        }
+
+        @Override
+        public Object removeProperty( String key )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys()
+        {
+            return null;
+        }
+
+        @Override
+        public Map<String,Object> getProperties( String... keys )
+        {
+            return null;
+        }
+    }
+
+    private static class NodeImpl implements Node
+    {
+
+        private final HashMap<String,Object> propertyMap = new HashMap<String,Object>();
+
+        private static AtomicLong MIN_ID = new AtomicLong( -1 );
+        private final long id;
+        private final Label label;
+
+        public NodeImpl( final String label, Map<String,Object> properties )
+        {
+            this.id = MIN_ID.getAndDecrement();
+            this.label = Label.label( label );
+            propertyMap.putAll( properties );
+            propertyMap.put( "name", label );
+        }
+
+        @Override
+        public long getId()
+        {
+            return id;
+        }
+
+        @Override
+        public Map<String,Object> getAllProperties()
+        {
+            return propertyMap;
+        }
+
+        @Override
+        public Iterable<Label> getLabels()
+        {
+            return Arrays.asList( label );
+        }
+
+        @Override
+        public void delete()
+        {
+
+        }
+
+        @Override
+        public Iterable<Relationship> getRelationships()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean hasRelationship()
+        {
+            return false;
+        }
+
+        @Override
+        public Iterable<Relationship> getRelationships( RelationshipType... types )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<Relationship> getRelationships( Direction direction, RelationshipType... types )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<Relationship> getRelationships( RelationshipType type, Direction direction )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<Relationship> getRelationships( Direction direction )
+        {
+            return null;
+        }
+
+        @Override
+        public boolean hasRelationship( RelationshipType... types )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean hasRelationship( Direction direction, RelationshipType... types )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean hasRelationship( RelationshipType type, Direction direction )
+        {
+            return false;
+        }
+
+        @Override
+        public boolean hasRelationship( Direction direction )
+        {
+            return false;
+        }
+
+        @Override
+        public Relationship getSingleRelationship( RelationshipType type, Direction dir )
+        {
+            return null;
+        }
+
+        @Override
+        public Relationship createRelationshipTo( Node otherNode, RelationshipType type )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<RelationshipType> getRelationshipTypes()
+        {
+            return null;
+        }
+
+        @Override
+        public int getDegree()
+        {
+            return 0;
+        }
+
+        @Override
+        public int getDegree( RelationshipType type )
+        {
+            return 0;
+        }
+
+        @Override
+        public int getDegree( RelationshipType type, Direction direction )
+        {
+            return 0;
+        }
+
+        @Override
+        public int getDegree( Direction direction )
+        {
+            return 0;
+        }
+
+        @Override
+        public void addLabel( Label label )
+        {
+
+        }
+
+        @Override
+        public void removeLabel( Label label )
+        {
+
+        }
+
+        @Override
+        public boolean hasLabel( Label label )
+        {
+            return false;
+        }
+
+        @Override
+        public GraphDatabaseService getGraphDatabase()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean hasProperty( String key )
+        {
+            return false;
+        }
+
+        @Override
+        public Object getProperty( String key )
+        {
+            return null;
+        }
+
+        @Override
+        public Object getProperty( String key, Object defaultValue )
+        {
+            return null;
+        }
+
+        @Override
+        public void setProperty( String key, Object value )
+        {
+
+        }
+
+        @Override
+        public Object removeProperty( String key )
+        {
+            return null;
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys()
+        {
+            return null;
+        }
+
+        @Override
+        public Map<String,Object> getProperties( String... keys )
+        {
+            return null;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
@@ -42,10 +45,13 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.proc.BasicContext;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Key;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.factory.Edition;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.proc.TypeMappers;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.Token;
 
 import static java.util.Collections.emptyIterator;
@@ -62,6 +68,10 @@ import static org.mockito.Mockito.when;
 
 import static org.neo4j.kernel.api.proc.Context.KERNEL_TRANSACTION;
 
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
+
 public class BuiltInProceduresTest
 {
     private final List<IndexDescriptor> indexes = new LinkedList<>();
@@ -75,6 +85,7 @@ public class BuiltInProceduresTest
     private final Statement statement = mock( Statement.class );
     private final KernelTransaction tx = mock( KernelTransaction.class );
     private final DependencyResolver resolver = mock( DependencyResolver.class );
+    private final GraphDatabaseAPI graphDatabaseAPI = mock(GraphDatabaseAPI.class);
 
     private final Procedures procs = new Procedures();
 
@@ -181,6 +192,8 @@ public class BuiltInProceduresTest
             record( "db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)", "List all relationship types in the database." ),
             record( "db.resampleIndex", "db.resampleIndex(index :: STRING?) :: VOID", "Schedule resampling of an index (for example: CALL db.resampleIndex(\":Person(name)\"))." ),
             record( "db.resampleOutdatedIndexes", "db.resampleOutdatedIndexes() :: VOID", "Schedule resampling of all outdated indexes." ),
+            record( "db.schema", "db.schema() :: (nodes :: LIST? OF NODE?, relationships :: LIST? OF RELATIONSHIP?)",
+             "Show the schema of the data."),
             record( "dbms.components", "dbms.components() :: (name :: STRING?, versions :: LIST? OF STRING?, edition :: STRING?)", "List DBMS components and their versions." ),
             record( "dbms.procedures", "dbms.procedures() :: (name :: STRING?, signature :: STRING?, description :: STRING?)", "List all procedures in the DBMS." ),
             record( "dbms.functions", "dbms.functions() :: (name :: STRING?, signature :: STRING?, description :: STRING?)", "List all user functions in the DBMS." ),
@@ -268,6 +281,12 @@ public class BuiltInProceduresTest
     {
         procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
         procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ) );
+        procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ) );
+
+        procs.registerType( Node.class, new TypeMappers.SimpleConverter( NTNode, Node.class ) );
+        procs.registerType( Relationship.class, new TypeMappers.SimpleConverter( NTRelationship, Relationship.class ) );
+        procs.registerType( Path.class, new TypeMappers.SimpleConverter( NTPath, Path.class ) );
+
         new SpecialBuiltInProcedures("1.3.37", Edition.enterprise.toString() ).accept( procs );
         procs.registerProcedure( BuiltInProcedures.class );
 
@@ -312,9 +331,13 @@ public class BuiltInProceduresTest
         BasicContext ctx = new BasicContext();
         ctx.put( KERNEL_TRANSACTION, tx );
         ctx.put( DEPENDENCY_RESOLVER, resolver );
+        ctx.put( GRAPHDATABASEAPI, graphDatabaseAPI);
         return Iterators.asList( procs.callProcedure( ctx, ProcedureSignature.procedureName( name.split( "\\." ) ), args ) );
     }
 
     private static final Key<DependencyResolver> DEPENDENCY_RESOLVER =
             Key.key( "DependencyResolver", DependencyResolver.class );
+
+    private static final Key<GraphDatabaseAPI> GRAPHDATABASEAPI =
+            Key.key( "GraphDatabaseAPI", GraphDatabaseAPI.class );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.Iterators.asList;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
+
+public class SchemaProcedureIT extends KernelIntegrationTest
+{
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testEmptyGraph() throws Throwable
+    {
+        // Given the database is empty
+
+        // When
+        RawIterator<Object[],ProcedureException> stream =
+                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+
+        // Then
+        assertThat( asList( stream ), contains( equalTo( new Object[]{new ArrayList<>(), new ArrayList<>()} ) ) );
+    }
+
+    @Test
+    public void testLabelIndex() throws Throwable
+    {
+        // Given there is label with index and a constraint
+        DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+        long nodeId = ops.nodeCreate();
+        int labelId = ops.labelGetOrCreateForName( "Person" );
+        ops.nodeAddLabel( nodeId, labelId );
+        int propertyIdName = ops.propertyKeyGetOrCreateForName( "name" );
+        int propertyIdAge = ops.propertyKeyGetOrCreateForName( "age" );
+        ops.nodeSetProperty( nodeId, DefinedProperty.stringProperty( propertyIdName, "Emil" ) );
+        commit();
+
+        SchemaWriteOperations schemaOps = schemaWriteOperationsInNewTransaction();
+        schemaOps.indexCreate( labelId, propertyIdName );
+        schemaOps.uniquePropertyConstraintCreate( labelId, propertyIdAge );
+        commit();
+
+        // When
+        RawIterator<Object[],ProcedureException> stream =
+                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+
+        // Then
+        while ( stream.hasNext() )
+        {
+            Object[] next = stream.next();
+            assertTrue( next.length == 2 );
+            ArrayList<Node> nodes = (ArrayList<Node>) next[0];
+            assertTrue( nodes.size() == 1 );
+            assertThat( nodes.get( 0 ).getLabels(), contains( equalTo( Label.label( "Person" ) ) ) );
+            assertEquals( nodes.get( 0 ).getAllProperties().get( "name" ), new String( "Person" ) );
+            assertEquals( nodes.get( 0 ).getAllProperties().get( "indexes" ), Arrays.asList( "name" ) );
+            assertEquals( nodes.get( 0 ).getAllProperties().get( "constraints" ),
+                    Arrays.asList( "CONSTRAINT ON ( person:Person ) ASSERT person.age IS UNIQUE" ) );
+        }
+    }
+
+    @Test
+    public void testRelationShip() throws Throwable
+    {
+        // Given there ar
+        DataWriteOperations ops = dataWriteOperationsInNewTransaction();
+        long nodeIdPerson = ops.nodeCreate();
+        int labelIdPerson = ops.labelGetOrCreateForName( "Person" );
+        ops.nodeAddLabel( nodeIdPerson, labelIdPerson );
+        long nodeIdLocation = ops.nodeCreate();
+        int labelIdLocation = ops.labelGetOrCreateForName( "Location" );
+        ops.nodeAddLabel( nodeIdLocation, labelIdLocation );
+        ops.relationshipCreate( ops.relationshipTypeGetOrCreateForName( "LIVES_IN" ), nodeIdPerson, nodeIdLocation );
+        commit();
+
+        // When
+        RawIterator<Object[],ProcedureException> stream =
+                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+
+        // Then
+        while ( stream.hasNext() )
+        {
+            Object[] next = stream.next();
+            assertTrue( next.length == 2 );
+            LinkedList<Relationship> relationships = (LinkedList<Relationship>) next[1];
+            assertTrue( relationships.size() == 1 );
+            assertEquals( "LIVES_IN", relationships.get( 0 ).getType().name() );
+            assertThat( relationships.get( 0 ).getStartNode().getLabels(),
+                    contains( equalTo( Label.label( "Person" ) ) ) );
+            assertThat( relationships.get( 0 ).getEndNode().getLabels(),
+                    contains( equalTo( Label.label( "Location" ) ) ) );
+
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -115,6 +115,9 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                         "Schedule resampling of all outdated indexes."} ),
                 equalTo( new Object[]{"db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING?)", "List all property keys in the database."} ),
                 equalTo( new Object[]{"db.labels", "db.labels() :: (label :: STRING?)", "List all labels in the database."} ),
+                equalTo( new Object[]{"db.schema", "db.schema() :: (nodes :: LIST? OF NODE?, relationships :: LIST? " +
+                        "OF " +
+                        "RELATIONSHIP?)", "Show the schema of the data."} ),
                 equalTo( new Object[]{"db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: " +
                         "STRING?)", "List all relationship types in the database."} ),
                 equalTo( new Object[]{"dbms.procedures", "dbms.procedures() :: (name :: STRING?, signature :: " +


### PR DESCRIPTION
Built in stored procedure allows you to see how Labels and Relationships types are connected (the meta graph of the data).  For generating this meta schema, the countstore is used.  On the labels, the indexes and constraints on properties are shown. Below is an image of the result in the browser.  Nodes and relationships get negative ids, so they don't allow for further expansion.
This procedure call was executed in 12 ms on a ~4GB chicago crime dataset.  Open for comments on code style and feature requests!

![screen shot 2016-08-19 at 16 53 43](https://cloud.githubusercontent.com/assets/4069725/17815868/1221cad0-662e-11e6-81ab-1262f768a136.png)
