### PR TITLE
Using generic dependency resolution mechanics to resolve GraphDatabaseQueryService.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -23,6 +23,16 @@ import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.bouncycastle.operator.OperatorCreationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
 import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.bolt.security.auth.BasicAuthentication;
 import org.neo4j.bolt.security.ssl.Certificates;
@@ -33,11 +43,11 @@ import org.neo4j.bolt.transport.Netty4LogBridge;
 import org.neo4j.bolt.transport.NettyServer;
 import org.neo4j.bolt.transport.NettyServer.ProtocolInitializer;
 import org.neo4j.bolt.transport.SocketTransport;
+import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.LifecycleManagedBoltFactory;
 import org.neo4j.bolt.v1.runtime.MonitoredWorkerFactory;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
-import org.neo4j.bolt.v1.runtime.BoltFactory;
-import org.neo4j.bolt.v1.runtime.LifecycleManagedBoltFactory;
 import org.neo4j.bolt.v1.runtime.concurrent.ThreadedWorkerFactory;
 import org.neo4j.bolt.v1.transport.BoltProtocolV1;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -65,20 +75,13 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 import org.neo4j.udc.UsageData;
 
-import java.io.File;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.time.Clock;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
 import static org.neo4j.kernel.configuration.GroupSettingSupport.enumerate;
