### PR TITLE
Allow relationship types of deleted relationships

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/DeleteAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/DeleteAcceptanceTest.scala
@@ -321,5 +321,17 @@ class DeleteAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
     updateWithBothPlannersAndCompatibilityMode(s"EXPLAIN $query")
   }
 
+  //https://github.com/neo4j/neo4j-java-driver/issues/212
+  test("should handle bidirectional match and relationship types") {
+    // GIVEN
+    val relId = relate(createNode(), createNode(), "T").getId
+
+    // WHEN
+    val result = updateWithBothPlannersAndCompatibilityMode("MATCH ()-[r:T]-() WHERE ID(r) = {id} DELETE r", "id" -> relId)
+
+    // THEN
+    assertStats(result, relationshipsDeleted = 1)
+  }
+
   override def timeLimit: Span = 10 seconds
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -52,14 +52,6 @@ class ReturnAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers w
     an [EntityNotFoundException] should be thrownBy updateWithBothPlanners(query)
   }
 
-  test("returning the type of deleted relationships should throw exception") {
-    relate(createNode(), createNode(), "T")
-
-    val query = "MATCH ()-[r:T]->() DELETE r RETURN type(r)"
-
-    an [EntityNotFoundException] should be thrownBy updateWithBothPlanners(query)
-  }
-
   test("should choke on an invalid unicode literal") {
     val query = "RETURN '\\uH' AS a"
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/RelationshipTypeFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/RelationshipTypeFunction.scala
@@ -23,19 +23,15 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsAllRelationships}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.frontend.v3_0.{EntityNotFoundException, ParameterWrongTypeException}
+import org.neo4j.cypher.internal.frontend.v3_0.ParameterWrongTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.graphdb.Relationship
 
 case class RelationshipTypeFunction(relationship: Expression) extends NullInNullOutExpression(relationship) {
 
   override def compute(value: Any, m: ExecutionContext)(implicit state: QueryState): String = value match {
-    case r: Relationship =>
-      if (state.query.relationshipOps.isDeletedInThisTx(r)) {
-        throw new EntityNotFoundException(s"Relationship with id ${r.getId} has been deleted in this transaction")
-      } else {
-        r.getType.name()
-      }
+    case r: Relationship => r.getType.name()
+
     case x => throw new ParameterWrongTypeException("Expected a Relationship, got: " + x)
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/RelationshipTypeFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/RelationshipTypeFunctionTest.scala
@@ -23,7 +23,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{Operations, QueryContext}
-import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, EntityNotFoundException, ParameterWrongTypeException}
+import org.neo4j.cypher.internal.frontend.v3_0.ParameterWrongTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Relationship, RelationshipType}
 
@@ -42,11 +42,11 @@ class RelationshipTypeFunctionTest extends CypherFunSuite with FakeEntityTestSup
     RelationshipTypeFunction(Variable("r")).compute(rel, null) should equal("T")
   }
 
-  test("should throw if the relationship was deleted in this tx") {
+  test("should handle deleted relationships since types are inlined") {
     doReturn(true).when(operations).isDeletedInThisTx(any())
 
     val rel = new FakeRel(null, null, RelationshipType.withName("T"))
-    an [EntityNotFoundException] should be thrownBy RelationshipTypeFunction(Variable("r")).compute(rel, null)
+    RelationshipTypeFunction(Variable("r")).compute(rel, null) should equal("T")
   }
 
   test("should throw if encountering anything other than a relationship") {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
@@ -408,51 +408,6 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
     }
 
     @Test
-    public void shouldFailIfTryingToReturnTypeOfDeletedRelationshipGraph()
-    {
-        // given
-        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
-
-        // execute and commit
-        Response commit = http.POST( commitResource,
-                queryAsJsonGraph( "MATCH (s)-[r:R]->(e) DELETE r RETURN type(r)" ) );
-
-        assertThat( commit, hasErrors( Status.Statement.EntityNotFound ) );
-        assertThat( commit.status(), equalTo( 200 ) );
-        assertThat( nodesInDatabase(), equalTo( 2L ) );
-    }
-
-    @Test
-    public void shouldFailIfTryingToReturnTypeOfDeletedRelationshipRow()
-    {
-        // given
-        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
-
-        // execute and commit
-        Response commit = http.POST( commitResource,
-                queryAsJsonRow( "MATCH (s)-[r:R]->(e) DELETE r RETURN type(r)" ) );
-
-        assertThat( commit, hasErrors( Status.Statement.EntityNotFound ) );
-        assertThat( commit.status(), equalTo( 200 ) );
-        assertThat( nodesInDatabase(), equalTo( 2L ) );
-    }
-
-    @Test
-    public void shouldFailIfTryingToReturnTypeOfDeletedRelationshipRest()
-    {
-        // given
-        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
-
-        // execute and commit
-        Response commit = http.POST( commitResource,
-                queryAsJsonRest( "MATCH (s)-[r:R]->(e) DELETE r RETURN type(r)" ) );
-
-        assertThat( commit, hasErrors( Status.Statement.EntityNotFound ) );
-        assertThat( commit.status(), equalTo( 200 ) );
-        assertThat( nodesInDatabase(), equalTo( 2L ) );
-    }
-
-    @Test
     public void returningADeletedPathGraph()
     {
         // given
@@ -626,7 +581,6 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
 
     /**
      * This matcher is hardcoded to check for a list containing one deleted node and one map with a deleted node mapped to the key `someKey`.
-     * @return
      */
     public static Matcher<? super Response> restContainsNestedDeleted()
     {


### PR DESCRIPTION
Since the types are inlined there is no point in throwing
`EntityNotFoundException` when trying to access the relationship type  of a
deleted relationship. Doing so also cause unwanted behaviour for queries like

```
MATCH ()-[r:T]-() WHERE id(r) = 42 DELETE r
```

Where the we filter out relationship access the type of `r` in order to filter
out unwanted relationships.
