### PR TITLE
Story copy server and client write through page cache when possible

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -81,6 +81,7 @@ import org.neo4j.kernel.impl.locking.ReentrantLockService;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -802,7 +803,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         kernel.registerTransactionHook( transactionEventHandlers );
 
         final NeoStoreFileListing fileListing = new NeoStoreFileListing( storeDir, labelScanStore, indexingService,
-                legacyIndexProviderLookup );
+                legacyIndexProviderLookup, storageEngine );
 
         return new KernelModule()
         {
@@ -949,7 +950,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         return kernelModule.kernelAPI();
     }
 
-    public ResourceIterator<File> listStoreFiles( boolean includeLogs ) throws IOException
+    public ResourceIterator<StoreFileMetadata> listStoreFiles( boolean includeLogs ) throws IOException
     {
         return kernelModule.fileListing().listStoreFiles( includeLogs );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -533,7 +533,6 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
         files.add( countStoreFileMetadata );
     }
 
-
     /**
      * @return the underlying {@link NeoStores} which should <strong>ONLY</strong> be accessed by tests
      * until all tests are properly converted to not rely on access to {@link NeoStores}. Currently there

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
@@ -69,15 +70,20 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.DefaultIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.transaction.command.CacheInvalidationBatchTransactionApplier;
 import org.neo4j.kernel.impl.transaction.command.HighIdBatchTransactionApplier;
 import org.neo4j.kernel.impl.transaction.command.IndexBatchTransactionApplier;
@@ -496,6 +502,37 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     {
         neoStores.deleteIdGenerators();
     }
+
+    @Override
+    public Collection<StoreFileMetadata> listStorageFiles()
+    {
+        List<StoreFileMetadata> files = new ArrayList<>();
+        for ( StoreType type : StoreType.values() )
+        {
+            if ( type.equals( StoreType.COUNTS ) )
+            {
+                addCurrentCountStoreFile( files );
+            }
+            else
+            {
+                final RecordStore<AbstractBaseRecord> recordStore = neoStores.getRecordStore( type );
+                StoreFileMetadata metadata =
+                        new StoreFileMetadata( recordStore.getStorageFileName(), Optional.of( type ),
+                                recordStore.getRecordSize() );
+                files.add( metadata );
+            }
+        }
+        return files;
+    }
+
+    private void addCurrentCountStoreFile( List<StoreFileMetadata> files )
+    {
+        File countStoreFile = neoStores.getCounts().currentFile();
+        StoreFileMetadata countStoreFileMetadata = new StoreFileMetadata( countStoreFile,
+                Optional.of( StoreType.COUNTS ), RecordFormat.NO_RECORD_SIZE );
+        files.add( countStoreFileMetadata );
+    }
+
 
     /**
      * @return the underlying {@link NeoStores} which should <strong>ONLY</strong> be accessed by tests

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
@@ -227,15 +228,34 @@ public enum StoreType
      */
     public static StoreType typeOf( String storeFileName )
     {
+        final Optional<StoreType> optional = isStoreType( storeFileName );
+        if ( optional.isPresent() )
+        {
+            return optional.get();
+        }
+        else
+        {
+            throw new IllegalArgumentException( "No enum constant for " + storeFileName + " file." );
+        }
+    }
+
+    /**
+     * Determine if a file name corresponds to any store type.
+     *
+     * @param fileName - name of the file to check for corresponding store type
+     * @return {@link Optional} wrapping store type, or empty optional if no store type corresponds to file name
+     */
+    public static Optional<StoreType> isStoreType( String fileName )
+    {
         StoreType[] values = StoreType.values();
         for ( StoreType value : values )
         {
-            if ( value.getStoreName().equals( storeFileName ) ||
-                    storeFileName.equals( MetaDataStore.DEFAULT_NAME + value.getStoreName() ) )
+            if ( value.getStoreName().equals( fileName ) ||
+                 fileName.equals( MetaDataStore.DEFAULT_NAME + value.getStoreName() ) )
             {
-                return value;
+                return Optional.of( value );
             }
         }
-        throw new IllegalArgumentException( "No enum constant for " + storeFileName + " file." );
+        return Optional.empty();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
@@ -229,14 +229,8 @@ public enum StoreType
     public static StoreType typeOf( String storeFileName )
     {
         final Optional<StoreType> optional = isStoreType( storeFileName );
-        if ( optional.isPresent() )
-        {
-            return optional.get();
-        }
-        else
-        {
-            throw new IllegalArgumentException( "No enum constant for " + storeFileName + " file." );
-        }
+        return optional.orElseThrow(
+                () -> new IllegalArgumentException( "No enum constant for " + storeFileName + " file." ) );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
@@ -37,6 +37,8 @@ import org.neo4j.kernel.impl.store.record.RecordLoad;
  */
 public interface RecordFormat<RECORD extends AbstractBaseRecord>
 {
+    int NO_RECORD_SIZE = 1;
+
     /**
      * Instantiates a new record to use in {@link #read(AbstractBaseRecord, PageCursor, RecordLoad, int)}
      * and {@link #write(AbstractBaseRecord, PageCursor, int)}. Records may be reused, which is why the instantiation

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
@@ -40,7 +40,7 @@ public class NoRecordFormat<RECORD extends AbstractBaseRecord> implements Record
     @Override
     public int getRecordSize( StoreHeader storeHeader )
     {
-        return 1;
+        return NO_RECORD_SIZE;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -21,10 +21,14 @@ package org.neo4j.kernel.impl.store.kvstore;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.locking.LockWrapper;
@@ -143,6 +147,13 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
     public final File currentFile()
     {
         return state.file();
+    }
+
+    public final Collection<File> allFiles()
+    {
+        List<File> countStoreFiles = new ArrayList<>();
+        Iterables.addToCollection( rotationStrategy.candidateFiles(), countStoreFiles );
+        return countStoreFiles;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -23,17 +23,20 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.neo4j.graphdb.Resource;
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
-import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
+import org.neo4j.storageengine.api.StorageEngine;
 
 import static java.util.Arrays.asList;
 import static org.neo4j.helpers.collection.Iterators.resourceIterator;
@@ -44,20 +47,28 @@ public class NeoStoreFileListing
     private final LabelScanStore labelScanStore;
     private final IndexingService indexingService;
     private final LegacyIndexProviderLookup legacyIndexProviders;
+    private final StorageEngine storageEngine;
+    private final Function<File,StoreFileMetadata> toNotAStoreTypeFile =
+            file -> new StoreFileMetadata( file, Optional.empty(), RecordFormat.NO_RECORD_SIZE );
 
-    public NeoStoreFileListing( File storeDir, LabelScanStore labelScanStore,
-            IndexingService indexingService, LegacyIndexProviderLookup legacyIndexProviders )
+    public NeoStoreFileListing( File storeDir, LabelScanStore labelScanStore, IndexingService indexingService,
+            LegacyIndexProviderLookup legacyIndexProviders, StorageEngine storageEngine )
     {
         this.storeDir = storeDir;
         this.labelScanStore = labelScanStore;
         this.indexingService = indexingService;
         this.legacyIndexProviders = legacyIndexProviders;
+        this.storageEngine = storageEngine;
     }
 
-    public ResourceIterator<File> listStoreFiles( boolean includeLogs ) throws IOException
+    public ResourceIterator<StoreFileMetadata> listStoreFiles( boolean includeLogs ) throws IOException
     {
-        Collection<File> files = new ArrayList<>();
-        gatherNeoStoreFiles( files, includeLogs );
+        Collection<StoreFileMetadata> files = new ArrayList<>();
+        gatherNeoStoreFiles( files );
+        if ( includeLogs )
+        {
+            gatherTransactionLogFiles( files );
+        }
         Resource labelScanStoreSnapshot = gatherLabelScanStoreFiles( files );
         Resource schemaIndexSnapshots = gatherSchemaIndexFiles( files );
         Resource legacyIndexSnapshots = gatherLegacyIndexFiles( files );
@@ -66,77 +77,52 @@ public class NeoStoreFileListing
                 new MultiResource( asList( labelScanStoreSnapshot, schemaIndexSnapshots, legacyIndexSnapshots ) ) );
     }
 
-    private Resource gatherLegacyIndexFiles( Collection<File> files ) throws IOException
+    private void gatherTransactionLogFiles( Collection<StoreFileMetadata> files )
+    {
+        for ( File file : storeDir.listFiles() )
+        {
+            if ( file != null && transactionLogFile( file.getName() ) )
+            {
+                files.add( toNotAStoreTypeFile.apply( file ) );
+            }
+        }
+    }
+
+    private Resource gatherLegacyIndexFiles( Collection<StoreFileMetadata> files ) throws IOException
     {
         final Collection<ResourceIterator<File>> snapshots = new ArrayList<>();
         for ( IndexImplementation indexProvider : legacyIndexProviders.all() )
         {
             ResourceIterator<File> snapshot = indexProvider.listStoreFiles();
             snapshots.add( snapshot );
-            Iterators.addToCollection( snapshot, files );
+            snapshot.stream().map( toNotAStoreTypeFile ).collect( Collectors.toCollection( () -> files ) );
         }
         // Intentionally don't close the snapshot here, return it for closing by the consumer of
         // the targetFiles list.
         return new MultiResource( snapshots );
     }
 
-    private Resource gatherSchemaIndexFiles(Collection<File> targetFiles) throws IOException
+    private Resource gatherSchemaIndexFiles( Collection<StoreFileMetadata> targetFiles ) throws IOException
     {
         ResourceIterator<File> snapshot = indexingService.snapshotStoreFiles();
-        Iterators.addToCollection(snapshot, targetFiles);
+        snapshot.stream().map( toNotAStoreTypeFile ).collect( Collectors.toCollection( () -> targetFiles ) );
         // Intentionally don't close the snapshot here, return it for closing by the consumer of
         // the targetFiles list.
         return snapshot;
     }
 
-    private Resource gatherLabelScanStoreFiles( Collection<File> targetFiles ) throws IOException
+    private Resource gatherLabelScanStoreFiles( Collection<StoreFileMetadata> targetFiles ) throws IOException
     {
         ResourceIterator<File> snapshot = labelScanStore.snapshotStoreFiles();
-        Iterators.addToCollection(snapshot, targetFiles);
+        snapshot.stream().map( toNotAStoreTypeFile ).collect( Collectors.toCollection( () -> targetFiles ) );
         // Intentionally don't close the snapshot here, return it for closing by the consumer of
         // the targetFiles list.
         return snapshot;
     }
 
-    private void gatherNeoStoreFiles( final Collection<File> targetFiles, boolean includeTransactionLogs )
+    private void gatherNeoStoreFiles( final Collection<StoreFileMetadata> targetFiles )
     {
-        File neostoreFile = null;
-        for ( File dbFile : Objects.requireNonNull( storeDir.listFiles() ) )
-        {
-            String name = dbFile.getName();
-            if ( dbFile.isFile() )
-            {
-                if ( name.equals( MetaDataStore.DEFAULT_NAME ) )
-                {   // Keep it, to add last
-                    neostoreFile = dbFile;
-                }
-                else if ( neoStoreFile( name ) )
-                {
-                    targetFiles.add( dbFile );
-                }
-                else if ( includeTransactionLogs && transactionLogFile( name ) )
-                {
-                    targetFiles.add( dbFile );
-                }
-            }
-        }
-        targetFiles.add( neostoreFile );
-    }
-
-    private boolean neoStoreFile( String name )
-    {
-        if ( name.endsWith( ".id" ) )
-        {
-            return false;
-        }
-
-        if ( name.equals( IndexConfigStore.INDEX_DB_FILE_NAME ) )
-        {
-            return true;
-        }
-
-        return name.startsWith( MetaDataStore.DEFAULT_NAME ) &&
-                !name.startsWith( MetaDataStore.DEFAULT_NAME + ".transaction" );
+        targetFiles.addAll( storageEngine.listStorageFiles() );
     }
 
     private boolean transactionLogFile( String name )

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -116,6 +116,12 @@ public interface StorageEngine
      */
     void prepareForRecoveryRequired();
 
+    /**
+     * @return a {@link Collection<StoreFileMetadata>} containing metadata about all store files managed by this
+     * {@link StorageEngine}.
+     */
+    Collection<StoreFileMetadata> listStorageFiles();
+
     // ====================================================================
     // All these methods below are temporary while in the process of
     // creating this API, take little notice to them, as they will go away

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -117,7 +117,7 @@ public interface StorageEngine
     void prepareForRecoveryRequired();
 
     /**
-     * @return a {@link Collection<StoreFileMetadata>} containing metadata about all store files managed by this
+     * @return a {@link Collection} of {@link StoreFileMetadata} containing metadata about all store files managed by this
      * {@link StorageEngine}.
      */
     Collection<StoreFileMetadata> listStorageFiles();

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
@@ -1,0 +1,35 @@
+package org.neo4j.storageengine.api;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.neo4j.kernel.impl.store.StoreType;
+
+public class StoreFileMetadata
+{
+    private final File file;
+    private final Optional<StoreType> storeType;
+    private final int recordSize;
+
+    public StoreFileMetadata( File file, Optional<StoreType> storeType, int recordSize )
+    {
+        this.file = file;
+        this.storeType = storeType;
+        this.recordSize = recordSize;
+    }
+
+    public File file()
+    {
+        return file;
+    }
+
+    public Optional<StoreType> storeType()
+    {
+        return storeType;
+    }
+
+    public int recordSize()
+    {
+        return recordSize;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.storageengine.api;
 
 import java.io.File;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -20,238 +20,120 @@
 package org.neo4j.kernel.impl.transaction.state;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.storemigration.StoreFile;
+import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
-import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
+import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.storageengine.api.StoreFileMetadata;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
-import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class NeoStoreFileListingTest
 {
-    private LabelScanStore labelScanStore;
-    private IndexingService indexingService;
-    private File storeDir;
-    private LegacyIndexProviderLookup legacyIndexes;
-
-    private static final String[] STANDARD_STORE_DIR_FILES = new String[]{
-            "lock",
-            "debug.log",
-            "neostore",
-            "neostore.id",
-            "neostore.counts.db.a",
-            "neostore.counts.db.b",
-            "neostore.labeltokenstore.db",
-            "neostore.labeltokenstore.db.id",
-            "neostore.labeltokenstore.db.names",
-            "neostore.labeltokenstore.db.names.id",
-            "neostore.nodestore.db",
-            "neostore.nodestore.db.id",
-            "neostore.nodestore.db.labels",
-            "neostore.nodestore.db.labels.id",
-            "neostore.propertystore.db",
-            "neostore.propertystore.db.arrays",
-            "neostore.propertystore.db.arrays.id",
-            "neostore.propertystore.db.id",
-            "neostore.propertystore.db.index",
-            "neostore.propertystore.db.index.id",
-            "neostore.propertystore.db.index.keys",
-            "neostore.propertystore.db.index.keys.id",
-            "neostore.propertystore.db.strings",
-            "neostore.propertystore.db.strings.id",
-            "neostore.relationshipstore.db",
-            "neostore.relationshipstore.db.id",
-            "neostore.relationshiptypestore.db",
-            "neostore.relationshiptypestore.db.id",
-            "neostore.relationshiptypestore.db.names",
-            "neostore.relationshiptypestore.db.names.id",
-            "neostore.schemastore.db",
-            "neostore.schemastore.db.id",
-            PhysicalLogFile.DEFAULT_NAME + ".active",
-            PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "0",
-            PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "1",
-            PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "2",
-            "store_lock"};
-
-    private static final String[] STANDARD_STORE_DIR_DIRECTORIES = new String[]{"schema", "index", "branched"};
+    @Rule
+    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( getClass() );
+    private NeoStoreDataSource neoStoreDataSource;
 
     @Before
     public void setUp() throws IOException
     {
-        labelScanStore = mock( LabelScanStore.class );
-        indexingService = mock( IndexingService.class );
-        legacyIndexes = mock( LegacyIndexProviderLookup.class );
-        when( legacyIndexes.all() ).thenReturn( Collections.<IndexImplementation>emptyList() );
-        storeDir = mock( File.class );
+        neoStoreDataSource = db.getDependencyResolver().resolveDependency( NeoStoreDataSource.class );
+    }
+
+    private Set<String> expectedStoreFiles( boolean includeLogFiles )
+    {
+        Set<String> storeFileNames = new HashSet<>();
+        for ( StoreType type : StoreType.values() )
+        {
+            if ( type.equals( StoreType.COUNTS ) )
+            {
+                // Skip
+            }
+            else
+            {
+                storeFileNames.add( type.getStoreFile().fileName( StoreFileType.STORE ) );
+            }
+        }
+        if ( includeLogFiles )
+        {
+            storeFileNames.add( PhysicalLogFile.DEFAULT_NAME + ".0" );
+        }
+        return storeFileNames;
+    }
+
+    private List<String> countStoreFiles()
+    {
+        List<String> countStoreFiles = new ArrayList<>();
+        countStoreFiles.add( StoreFile.COUNTS_STORE_LEFT.fileName( StoreFileType.STORE ) );
+        countStoreFiles.add( StoreFile.COUNTS_STORE_RIGHT.fileName( StoreFileType.STORE ) );
+        return countStoreFiles;
     }
 
     @Test
-    public void shouldOnlyListNeoStoreFiles() throws Exception
+    public void shouldNotIncludeTransactionLogFile() throws Exception
     {
-        // Given
-        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
-        scanStoreFilesAre( new String[]{} );
-        indexFilesAre( new String[]{} );
-        NeoStoreFileListing fileListing = newFileListing();
-
-        // When
-        ResourceIterator<File> result = fileListing.listStoreFiles( false );
-
-        // Then
-        assertThat( asSetOfPaths( result ), equalTo( asSet(
-                "neostore.labeltokenstore.db",
-                "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.a",
-                "neostore.counts.db.b",
-                "neostore.nodestore.db",
-                "neostore.nodestore.db.labels",
-                "neostore.propertystore.db",
-                "neostore.propertystore.db.arrays",
-                "neostore.propertystore.db.index",
-                "neostore.propertystore.db.index.keys",
-                "neostore.propertystore.db.strings",
-                "neostore.relationshipstore.db",
-                "neostore.relationshiptypestore.db",
-                "neostore.relationshiptypestore.db.names",
-                "neostore.schemastore.db",
-                "neostore" ) ) );
+        final ResourceIterator<StoreFileMetadata> storeFiles = neoStoreDataSource.listStoreFiles( false );
+        final Set<String> actual = asSetOfPaths( storeFiles );
+        final Set<String> expectedStoreFiles = expectedStoreFiles( false );
+        final List<String> countStoreFiles = countStoreFiles();
+        assertTrue( actual.containsAll( expectedStoreFiles ) );
+        assertFalse( Collections.disjoint( actual, countStoreFiles ) );
     }
 
     @Test
-    public void shouldListNeoStoreFiles() throws Exception
+    public void shouldIncludeTransactionLogFile() throws Exception
     {
-        // Given
-        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
-        scanStoreFilesAre( new String[]{} );
-        indexFilesAre( new String[]{} );
-        NeoStoreFileListing fileListing = newFileListing();
-
-        // When
-        ResourceIterator<File> result = fileListing.listStoreFiles( true );
-
-        // Then
-        Set<String> pathSet = asSetOfPaths( result );
-        assertThat( pathSet, equalTo( asSet(
-                "neostore.labeltokenstore.db",
-                "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.a",
-                "neostore.counts.db.b",
-                "neostore.nodestore.db",
-                "neostore.nodestore.db.labels",
-                "neostore.propertystore.db",
-                "neostore.propertystore.db.arrays",
-                "neostore.propertystore.db.index",
-                "neostore.propertystore.db.index.keys",
-                "neostore.propertystore.db.strings",
-                "neostore.relationshipstore.db",
-                "neostore.relationshiptypestore.db",
-                "neostore.relationshiptypestore.db.names",
-                "neostore.schemastore.db",
-                "neostore",
-                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "0",
-                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "1",
-                PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "2"
-        ) ) );
-    }
-
-    @Test
-    public void shouldListNeoStoreFilesAndLogicalLogs() throws Exception
-    {
-        // Given
-        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
-        scanStoreFilesAre( new String[]{} );
-        indexFilesAre( new String[]{} );
-        NeoStoreFileListing fileListing = newFileListing();
-
-        // When
-        ResourceIterator<File> result = fileListing.listStoreFiles( false );
-
-        // Then
-        Set<String> pathSet = asSetOfPaths( result );
-        assertThat( pathSet, equalTo( asSet(
-                "neostore.labeltokenstore.db",
-                "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.a",
-                "neostore.counts.db.b",
-                "neostore.nodestore.db",
-                "neostore.nodestore.db.labels",
-                "neostore.propertystore.db",
-                "neostore.propertystore.db.arrays",
-                "neostore.propertystore.db.index",
-                "neostore.propertystore.db.index.keys",
-                "neostore.propertystore.db.strings",
-                "neostore.relationshipstore.db",
-                "neostore.relationshiptypestore.db",
-                "neostore.relationshiptypestore.db.names",
-                "neostore.schemastore.db",
-                "neostore" ) ) );
-    }
-
-    @Test
-    public void shouldListLabelScanStoreAndSchemaIndexes() throws Exception
-    {
-        // Given
-        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
-        scanStoreFilesAre( new String[]{"blah/scan.store", "scan.more"} );
-        indexFilesAre( new String[]{"schema/index/my.index", "schema/index/their.index"} );
-        NeoStoreFileListing fileListing = newFileListing();
-
-        // When
-        ResourceIterator<File> result = fileListing.listStoreFiles( false );
-
-        // Then
-        assertThat( asSetOfPaths( result ), equalTo( asSet(
-                "blah/scan.store",
-                "scan.more",
-                "schema/index/my.index",
-                "schema/index/their.index",
-                "neostore.labeltokenstore.db",
-                "neostore.labeltokenstore.db.names",
-                "neostore.counts.db.a",
-                "neostore.counts.db.b",
-                "neostore.nodestore.db",
-                "neostore.nodestore.db.labels",
-                "neostore.propertystore.db",
-                "neostore.propertystore.db.arrays",
-                "neostore.propertystore.db.index",
-                "neostore.propertystore.db.index.keys",
-                "neostore.propertystore.db.strings",
-                "neostore.relationshipstore.db",
-                "neostore.relationshiptypestore.db",
-                "neostore.relationshiptypestore.db.names",
-                "neostore.schemastore.db",
-                "neostore" ) ) );
+        final ResourceIterator<StoreFileMetadata> storeFiles = neoStoreDataSource.listStoreFiles( true );
+        final Set<String> actual = asSetOfPaths( storeFiles );
+        final Set<String> expectedStoreFiles = expectedStoreFiles( true );
+        final List<String> countStoreFiles = countStoreFiles();
+        assertTrue( actual.containsAll( expectedStoreFiles ) );
+        assertFalse( Collections.disjoint( actual, countStoreFiles ) );
     }
 
     @Test
     public void shouldCloseIndexAndLabelScanSnapshots() throws Exception
     {
         // Given
-        filesInStoreDirAre( STANDARD_STORE_DIR_FILES, STANDARD_STORE_DIR_DIRECTORIES );
-        ResourceIterator<File> scanSnapshot = scanStoreFilesAre( new String[]{"blah/scan.store", "scan.more"} );
-        ResourceIterator<File> indexSnapshot = indexFilesAre( new String[]{"schema/index/my.index"} );
-        NeoStoreFileListing fileListing = newFileListing();
+        LabelScanStore labelScanStore = mock( LabelScanStore.class );
+        IndexingService indexingService = mock( IndexingService.class );
+        LegacyIndexProviderLookup legacyIndexes = mock( LegacyIndexProviderLookup.class );
+        when( legacyIndexes.all() ).thenReturn( Collections.emptyList() );
+        File storeDir = mock( File.class );
+        StorageEngine storageEngine = mock( StorageEngine.class );
+        NeoStoreFileListing fileListing = new NeoStoreFileListing(
+                storeDir, labelScanStore, indexingService, legacyIndexes, storageEngine );
 
-        ResourceIterator<File> result = fileListing.listStoreFiles( false );
+        ResourceIterator<File> scanSnapshot = scanStoreFilesAre( labelScanStore,
+                new String[]{"blah/scan.store", "scan.more"} );
+        ResourceIterator<File> indexSnapshot = indexFilesAre( indexingService, new String[]{"schema/index/my.index"} );
+
+        ResourceIterator<StoreFileMetadata> result = fileListing.listStoreFiles( false );
 
         // When
         result.close();
@@ -261,30 +143,27 @@ public class NeoStoreFileListingTest
         verify( indexSnapshot ).close();
     }
 
-    private NeoStoreFileListing newFileListing()
+    private String diffSet( Set<String> actual, Set<String> expected )
     {
-        return new NeoStoreFileListing( storeDir, labelScanStore, indexingService, legacyIndexes );
+        Set<String> extra = new HashSet<>( actual );
+        Set<String> missing = new HashSet<>( expected );
+        extra.removeAll( expected );
+        missing.removeAll( actual );
+        return "Extra entries: " + extra + "\nMissing entries: " + missing;
     }
 
-    private Set<String> asSetOfPaths( ResourceIterator<File> result )
+    private Set<String> asSetOfPaths( ResourceIterator<StoreFileMetadata> result )
     {
         List<String> fnames = new ArrayList<>();
         while ( result.hasNext() )
         {
-            fnames.add( result.next().getPath() );
+            fnames.add( result.next().file().getName() );
         }
         return Iterables.asUniqueSet( fnames );
     }
 
-    private void filesInStoreDirAre( String[] filenames, String[] dirs )
-    {
-        ArrayList<File> files = new ArrayList<>();
-        mockFiles( filenames, files, false );
-        mockFiles( dirs, files, true );
-        when( storeDir.listFiles() ).thenReturn( files.toArray( new File[files.size()] ) );
-    }
-
-    private ResourceIterator<File> scanStoreFilesAre( String[] fileNames ) throws IOException
+    private ResourceIterator<File> scanStoreFilesAre( LabelScanStore labelScanStore, String[] fileNames )
+            throws IOException
     {
         ArrayList<File> files = new ArrayList<>();
         mockFiles( fileNames, files, false );
@@ -293,7 +172,8 @@ public class NeoStoreFileListingTest
         return snapshot;
     }
 
-    private ResourceIterator<File> indexFilesAre( String[] fileNames ) throws IOException
+    private ResourceIterator<File> indexFilesAre( IndexingService indexingService, String[] fileNames )
+            throws IOException
     {
         ArrayList<File> files = new ArrayList<>();
         mockFiles( fileNames, files, false );

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.OsBeanUtil;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
@@ -175,7 +176,7 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
             return;
         }
 
-        try ( ResourceIterator<File> files = neoStoreDataSource.listStoreFiles( false ) )
+        try ( ResourceIterator<StoreFileMetadata> files = neoStoreDataSource.listStoreFiles( false ) )
         {
             addStoreFileSizes( udcFields, files );
         }
@@ -185,13 +186,13 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
         }
     }
 
-    private void addStoreFileSizes( Map<String,String> udcFields, ResourceIterator<File> files )
+    private void addStoreFileSizes( Map<String,String> udcFields, ResourceIterator<StoreFileMetadata> files )
     {
         long size = 0;
 
         while ( files.hasNext() )
         {
-            File file = files.next();
+            File file = files.next().file();
 
             size += file.length();
         }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -137,7 +137,7 @@ class BackupService
         }
         long timestamp = System.currentTimeMillis();
         long lastCommittedTx = -1;
-        try ( PageCache pageCache = createPageCache( fileSystem ) )
+        try ( PageCache pageCache = createPageCache( fileSystem, tuningConfiguration ) )
         {
             StoreCopyClient storeCopier = new StoreCopyClient( targetDirectory, tuningConfiguration,
                     loadKernelExtensions(), logProvider, new DefaultFileSystemAbstraction(), pageCache,

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -62,6 +63,8 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
         Supplier<LogFileInformation> logFileInformationSupplier();
 
         FileSystemAbstraction fileSystemAbstraction();
+
+        PageCache pageCache();
     }
 
     public OnlineBackupExtensionFactory()
@@ -85,6 +88,7 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
                 dependencies.transactionIdStoreSupplier(),
                 dependencies.logicalTransactionStoreSupplier(),
                 dependencies.logFileInformationSupplier(),
-                dependencies.fileSystemAbstraction());
+                dependencies.fileSystemAbstraction(),
+                dependencies.pageCache() );
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Protocol.java
@@ -19,17 +19,17 @@
  */
 package org.neo4j.com;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.handler.codec.frame.LengthFieldBasedFrameDecoder;
 import org.jboss.netty.handler.codec.frame.LengthFieldPrepender;
 import org.jboss.netty.handler.queue.BlockingReadHandler;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.helpers.collection.Visitor;
@@ -293,7 +293,9 @@ public abstract class Protocol
             {
                 String path = readString( buffer, pathLength );
                 boolean hasData = buffer.readByte() == 1;
-                writer.write( path, hasData ? new BlockLogReader( buffer ) : null, temporaryBuffer, hasData );
+                int recordSize = buffer.readInt();
+                writer.write( path, hasData ? new BlockLogReader( buffer ) : null, temporaryBuffer, hasData,
+                        recordSize );
             }
             writer.close();
             return null;

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -188,7 +188,7 @@ public class StoreCopyClient
         // Request store files and transactions that will need recovery
         monitor.startReceivingStoreFiles();
         try ( Response<?> response = requester.copyStore( decorateWithProgressIndicator(
-                new ToFileStoreWriter( tempStore, monitor ) ) ) )
+                new ToFileStoreWriter( tempStore, monitor, pageCache ) ) ) )
         {
             monitor.finishReceivingStoreFiles();
             // Update highest archived log id

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -333,10 +333,10 @@ public class StoreCopyClient
 
             @Override
             public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
-                              boolean hasData ) throws IOException
+                              boolean hasData, int recordSize ) throws IOException
             {
                 log.info( "Copying %s", path );
-                long written = actual.write( path, data, temporaryBuffer, hasData );
+                long written = actual.write( path, data, temporaryBuffer, hasData, recordSize );
                 log.info( "Copied %s %s", path, bytes( written ) );
                 totalFiles++;
                 return written;

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -162,7 +162,7 @@ public class StoreCopyServer
                     File file = files.next().file();
 
                     // Read from paged file if mapping exists. Otherwise read through file system.
-                    final Optional<PagedFile> optionalPagedFile = pageCache.tryMappedPagedFile( file );
+                    final Optional<PagedFile> optionalPagedFile = pageCache.getExistingMapping( file );
                     try ( ReadableByteChannel fileChannel = optionalPagedFile.isPresent() ?
                                                             optionalPagedFile.get().openReadableByteChannel() :
                                                             fileSystem.open( file, "r" ) )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -159,7 +159,9 @@ public class StoreCopyServer
             {
                 while ( files.hasNext() )
                 {
-                    File file = files.next().file();
+                    StoreFileMetadata meta = files.next();
+                    File file = meta.file();
+                    int recordSize = meta.recordSize();
 
                     // Read from paged file if mapping exists. Otherwise read through file system.
                     final Optional<PagedFile> optionalPagedFile = pageCache.getExistingMapping( file );
@@ -169,7 +171,7 @@ public class StoreCopyServer
                     {
                         monitor.startStreamingStoreFile( file );
                         writer.write( relativePath( storeDirectory, file ), fileChannel,
-                                temporaryBuffer, file.length() > 0 );
+                                temporaryBuffer, file.length() > 0, recordSize );
                         monitor.finishStreamingStoreFile( file );
                     }
                     finally

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -33,6 +33,7 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 
 import static org.neo4j.com.RequestContext.anonymous;
 import static org.neo4j.io.fs.FileUtils.getMostCanonicalFile;
@@ -149,11 +150,11 @@ public class StoreCopyServer
 
             // Copy the store files
             monitor.startStreamingStoreFiles();
-            try ( ResourceIterator<File> files = dataSource.listStoreFiles( includeLogs ) )
+            try ( ResourceIterator<StoreFileMetadata> files = dataSource.listStoreFiles( includeLogs ) )
             {
                 while ( files.hasNext() )
                 {
-                    File file = files.next();
+                    File file = files.next().file();
                     try ( StoreChannel fileChannel = fileSystem.open( file, "r" ) )
                     {
                         monitor.startStreamingStoreFile( file );

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreWriter.java
@@ -29,7 +29,7 @@ public interface StoreWriter extends Closeable
     // "hasData" is an effect of the block format not supporting a zero length block
     // whereas a neostore file may actually be 0 bytes we'll have to keep track
     // of that special case.
-    long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer, boolean hasData )
+    long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer, boolean hasData, int recordSize )
             throws IOException;
 
     @Override

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -49,8 +49,8 @@ public class ToFileStoreWriter implements StoreWriter
     }
 
     @Override
-    public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
-            boolean hasData ) throws IOException
+    public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer, boolean hasData,
+            int recordSize ) throws IOException
     {
         try
         {
@@ -74,7 +74,8 @@ public class ToFileStoreWriter implements StoreWriter
                 }
                 if ( storeType.isPresent() && storeType.get().isRecordStore() )
                 {
-                    try ( PagedFile pagedFile = pageCache.map( file, pageCache.pageSize(), CREATE, WRITE ) )
+                    int filePageSize = pageCache.pageSize() - pageCache.pageSize() % recordSize;
+                    try ( PagedFile pagedFile = pageCache.map( file, filePageSize, CREATE, WRITE ) )
                     {
                         return writeDataThroughPageCache( pagedFile, data, temporaryBuffer, hasData );
                     }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -56,6 +56,7 @@ public class ToFileStoreWriter implements StoreWriter
         {
             temporaryBuffer.clear();
             File file = new File( basePath, path );
+            file.getParentFile().mkdirs();
 
             String filename = file.getName();
             final Optional<StoreType> storeType = isStoreType( filename );
@@ -80,7 +81,6 @@ public class ToFileStoreWriter implements StoreWriter
                 }
                 else
                 {
-                    file.getParentFile().mkdirs();
                     return writeDataThroughFileSystem( file, data, temporaryBuffer, hasData );
                 }
             }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToNetworkStoreWriter.java
@@ -45,7 +45,7 @@ public class ToNetworkStoreWriter implements StoreWriter
 
     @Override
     public long write( String path, ReadableByteChannel data, ByteBuffer temporaryBuffer,
-            boolean hasData ) throws IOException
+            boolean hasData, int recordSize ) throws IOException
     {
         char[] chars = path.toCharArray();
         targetBuffer.writeShort( chars.length );
@@ -56,6 +56,8 @@ public class ToNetworkStoreWriter implements StoreWriter
         long totalWritten = 2 + chars.length*2 + 1;
         if ( hasData )
         {
+            targetBuffer.writeInt( recordSize );
+            totalWritten += 4;
             totalWritten += buffer.write( data );
             buffer.close();
 

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -300,12 +300,16 @@ public class StoreCopyClientTest
                     CheckPointer checkPointer =
                             original.getDependencyResolver().resolveDependency( CheckPointer.class );
 
-                    RequestContext requestContext = new StoreCopyServer( neoStoreDataSource,
-                            checkPointer, fs, originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ) )
+                    PageCache pageCache =
+                            original.getDependencyResolver().resolveDependency( PageCache.class );
+
+                    RequestContext requestContext = new StoreCopyServer( neoStoreDataSource, checkPointer, fs,
+                            originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ), pageCache )
                             .flushStoresAndStreamStoreFiles( "test", writer, false );
 
