### PR TITLE
Remove flag that force usage of thread-local Marsaglia's xorshift generator since it's selected by default now.

### DIFF
--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -163,10 +163,6 @@ dbms.jvm.additional=-XX:+AlwaysPreTouch
 dbms.jvm.additional=-XX:+UnlockExperimentalVMOptions
 dbms.jvm.additional=-XX:+TrustFinalNonStaticFields
 
-# Reduce probability of objects getting the same identity hash code
-# via a race, by computing them with thread-local PRNGs.
-dbms.jvm.additional=-XX:hashCode=5
-
 # Disable explicit garbage collection, which is occasionally invoked by the JDK itself.
 dbms.jvm.additional=-XX:+DisableExplicitGC
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -359,10 +359,6 @@ dbms.jvm.additional=-XX:+AlwaysPreTouch
 dbms.jvm.additional=-XX:+UnlockExperimentalVMOptions
 dbms.jvm.additional=-XX:+TrustFinalNonStaticFields
 
-# Reduce probability of objects getting the same identity hash code
-# via a race, by computing them with thread-local PRNGs.
-dbms.jvm.additional=-XX:hashCode=5
-
 # Disable explicit garbage collection, which is occasionally invoked by the JDK itself.
 dbms.jvm.additional=-XX:+DisableExplicitGC
 


### PR DESCRIPTION
See https://bugs.openjdk.java.net/browse/JDK-8006176 for details and when switch happened.
