### PR TITLE
Include neo4j version in INIT

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -326,6 +326,8 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             {
                                 machine.ctx.onMetadata( "credentials_expired", true );
                             }
+                            machine.ctx.onMetadata( "neo4j_version", machine.spi.version() );
+
                             machine.spi.udcRegisterClient( userAgent );
                             if ( authToken.containsKey( PRINCIPAL ) )
                             {
@@ -437,6 +439,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             machine.ctx.statementProcessor.streamResult( recordStream -> {
                                 machine.ctx.responseHandler.onRecords( recordStream, true );
                             } );
+
                             return READY;
                         }
                         catch ( Throwable e )
@@ -769,6 +772,8 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
         TransactionStateMachine.SPI transactionSpi();
 
         void onTerminate( BoltStateMachine machine );
+
+        String version();
     }
 
     private static class NullStatementProcessor implements StatementProcessor

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -326,7 +326,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             {
                                 machine.ctx.onMetadata( "credentials_expired", true );
                             }
-                            machine.ctx.onMetadata( "neo4j_version", machine.spi.version() );
+                            machine.ctx.onMetadata( "server", machine.spi.version() );
 
                             machine.spi.udcRegisterClient( userAgent );
                             if ( authToken.containsKey( PRINCIPAL ) )

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
@@ -54,7 +54,7 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
         this.connectionTracker = connectionTracker;
         this.authentication = authentication;
         this.transactionSpi = transactionStateMachineSPI;
-        this.version = Version.getKernel().getReleaseVersion();
+        this.version = "Neo4j/" + Version.getKernel().getReleaseVersion();
     }
 
     @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
@@ -26,6 +26,7 @@ import org.neo4j.bolt.security.auth.AuthenticationException;
 import org.neo4j.bolt.security.auth.AuthenticationResult;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
@@ -36,7 +37,9 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
     private final ErrorReporter errorReporter;
     private final BoltConnectionTracker connectionTracker;
     private final Authentication authentication;
-    private final TransactionStateMachine.SPI transactionSpi;
+    private final String version;
+
+    final TransactionStateMachine.SPI transactionSpi;
 
     BoltStateMachineSPI( String connectionDescriptor,
                          UsageData usageData,
@@ -51,6 +54,7 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
         this.connectionTracker = connectionTracker;
         this.authentication = authentication;
         this.transactionSpi = transactionStateMachineSPI;
+        this.version = Version.getKernel().getReleaseVersion();
     }
 
     @Override
@@ -93,5 +97,11 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
     public void udcRegisterClient( String clientName )
     {
         usageData.get( UsageDataKeys.clientNames ).add( clientName );
+    }
+
+    @Override
+    public String version()
+    {
+        return version;
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
@@ -215,5 +215,11 @@ public class ResetFuzzTest
         {
             // do nothing
         }
+
+        @Override
+        public String version()
+        {
+            return "<test-version>";
+        }
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
@@ -68,7 +68,7 @@ public class BoltConnectionAuthIT
         // identify expired credentials as the cause of not being authenticated
         BoltStateMachine machine = env.newMachine( "test" );
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        String version = Version.getKernel().getReleaseVersion();
+        String version = "Neo4j/" + Version.getKernel().getReleaseVersion();
         // When
         machine.init( USER_AGENT, map(
                 "scheme", "basic",
@@ -77,7 +77,7 @@ public class BoltConnectionAuthIT
         machine.run( "CREATE ()", map(), recorder );
 
         // Then
-        assertThat( recorder.nextResponse(), succeededWithMetadata( "neo4j_version", version ) );
+        assertThat( recorder.nextResponse(), succeededWithMetadata( "server", version ) );
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -35,16 +35,17 @@ import java.util.function.Consumer;
 import org.neo4j.bolt.v1.messaging.message.InitMessage;
 import org.neo4j.bolt.v1.messaging.message.PullAllMessage;
 import org.neo4j.bolt.v1.messaging.message.RunMessage;
-import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
 import org.neo4j.bolt.v1.transport.socket.client.SecureWebSocketConnection;
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.bolt.v1.transport.socket.client.WebSocketConnection;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Arrays.asList;
@@ -78,6 +79,7 @@ public class AuthenticationIT
     public HostnamePort address;
 
     protected TransportConnection client;
+    private final String version = Version.getKernel().getReleaseVersion();
 
     @Parameterized.Parameters
     public static Collection<Object[]> transports()
@@ -113,7 +115,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
     }
 
     @Test
@@ -235,7 +237,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess(map( "credentials_expired", true , "neo4j_version", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -279,7 +281,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -310,7 +312,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version) ) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -334,7 +336,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version) ) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -358,7 +360,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( Collections.singletonMap( "credentials_expired", true )) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -79,7 +79,7 @@ public class AuthenticationIT
     public HostnamePort address;
 
     protected TransportConnection client;