-                    final StoreId storeId = original.getDependencyResolver().resolveDependency( RecordStorageEngine.class )
-                    .testAccessNeoStores().getMetaDataStore().getStoreId();
+                    final StoreId storeId =
+                            original.getDependencyResolver().resolveDependency( RecordStorageEngine.class )
+                                    .testAccessNeoStores().getMetaDataStore().getStoreId();
 
                     ResponsePacker responsePacker = new ResponsePacker( logicalTransactionStore,
                             transactionIdStore, () -> storeId );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/GetStoreRequestHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/GetStoreRequestHandler.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.coreedge.catchup.storecopy;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.stream.ChunkedNioStream;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.function.Supplier;
-
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.stream.ChunkedNioStream;
 
 import org.neo4j.coreedge.catchup.CatchupServerProtocol;
 import org.neo4j.coreedge.catchup.ResponseMessageType;
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 
 import static org.neo4j.coreedge.catchup.CatchupServerProtocol.State;
 
@@ -65,11 +66,11 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
 
     private void sendFiles( ChannelHandlerContext ctx ) throws IOException
     {
-        try ( ResourceIterator<File> files = dataSource.get().listStoreFiles( false ) )
+        try ( ResourceIterator<StoreFileMetadata> files = dataSource.get().listStoreFiles( false ) )
         {
             while ( files.hasNext() )
             {
-                sendFile( ctx, files.next() );
+                sendFile( ctx, files.next().file() );
             }
         }
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -415,7 +415,8 @@ public class HighlyAvailableEditionModule
                         platformModule.dependencies.resolveDependency( CheckPointer.class ),
                         platformModule.dependencies.resolveDependency( TransactionIdStore.class ),
                         platformModule.dependencies.resolveDependency( LogicalTransactionStore.class ),
-                        platformModule.dependencies.resolveDependency( NeoStoreDataSource.class ));
+                        platformModule.dependencies.resolveDependency( NeoStoreDataSource.class ),
+                        platformModule.dependencies.resolveDependency( PageCache.class ) );
 
         final Factory<ConversationSPI> conversationSPIFactory =
                 () -> new DefaultConversationSPI( lockManager, platformModule.jobScheduler );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.impl.logging.StoreLogService;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.impl.util.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
