### PR TITLE
Moved user management to community edition

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
@@ -41,7 +41,7 @@ public class ProcedureRegistry
      *
      * @param proc the procedure.
      */
-    public void register( CallableProcedure proc ) throws ProcedureException
+    public void register( CallableProcedure proc, boolean overrideCurrentImplementation ) throws ProcedureException
     {
         ProcedureSignature signature = proc.signature();
         ProcedureSignature.ProcedureName name = signature.name();
@@ -49,10 +49,22 @@ public class ProcedureRegistry
         validateSignature( signature, signature.inputSignature(), "input" );
         validateSignature( signature, signature.outputSignature(), "output" );
 
-        if ( procedures.putIfAbsent( name, proc ) != null )
+        CallableProcedure oldImplementation = procedures.get( name );
+        if ( oldImplementation == null )
         {
-            throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
-                    "Unable to register procedure, because the name `%s` is already in use.", name );
+            procedures.put( name, proc );
+        }
+        else
+        {
+            if ( overrideCurrentImplementation )
+            {
+                procedures.put( name, proc );
+            }
+            else
+            {
+                throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
+                        "Unable to register procedure, because the name `%s` is already in use.", name );
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -66,7 +66,16 @@ public class Procedures extends LifecycleAdapter
      */
     public void register( CallableProcedure proc ) throws ProcedureException
     {
-        registry.register( proc );
+        register( proc, false );
+    }
+
+    /**
+     * Register a new procedure. This method must not be called concurrently with {@link #get(ProcedureSignature.ProcedureName)}.
+     * @param proc the procedure.
+     */
+    public void register( CallableProcedure proc, boolean overrideCurrentImplementation ) throws ProcedureException
+    {
+        registry.register( proc, overrideCurrentImplementation );
     }
 
     /**
@@ -75,9 +84,18 @@ public class Procedures extends LifecycleAdapter
      */
     public void register( Class<?> proc ) throws KernelException
     {
+        register( proc, false );
+    }
+
+    /**
+     * Register a new procedure defined with annotations on a java class.
+     * @param proc the procedure class
+     */
+    public void register( Class<?> proc, boolean overrideCurrentImplementation ) throws KernelException
+    {
         for ( CallableProcedure procedure : compiler.compile( proc ) )
         {
-            register( procedure );
+            register( procedure, overrideCurrentImplementation );
         }
     }
 

--- a/community/security/pom.xml
+++ b/community/security/pom.xml
@@ -98,6 +98,12 @@ the relevant Commercial Agreement.
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-cypher</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-logging</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -38,7 +38,7 @@ public class AuthProcedures
     @Context
     public AuthSubject authSubject;
 
-    @Procedure( name = "dbms.communityAuth.createUser", mode = DBMS )
+    @Procedure( name = "dbms.createUser", mode = DBMS )
     public void createUser( @Name( "username" ) String username, @Name( "password" ) String password,
             @Name( "requirePasswordChange" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
@@ -47,7 +47,7 @@ public class AuthProcedures
         subject.getAuthManager().newUser( username, password, requirePasswordChange );
     }
 
-    @Procedure( name = "dbms.communityAuth.deleteUser", mode = DBMS )
+    @Procedure( name = "dbms.deleteUser", mode = DBMS )
     public void deleteUser( @Name( "username" ) String username ) throws InvalidArgumentsException, IOException
     {
         BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
@@ -64,7 +64,7 @@ public class AuthProcedures
         authSubject.setPassword( password );
     }
 
-    @Procedure( name = "dbms.communityAuth.showCurrentUser", mode = DBMS )
+    @Procedure( name = "dbms.showCurrentUser", mode = DBMS )
     public Stream<UserResult> showCurrentUser() throws InvalidArgumentsException, IOException
     {
         BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
@@ -74,7 +74,7 @@ public class AuthProcedures
             ) );
     }
 
