### PR TITLE
Improve query replanning default settings

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -1045,14 +1045,14 @@ order by a.COL1""")
 
     // WHEN
     eengine.execute(s"match (n:Person) return n").toList
-    planningListener.planRequests.toSeq should equal(Seq(
+    planningListener.planRequests should equal(Seq(
       s"match (n:Person) return n"
     ))
-    (0 until 150).foreach { _ => createLabeledNode("Person") }
+    (0 until 350).foreach { _ => createLabeledNode("Person") }
     eengine.execute(s"match (n:Person) return n").toList
 
     //THEN
-    planningListener.planRequests.toSeq should equal (Seq(
+    planningListener.planRequests should equal (Seq(
       s"match (n:Person) return n",
       s"match (n:Person) return n"
     ))

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -129,7 +129,7 @@ public abstract class GraphDatabaseSettings
                   "the plan is considered stale and will be replanned. " +
                   "A value of 0 means always replan, and 1 means never replan." )
     public static Setting<Double> query_statistics_divergence_threshold = setting(
-            "dbms.cypher.statistics_divergence_threshold", DOUBLE, "0.5", min( 0.0 ), max(
+            "dbms.cypher.statistics_divergence_threshold", DOUBLE, "0.75", min( 0.0 ), max(
                     1.0 ) );
 
     @Description( "The threshold when a warning is generated if a label scan is done after a load csv " +
@@ -153,7 +153,7 @@ public abstract class GraphDatabaseSettings
             "dbms.cypher.idp_solver_duration_threshold", LONG, "1000", min( 10L ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
-    public static Setting<Long> cypher_min_replan_interval = setting( "dbms.cypher.min_replan_interval", DURATION, "1s" );
+    public static Setting<Long> cypher_min_replan_interval = setting( "dbms.cypher.min_replan_interval", DURATION, "60m" );
 
     @Description( "Determines if Cypher will allow using file URLs when loading data using `LOAD CSV`. Setting this "
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )


### PR DESCRIPTION
We have seen many cases where replanning default settings were
suboptimal and causing a lot of unnedded replans, e.g., replan
triggered every 2/3 seconds. This is suboptimal and very likely
unwanted behaviour. This commit change the ttl to 1 hour and increase
the threshold needed for replanning when the ttl is experied.
