### PR TITLE
Update relationship type to take up to 24 bits in high limit format

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -52,11 +52,11 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.Randoms;
@@ -162,7 +162,7 @@ public class ParallelBatchImporterTest
         ExecutionMonitor processorAssigner = eagerRandomSaturation( config.maxNumberOfProcessors() );
         final BatchImporter inserter = new ParallelBatchImporter( directory.graphDbDir(),
                 new DefaultFileSystemAbstraction(), config, NullLogService.getInstance(),
-                processorAssigner, EMPTY, new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), getFormatName() ) ) );
+                processorAssigner, EMPTY, Config.empty(), getFormat() );
 
         boolean successful = false;
         IdGroupDistribution groups = new IdGroupDistribution( NODE_COUNT, 5, random.random() );
@@ -234,9 +234,9 @@ public class ParallelBatchImporterTest
                 result.isSuccessful() );
     }
 
-    protected String getFormatName()
+    protected RecordFormats getFormat()
     {
-        return StandardV3_0.NAME;
+        return StandardV3_0.RECORD_FORMATS;
     }
 
     public abstract static class InputIdGenerator

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/Capability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/Capability.java
@@ -38,6 +38,11 @@ public enum Capability
     DENSE_NODES( CapabilityType.FORMAT, CapabilityType.STORE ),
 
     /**
+     * 3 bytes relationship type support
+     */
+    RELATIONSHIP_TYPE_3BYTES( CapabilityType.FORMAT, CapabilityType.STORE ),
+
+    /**
      * Store has version trailers in the end of cleanly shut down store
      */
     VERSION_TRAILERS( CapabilityType.STORE ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -416,7 +416,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
             BatchImporter importer = new ParallelBatchImporter( migrationDir.getAbsoluteFile(), fileSystem,
                     importConfig, logService,
                     withDynamicProcessorAssignment( migrationBatchImporterMonitor( legacyStore, progressMonitor,
-                            importConfig ), importConfig ), additionalInitialIds, config );
+                            importConfig ), importConfig ), additionalInitialIds, config, newFormat );
             InputIterable<InputNode> nodes =
                     legacyNodesAsInput( legacyStore, requiresPropertyMigration, nodeInputCursors );
             InputIterable<InputRelationship> relationships =

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
@@ -183,8 +183,7 @@ public class RelationshipGroupCache implements Iterable<RelationshipGroupRecord>
 
             if ( desiredIndex == -1 )
             {
-                // ?? do we need mask here?
-                int existingType = cache.get3ByteInt( candidateIndex, 1 ) & 0xFFFFFF;
+                int existingType = cache.get3ByteInt( candidateIndex, 1 );
                 if ( existingType == type )
                 {
                     throw new IllegalStateException( "Tried to put multiple groups with same type " + type );
@@ -256,8 +255,7 @@ public class RelationshipGroupCache implements Iterable<RelationshipGroupRecord>
                     {
                         // Here we have an alive group
                         group = new RelationshipGroupRecord( -1 ).initialize( true,
-                                //do we need mask here?
-                                cache.get3ByteInt( cursor, 1 ) & 0xFFFFFF,
+                                cache.get3ByteInt( cursor, 1 ),
                                 cache.get6ByteLong( cursor, 1 + 3 ),
                                 cache.get6ByteLong( cursor, 1 + 3 + 6 ),
                                 cache.get6ByteLong( cursor, 1 + 3 + 6 + 6 ),

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
@@ -153,4 +153,24 @@ public interface ByteArray extends NumberArray<ByteArray>
      * @param value the long value to set at the given offset at the given array index.
      */
     void setLong( long index, int offset, long value );
+
+    /**
+     * Gets a part of an item, at the given {@code index}. An item in this array can consist of
+     * multiple values. This call will get a 3-byte int at the given {@code offset}.
+     *
+     * @param index array index to get.
+     * @param offset offset into this index to get the value from.
+     * @return the 3-byte int at the given offset at the given array index.
+     */
+    int get3ByteInt( long index, int offset );
+
+    /**
+     * Sets a part of an item, at the given {@code index}. An item in this array can consist of
+     * multiple values. This call will set a 3-byte int at the given {@code offset}.
+     *
+     * @param index array index to get.
+     * @param offset offset into this index to set the value for.
+     * @param value the 3-byte int value to set at the given offset at the given array index.
+     */
+    void set3ByteInt( long index, int offset, int value );
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport.cache;
 
 import java.nio.ByteBuffer;
 
+import static org.neo4j.unsafe.impl.batchimport.cache.HeapByteArray.get3ByteIntFromByteBuffer;
 import static org.neo4j.unsafe.impl.batchimport.cache.HeapByteArray.get6BLongFromByteBuffer;
 
 public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements ByteArray
@@ -86,6 +87,14 @@ public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements B
     }
 
     @Override
+    public int get3ByteInt( long index, int offset )
+    {
+        ByteArray chunk = chunkOrNullAt( index );
+        return chunk != null ? chunk.get3ByteInt( index, offset ) :
+               get3ByteIntFromByteBuffer( defaultValueConvenienceBuffer, offset );
+    }
+
+    @Override
     public long get6ByteLong( long index, int offset )
     {
         ByteArray chunk = chunkOrNullAt( index );
@@ -134,6 +143,12 @@ public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements B
     public void setLong( long index, int offset, long value )
     {
         at( index ).setLong( index, offset, value );
+    }
+
+    @Override
+    public void set3ByteInt( long index, int offset, int value )
+    {
+        at( index ).set3ByteInt( index, offset, value );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -112,9 +112,23 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     }
 
     @Override
+    public int get3ByteInt( long index, int offset )
+    {
+        int address = index( index, offset );
+        return get3ByteIntFromByteBuffer( buffer, address );
+    }
+
+    @Override
     public long get6ByteLong( long index, int offset )
     {
         return get6BLongFromByteBuffer( buffer, index( index, offset ) );
+    }
+
+    protected static int get3ByteIntFromByteBuffer( ByteBuffer buffer, int address )
+    {
+        int lowWord = buffer.getShort( address ) & 0xFFFF;
+        int highByte = buffer.get( address + Short.BYTES );
+        return lowWord | (highByte << Short.SIZE);
     }
 
     protected static long get6BLongFromByteBuffer( ByteBuffer buffer, int startOffset )
@@ -166,6 +180,14 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     public void setLong( long index, int offset, long value )
     {
         buffer.putLong( index( index, offset ), value );
+    }
+
+    @Override
+    public void set3ByteInt( long index, int offset, int value )
+    {
+        int address = index( index, offset );
+        buffer.putShort( address, (short) value );
+        buffer.put( address + Short.BYTES, (byte) (value >>> Short.SIZE) );
     }
 
     private int index( long index, int offset )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -164,6 +164,23 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
         UnsafeUtil.putLong( address( index, offset ), value );
     }
 
+    @Override
+    public int get3ByteInt( long index, int offset )
+    {
+        long address = address( index, offset );
+        int lowWord = UnsafeUtil.getShort( address ) & 0xFFFF;
+        byte highByte = UnsafeUtil.getByte( address + Short.BYTES );
+        return lowWord | (highByte << Short.SIZE);
+    }
+
+    @Override
+    public void set3ByteInt( long index, int offset, int value )
+    {
+        long address = address( index, offset );
+        UnsafeUtil.putShort( address, (short) value );
+        UnsafeUtil.putByte( address + Short.BYTES, (byte) (value >>> Short.SIZE) );
+    }
+
     private long address( long index, int offset )
     {
         return address + (rebase( index ) * itemSize) + offset;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
@@ -169,7 +169,7 @@ public class RelationshipGroupCacheTest
         int[] types = new int[count];
         for ( int i = 0; i < count; i++ )
         {
-            types[i] = i;
+            types[i] = i + Short.MAX_VALUE ;
         }
 
         for ( int i = 0; i < 10; i++ )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith( Parameterized.class )
 public class ByteArrayTest
 {
-    private static final byte[] DEFAULT = new byte[15];
+    private static final byte[] DEFAULT = new byte[25];
 
     @Parameters
     public static Collection<Supplier<ByteArray>> data()
@@ -74,12 +74,14 @@ public class ByteArrayTest
         array.setShort( 0, 1, (short) 1234 );
         array.setInt( 0, 5, 12345 );
         array.setLong( 0, 9, Long.MAX_VALUE - 100 );
+        array.set3ByteInt( 0, 17, 76767 );
 
         // THEN
         assertEquals( (byte) 123, array.getByte( 0, 0 ) );
         assertEquals( (short) 1234, array.getShort( 0, 1 ) );
         assertEquals( 12345, array.getInt( 0, 5 ) );
         assertEquals( Long.MAX_VALUE - 100, array.getLong( 0, 9 ) );
+        assertEquals( 76767, array.get3ByteInt( 0, 17 ) );
     }
 
     @Test

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -52,6 +52,8 @@ import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.api.index.BatchingMultipleIndexPopulator;
 import org.neo4j.kernel.impl.api.index.MultipleIndexPopulator;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.RepeatRule;
@@ -298,8 +300,11 @@ public class MultipleIndexPopulationStressIT
 
     private void createRandomData( int count ) throws IOException
     {
+        Config config = Config.empty();
+        RecordFormats recordFormats =
+                RecordFormatSelector.selectForConfig( config, NullLogProvider.getInstance() );
         BatchImporter importer = new ParallelBatchImporter( directory.graphDbDir(), fs,
-                DEFAULT, NullLogService.getInstance(), ExecutionMonitors.invisible(), EMPTY, Config.empty() );
+                DEFAULT, NullLogService.getInstance(), ExecutionMonitors.invisible(), EMPTY, config, recordFormats );
         importer.doImport( new RandomDataInput( count ) );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -56,7 +56,8 @@ public class HighLimit extends BaseRecordFormats
 
     public HighLimit()
     {
-        super( STORE_VERSION, 3, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
+        super( STORE_VERSION, 3, Capability.DENSE_NODES, Capability.RELATIONSHIP_TYPE_3BYTES, Capability.SCHEMA,
+                Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -122,7 +122,8 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
         else
         {
             int typeLowWord = cursor.getShort() & 0xFFFF;
-            int type = (((cursor.getByte() & 0xFF) << Short.SIZE) | typeLowWord);
+            int typeHighWord = cursor.getByte() & 0xFF;
+            int type = ((typeHighWord << Short.SIZE) | typeLowWord);
             long recordId = record.getId();
             record.initialize( inUse,
                     decodeCompressedReference( cursor, headerByte, HAS_PROPERTY_BIT, NULL ),

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -70,6 +70,8 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
                                                 Integer.BYTES /* second next rel */ +
                                                 Integer.BYTES /* next property */;
 
+    private static final int TYPE_FIELD_BYTES = 3;
+
     private static final int FIRST_IN_FIRST_CHAIN_BIT = 0b0000_1000;
     private static final int FIRST_IN_SECOND_CHAIN_BIT = 0b0001_0000;
     private static final int HAS_FIRST_CHAIN_NEXT_BIT = 0b0010_0000;
@@ -110,15 +112,17 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     protected void doReadInternal(
             RelationshipRecord record, PageCursor cursor, int recordSize, long headerByte, boolean inUse )
     {
-        int type = cursor.getShort() & 0xFFFF;
         if (record.isUseFixedReferences())
         {
+            int type = cursor.getShort() & 0xFFFF;
             // read record in fixed reference format
             readFixedReferencesRecord( record, cursor, headerByte, inUse, type );
             record.setUseFixedReferences( true );
         }
         else
         {
+            int typeLowWord = cursor.getShort() & 0xFFFF;
+            int type = (((cursor.getByte() & 0xFF) << Short.SIZE) | typeLowWord);
             long recordId = record.getId();
             record.initialize( inUse,
                     decodeCompressedReference( cursor, headerByte, HAS_PROPERTY_BIT, NULL ),
@@ -150,7 +154,7 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     protected int requiredDataLength( RelationshipRecord record )
     {
         long recordId = record.getId();
-        return Short.BYTES + // type
+        return TYPE_FIELD_BYTES +
                length( record.getNextProp(), NULL ) +
                length( record.getFirstNode() ) +
                length( record.getSecondNode() ) +
@@ -164,7 +168,6 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     protected void doWriteInternal( RelationshipRecord record, PageCursor cursor )
             throws IOException
     {
-        cursor.putShort( (short) record.getType() );
         if (record.isUseFixedReferences())
         {
             // write record in fixed reference format
@@ -172,6 +175,10 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
         }
         else
         {
+            int type = record.getType();
+            cursor.putShort( (short) type );
+            cursor.putByte( (byte) (type >>> Short.SIZE) );
+
             long recordId = record.getId();
             encode( cursor, record.getNextProp(), NULL );
             encode( cursor, record.getFirstNode() );
@@ -194,6 +201,7 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
     protected boolean canUseFixedReferences( RelationshipRecord record, int recordSize )
     {
            return (isRecordBigEnoughForFixedReferences( recordSize ) &&
+                  (record.getType() < (1 << Short.SIZE)) &&
                   (record.getFirstNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
                   ((record.getSecondNode() & ONE_BIT_OVERFLOW_BIT_MASK) == 0) &&
                   ((record.getFirstPrevRel() == NULL) || ((record.getFirstPrevRel() & ONE_BIT_OVERFLOW_BIT_MASK) == 0)) &&
@@ -285,6 +293,8 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
 
     private void writeFixedReferencesRecord( RelationshipRecord record, PageCursor cursor )
     {
+        cursor.putShort( (short) record.getType() );
+
         long firstNode = record.getFirstNode();
         short firstNodeMod = (short)((firstNode & HIGH_DWORD_LAST_BIT_MASK) >> 32);
 

--- a/enterprise/neo4j-enterprise/src/test/java/batchimport/ParallelBatchImporterTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/batchimport/ParallelBatchImporterTest.java
@@ -19,6 +19,7 @@
  */
 package batchimport;
 
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
@@ -36,8 +37,8 @@ public class ParallelBatchImporterTest extends org.neo4j.unsafe.impl.batchimport
     }
 
     @Override
-    public String getFormatName()
+    public RecordFormats getFormat()
     {
-        return HighLimit.NAME;
+        return HighLimit.RECORD_FORMATS;
     }
 }


### PR DESCRIPTION
Increase relationship type to take up to 24 bits in high limit enterprise record format.
Adapt batch import to support new relationship group types.

changelog: Enhance high limit record format to allow relationship types to take up to 24 bits instead of 16 as it was previously, allowing for many more relationship types than before.