-    private final String version = Version.getKernel().getReleaseVersion();
+    private final String version = "Neo4j/" + Version.getKernel().getReleaseVersion();
 
     @Parameterized.Parameters
     public static Collection<Object[]> transports()
@@ -115,7 +115,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "server", version)) ) );
     }
 
     @Test
@@ -147,7 +147,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                String.format( "The value associated with the key `principal` must be a String but was: ArrayList") ) ) );
+                "The value associated with the key `principal` must be a String but was: ArrayList" ) ) );
     }
 
     @Test
@@ -163,7 +163,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                String.format( "The value associated with the key `credentials` must be a String but was: null") ) ) );
+                "The value associated with the key `credentials` must be a String but was: null" ) ) );
     }
 
     @Test
@@ -237,7 +237,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess(map( "credentials_expired", true , "neo4j_version", version)) ) );
+        assertThat( client, eventuallyReceives( msgSuccess(map( "credentials_expired", true , "server", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -281,7 +281,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "server", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -312,7 +312,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version) ) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "server", version) ) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -336,7 +336,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version) ) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "server", version) ) ) );
 
         // When
         client.send( TransportTestUtil.chunk(
@@ -360,7 +360,7 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "neo4j_version", version)) ) );
+        assertThat( client, eventuallyReceives( msgSuccess( map( "credentials_expired", true , "server", version)) ) );
 
         // When
         client.send( TransportTestUtil.chunk(

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportErrorIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportErrorIT.java
@@ -25,6 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.neo4j.bolt.v1.messaging.RecordingByteChannel;
 import org.neo4j.bolt.v1.packstream.BufferedChannelOutput;
 import org.neo4j.bolt.v1.packstream.PackStream;
@@ -32,14 +36,14 @@ import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.function.Factory;
 import org.neo4j.helpers.HostnamePort;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.bolt.v1.messaging.BoltRequestMessage.RUN;
 import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
 import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.serialize;
-import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.*;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.acceptedVersions;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.chunk;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyDisconnects;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyReceives;
 
 @RunWith( Parameterized.class )
 public class TransportErrorIT

--- a/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
@@ -82,7 +82,7 @@ public class BoltQueryLoggingIT
                 "63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72\n" +
                 "65 74 00 00" );
         // Receive SUCCESS {}
-        receive( dataIn, "00 03 b1 70 a0 00 00" );
+        receiveSuccess( dataIn );
 
         // *** WHEN ***
 
@@ -92,7 +92,7 @@ public class BoltQueryLoggingIT
             send( dataOut, "00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53 20 6e 75 6d  a0 00 00" );
             // Receive SUCCESS { "fields": ["num"], "result_available_after": X }
             //non-deterministic so just ignore it here
-            skip( dataIn );
+            receiveSuccess( dataIn );
 
             //receive( dataIn, "00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75 6d 00 00" );
 
@@ -102,7 +102,7 @@ public class BoltQueryLoggingIT
             receive( dataIn, "00 04 b1 71  91 01 00 00" );
             // Receive SUCCESS { "type": "r", "result_consumed_after": Y }
             //non-deterministic so just ignore it here
-            skip( dataIn );
+            receiveSuccess(  dataIn );
         }
 
         // *** THEN ***
@@ -130,15 +130,6 @@ public class BoltQueryLoggingIT
         socket.close();
     }
 