-import static org.neo4j.kernel.configuration.Settings.*;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.derivedSetting;
+import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.boltNetworkIO;
 
 /**
@@ -153,7 +156,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         BoltFactory boltConnectionManagerFactory = life.add(
                 new LifecycleManagedBoltFactory( api, dependencies.usageData(), logService, dependencies.txBridge(),
-                        authentication, dependencies.dataSource(), dependencies.sessionTracker() ) );
+                        authentication, dependencies.sessionTracker() ) );
         ThreadedWorkerFactory threadedSessions = new ThreadedWorkerFactory( boltConnectionManagerFactory, scheduler, logService );
         WorkerFactory workerFactory = new MonitoredWorkerFactory( dependencies.monitors(), threadedSessions, Clock.systemUTC() );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.bolt.v1.runtime.integration;
 
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -26,10 +30,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
-
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.bolt.security.auth.BasicAuthentication;
@@ -39,7 +39,6 @@ import org.neo4j.bolt.v1.transport.integration.Neo4jWithSocket;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
@@ -77,8 +76,7 @@ class SessionRule implements TestRule
                         resolver.resolveDependency( AuthManager.class ), logService );
                 boltFactory = new LifecycleManagedBoltFactory( gdb, new UsageData( null ), logService,
                                 resolver.resolveDependency( ThreadToStatementContextBridge.class ),
-                                authentication, resolver.resolveDependency( NeoStoreDataSource.class ),
-                                BoltConnectionTracker.NOOP );
+                                authentication, BoltConnectionTracker.NOOP );
                 boltFactory.start();
                 try
                 {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/CypherEngineProvider.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/CypherEngineProvider.java
@@ -20,11 +20,13 @@
 package org.neo4j.cypher.internal.javacompat;
 
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 @Service.Implementation(QueryEngineProvider.class)
 public class CypherEngineProvider extends QueryEngineProvider
@@ -35,9 +37,13 @@ public class CypherEngineProvider extends QueryEngineProvider
     }
 
     @Override
-    protected QueryExecutionEngine createEngine( GraphDatabaseAPI graphAPI )
+    protected QueryExecutionEngine createEngine( Dependencies deps, GraphDatabaseAPI graphAPI )
     {
-        LogService logService = graphAPI.getDependencyResolver().resolveDependency( LogService.class );
-        return new ExecutionEngine( new GraphDatabaseCypherService( graphAPI ), logService.getInternalLogProvider() );
+        GraphDatabaseCypherService queryService = new GraphDatabaseCypherService( graphAPI );
+        deps.satisfyDependency( queryService );
+
+        DependencyResolver resolver = graphAPI.getDependencyResolver();
+        LogService logService = resolver.resolveDependency( LogService.class );
+        return new ExecutionEngine( queryService, logService.getInternalLogProvider() );
     }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ExecutionEngine.java
@@ -51,12 +51,6 @@ public class ExecutionEngine implements QueryExecutionEngine
     }
 
     @Override
-    public GraphDatabaseQueryService queryService()
-    {
-        return inner.queryService();
-    }
-
-    @Override
     public Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession ) throws
             QueryExecutionKernelException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -139,7 +139,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     @Override
     public GraphDatabaseQueryService queryService()
     {
-        return dataSource.queryExecutor.get().queryService();
+        return platform.dependencies.resolveDependency( GraphDatabaseQueryService.class );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -230,10 +230,8 @@ public class DataSourceModule
             {
                 if ( engine == null )
                 {
-                    engine = QueryEngineProvider.initialize( platformModule.graphDatabaseFacade,
+                    engine = QueryEngineProvider.initialize( deps, platformModule.graphDatabaseFacade,
                             dependencies.executionEngines() );
-
-                    deps.satisfyDependency( engine );
                 }
 
                 queryExecutor.set( engine );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -186,7 +186,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
     @Override
     public GraphDatabaseQueryService queryService()
     {
-        return queryExecutor.get().queryService();
+        return resolver.resolveDependency( GraphDatabaseQueryService.class );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/NoQueryEngine.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.query;
 import java.util.Map;
 
 import org.neo4j.graphdb.Result;
-import org.neo4j.kernel.GraphDatabaseQueryService;
 
 enum NoQueryEngine implements QueryExecutionEngine
 {
@@ -48,12 +47,6 @@ enum NoQueryEngine implements QueryExecutionEngine
 
     @Override
     public boolean isPeriodicCommit( String query )
-    {
-        throw noQueryEngine();
-    }
-
-    @Override
-    public GraphDatabaseQueryService queryService()
     {
         throw noQueryEngine();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryEngineProvider.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.query;
 
 import org.neo4j.helpers.Service;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import static java.lang.String.format;
@@ -31,9 +32,10 @@ public abstract class QueryEngineProvider extends Service
         super( name );
     }
 
-    protected abstract QueryExecutionEngine createEngine( GraphDatabaseAPI graphAPI );
+    protected abstract QueryExecutionEngine createEngine( Dependencies deps, GraphDatabaseAPI graphAPI );
 
-    public static QueryExecutionEngine initialize( GraphDatabaseAPI graphAPI, Iterable<QueryEngineProvider> providers )
+    public static QueryExecutionEngine initialize( Dependencies deps, GraphDatabaseAPI graphAPI,
+            Iterable<QueryEngineProvider> providers )
     {
         QueryEngineProvider provider = null;
         for ( QueryEngineProvider candidate : providers )
@@ -49,9 +51,10 @@ public abstract class QueryEngineProvider extends Service
         }
         if ( provider == null )
         {
-            return NoQueryEngine.INSTANCE;
+            return noEngine();
         }
-        return provider.createEngine( graphAPI );
+        QueryExecutionEngine engine = provider.createEngine( deps, graphAPI );
+        return deps.satisfyDependency( engine );
     }
 
     public static QueryExecutionEngine noEngine()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/QueryExecutionEngine.java
@@ -22,12 +22,9 @@ package org.neo4j.kernel.impl.query;
 import java.util.Map;
 
 import org.neo4j.graphdb.Result;
-import org.neo4j.kernel.GraphDatabaseQueryService;
 
 public interface QueryExecutionEngine
 {
-    GraphDatabaseQueryService queryService();
-
     Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession ) throws QueryExecutionKernelException;
 
     Result profileQuery( String query, Map<String, Object> parameters, QuerySession querySession) throws QueryExecutionKernelException;

--- a/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
@@ -22,9 +22,10 @@ package org.neo4j.server.database;
 import javax.servlet.http.HttpServletRequest;
 
 import org.neo4j.cypher.internal.javacompat.ExecutionEngine;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.GraphDatabaseQueryService;
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker;
@@ -57,9 +58,9 @@ public class CypherExecutor extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        this.executionEngine = (ExecutionEngine) database.getGraph().getDependencyResolver()
-                .resolveDependency( QueryExecutionEngine.class );
-        this.service = executionEngine.queryService();
+        DependencyResolver dependencyResolver = database.getGraph().getDependencyResolver();
+        this.executionEngine = (ExecutionEngine) dependencyResolver.resolveDependency( QueryExecutionEngine.class );
+        this.service = dependencyResolver.resolveDependency( GraphDatabaseQueryService.class );
         this.txBridge = service.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
     }
 

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 
+import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.logging.LogProvider;
@@ -55,12 +56,14 @@ public class TransactionFacade
     private final QueryExecutionEngine engine;
     private final TransactionRegistry registry;
     private final LogProvider logProvider;
+    private GraphDatabaseQueryService queryService;
 
     public TransactionFacade( TransitionalPeriodTransactionMessContainer kernel, QueryExecutionEngine engine,
-                              TransactionRegistry registry, LogProvider logProvider )
+            GraphDatabaseQueryService queryService, TransactionRegistry registry, LogProvider logProvider )
     {
         this.kernel = kernel;
         this.engine = engine;
+        this.queryService = queryService;
         this.registry = registry;
         this.logProvider = logProvider;
     }
@@ -68,7 +71,7 @@ public class TransactionFacade
     public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme, boolean implicitTransaction, AccessMode mode )
             throws TransactionLifecycleException
     {
-        return new TransactionHandle( kernel, engine, registry, uriScheme, implicitTransaction, mode, logProvider );
+        return new TransactionHandle( kernel, engine, queryService, registry, uriScheme, implicitTransaction, mode, logProvider );
     }
 
     public TransactionHandle findTransactionHandle( long txId ) throws TransactionLifecycleException

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -30,6 +30,7 @@ import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction.Type;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -76,13 +77,15 @@ public class TransactionHandle implements TransactionTerminationHandle
     private final Log log;
     private final long id;
     private TransitionalTxManagementKernelTransaction context;
+    private GraphDatabaseQueryService queryService;
 
     TransactionHandle( TransitionalPeriodTransactionMessContainer txManagerFacade, QueryExecutionEngine engine,
-            TransactionRegistry registry, TransactionUriScheme uriScheme, boolean implicitTransaction, AccessMode mode,
-            LogProvider logProvider )
+            GraphDatabaseQueryService queryService, TransactionRegistry registry, TransactionUriScheme uriScheme,
+            boolean implicitTransaction, AccessMode mode, LogProvider logProvider )
     {
         this.txManagerFacade = txManagerFacade;
         this.engine = engine;
+        this.queryService = queryService;
         this.registry = registry;
         this.uriScheme = uriScheme;
         this.type = implicitTransaction ? Type.implicit : Type.explicit;
@@ -311,7 +314,7 @@ public class TransactionHandle implements TransactionTerminationHandle
                     }
 
                     hasPrevious = true;
-                    QuerySession querySession = txManagerFacade.create( engine.queryService(), type, mode, request );
+                    QuerySession querySession = txManagerFacade.create( queryService, type, mode, request );
                     Result result = safelyExecute( statement, hasPeriodicCommit, querySession );
                     output.statementResult( result, statement.includeStats(), statement.resultDataContents() );
                     output.notifications( result.getNotifications() );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import javax.servlet.http.HttpServletRequest;
 
 import org.neo4j.helpers.Clock;
+import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.logging.NullLogProvider;
@@ -47,9 +48,10 @@ public class ConcurrentTransactionAccessTest
         TransactionRegistry registry =
                 new TransactionHandleRegistry( mock( Clock.class), 0, NullLogProvider.getInstance() );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
         when(kernel.newTransaction( any( KernelTransaction.Type.class ), any( AccessMode.class ) ) )
                 .thenReturn( mock(TransitionalTxManagementKernelTransaction.class) );
-        TransactionFacade actions = new TransactionFacade( kernel, null, registry, NullLogProvider.getInstance() );
+        TransactionFacade actions = new TransactionFacade( kernel, null, queryService, registry, NullLogProvider.getInstance() );
 
         final TransactionHandle transactionHandle = actions.newTransactionHandle( new DisgustingUriScheme(), true, AccessMode.Static.FULL );
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -85,8 +85,7 @@ public class TransactionHandleTest
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -122,8 +121,7 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -158,8 +156,7 @@ public class TransactionHandleTest
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
                 any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         handle.execute( statements( new Statement( "query", map(), false, (ResultDataContent[]) null ) ), output,
@@ -207,8 +204,7 @@ public class TransactionHandleTest
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
         Statement statement = new Statement( queryText, map(), false, (ResultDataContent[]) null );
 
@@ -243,7 +239,8 @@ public class TransactionHandleTest
         Result result = mock( Result.class );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( result );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, engine, registry, uriScheme, false, FULL,
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, false, FULL,
                 NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
@@ -273,8 +270,9 @@ public class TransactionHandleTest
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, mock( QueryExecutionEngine.class ), registry,
-                uriScheme, true, FULL, NullLogProvider.getInstance() );
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( kernel, mock( QueryExecutionEngine.class ), queryService,
+                registry, uriScheme, true, FULL, NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -307,7 +305,8 @@ public class TransactionHandleTest
                 any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, engine, registry, uriScheme, true, FULL,
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, true, FULL,
                 NullLogProvider.getInstance() );
 
         // then
@@ -346,8 +345,7 @@ public class TransactionHandleTest
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenThrow( new NullPointerException() );
 
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -386,8 +384,8 @@ public class TransactionHandleTest
                 any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle =
-                new TransactionHandle( kernel, engine, registry, uriScheme, false, FULL, logProvider );
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( kernel, engine, queryService, registry, uriScheme, false, FULL, logProvider );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -421,7 +419,8 @@ public class TransactionHandleTest
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, false, FULL,
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, queryService, registry, uriScheme, false, FULL,
                 NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
@@ -448,7 +447,8 @@ public class TransactionHandleTest
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
-        TransactionHandle handle = new TransactionHandle( mockKernel(), executionEngine, registry, uriScheme, false, FULL,
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        TransactionHandle handle = new TransactionHandle( mockKernel(), executionEngine, queryService, registry, uriScheme, false, FULL,
                 NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
@@ -475,8 +475,7 @@ public class TransactionHandleTest
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
 
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
         Statement statement = new Statement( "MATCH (n) RETURN n", map(), false, (ResultDataContent[]) null );
@@ -498,8 +497,9 @@ public class TransactionHandleTest
         when( executionEngine.executeQuery( anyString(), anyMap(), any( QuerySession.class ) ) )
                 .thenThrow( new DeadlockDetectedException( "deadlock" ) );
 
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
         TransactionHandle handle = new TransactionHandle( mockKernel(), executionEngine,
-                mock( TransactionRegistry.class ), uriScheme, true, FULL, NullLogProvider.getInstance() );
+                queryService, mock( TransactionRegistry.class ), uriScheme, true, FULL, NullLogProvider.getInstance() );
 
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
@@ -509,6 +509,14 @@ public class TransactionHandleTest
 
         // then
         verify( output ).errors( argThat( hasErrors( Status.Transaction.DeadlockDetected ) ) );
+    }
+
+    private TransactionHandle getTransactionHandle( TransitionalPeriodTransactionMessContainer kernel,
+            QueryExecutionEngine executionEngine, TransactionRegistry registry )
+    {
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        return new TransactionHandle( kernel, executionEngine, queryService, registry, uriScheme, true, FULL,
+                NullLogProvider.getInstance() );
     }
 
     private static final TransactionUriScheme uriScheme = new TransactionUriScheme()

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
@@ -24,6 +24,7 @@ import java.rmi.RemoteException;
 import java.text.MessageFormat;
 import java.util.Map;
 
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.GraphDatabaseQueryService;
@@ -172,9 +173,14 @@ public class Start extends TransactionProvidingApp
     {
         if ( this.engine == null )
         {
-            this.engine = getServer().getDb().getDependencyResolver().resolveDependency( QueryExecutionEngine.class );
+            this.engine = getDependencyResolver().resolveDependency( QueryExecutionEngine.class );
         }
         return this.engine;
+    }
+
+    private DependencyResolver getDependencyResolver()
+    {
+        return getServer().getDb().getDependencyResolver();
     }
 
     protected long now()
@@ -184,10 +190,10 @@ public class Start extends TransactionProvidingApp
 
     private QuerySession shellSession( Session session )
     {
-        GraphDatabaseQueryService graph = this.engine.queryService();
+        DependencyResolver dependencyResolver = getDependencyResolver();
+        GraphDatabaseQueryService graph = dependencyResolver.resolveDependency( GraphDatabaseQueryService.class );
         InternalTransaction transaction = graph.beginTransaction( KernelTransaction.Type.implicit, AccessMode.Static.FULL );
-        Statement statement =
-                graph.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get();
+        Statement statement = dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ).get();
         Neo4jTransactionalContext context =
                 new Neo4jTransactionalContext( graph, transaction, statement, new PropertyContainerLocker() );
         return new ShellQuerySession( session, context );


### PR DESCRIPTION
Use dependency resolver to resolve GraphDatabaseQueryService instances instead of using QueryExecutionEngine for that.
Remove `queryService` method from QueryExecutionEngine interface.