-    @Procedure( name = "dbms.communityAuth.listUsers", mode = DBMS )
+    @Procedure( name = "dbms.listUsers", mode = DBMS )
     public Stream<UserResult> listUsers() throws InvalidArgumentsException, IOException
     {
         BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -20,6 +20,10 @@
 package org.neo4j.server.security.auth;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
@@ -34,9 +38,68 @@ public class AuthProcedures
     @Context
     public AuthSubject authSubject;
 
+    @Procedure( name = "dbms.communityAuth.createUser", mode = DBMS )
+    public void createUser( @Name( "username" ) String username, @Name( "password" ) String password,
+            @Name( "requirePasswordChange" ) boolean requirePasswordChange )
+            throws InvalidArgumentsException, IOException
+    {
+        BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
+        subject.getAuthManager().newUser( username, password, requirePasswordChange );
+    }
+
+    @Procedure( name = "dbms.communityAuth.deleteUser", mode = DBMS )
+    public void deleteUser( @Name( "username" ) String username ) throws InvalidArgumentsException, IOException
+    {
+        BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
+        if ( subject.doesUsernameMatch( username ) )
+        {
+            throw new InvalidArgumentsException( "Deleting yourself (user '" + username + "') is not allowed." );
+        }
+        subject.getAuthManager().deleteUser( username );
+    }
+
     @Procedure( name = "dbms.changePassword", mode = DBMS )
     public void changePassword( @Name( "password" ) String password ) throws InvalidArgumentsException, IOException
     {
         authSubject.setPassword( password );
+    }
+
+    @Procedure( name = "dbms.communityAuth.showCurrentUser", mode = DBMS )
+    public Stream<UserResult> showCurrentUser() throws InvalidArgumentsException, IOException
+    {
+        BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
+        return Stream.of( new UserResult(
+                subject.name(),
+                subject.getAuthManager().getUser( subject.name() ).getFlags()
+            ) );
+    }
+
+    @Procedure( name = "dbms.communityAuth.listUsers", mode = DBMS )
+    public Stream<UserResult> listUsers() throws InvalidArgumentsException, IOException
+    {
+        BasicAuthSubject subject = BasicAuthSubject.castOrFail( authSubject );
+        Set<String> usernames = subject.getAuthManager().getAllUsernames();
+        List<UserResult> results = new ArrayList<>();
+        for ( String username : usernames )
+        {
+            results.add( new UserResult(
+                    username,
+                    subject.getAuthManager().getUser( username ).getFlags()
+                ) );
+        }
+        return results.stream();
+    }
+
+    public static class UserResult
+    {
+        public final String username;
+        public final List<String> flags;
+
+        UserResult( String username, Iterable<String> flags )
+        {
+            this.username = username;
+            this.flags = new ArrayList<>();
+            for ( String f : flags ) {this.flags.add( f );}
+        }
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
@@ -97,6 +97,11 @@ public class BasicAuthSubject implements AuthSubject
         }
     }
 
+    public BasicAuthManager getAuthManager()
+    {
+        return authManager;
+    }
+
     public boolean doesUsernameMatch( String username )
     {
         return user.name().equals( username );
@@ -135,6 +140,6 @@ public class BasicAuthSubject implements AuthSubject
     @Override
     public String name()
     {
-        return accessMode.name();
+        return user.name();
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
@@ -20,6 +20,7 @@
 package org.neo4j.server.security.auth;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
 
@@ -33,4 +34,6 @@ public interface UserManager
     User getUser( String username ) throws InvalidArgumentsException;
 
     void setUserPassword( String username, String password ) throws IOException, InvalidArgumentsException;
+
+    Set<String> getAllUsernames();
 }

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -127,5 +127,4 @@ public class SetPasswordCommandTest extends CommandTestBase
         // Then - the new user no longer requires a password change
         assertUserDoesNotRequirePasswordChange( "another" );
     }
