### PR TITLE
Add type back to `db.indexes()`

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -204,6 +204,6 @@ class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest {
 
     // Then
     result.toList should equal(
-      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "ONLINE")))
+      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "ONLINE", "type" -> "node_label_property")))
   }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.kernel.builtinprocs;
 
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.stubbing.Answer;
 
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -48,7 +48,6 @@ import org.neo4j.storageengine.api.Token;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -57,12 +56,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.api.proc.CallableProcedure.Context.KERNEL_TRANSACTION;
 
 public class BuiltInProceduresTest
 {
     private final List<IndexDescriptor> indexes = new LinkedList<>();
+    private final List<IndexDescriptor> uniqueIndexes = new LinkedList<>();
     private final List<PropertyConstraint> constraints = new LinkedList<>();
     private final Map<Integer, String> labels = new HashMap<>();
     private final Map<Integer, String> propKeys = new HashMap<>();
@@ -82,7 +81,18 @@ public class BuiltInProceduresTest
 
         // When/Then
         assertThat( call("db.indexes"),
-            contains( record( "INDEX ON :User(name)", "ONLINE" ) ) );
+            contains( record( "INDEX ON :User(name)", "ONLINE", "node_label_property" ) ) );
+    }
+
+    @Test
+    public void shouldListAllUniqueIndexes() throws Throwable
+    {
+        // Given
+        givenUniqueConstraint( "User", "name" );
+
+        // When/Then
+        assertThat( call( "db.indexes" ),
+                contains( record( "INDEX ON :User(name)", "ONLINE", "node_unique_property" ) ) );
     }
 
     @Test
@@ -145,7 +155,7 @@ public class BuiltInProceduresTest
         assertThat( call( "dbms.procedures" ), contains(
             record( "db.awaitIndex", "db.awaitIndex(label :: STRING?, property :: STRING?, timeOutSeconds :: INTEGER?) :: VOID" ),
             record( "db.constraints", "db.constraints() :: (description :: STRING?)" ),
-            record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?)" ),
+            record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)" ),
             record( "db.labels", "db.labels() :: (label :: STRING?)" ),
             record( "db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING?)" ),
             record( "db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)" ),
@@ -182,6 +192,7 @@ public class BuiltInProceduresTest
         int labelId = token( label, labels );
         int propId = token( propKey, propKeys );
 
+        uniqueIndexes.add( new IndexDescriptor( labelId, propId )  );
         constraints.add( new UniquenessConstraint( labelId, propId ) );
     }
 
@@ -243,6 +254,7 @@ public class BuiltInProceduresTest
         when(read.labelsGetAllTokens()).thenAnswer( asTokens(labels) );
         when(read.relationshipTypesGetAllTokens()).thenAnswer( asTokens(relTypes) );
         when(read.indexesGetAll()).thenAnswer( (i) -> indexes.iterator() );
+        when(read.uniqueIndexesGetAll()).thenAnswer( (i) -> uniqueIndexes.iterator() );
         when(read.constraintsGetAll()).thenAnswer( (i) -> constraints.iterator() );
         when(read.proceduresGetAll() ).thenReturn( procs.getAll() );
 


### PR DESCRIPTION
The type was added in 3.0 but has disappeared in 3.1 due to a
merge/refactoring. This PR adds the type back to the output of
`db.indexes()`.