-    /*
-     * Just consumes the bytes without asserting on the results.
-     */
-    private void skip( DataInputStream dataIn ) throws IOException
-    {
-        short bytes = dataIn.readShort();
-        dataIn.skipBytes( bytes + 2 );
-    }
-
     private static void send( DataOutputStream dataOut, String toSend ) throws IOException
     {
         send( dataOut, hexBytes( toSend ) );
@@ -148,6 +139,14 @@ public class BoltQueryLoggingIT
     {
         dataOut.write( bytesToSend );
         dataOut.flush();
+    }
+
+    private void receiveSuccess( DataInputStream dataIn ) throws IOException
+    {
+        short bytes = dataIn.readShort();
+        assertThat(dataIn.readUnsignedByte(), equalTo(0xB1));
+        assertThat(dataIn.readUnsignedByte(), equalTo(0x70));
+        dataIn.skipBytes( bytes);
     }
 
     private static void receive( DataInputStream dataIn, String expected ) throws IOException

--- a/manual/bolt/src/docs/dev/examples.asciidoc
+++ b/manual/bolt/src/docs/dev/examples.asciidoc
@@ -24,9 +24,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 Client: RUN "RETURN 1 AS num" {}
 
@@ -79,9 +80,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Batch of messages
 Client: RUN "RETURN 1 AS num" {}
@@ -159,9 +161,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Message with syntax error
 Client: RUN "This will cause a syntax error" {}
@@ -249,9 +252,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 
 # We explicitly create a transaction
@@ -354,9 +358,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Running a read-only statement will not return any statistics
 Client: RUN "RETURN 1 AS num" {}
@@ -436,9 +441,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Explaining the query will not execute it, so it returns an empty result and the query plan
 Client: RUN "EXPLAIN RETURN 1 AS num" {}
@@ -617,9 +623,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 B1 70  A0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Sending a statement that would result in notifications
 Client: RUN "EXPLAIN MATCH (n), (m) RETURN n, m" {}
@@ -776,9 +783,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS {}
+Server: SUCCESS { "neo4j_version": "3.1.0" }
 
-  00 03 b1 70  a0 00 00
+  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
+  69 6F 6E 85  33 2E 31 2E  30 00 00
 
 # Batch of messages
 Client: RUN "RETURN 1 AS num" {}

--- a/manual/bolt/src/docs/dev/examples.asciidoc
+++ b/manual/bolt/src/docs/dev/examples.asciidoc
@@ -24,10 +24,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 Client: RUN "RETURN 1 AS num" {}
 
@@ -80,10 +80,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Batch of messages
 Client: RUN "RETURN 1 AS num" {}
@@ -161,10 +161,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Message with syntax error
 Client: RUN "This will cause a syntax error" {}
@@ -252,10 +252,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 
 # We explicitly create a transaction
@@ -358,10 +358,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Running a read-only statement will not return any statistics
 Client: RUN "RETURN 1 AS num" {}
@@ -441,10 +441,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Explaining the query will not execute it, so it returns an empty result and the query plan
 Client: RUN "EXPLAIN RETURN 1 AS num" {}
@@ -623,10 +623,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Sending a statement that would result in notifications
 Client: RUN "EXPLAIN MATCH (n), (m) RETURN n, m" {}
@@ -783,10 +783,10 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
   63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
   65 74 00 00
 
-Server: SUCCESS { "neo4j_version": "3.1.0" }
+Server: SUCCESS { "server": "Neo4j/3.1.0" }
 
-  00 17 B1 70  A1 8D 6E 65  6F 34 6A 5F  76 65 72 73
-  69 6F 6E 85  33 2E 31 2E  30 00 00
+  00 16 B1 70  A1 86 73 65  72 76 65 72  8B 4E 65 6F
+  34 6A 2F 33  2E 31 2E 30  00 00
 
 # Batch of messages
 Client: RUN "RETURN 1 AS num" {}

--- a/manual/bolt/src/test/java/org/neo4j/bolt/v1/docs/BoltFullExchangesDocTest.java
+++ b/manual/bolt/src/test/java/org/neo4j/bolt/v1/docs/BoltFullExchangesDocTest.java
@@ -62,7 +62,7 @@ import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.receiveO
 public class BoltFullExchangesDocTest
 {
     private static final long DEFAULT_TIME = 12L;
-    private static final String VERSION = "3.1.0";
+    private static final String VERSION = "Neo4j/3.1.0";
 
     @Rule
     public Neo4jWithSocket server = new Neo4jWithSocket( settings -> {
@@ -213,9 +213,9 @@ public class BoltFullExchangesDocTest
             {
                 meta.put( "result_consumed_after", DEFAULT_TIME );
             }
-            if ( meta.containsKey( "neo4j_version" ) )
+            if ( meta.containsKey( "server" ) )
             {
-                meta.put( "neo4j_version", VERSION );
+                meta.put( "server", VERSION );
             }
 
             return new SuccessMessage( meta );

--- a/manual/bolt/src/test/java/org/neo4j/bolt/v1/docs/BoltFullExchangesDocTest.java
+++ b/manual/bolt/src/test/java/org/neo4j/bolt/v1/docs/BoltFullExchangesDocTest.java
@@ -61,7 +61,9 @@ import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.receiveO
 @RunWith( Parameterized.class )
 public class BoltFullExchangesDocTest
 {
-    private  static final long DEFAULT_TIME = 12L;
+    private static final long DEFAULT_TIME = 12L;
+    private static final String VERSION = "3.1.0";
+
     @Rule
     public Neo4jWithSocket server = new Neo4jWithSocket( settings -> {
         settings.put( GraphDatabaseSettings.auth_enabled, "true" );
@@ -210,6 +212,10 @@ public class BoltFullExchangesDocTest
             if ( meta.containsKey( "result_consumed_after" ) )
             {
                 meta.put( "result_consumed_after", DEFAULT_TIME );
+            }
+            if ( meta.containsKey( "neo4j_version" ) )
+            {
+                meta.put( "neo4j_version", VERSION );
             }
 
             return new SuccessMessage( meta );


### PR DESCRIPTION
In order for clients to be able to figure out the version of Neo4j it is
connected to we now include the version in the metadata returned with INIT.

Fixes #7493