-
 }

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.auth;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.TestGraphDatabaseBuilder;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.security.AuthenticationResult.PASSWORD_CHANGE_REQUIRED;
+
+public class AuthProceduresIT
+{
+    static final String PWD_CHANGE = PASSWORD_CHANGE_REQUIRED.name().toLowerCase();
+
+    protected GraphDatabaseAPI db;
+    private EphemeralFileSystemAbstraction fs;
+    private BasicAuthManager authManager;
+    private BasicAuthSubject admin;
+
+    //---------- change password -----------
+
+    @Test
+    public void shouldChangePassword() throws Throwable
+    {
+
+        // Given
+        assertEmpty( admin, "CALL dbms.changePassword('abc')" );
+
+        assert( authManager.getUser( "neo4j" ).credentials().matchesPassword( "abc" ) );
+    }
+
+    @Test
+    public void shouldNotChangeOwnPasswordIfNewPasswordInvalid() throws Exception
+    {
+        assertFail( admin, "CALL dbms.changePassword( '' )", "Password cannot be empty." );
+        assertFail( admin, "CALL dbms.changePassword( 'neo4j' )", "Old password and new password cannot be the same." );
+    }
+
+    //---------- create user -----------
+
+    @Test
+    public void shouldCreateUser() throws Exception
+    {
+        assertEmpty( admin, "CALL dbms.communityAuth.createUser('andres', '123', true)" );
+        try
+        {
+            authManager.getUser( "andres" );
+        }
+        catch ( Throwable t )
+        {
+            fail( "Expected no exception!" );
+        }
+    }
+
+    @Test
+    public void shouldNotCreateUserIfInvalidUsername() throws Exception
+    {
+        assertFail( admin, "CALL dbms.communityAuth.createUser('', '1234', true)", "The provided user name is empty." );
+        assertFail( admin, "CALL dbms.communityAuth.createUser('&%ss!', '1234', true)",
+                "User name '&%ss!' contains illegal characters." );
+        assertFail( admin, "CALL dbms.communityAuth.createUser('&%ss!', '', true)", "User name '&%ss!' contains illegal characters." );
+    }
+
+    @Test
+    public void shouldNotCreateUserIfInvalidPassword() throws Exception
+    {
+        assertFail( admin, "CALL dbms.communityAuth.createUser('andres', '', true)", "Password cannot be empty." );
+    }
+
+    @Test
+    public void shouldNotCreateExistingUser() throws Exception
+    {
+        assertFail( admin, "CALL dbms.communityAuth.createUser('neo4j', '1234', true)",
+                "The specified user already exists" );
+        assertFail( admin, "CALL dbms.communityAuth.createUser('neo4j', '', true)", "Password cannot be empty." );
+    }
+
+    //---------- delete user -----------
+
+    @Test
+    public void shouldDeleteUser() throws Exception
+    {
+        authManager.newUser( "andres", "123", false );
+        assertEmpty( admin, "CALL dbms.communityAuth.deleteUser('andres')" );
+        try
+        {
+            authManager.getUser( "andres" );
+            fail("Andres should no longer exist, expected exception.");
+        }
+        catch ( InvalidArgumentsException e )
+        {
+            assertThat( e.getMessage(), containsString( "User 'andres' does not exist." ) );
+        }
+        catch ( Throwable t )
+        {
+            assertThat( t.getClass(), equalTo( InvalidArgumentsException.class ) );
+        }
+    }
+
+    @Test
+    public void shouldNotDeleteNonExistentUser() throws Exception
+    {
+        assertFail( admin, "CALL dbms.communityAuth.deleteUser('nonExistentUser')", "User 'nonExistentUser' does not exist" );
+    }
+
+    //---------- list users -----------
+
+    @Test
+    public void shouldListUsers() throws Exception
+    {
+        authManager.newUser( "andres", "123", false );
+        assertSuccess( admin, "CALL dbms.communityAuth.listUsers() YIELD username",
+                r -> assertKeyIs( r, "username", "neo4j", "andres" ) );
+    }
+
+    @Test
+    public void shouldReturnUsersWithFlags() throws Exception
+    {
+        authManager.newUser( "andres", "123", false );
+        Map<String,Object> expected = map(
+                "neo4j", listOf( PWD_CHANGE ),
+                "andres", listOf()
+        );
+        assertSuccess( admin, "CALL dbms.communityAuth.listUsers()",
+                r -> assertKeyIsMap( r, "username", "flags", expected ) );
+    }
+
+    @Test
+    public void shouldShowCurrentUser() throws Exception
+    {
+        assertSuccess( admin, "CALL dbms.communityAuth.showCurrentUser()",
+                r -> assertKeyIsMap( r, "username", "flags", map( "neo4j", listOf( PWD_CHANGE ) ) ) );
+
+        authManager.newUser( "andres", "123", false );
+        BasicAuthSubject andres = login( "andres", "123" );
+        assertSuccess( andres, "CALL dbms.communityAuth.showCurrentUser()",
+                r -> assertKeyIsMap( r, "username", "flags", map( "andres", listOf() ) ) );
+    }
+
+    //---------- utility -----------
+
+    @Before
+    public void setup() throws InvalidAuthTokenException
+    {
+        fs = new EphemeralFileSystemAbstraction();
+        db = (GraphDatabaseAPI) createGraphDatabase( fs );
+        authManager = db.getDependencyResolver().resolveDependency( BasicAuthManager.class );
+        admin = login( "neo4j", "neo4j" );
+    }
+
+    @After
+    public void cleanup() throws Exception
+    {
+        db.shutdown();
+        fs.shutdown();
+    }
+
+    protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
+    {
+
+        Map<Setting<?>, String> settings = new HashMap<>();
+        settings.put( GraphDatabaseSettings.auth_enabled, "true" );
+        settings.put( GraphDatabaseSettings.auth_manager, "basic-auth-manager" );
+
+        TestGraphDatabaseBuilder graphDatabaseFactory = (TestGraphDatabaseBuilder) new TestGraphDatabaseFactory()
+                .setFileSystem( fs )
+            .newImpermanentDatabaseBuilder()
+                .setConfig( GraphDatabaseSettings.auth_enabled, "true" )
+                .setConfig( GraphDatabaseSettings.auth_manager, "basic-auth-manager" );
+
+        return graphDatabaseFactory.newGraphDatabase();
+    }
+
+    protected BasicAuthSubject login( String username, String password ) throws InvalidAuthTokenException
+    {
+        return authManager.login( SecurityTestUtils.authToken( username, password ) );
+    }
+
+    private void assertEmpty( BasicAuthSubject subject, String query )
+    {
+        assertThat(
+                execute( subject, query, r -> { assert(!r.hasNext() ); } ),
+                equalTo( "" ) );
+    }
+
+    private void assertFail( BasicAuthSubject subject, String query, String partOfErrorMsg )
+    {
+        assertThat(
+                execute( subject, query, r -> { assert(!r.hasNext() ); } ),
+                containsString( partOfErrorMsg ) );
+    }
+
+    void assertSuccess( BasicAuthSubject subject, String query,
+            Consumer<ResourceIterator<Map<String, Object>>> resultConsumer )
+    {
+        assertThat(
+                execute( subject, query, resultConsumer ),
+                equalTo( "" ) );
+    }
+
+    private String execute( BasicAuthSubject subject, String query,
+            Consumer<ResourceIterator<Map<String, Object>>> resultConsumer )
+    {
+        try ( Transaction tx = db.beginTransaction( KernelTransaction.Type.implicit, subject ) )
+        {
+            resultConsumer.accept( db.execute( query ) );
+            tx.success();
+            return "";
+        }
+        catch ( Exception e )
+        {
+            return e.getMessage();
+        }
+    }
+
+    List<Object> getObjectsAsList( ResourceIterator<Map<String, Object>> r, String key )
+    {
+        return r.stream().map( s -> s.get( key ) ).collect( Collectors.toList() );
+    }
+
+    void assertKeyIs( ResourceIterator<Map<String, Object>> r, String key, String... items )
+    {
+        assertKeyIsArray( r, key, items );
+    }
+
+    void assertKeyIsArray( ResourceIterator<Map<String, Object>> r, String key, String[] items )
+    {
+        List<Object> results = getObjectsAsList( r, key );
+        assertEquals( Arrays.asList( items ).size(), results.size() );
+        Assert.assertThat( results, containsInAnyOrder( items ) );
+    }
+
+    protected void assertKeyIsMap( ResourceIterator<Map<String, Object>> r, String keyKey, String valueKey, Map<String,Object> expected )
+    {
+        List<Map<String, Object>> result = r.stream().collect( Collectors.toList() );
+
+        assertEquals( "Results for should have size " + expected.size() + " but was " + result.size(),
+                expected.size(), result.size() );
+
+        for ( Map<String, Object> row : result )
+        {
+            String key = (String) row.get( keyKey );
+            assertTrue( "Unexpected key '" + key + "'", expected.containsKey( key ) );
+
+            assertTrue( "Value key '" + valueKey + "' not found in results", row.containsKey( valueKey ) );
+            Object objectValue = row.get( valueKey );
+            if ( objectValue instanceof List )
+            {
+                List<String> value = (List<String>) objectValue;
+                List<String> expectedValues = (List<String>) expected.get( key );
+                assertEquals( "Results for '" + key + "' should have size " + expectedValues.size() + " but was " +
+                        value.size(), value.size(), expectedValues.size() );
+                assertThat( value, containsInAnyOrder( expectedValues.toArray() ) );
+            }
+            else
+            {
+                String value = objectValue.toString();
+                String expectedValue = expected.get( key ).toString();
+                assertTrue(
+                        String.format( "Wrong value for '%s', expected '%s', got '%s'", key, expectedValue, value),
+                        value.equals( expectedValue )
+                );
+            }
+        }
+    }
+
+    protected String[] with( String[] strs, String... moreStr )
+    {
+        return Stream.concat( Arrays.stream(strs), Arrays.stream( moreStr ) ).toArray( String[]::new );
+    }
+
+    protected List<String> listOf( String... values )
+    {
+        return Stream.of( values ).collect( Collectors.toList() );
+    }
+}

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -24,6 +24,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -187,7 +191,7 @@ public class AuthProceduresIT
     //---------- utility -----------
 
     @Before
