### PR TITLE
Add dump and load commands to neo4j-admin

### DIFF
--- a/community/command-line/pom.xml
+++ b/community/command-line/pom.xml
@@ -66,25 +66,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-io</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-kernel</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-dbms</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -129,18 +129,9 @@ public class AdminTool
     {
         if ( debug )
         {
-            failure( e, format( "%s: %s", message, e.getMessage() ) );
+            outsideWorld.printStacktrace( e );
         }
-        else
-        {
-            failure( e.getMessage() );
-        }
-    }
-
-    private void failure( Exception e, String message )
-    {
-        outsideWorld.printStacktrace( e );
-        failure( message );
+        failure( format( "%s: %s", message, e.getMessage() ) );
     }
 
     private void failure( String message )

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
@@ -25,4 +25,9 @@ public class CommandFailed extends Exception
     {
         super( message, cause );
     }
+
+    public CommandFailed( String message )
+    {
+        super( message );
+    }
 }

--- a/community/command-line/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/command-line/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,1 +1,0 @@
-org.neo4j.commandline.admin.ImportCommand$Provider

--- a/community/dbms/LICENSES.txt
+++ b/community/dbms/LICENSES.txt
@@ -4,7 +4,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Compress
-  Apache Commons Lang
   Lucene Core
   Lucene Memory
 ------------------------------------------------------------------------------

--- a/community/dbms/LICENSES.txt
+++ b/community/dbms/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -27,7 +27,6 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Compress
-  Apache Commons Lang
   Lucene Core
   Lucene Memory
 

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -109,5 +109,9 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -55,6 +55,27 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-graphdb-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-command-line</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-collections</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-io</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
@@ -65,6 +86,13 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -79,11 +107,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -54,7 +54,18 @@
       <artifactId>neo4j-kernel</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-io</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -113,5 +113,10 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -137,16 +137,7 @@ public class DumpCommand implements AdminCommand
 
     private Path calculateArchive( String database, Path to )
     {
-        Path archive;
-        if ( Files.exists( to ) && Files.isDirectory( to ) )
-        {
-            archive = to.resolve( database + ".dump" );
-        }
-        else
-        {
-            archive = to;
-        }
-        return archive;
+        return Files.isDirectory( to ) ? to.resolve( database + ".dump" ) : to;
     }
 
     private Closeable withLock( Path databaseDirectory ) throws CommandFailed

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -142,7 +142,7 @@ public class DumpCommand implements AdminCommand
         }
         catch ( NoSuchFileException e )
         {
-            if ( databaseDirectory.toString().equals( e.getMessage() ) )
+            if ( Paths.get( e.getMessage() ).toAbsolutePath().equals( databaseDirectory.toAbsolutePath() ) )
             {
                 throw new CommandFailed( "database does not exist: " + database, e );
             }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -62,13 +62,15 @@ public class DumpCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "" );
