### PR TITLE
Escape when listing constraints containing `:`

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.constraints;
 
+import org.neo4j.kernel.api.TokenNameLookup;
+
 /**
  * Base class describing property constraint on nodes.
  */
@@ -51,6 +53,20 @@ public abstract class NodePropertyConstraint extends PropertyConstraint
         NodePropertyConstraint that = (NodePropertyConstraint) o;
         return propertyKeyId == that.propertyKeyId && labelId == that.labelId;
 
+    }
+
+    protected String labelName( TokenNameLookup tokenNameLookup)
+    {
+        String labelName = tokenNameLookup.labelGetName( labelId );
+        //if the labelName contains a `:` we must escape it to avoid disambiguation,
+        //e.g. CONSTRAINT on foo:bar:foo:bar
+        if (labelName.contains( ":" )) {
+            return "`" + labelName + "`";
+        }
+        else
+        {
+            return labelName;
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
@@ -47,7 +47,7 @@ public class NodePropertyExistenceConstraint extends NodePropertyConstraint
     @Override
     public String userDescription( TokenNameLookup tokenNameLookup )
     {
-        String labelName = tokenNameLookup.labelGetName( labelId );
+        String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
         return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT exists(%s.%s)",
                 boundIdentifier, labelName, boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
@@ -46,7 +46,7 @@ public class UniquenessConstraint extends NodePropertyConstraint
     @Override
     public String userDescription( TokenNameLookup tokenNameLookup )
     {
-        String labelName = tokenNameLookup.labelGetName( labelId );
+        String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
         return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS UNIQUE",
                 boundIdentifier, labelName, boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -155,6 +155,21 @@ public class BuiltInProceduresTest
     }
 
     @Test
+    public void shouldEscapeLabelNameContainingColons() throws Throwable
+    {
+        // Given
+        givenUniqueConstraint( "FOO:BAR", "x.y" );
+        givenNodePropExistenceConstraint( "FOO:BAR", "x.y" );
+
+        // When/Then
+        List<Object[]> call = call( "db.constraints" );
+        assertThat( call,
+                contains(
+                        record( "CONSTRAINT ON ( `foo:bar`:`FOO:BAR` ) ASSERT `foo:bar`.x.y IS UNIQUE" ),
+                        record( "CONSTRAINT ON ( `foo:bar`:`FOO:BAR` ) ASSERT exists(`foo:bar`.x.y)" ) ) );
+    }
+
+    @Test
     public void shouldListCorrectBuiltinProcedures() throws Throwable
     {
         // When/Then


### PR DESCRIPTION
Whenever listing constraints on labels containing a `:` the bound identifier
 and the label name needs to be escaped to avoid disambiguity, e.g.

```
 CREATE CONSTRAINT ON (n:`Foo:Bar`) ASSERT n.`blah.baz` IS UNIQUE
CALL db.constraints()
```

the results need to be

```
CONSTRAINT ON ( `foo:bar`:`Foo:Bar` ) ASSERT `foo:bar`.`blah.baz` IS UNIQUE
```

instead of

```
CONSTRAINT ON ( foo:bar:Foo:Bar ) ASSERT foo:bar.blah.baz IS UNIQUE
```

fixes #7634
