### PR TITLE
Fixes a race in decorating input entities

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -108,10 +108,10 @@ public class CsvInput implements Input
             public InputIterator<InputNode> iterator()
             {
                 return new InputGroupsDeserializer<>( nodeDataFactory.iterator(),
-                        nodeHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader, decorator) ->
+                        nodeHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader) ->
                         new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputNodeDeserialization( dataStream, dataHeader, groups, idType.idsAreExternal() ),
-                                decorator, Validators.<InputNode>emptyValidator(), badCollector ), InputNode.class );
+                                badCollector ), InputNode.class, Validators.<InputNode>emptyValidator() );
             }
 
             @Override
@@ -131,10 +131,10 @@ public class CsvInput implements Input
             public InputIterator<InputRelationship> iterator()
             {
                 return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(),
-                        relationshipHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader, decorator) ->
+                        relationshipHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader) ->
                         new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputRelationshipDeserialization( dataStream, dataHeader, groups ),
-                                decorator, new InputRelationshipValidator(), badCollector ), InputRelationship.class );
+                                badCollector ), InputRelationship.class, new InputRelationshipValidator() );
             }
 
             @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -22,7 +22,6 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 import java.util.function.Function;
 
 import org.neo4j.csv.reader.CharSeeker;
-import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
@@ -68,7 +67,7 @@ public class ExternalPropertiesDecorator implements Function<InputNode,InputNode
         Header header = headerFactory.create( dataStream, config, idType );
         this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
                 new InputNodeDeserialization( dataStream, header, new Groups(), idType.idsAreExternal() ),
-                value -> value, Validators.<InputNode>emptyValidator(), badCollector );
+                badCollector );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
@@ -20,13 +20,10 @@
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
 import java.io.IOException;
-import java.util.function.Function;
-
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.csv.reader.Extractors;
 import org.neo4j.csv.reader.Mark;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.kernel.impl.util.Validator;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
@@ -45,22 +42,17 @@ public class InputEntityDeserializer<ENTITY extends InputEntity> extends InputIt
     private final CharSeeker data;
     private final Mark mark = new Mark();
     private final int delimiter;
-    private final Function<ENTITY,ENTITY> decorator;
     private final Deserialization<ENTITY> deserialization;
-    private final Validator<ENTITY> validator;
     private final Extractors.StringExtractor stringExtractor = new Extractors.StringExtractor( false );
     private final Collector badCollector;
 
     InputEntityDeserializer( Header header, CharSeeker data, int delimiter,
-            Deserialization<ENTITY> deserialization, Function<ENTITY,ENTITY> decorator,
-            Validator<ENTITY> validator, Collector badCollector )
+            Deserialization<ENTITY> deserialization, Collector badCollector )
     {
         this.header = header;
         this.data = data;
         this.delimiter = delimiter;
         this.deserialization = deserialization;
-        this.decorator = decorator;
-        this.validator = validator;
         this.badCollector = badCollector;
     }
 
@@ -93,9 +85,6 @@ public class InputEntityDeserializer<ENTITY extends InputEntity> extends InputIt
                 badCollector.collectExtraColumns(
                         data.sourceDescription(), lineNumber, stringExtractor.value() );
             }
-
-            entity = decorator.apply( entity );
-            validator.validate( entity );
 
             return entity;
         }