@@ -198,11 +199,11 @@ public class TestBranchedData
     {
         Collection<File> result = new ArrayList<>();
         NeoStoreDataSource ds = db.getDependencyResolver().resolveDependency( NeoStoreDataSource.class );
-        try ( ResourceIterator<File> files = ds.listStoreFiles( false ) )
+        try ( ResourceIterator<StoreFileMetadata> files = ds.listStoreFiles( false ) )
         {
             while ( files.hasNext() )
             {
-                File file = files.next();
+                File file = files.next().file();
                 if ( file.getPath().contains( indexName ) )
                 {
                     result.add( file );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha.cluster;
 
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.com.storecopy.StoreWriter;
@@ -55,7 +54,7 @@ public class DefaultMasterImplSPITest
         CheckPointer checkPointer = mock( CheckPointer.class );
 
         NeoStoreDataSource dataSource = mock( NeoStoreDataSource.class );
-        when( dataSource.listStoreFiles( anyBoolean() ) ).thenReturn( Iterators.<File>emptyIterator() );
+        when( dataSource.listStoreFiles( anyBoolean() ) ).thenReturn( Iterators.emptyIterator() );
 
         DefaultMasterImplSPI master = new DefaultMasterImplSPI( mock( GraphDatabaseAPI.class, RETURNS_MOCKS ),
                 mock( FileSystemAbstraction.class ), new Monitors(), mock( LabelTokenHolder.class ),

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -61,7 +62,7 @@ public class DefaultMasterImplSPITest
                 mock( PropertyKeyTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ),
                 mock( IdGeneratorFactory.class ), mock( TransactionCommitProcess.class ), checkPointer,
                 mock( TransactionIdStore.class ), mock( LogicalTransactionStore.class ),
-                dataSource );
+                dataSource, mock( PageCache.class ) );
 
         master.flushStoresAndStreamStoreFiles( mock( StoreWriter.class ) );
 


### PR DESCRIPTION
Server
Read through paged file mapped by page cache if mapping exist, otherwise read through file system.

Client
Write through already mapped file if mapping exist or create new mapping if file to write is a store file. If file is not mapped and is not a store file then use the file system.

This is needed to support store copy for blockdevice.