-    public void setup() throws InvalidAuthTokenException
+    public void setup() throws InvalidAuthTokenException, IOException
     {
         fs = new EphemeralFileSystemAbstraction();
         db = (GraphDatabaseAPI) createGraphDatabase( fs );
@@ -202,9 +206,9 @@ public class AuthProceduresIT
         fs.shutdown();
     }
 
-    protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
+    private GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs ) throws IOException
     {
-
+        removePreviousAuthFile();
         Map<Setting<?>, String> settings = new HashMap<>();
         settings.put( GraphDatabaseSettings.auth_enabled, "true" );
         settings.put( GraphDatabaseSettings.auth_manager, "basic-auth-manager" );
@@ -218,7 +222,16 @@ public class AuthProceduresIT
         return graphDatabaseFactory.newGraphDatabase();
     }
 
-    protected BasicAuthSubject login( String username, String password ) throws InvalidAuthTokenException
+    private void removePreviousAuthFile() throws IOException
+    {
+        Path file = Paths.get( "target/test-data/impermanent-db/data/dbms/auth" );
+        if ( Files.exists( file ) )
+        {
+            Files.delete( file );
+        }
+    }
+
+    private BasicAuthSubject login( String username, String password ) throws InvalidAuthTokenException
     {
         return authManager.login( SecurityTestUtils.authToken( username, password ) );
     }

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -83,7 +83,7 @@ public class AuthProceduresIT
     @Test
     public void shouldNotChangeOwnPasswordIfNewPasswordInvalid() throws Exception
     {
-        assertFail( admin, "CALL dbms.changePassword( '' )", "Password cannot be empty." );
+        assertFail( admin, "CALL dbms.changePassword( '' )", "A password cannot be empty." );
         assertFail( admin, "CALL dbms.changePassword( 'neo4j' )", "Old password and new password cannot be the same." );
     }
 