+            return Optional.of( "--database=<database> --to=<destination-path>" );
         }
 
         @Override
         public String description()
         {
-            return "";
+            return "Dump a database into a single-file archive. The archive can be used by the load command. " +
+                    "<destination-path> can be a file or directory (in which case a file called <database>.dump will " +
+                    "be created). It is not possible to dump a database that is mounted in a running Neo4j server.";
         }
 
         @Override

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.dbms.archive.Dumper;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.server.configuration.ConfigLoader;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.Converters.mandatory;
+
+public class DumpCommand implements AdminCommand
+{
+    public static class Provider extends AdminCommand.Provider
+    {
+        public Provider()
+        {
+            super( "dump" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "" );
+        }
+
+        @Override
+        public String description()
+        {
+            return "";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new DumpCommand( homeDir, configDir, new Dumper() );
+        }
+    }
+
+    private final Path homeDir;
+    private final Path configDir;
+    private final Dumper dumper;
+
+    public DumpCommand( Path homeDir, Path configDir, Dumper dumper )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+        this.dumper = dumper;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        Path databaseDirectory = parse( args, "database", this::toDatabaseDirectory );
+        Path archive = parse( args, "to", Paths::get );
+        try
+        {
+            dumper.dump( databaseDirectory, archive );
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( "unable to dump database", e );
+        }
+    }
+
+    private <T> T parse( String[] args, String argument, Function<String, T> converter ) throws IncorrectUsage
+    {
+        try
+        {
+            return Args.parse( args ).interpretOption( argument, mandatory(), converter );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+    }
+
+    private Path toDatabaseDirectory( String databaseName )
+    {
+        //noinspection unchecked
+        return new ConfigLoader( asList( DatabaseManagementSystemSettings.class, GraphDatabaseSettings.class     ) )
+                .loadConfig(
+                        Optional.of( homeDir.toFile() ),
+                        Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) )
+                .with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) )
+                .get( database_path ).toPath();
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.commandline.admin;
+package org.neo4j.commandline.dbms;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.dbms.archive.IncorrectFormat;
+import org.neo4j.dbms.archive.Loader;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.server.configuration.ConfigLoader;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.util.Converters.mandatory;
+
+public class LoadCommand implements AdminCommand
+{
+    public static class Provider extends AdminCommand.Provider
+    {
+        public Provider()
+        {
+            super( "load" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "" );
+        }
+
+        @Override
+        public String description()
+        {
+            return "";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new LoadCommand( homeDir, configDir, new Loader() );
+        }
+    }
+
+    private final Path homeDir;
+    private final Path configDir;
+    private final Loader loader;
+
+    public LoadCommand( Path homeDir, Path configDir, Loader loader )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+        this.loader = loader;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        Path archive = parse( args, "from", Paths::get );
+        Path databaseDirectory = parse( args, "database", this::toDatabaseDirectory );
+        try
+        {
+            loader.load( archive, databaseDirectory );
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( "unable to load database: " + e.getMessage(), e );
+        }
+        catch ( IncorrectFormat incorrectFormat )
+        {
+            throw new CommandFailed( "Not a valid Neo4j archive: " + archive, incorrectFormat );
+        }
+    }
+
+    private <T> T parse( String[] args, String argument, Function<String, T> converter ) throws IncorrectUsage
+    {
+        try
+        {
+            return Args.parse( args ).interpretOption( argument, mandatory(), converter );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+    }
+
+    private Path toDatabaseDirectory( String databaseName )
+    {
+        //noinspection unchecked
+        return new ConfigLoader( asList( DatabaseManagementSystemSettings.class, GraphDatabaseSettings.class ) )
+                .loadConfig(
+                        Optional.of( homeDir.toFile() ),
+                        Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) )
+                .with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) )
+                .get( database_path ).toPath();
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -63,13 +63,16 @@ public class LoadCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "" );
+            return Optional.of( "--from=<archive-path> --database=<database> [--force]" );
         }
 
         @Override
         public String description()
         {
-            return "";
+            return "Load a database from an archive. <archive-path> must be an archive created with the dump " +
+                    "command. <database> is the name of the database to create. Existing databases can be replaced " +
+                    "by specifying --force. It is not possible to replace a database that is mounted in a running " +
+                    "Neo4j server.";
         }
 
         @Override

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -149,11 +149,17 @@ public class LoadCommand implements AdminCommand
     {
         try
         {
-            new StoreLocker( new DefaultFileSystemAbstraction() ).checkLock( databaseDirectory.toFile() );
+            StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
+            storeLocker.checkLock( databaseDirectory.toFile() );
+            storeLocker.release();
         }
         catch ( StoreLockException e )
         {
             throw new CommandFailed( "the database is in use -- stop Neo4j and try again", e );
+        }
+        catch ( IOException e )
+        {
+            wrapIOException( e );
         }
     }
 

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Dumper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.stream.Stream;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+
+import static java.nio.file.Files.isRegularFile;
+
+import static org.neo4j.dbms.archive.Utils.checkWritableDirectory;
+import static org.neo4j.dbms.archive.Utils.copy;
+
+public class Dumper
+{
+    public void dump( Path root, Path archive ) throws IOException
+    {
+        checkWritableDirectory( archive.getParent() );
+        try ( Stream<Path> files = Files.walk( root );
+              ArchiveOutputStream stream = openArchiveOut( archive ) )
+        {
+            files.forEach( file -> dumpFile( file, root, stream ) );
+        }
+        catch ( TunnellingException e )
+        {
+            throw e.getWrapped();
+        }
+    }
+
+    private static ArchiveOutputStream openArchiveOut( Path archive ) throws IOException
+    {
+        // StandardOpenOption.CREATE_NEW is important here because it atomically asserts that the file doesn't
+        // exist as it is opened, avoiding a TOCTOU race condition which results in a security vulnerability. I
+        // can't see a way to write a test to verify that we are using this option rather than just implementing
+        // the check ourselves non-atomically.
+        TarArchiveOutputStream tarball =
+                new TarArchiveOutputStream( new GzipCompressorOutputStream(
+                        Files.newOutputStream( archive, StandardOpenOption.CREATE_NEW ) ) );
+        tarball.setLongFileMode( TarArchiveOutputStream.LONGFILE_POSIX );
+        return tarball;
+    }
+
+    private static void dumpFile( Path file, Path root, ArchiveOutputStream archive )
+    {
+        try
+        {
+            ArchiveEntry entry = createEntry( file, root, archive );
+            archive.putArchiveEntry( entry );
+            if ( isRegularFile( file ) )
+            {
+                writeFile( file, archive );
+            }
+            archive.closeArchiveEntry();
+        }
+        catch ( IOException e )
+        {
+            throw new TunnellingException( e );
+        }
+    }
+
+    private static ArchiveEntry createEntry( Path file, Path root, ArchiveOutputStream archive ) throws IOException
+    {
+        return archive.createArchiveEntry( file.toFile(), "./" + root.relativize( file ).toString() );
+    }
+
+    private static void writeFile( Path file, ArchiveOutputStream archiveStream ) throws IOException
+    {
+        try ( InputStream in = Files.newInputStream( file ) )
+        {
+            copy( in, archiveStream );
+        }
+    }
+
+    private static class TunnellingException extends RuntimeException
+    {
+        public TunnellingException( IOException e )
+        {
+            super( e );
+        }
+
+        public IOException getWrapped()
+        {
+            return (IOException) getCause();
+        }
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/IncorrectFormat.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/IncorrectFormat.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class IncorrectFormat extends Exception
+{
+    public IncorrectFormat( Path archive, IOException cause )
+    {
+        super( archive.toString(), cause );
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import static java.nio.file.Files.exists;
+
+import static org.neo4j.dbms.archive.Utils.checkWritableDirectory;
+
+public class Loader
+{
+    public void load( Path archive, Path destination ) throws IOException, IncorrectFormat
+    {
+        if ( exists( destination ) )
+        {
+            throw new FileAlreadyExistsException( destination.toString() );
+        }
+        checkWritableDirectory( destination.getParent() );
+        try ( ArchiveInputStream stream = openArchiveIn( archive ) )
+        {
+            ArchiveEntry entry;
+            while ( (entry = nextEntry( stream, archive )) != null )
+            {
+                loadEntry( destination, stream, entry );
+            }
+        }
+    }
+
+    private ArchiveEntry nextEntry( ArchiveInputStream stream, Path archive ) throws IncorrectFormat
+    {
+        try
+        {
+            return stream.getNextEntry();
+        }
+        catch ( IOException e )
+        {
+            throw new IncorrectFormat(archive, e );
+        }
+    }
+
+    private void loadEntry( Path destination, ArchiveInputStream stream, ArchiveEntry entry ) throws IOException
+    {
+        Path file = destination.resolve( entry.getName() );
+        if ( entry.isDirectory() )
+        {
+            Files.createDirectories( file );
+        }
+        else
+        {
+            try ( OutputStream output = Files.newOutputStream( file ) )
+            {
+                Utils.copy( stream, output );
+            }
+        }
+    }
+
+    private static ArchiveInputStream openArchiveIn( Path archive ) throws IOException, IncorrectFormat
+    {
+        InputStream input = Files.newInputStream( archive );
+        GzipCompressorInputStream compressor;
+        try
+        {
+            compressor = new GzipCompressorInputStream( input );
+        }
+        catch ( IOException e )
+        {
+            throw new IncorrectFormat( archive, e );
+        }
+        return new TarArchiveInputStream( compressor );
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Loader.java
@@ -62,7 +62,7 @@ public class Loader
         }
         catch ( IOException e )
         {
-            throw new IncorrectFormat(archive, e );
+            throw new IncorrectFormat( archive, e );
         }
     }
 
@@ -92,6 +92,7 @@ public class Loader
         }
         catch ( IOException e )
         {
+            input.close();
             throw new IncorrectFormat( archive, e );
         }
         return new TarArchiveInputStream( compressor );

--- a/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/archive/Utils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isRegularFile;
+import static java.nio.file.Files.isWritable;
+
+public class Utils
+{
+    public static void checkWritableDirectory( Path directory ) throws FileSystemException
+    {
+        if ( !exists( directory ) )
+        {
+            throw new NoSuchFileException( directory.toString() );
+        }
+        if ( isRegularFile( directory ) )
+        {
+            throw new FileSystemException( directory.toString() + ": Not a directory" );
+        }
+        if ( !isWritable( directory ) )
+        {
+            throw new AccessDeniedException( directory.toString() );
+        }
+    }
+
+    public static void copy( InputStream in, OutputStream out ) throws IOException
+    {
+        final byte[] buffer = new byte[8192];
+        int n;
+        while ( -1 != (n = in.read( buffer )) )
+        {
+            out.write( buffer, 0, n );
+        }
+    }
+}

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,0 +1,1 @@
+org.neo4j.commandline.dbms.ImportCommand$Provider

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,1 +1,3 @@
 org.neo4j.commandline.dbms.ImportCommand$Provider
+org.neo4j.commandline.dbms.DumpCommand$Provider
+org.neo4j.commandline.dbms.LoadCommand$Provider

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.dbms.archive.Dumper;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+
+public class DumpCommandTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    private Path homeDir;
+    private Path configDir;
+    private Path archive;
+    private Dumper dumper;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        homeDir = testDirectory.directory( "home-dir" ).toPath();
+        configDir = testDirectory.directory( "config-dir" ).toPath();
+        archive = testDirectory.directory( "some-archive.dump" ).toPath();
+        dumper = mock( Dumper.class );
+    }
+
+    @Test
+    public void shouldDumpTheDatabaseToTheArchive() throws CommandFailed, IncorrectUsage, IOException
+    {
+        execute( "foo.db" );
+        verify( dumper ).dump( homeDir.resolve( "data/databases/foo.db" ), archive );
+    }
+
+    @Test
+    public void shouldCalculateTheDatabaseDirectoryFromConfig() throws IOException, CommandFailed, IncorrectUsage
+    {
+        Files.write( configDir.resolve( "neo4j.conf" ), asList( data_directory.name() + "=/some/data/dir" ) );
+        execute( "foo.db" );
+        verify( dumper ).dump( eq( Paths.get( "/some/data/dir/databases/foo.db" ) ), any() );
+    }
+
+    @Test
+    public void shouldObjectIfTheDatabaseArgumentIsMissing() throws CommandFailed
+    {
+        try
+        {
+            new DumpCommand( null, null, null ).execute( new String[]{"--to=something"} );
+            fail( "expected exception" );
+        }
+        catch ( IncorrectUsage e )
+        {
+            assertThat( e.getMessage(), equalTo( "Missing argument 'database'" ) );
+        }
+    }
+
+    @Test
+    public void shouldObjectIfTheArchiveArgumentIsMissing() throws CommandFailed
+    {
+        try
+        {
+            new DumpCommand( homeDir, configDir, null ).execute( new String[]{"--database=something"} );
+            fail( "expected exception" );
+        }
+        catch ( IncorrectUsage e )
+        {
+            assertThat( e.getMessage(), equalTo( "Missing argument 'to'" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowIfTheCommandFails() throws IOException, IncorrectUsage
+    {
+        doThrow( IOException.class ).when( dumper ).dump( any(), any() );
+        try
+        {
+            execute( null );
+            fail( "expected exception" );
+        }
+        catch ( CommandFailed ignored )
+        {
+        }
+    }
+
+    private void execute( final String database ) throws IncorrectUsage, CommandFailed
+    {
+        new DumpCommand( homeDir, configDir, dumper )
+                .execute( new String[]{"--database=" + database, "--to=" + archive} );
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -17,7 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.commandline.admin;
+package org.neo4j.commandline.dbms;
+
+import java.io.File;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -25,8 +27,7 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
-
+import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.util.Validators;

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -26,7 +26,6 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,6 +40,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.test.rule.TestDirectory;
 
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 import static org.hamcrest.Matchers.containsString;
@@ -85,9 +85,14 @@ public class LoadCommandTest
     public void shouldCalculateTheDatabaseDirectoryFromConfig()
             throws IOException, CommandFailed, IncorrectUsage, IncorrectFormat
     {
-        Files.write( configDir.resolve( "neo4j.conf" ), asList( data_directory.name() + "=/some/data/dir" ) );
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/foo.db" );
+        Files.createDirectories( databaseDir );
+        Files.write( configDir.resolve( "neo4j.conf" ),
+                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+
         execute( "foo.db" );
-        verify( loader ).load( any(), eq( Paths.get( "/some/data/dir/databases/foo.db" ) ) );
+        verify( loader ).load( any(), eq( databaseDir ) );
     }
 
     @Test

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.dbms.archive.IncorrectFormat;
+import org.neo4j.dbms.archive.Loader;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+
+public class LoadCommandTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    private Path homeDir;
+    private Path configDir;
+    private Path archive;
+    private Loader loader;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        homeDir = testDirectory.directory( "home-dir" ).toPath();
+        configDir = testDirectory.directory( "config-dir" ).toPath();
+        archive = testDirectory.directory( "some-archive.dump" ).toPath();
+        loader = mock( Loader.class );
+    }
+
+    @Test
+    public void shouldLoadTheDatabaseFromTheArchive() throws CommandFailed, IncorrectUsage, IOException, IncorrectFormat
+    {
+        execute( "foo.db" );
+        verify( loader ).load( archive, homeDir.resolve( "data/databases/foo.db" ) );
+    }
+
+    @Test
+    public void shouldCalculateTheDatabaseDirectoryFromConfig()
+            throws IOException, CommandFailed, IncorrectUsage, IncorrectFormat
+    {
+        Files.write( configDir.resolve( "neo4j.conf" ), asList( data_directory.name() + "=/some/data/dir" ) );
+        execute( "foo.db" );
+        verify( loader ).load( any(), eq( Paths.get( "/some/data/dir/databases/foo.db" ) ) );
+    }
+
+    @Test
+    public void shouldObjectIfTheDatabaseArgumentIsMissing() throws CommandFailed
+    {
+        try
+        {
+            new LoadCommand( null, null, null ).execute( new String[]{"--from=something"} );
+            fail( "expected exception" );
+        }
+        catch ( IncorrectUsage e )
+        {
+            assertThat( e.getMessage(), equalTo( "Missing argument 'database'" ) );
+        }
+    }
+
+    @Test
+    public void shouldObjectIfTheArchiveArgumentIsMissing() throws CommandFailed
+    {
+        try
+        {
+            new LoadCommand( homeDir, configDir, null ).execute( new String[]{"--database=something"} );
+            fail( "expected exception" );
+        }
+        catch ( IncorrectUsage e )
+        {
+            assertThat( e.getMessage(), equalTo( "Missing argument 'from'" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowIfTheCommandFails() throws IOException, IncorrectUsage, IncorrectFormat
+    {
+        doThrow( IOException.class ).when( loader ).load( any(), any() );
+        try
+        {
+            execute( null );
+            fail( "expected exception" );
+        }
+        catch ( CommandFailed ignored )
+        {
+        }
+    }
+
+    @Test
+    public void shouldThrowIfTheArchiveFormatIsInvalid() throws IOException, IncorrectUsage, IncorrectFormat
+    {
+        doThrow( IncorrectFormat.class ).when( loader ).load( any(), any() );
+        try
+        {
+            execute( null );
+            fail( "expected exception" );
+        }
+        catch ( CommandFailed e )
+        {
+            assertThat( e.getMessage(), containsString( archive.toString() ) );
+            assertThat( e.getMessage(), containsString( "valid Neo4j archive" ) );
+        }
+    }
+
+    private void execute( final String database ) throws IncorrectUsage, CommandFailed
+    {
+        new LoadCommand( homeDir, configDir, loader )
+                .execute( new String[]{"--database=" + database, "--from=" + archive} );
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/ArchiveTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/ArchiveTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.nio.file.Files.isDirectory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.Pair.pair;
+
+public class ArchiveTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldRoundTripAnEmptyDirectory() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Files.createDirectories( directory );
+
+        assertRoundTrips( directory );
+    }
+
+    @Test
+    public void shouldRoundTripASingleFile() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Files.createDirectories( directory );
+        Files.write( directory.resolve( "a-file" ), "text".getBytes() );
+
+        assertRoundTrips( directory );
+    }
+
+    @Test
+    public void shouldRoundTripFilesWithDifferentContent() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Files.createDirectories( directory );
+        Files.write( directory.resolve( "a-file" ), "text".getBytes() );
+        Files.write( directory.resolve( "another-file" ), "some-different-text".getBytes() );
+
+        assertRoundTrips( directory );
+    }
+
+    @Test
+    public void shouldRoundTripEmptyDirectories() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path subdir = directory.resolve( "a-subdirectory" );
+        Files.createDirectories( subdir );
+        assertRoundTrips( directory );
+    }
+
+    @Test
+    public void shouldRoundTripFilesInDirectories() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path subdir = directory.resolve( "a-subdirectory" );
+        Files.createDirectories( subdir );
+        Files.write( subdir.resolve( "a-file" ), "text".getBytes() );
+        assertRoundTrips( directory );
+    }
+
+    @Test
+    public void shouldCopeWithLongPaths() throws IOException, IncorrectFormat
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path subdir = directory.resolve( "a/very/long/path/which/is/not/realistic/for/a/database/today/but/which" +
+                "/ensures/that/we/dont/get/caught/out/at/in/the/future/the/point/being/that/there/are/multiple/tar" +
+                "/formats/some/of/which/do/not/cope/with/long/paths" );
+        Files.createDirectories( subdir );
+        Files.write( subdir.resolve( "a-file" ), "text".getBytes() );
+        assertRoundTrips( directory );
+    }
+
+    private void assertRoundTrips( Path oldDirectory ) throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        new Dumper().dump( oldDirectory, archive );
+        Path newDirectory = testDirectory.file( "the-new-directory" ).toPath();
+        new Loader().load( archive, newDirectory );
+
+        assertEquals( describeRecursively( oldDirectory ), describeRecursively( newDirectory ) );
+    }
+
+    private Map<Path, Description> describeRecursively( Path directory ) throws IOException
+    {
+        return Files.walk( directory )
+                .map( path -> pair( directory.relativize( path ), describe( path ) ) )
+                .collect( HashMap::new,
+                        ( pathDescriptionHashMap, pathDescriptionPair ) ->
+                                pathDescriptionHashMap.put( pathDescriptionPair.first(), pathDescriptionPair.other() ),
+                        HashMap::putAll );
+    }
+
+    private Description describe( Path file )
+    {
+        try
+        {
+            return isDirectory( file ) ? new DirectoryDescription() : new FileDescription( Files.readAllBytes( file ) );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private interface Description
+    {
+    }
+
+    private class DirectoryDescription implements Description
+    {
+        @Override
+        public boolean equals( Object o )
+        {
+            return this == o || !(o == null || getClass() != o.getClass());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 1;
+        }
+    }
+
+    private class FileDescription implements Description
+    {
+        private final byte[] bytes;
+
+        public FileDescription( byte[] bytes )
+        {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            FileDescription that = (FileDescription) o;
+            return Arrays.equals( bytes, that.bytes );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Arrays.hashCode( bytes );
+        }
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -37,6 +38,7 @@ import static java.util.Collections.emptySet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 public class DumperTest
 {
@@ -112,6 +114,8 @@ public class DumperTest
     @Test
     public void shouldGiveAClearErrorMessageIfTheArchivesParentDirectoryIsNotWritable() throws IOException
     {
+        assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
+
         Path directory = testDirectory.directory( "a-directory" ).toPath();
         Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
         Files.createDirectories( archive.getParent() );

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.Collections.emptySet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DumperTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldGiveAClearErrorIfTheArchiveAlreadyExists() throws IOException
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Files.write( archive, new byte[0] );
+        try
+        {
+            new Dumper().dump( directory, archive );
+            fail( "Expected an exception" );
+        }
+        catch ( FileAlreadyExistsException e )
+        {
+            assertEquals( archive.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheDirectoryDoesntExist() throws IOException
+    {
+        Path directory = testDirectory.file( "a-directory" ).toPath();
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        try
+        {
+            new Dumper().dump( directory, archive );
+            fail( "Expected an exception" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            assertEquals( directory.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchivesParentDirectoryDoesntExist() throws IOException
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
+        try
+        {
+            new Dumper().dump( directory, archive );
+            fail( "Expected an exception" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            assertEquals( archive.getParent().toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchivesParentDirectoryIsAFile() throws IOException
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
+        Files.write( archive.getParent(), new byte[0] );
+        try
+        {
+            new Dumper().dump( directory, archive );
+            fail( "Expected an exception" );
+        }
+        catch ( FileSystemException e )
+        {
+            assertEquals( archive.getParent().toString() + ": Not a directory", e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchivesParentDirectoryIsNotWritable() throws IOException
+    {
+        Path directory = testDirectory.directory( "a-directory" ).toPath();
+        Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
+        Files.createDirectories( archive.getParent() );
+        try ( Closeable ignored = TestUtils.withPermissions( archive.getParent(), emptySet() ) )
+        {
+            new Dumper().dump( directory, archive );
+            fail( "Expected an exception" );
+        }
+        catch ( AccessDeniedException e )
+        {
+            assertEquals( archive.getParent().toString(), e.getMessage() );
+        }
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Random;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -40,6 +41,7 @@ import static java.util.Collections.emptySet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 
@@ -160,6 +162,8 @@ public class LoaderTest
     public void shouldGiveAClearErrorMessageIfTheDestinationsParentDirectoryIsNotWritable()
             throws IOException, IncorrectFormat
     {
+        assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
+
         Path archive = testDirectory.file( "the-archive.dump" ).toPath();
         Path destination = testDirectory.directory( "subdir/the-destination" ).toPath();
         Files.createDirectories( destination.getParent() );

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Random;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.dbms.archive.TestUtils.withPermissions;
+
+public class LoaderTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchiveDoesntExist() throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.file( "the-destination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            assertEquals( archive.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchiveIsNotInGzipFormat() throws IOException
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Files.write( archive, asList( "some incorrectly formatted data" ) );
+        Path destination = testDirectory.file( "the-destination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( IncorrectFormat e )
+        {
+            assertEquals( archive.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheArchiveIsNotInTarFormat() throws IOException
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        try ( GzipCompressorOutputStream compressor =
+                      new GzipCompressorOutputStream( Files.newOutputStream( archive ) ) )
+        {
+            byte[] bytes = new byte[1000];
+            new Random().nextBytes( bytes );
+            compressor.write( bytes );
+        }
+
+        Path destination = testDirectory.file( "the-destination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( IncorrectFormat e )
+        {
+            assertEquals( archive.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorIfTheDestinationAlreadyExists() throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.directory( "the-destination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( FileAlreadyExistsException e )
+        {
+            assertEquals( destination.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheDestinationsParentDirectoryDoesntExist()
+            throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.directory( "subdir/the-destination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            assertEquals( destination.getParent().toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheDestinationsParentDirectoryIsAFile()
+            throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.directory( "subdir/the-destination" ).toPath();
+        Files.write( destination.getParent(), new byte[0] );
+        try
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( FileSystemException e )
+        {
+            assertEquals( destination.getParent().toString() + ": Not a directory", e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheDestinationsParentDirectoryIsNotWritable()
+            throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.directory( "subdir/the-destination" ).toPath();
+        Files.createDirectories( destination.getParent() );
+        try ( Closeable ignored = withPermissions( destination.getParent(), emptySet() ) )
+        {
+            new Loader().load( archive, destination );
+            fail( "Expected an exception" );
+        }
+        catch ( AccessDeniedException e )
+        {
+            assertEquals( destination.getParent().toString(), e.getMessage() );
+        }
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/TestUtils.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/TestUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.archive;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+public class TestUtils
+{
+    public static Closeable withPermissions( Path file, Set<PosixFilePermission> permissions ) throws IOException
+    {
+        Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions( file );
+        Files.setPosixFilePermissions( file, permissions );
+        return () -> Files.setPosixFilePermissions( file, originalPermissions );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
@@ -20,6 +20,8 @@
 package org.neo4j.kernel.impl.util;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -48,6 +50,11 @@ public class Converters
     public static Function<String,File> toFile()
     {
         return File::new;
+    }
+
+    public static Function<String, Path> toPath()
+    {
+        return Paths::get;
     }
 
     public static final Comparator<File> BY_FILE_NAME = ( o1, o2 ) -> o1.getName().compareTo( o2.getName() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
@@ -57,6 +57,11 @@ public class Converters
         return Paths::get;
     }
 
+    public static Function<String, String> identity()
+    {
+        return s -> s;
+    }
+
     public static final Comparator<File> BY_FILE_NAME = ( o1, o2 ) -> o1.getName().compareTo( o2.getName() );
 
     public static final Comparator<File> BY_FILE_NAME_WITH_CLEVER_NUMBERS =

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Commons BeanUtils

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Commons BeanUtils

--- a/community/security/LICENSES.txt
+++ b/community/security/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/community/security/NOTICE.txt
+++ b/community/security/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Commons BeanUtils

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Commons BeanUtils

--- a/enterprise/backup/LICENSES.txt
+++ b/enterprise/backup/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/enterprise/backup/NOTICE.txt
+++ b/enterprise/backup/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory

--- a/enterprise/core-edge/LICENSES.txt
+++ b/enterprise/core-edge/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache
   Commons BeanUtils

--- a/enterprise/core-edge/NOTICE.txt
+++ b/enterprise/core-edge/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache
   Commons BeanUtils

--- a/enterprise/ha/LICENSES.txt
+++ b/enterprise/ha/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/enterprise/security/LICENSES.txt
+++ b/enterprise/security/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache
   Commons BeanUtils

--- a/enterprise/security/NOTICE.txt
+++ b/enterprise/security/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Shiro :: Core
   Apache Shiro :: Support :: EHCache
   Commons BeanUtils

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   ColorBrewer

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   ColorBrewer

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   ColorBrewer

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   ColorBrewer

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -25,6 +25,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Shiro :: Core

--- a/pom.xml
+++ b/pom.xml
@@ -581,6 +581,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.3.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.12</version>
+      </dependency>
 
       <!-- Netty is used by three components: Com, Cluster and Bolt Socket Transport.
            Netty 4 is a significant improvement over Netty 3, in that it introduces


### PR DESCRIPTION
To avoid people having to directly access the filesystem we introduce `dump` and `load` commands on `neo4j-admin`. This functionality will only work if the database is not in use.

```
neo4j-admin dump --database=foo.db --to=/some/path/foo.dump
```

Writes a single-file dump of a single database.

```
neo4j-admin load --database=foo.db --from=/some/path/foo.dump
```

Creates a new database from the dump file. Fails if the database already exists (but can overwrite with `--force`).

changelog [tools]