@@ -174,7 +163,7 @@ public class InputEntityDeserializer<ENTITY extends InputEntity> extends InputIt
                     e.getMessage() );
             if ( e instanceof InputException )
             {
-                throw Exceptions.withMessage( e, message );
+                throw Exceptions.withMessage( e, e.getMessage() + " - " + message );
             }
             throw new InputException( message, e );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -29,9 +29,12 @@ import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 
 /**
- * Able to deserialize one input group. An input group is a list of one or more input files that all have the same
- * header. All files in the same group have the same header and vice versa.
- * An import can read multiple input groups. Each group is deserialized by {@link InputEntityDeserializer}.
+ * Able to deserialize one input group. An input group is a list of one or more input files logically seen
+ * as one stream of data. The first line in this data stream defines the header, a header which applies to
+ * all data in its group.
+ *
+ * Depending on how the data is structured, see {@link Configuration#multilineFields()} data may or may not
+ * be parsed and processed in parallel for higher throughput.
  */
 class InputGroupsDeserializer<ENTITY extends InputEntity>
         extends NestingIterator<ENTITY,DataFactory<ENTITY>>

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -29,9 +29,9 @@ import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 
 /**
- * Able to deserialize one input group. An input group is a list of one or more input files containing
- * its own header. An import can read multiple input groups. Each group is deserialized by
- * {@link InputEntityDeserializer}.
+ * Able to deserialize one input group. An input group is a list of one or more input files that all have the same
+ * header. All files in the same group have the same header and vice versa.
+ * An import can read multiple input groups. Each group is deserialized by {@link InputEntityDeserializer}.
  */
 class InputGroupsDeserializer<ENTITY extends InputEntity>
         extends NestingIterator<ENTITY,DataFactory<ENTITY>>

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -83,7 +83,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
             // Initialize the processing logic for parsing the data in the first chunk, as well as in all other chunk
             processing = new TicketedProcessing<>( "Parallel input parser", maxProcessors, (seeker, header) ->
             {
-                InputEntityDeserializer<ENTITY> chunkDeserializer = factory.create( seeker, header, data.decorator() );
+                InputEntityDeserializer<ENTITY> chunkDeserializer = factory.create( seeker, header );
                 chunkDeserializer.initialize();
                 List<ENTITY> entities = new ArrayList<>();
                 while ( chunkDeserializer.hasNext() )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.function.Suppliers;
+import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 
 import static java.util.Arrays.asList;
@@ -51,7 +52,7 @@ public class InputGroupsDeserializerTest
         final AtomicReference<InputGroupsDeserializer<InputNode>> deserializerTestHack = new AtomicReference<>( null );
         InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<>(
                 data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS ), INTEGER,
-                Runtime.getRuntime().availableProcessors(), (stream,header,decorator) ->
+                Runtime.getRuntime().availableProcessors(), (stream,header) ->
                 {
                     // This is the point where the currentInput field in InputGroupsDeserializer was null
                     // so ensure that's no longer the case, just by poking those source methods right here and now.
@@ -69,7 +70,7 @@ public class InputGroupsDeserializerTest
                     InputEntityDeserializer<InputNode> result = mock( InputEntityDeserializer.class );
                     when( result.sourceDescription() ).thenReturn( String.valueOf( flips.get() ) );
                     return result;
-                }, InputNode.class );
+                }, InputNode.class, Validators.emptyValidator() );
         deserializerTestHack.set( deserializer );
 
         // WHEN running through the iterator

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 
 import org.neo4j.csv.reader.CharReadable;
-import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.test.RandomRule;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
@@ -69,14 +68,14 @@ public class ParallelInputEntityDeserializerTest
         Groups groups = new Groups();
         Set<Thread> observedProcessingThreads = new CopyOnWriteArraySet<>();
         int threads = 4;
-        DeserializerFactory<InputNode> deserializerFactory = (chunk,header,decorator) ->
+        DeserializerFactory<InputNode> deserializerFactory = (chunk,header) ->
         {
             observedProcessingThreads.add( Thread.currentThread() );
             // Make sure there will be 4 different processing threads doing this
             while ( observedProcessingThreads.size() < threads );
             return new InputEntityDeserializer<>( header, chunk, config.delimiter(),
-                    new InputNodeDeserialization( chunk, header, groups, idType.idsAreExternal() ), decorator,
-                    Validators.<InputNode>emptyValidator(), badCollector );
+                    new InputNodeDeserialization( chunk, header, groups, idType.idsAreExternal() ),
+                    badCollector );
         };
         try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,
                 defaultFormatNodeFileHeader(), config, idType, threads, deserializerFactory, InputNode.class ) )


### PR DESCRIPTION
when parallel input processing was enabled. The decoration and validation
was done in each processing thread, which put constraints on decorators
and what they could do. Now decoration and validation is done in the
"groups" deserializer, i.e. right before returning to user.