@@ -115,15 +115,15 @@ public class AuthProceduresIT
     @Test
     public void shouldNotCreateUserIfInvalidPassword() throws Exception
     {
-        assertFail( admin, "CALL dbms.createUser('andres', '', true)", "Password cannot be empty." );
+        assertFail( admin, "CALL dbms.createUser('andres', '', true)", "A password cannot be empty." );
     }
 
     @Test
     public void shouldNotCreateExistingUser() throws Exception
     {
         assertFail( admin, "CALL dbms.createUser('neo4j', '1234', true)",
-                "The specified user already exists" );
-        assertFail( admin, "CALL dbms.createUser('neo4j', '', true)", "Password cannot be empty." );
+                "The specified user 'neo4j' already exists" );
+        assertFail( admin, "CALL dbms.createUser('neo4j', '', true)", "A password cannot be empty." );
     }
 
     //---------- delete user -----------

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -88,7 +88,7 @@ public class AuthProceduresIT
     @Test
     public void shouldCreateUser() throws Exception
     {
-        assertEmpty( admin, "CALL dbms.communityAuth.createUser('andres', '123', true)" );
+        assertEmpty( admin, "CALL dbms.createUser('andres', '123', true)" );
         try
         {
             authManager.getUser( "andres" );
@@ -102,24 +102,24 @@ public class AuthProceduresIT
     @Test
     public void shouldNotCreateUserIfInvalidUsername() throws Exception
     {
-        assertFail( admin, "CALL dbms.communityAuth.createUser('', '1234', true)", "The provided user name is empty." );
-        assertFail( admin, "CALL dbms.communityAuth.createUser('&%ss!', '1234', true)",
+        assertFail( admin, "CALL dbms.createUser('', '1234', true)", "The provided user name is empty." );
+        assertFail( admin, "CALL dbms.createUser('&%ss!', '1234', true)",
                 "User name '&%ss!' contains illegal characters." );
-        assertFail( admin, "CALL dbms.communityAuth.createUser('&%ss!', '', true)", "User name '&%ss!' contains illegal characters." );
+        assertFail( admin, "CALL dbms.createUser('&%ss!', '', true)", "User name '&%ss!' contains illegal characters." );
     }
 
     @Test
     public void shouldNotCreateUserIfInvalidPassword() throws Exception
     {
-        assertFail( admin, "CALL dbms.communityAuth.createUser('andres', '', true)", "Password cannot be empty." );
+        assertFail( admin, "CALL dbms.createUser('andres', '', true)", "Password cannot be empty." );
     }
 
     @Test
     public void shouldNotCreateExistingUser() throws Exception
     {
-        assertFail( admin, "CALL dbms.communityAuth.createUser('neo4j', '1234', true)",
+        assertFail( admin, "CALL dbms.createUser('neo4j', '1234', true)",
                 "The specified user already exists" );
-        assertFail( admin, "CALL dbms.communityAuth.createUser('neo4j', '', true)", "Password cannot be empty." );
+        assertFail( admin, "CALL dbms.createUser('neo4j', '', true)", "Password cannot be empty." );
     }
 
     //---------- delete user -----------
@@ -128,7 +128,7 @@ public class AuthProceduresIT
     public void shouldDeleteUser() throws Exception
     {
         authManager.newUser( "andres", "123", false );
-        assertEmpty( admin, "CALL dbms.communityAuth.deleteUser('andres')" );
+        assertEmpty( admin, "CALL dbms.deleteUser('andres')" );
         try
         {
             authManager.getUser( "andres" );
@@ -147,7 +147,7 @@ public class AuthProceduresIT
     @Test
     public void shouldNotDeleteNonExistentUser() throws Exception
     {
-        assertFail( admin, "CALL dbms.communityAuth.deleteUser('nonExistentUser')", "User 'nonExistentUser' does not exist" );
+        assertFail( admin, "CALL dbms.deleteUser('nonExistentUser')", "User 'nonExistentUser' does not exist" );
     }
 
     //---------- list users -----------
@@ -156,7 +156,7 @@ public class AuthProceduresIT
     public void shouldListUsers() throws Exception
     {
         authManager.newUser( "andres", "123", false );
-        assertSuccess( admin, "CALL dbms.communityAuth.listUsers() YIELD username",
+        assertSuccess( admin, "CALL dbms.listUsers() YIELD username",
                 r -> assertKeyIs( r, "username", "neo4j", "andres" ) );
     }
 
@@ -168,19 +168,19 @@ public class AuthProceduresIT
                 "neo4j", listOf( PWD_CHANGE ),
                 "andres", listOf()
         );
-        assertSuccess( admin, "CALL dbms.communityAuth.listUsers()",
+        assertSuccess( admin, "CALL dbms.listUsers()",
                 r -> assertKeyIsMap( r, "username", "flags", expected ) );
     }
 
     @Test
     public void shouldShowCurrentUser() throws Exception
     {
-        assertSuccess( admin, "CALL dbms.communityAuth.showCurrentUser()",
+        assertSuccess( admin, "CALL dbms.showCurrentUser()",
                 r -> assertKeyIsMap( r, "username", "flags", map( "neo4j", listOf( PWD_CHANGE ) ) ) );
 
         authManager.newUser( "andres", "123", false );
         BasicAuthSubject andres = login( "andres", "123" );
-        assertSuccess( andres, "CALL dbms.communityAuth.showCurrentUser()",
+        assertSuccess( andres, "CALL dbms.showCurrentUser()",
                 r -> assertKeyIsMap( r, "username", "flags", map( "andres", listOf() ) ) );
     }
 

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -39,39 +39,39 @@ import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
 public class AuthProceduresTest extends KernelIntegrationTest
 {
     @Test
-        public void callChangePasswordWithAccessModeInDbmsMode() throws Throwable
+    public void callChangePasswordWithAccessModeInDbmsMode() throws Throwable
+    {
+        // Given
+        Object[] inputArray = new Object[1];
+        inputArray[0] = "newPassword";
+        AuthSubject authSubject = mock( AuthSubject.class );
+
+        // When
+        RawIterator<Object[], ProcedureException> stream = dbmsOperations( authSubject )
+                .procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray );
+
+        // Then
+        verify( authSubject ).setPassword( (String) inputArray[0] );
+        assertThat( asList( stream ), emptyIterable() );
+    }
+
+    @Test
+    public void shouldFailWhenChangePasswordWithStaticAccessModeInDbmsMode() throws Throwable
+    {
+        try
         {
             // Given
             Object[] inputArray = new Object[1];
             inputArray[0] = "newPassword";
-            AuthSubject authSubject = mock( AuthSubject.class );
 
             // When
-            RawIterator<Object[], ProcedureException> stream = dbmsOperations( authSubject )
-                    .procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray );
-
-            // Then
-            verify( authSubject ).setPassword( (String) inputArray[0] );
-            assertThat( asList( stream ), emptyIterable() );
+            dbmsOperations( AccessMode.Static.NONE ).procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray );
+            fail( "Should have failed." );
         }
-
-        @Test
-        public void shouldFailWhenChangePasswordWithStaticAccessModeInDbmsMode() throws Throwable
+        catch ( Exception e )
         {
-            try
-            {
-                // Given
-                Object[] inputArray = new Object[1];
-                inputArray[0] = "newPassword";
-
-                // When
-                dbmsOperations( AccessMode.Static.NONE ).procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray );
-                fail( "Should have failed." );
-            }
-            catch ( Exception e )
-            {
-                // Then
-                assertThat( e.getClass(), equalTo( ProcedureException.class ) );
-            }
+            // Then
+            assertThat( e.getClass(), equalTo( ProcedureException.class ) );
         }
+    }
 }

--- a/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.security.auth;
 
+import junit.framework.TestCase;
+import org.hamcrest.core.IsEqual;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +32,7 @@ import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -149,13 +152,25 @@ public class BasicAuthManagerTest
     }
 
     @Test
-    public void shouldDeleteUnknownUser() throws Throwable
+    public void shouldFailToDeleteUnknownUser() throws Throwable
     {
         // Given
         manager.newUser( "jake", "abc123", true );
 
-        // When
-        manager.deleteUser( "unknown" );
+        try
+        {
+            // When
+            manager.deleteUser( "nonExistentUser" );
+            TestCase.fail("User 'nonExistentUser' should no longer exist, expected exception.");
+        }
+        catch ( InvalidArgumentsException e )
+        {
+            assertThat( e.getMessage(), containsString( "User 'nonExistentUser' does not exist." ) );
+        }
+        catch ( Throwable t )
+        {
+            assertThat( t.getClass(), IsEqual.equalTo( InvalidArgumentsException.class ) );
+        }
 
         // Then
         assertNotNull( users.getUserByName( "jake" ) );

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.server.security.auth.BasicAuthManager;
+import org.neo4j.server.security.auth.BasicAuthSubject;
 
 import static javax.servlet.http.HttpServletRequest.BASIC_AUTH;
 
@@ -167,7 +168,7 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        AuthSubject authSubject = mock( AuthSubject.class );
+        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
@@ -195,7 +196,7 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        AuthSubject authSubject = mock( AuthSubject.class );
+        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/user/foo" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
@@ -216,7 +217,7 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        AuthSubject authSubject = mock( AuthSubject.class );
+        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getRequestURL() ).thenReturn( new StringBuffer( "http://bar.baz:7474/db/data/" ) );
@@ -243,7 +244,7 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        AuthSubject authSubject = mock( AuthSubject.class );
+        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
@@ -267,7 +268,7 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        AuthSubject authSubject = mock( AuthSubject.class );
+        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthProceduresProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthProceduresProvider.java
@@ -37,7 +37,7 @@ public class EnterpriseAuthProceduresProvider extends Service implements Procedu
     {
         try
         {
-            procedures.register( AuthProcedures.class );
+            procedures.register( AuthProcedures.class, true );
         }
         catch ( KernelException e )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
@@ -31,8 +31,6 @@ public interface EnterpriseUserManager extends UserManager
 
     void activateUser( String username ) throws IOException, InvalidArgumentsException;
 
-    Set<String> getAllUsernames();
-
     RoleRecord newRole( String roleName, String... usernames ) throws IOException, InvalidArgumentsException;
 
     RoleRecord getRole( String roleName ) throws InvalidArgumentsException;


### PR DESCRIPTION
The following procedures are now in both community and enterprise edition:

dbms.createUser
dbms.deleteUser
dbms.showCurrentUser
dbms.listUsers

Note that some of there procedures have richer functionality in enterprise, such as listing user roles, or terminating running transactions on user deletion.
