### PR TITLE
Fix TxPushStrategyConfigIT.twoRoundRobin flakyness

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -572,7 +572,7 @@ public class HighlyAvailableEditionModule
                 TransactionCommitProcess.class );
 
         CommitProcessSwitcher commitProcessSwitcher = new CommitProcessSwitcher( transactionPropagator,
-                master, commitProcessDelegate, requestContextFactory, dependencies );
+                master, commitProcessDelegate, requestContextFactory, monitors, dependencies );
         componentSwitcherContainer.add( commitProcessSwitcher );
 
         return new HighlyAvailableCommitProcessFactory( commitProcessDelegate );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
@@ -162,12 +162,12 @@ public class TransactionPropagator implements Lifecycle
     }
 
     @Override
-    public void init() throws Throwable
+    public void init()
     {
     }
 
     @Override
-    public void start() throws Throwable
+    public void start()
     {
         this.slaveCommitters = Executors.newCachedThreadPool( new NamedThreadFactory( "slave-committer" ) );
         desiredReplicationFactor = config.getTxPushFactor();
@@ -175,17 +175,23 @@ public class TransactionPropagator implements Lifecycle
     }
 
     @Override
-    public void stop() throws Throwable
+    public void stop()
     {
         this.slaveCommitters.shutdown();
     }
 
     @Override
-    public void shutdown() throws Throwable
+    public void shutdown()
     {
     }
 
-    public void committed( long txId, int authorId )
+    /**
+     *
+     * @param txId transaction id to replicate
+     * @param authorId author id for such transaction id
+     * @return the number of missed replicas (e.g., desired replication factor - number of successful replications)
+     */
+    public int committed( long txId, int authorId )
     {
         int replicationFactor = desiredReplicationFactor;
         // If the author is not this instance, then we need to push to one less - the committer already has it
@@ -197,94 +203,100 @@ public class TransactionPropagator implements Lifecycle
 
         if ( replicationFactor == 0 )
         {
-            return;
+            return replicationFactor;
         }
         Collection<ReplicationContext> committers = new HashSet<>();
-        try
+
+        // TODO: Move this logic into {@link CommitPusher}
+        // Commit at the configured amount of slaves in parallel.
+        int successfulReplications = 0;
+        Iterator<Slave> slaveList = filter( replicationStrategy.prioritize( slaves.getSlaves() ).iterator(), authorId );
+        CompletionNotifier notifier = new CompletionNotifier();
+
+        // Start as many initial committers as needed
+        for ( int i = 0; i < replicationFactor && slaveList.hasNext(); i++ )
         {
-            // TODO: Move this logic into {@link CommitPusher}
-            // Commit at the configured amount of slaves in parallel.
-            int successfulReplications = 0;
-            Iterator<Slave> slaveList = filter( replicationStrategy.prioritize( slaves.getSlaves() ).iterator(),
-                    authorId );
-            CompletionNotifier notifier = new CompletionNotifier();
-
-            // Start as many initial committers as needed
-            for ( int i = 0; i < replicationFactor && slaveList.hasNext(); i++ )
-            {
-                Slave slave = slaveList.next();
-                Callable<Void> slaveCommitter = slaveCommitter( slave, txId, notifier );
-                committers.add( new ReplicationContext( slaveCommitters.submit( slaveCommitter ), slave ) );
-            }
-
-            // Wait for them and perhaps spawn new ones for failing committers until we're done
-            // or until we have no more slaves to try out.
-            Collection<ReplicationContext> toAdd = new ArrayList<>();
-            Collection<ReplicationContext> toRemove = new ArrayList<>();
-            while ( !committers.isEmpty() && successfulReplications < replicationFactor )
-            {
-                toAdd.clear();
-                toRemove.clear();
-                for ( ReplicationContext context : committers )
-                {
-                    if ( !context.future.isDone() )
-                    {
-                        continue;
-                    }
-
-                    if ( isSuccessful( context ) )
-                    // This committer was successful, increment counter
-                    {
-                        successfulReplications++;
-                    }
-                    else if ( slaveList.hasNext() )
-                    // This committer failed, spawn another one
-                    {
-                        Slave newSlave = slaveList.next();
-                        Callable<Void> slaveCommitter = slaveCommitter( newSlave, txId, notifier );
-                        toAdd.add( new ReplicationContext( slaveCommitters.submit( slaveCommitter ), newSlave ) );
-                    }
-                    toRemove.add( context );
-                }
-
-                // Incorporate the results into committers collection
-                if ( !toAdd.isEmpty() )
-                {
-                    committers.addAll( toAdd );
-                }
-                if ( !toRemove.isEmpty() )
-                {
-                    committers.removeAll( toRemove );
-                }
-
-                if ( !committers.isEmpty() )
-                // There are committers doing work right now, so go and wait for
-                // any of the committers to be done so that we can reevaluate
-                // the situation again.
-                {
-                    notifier.waitForAnyCompletion();
-                }
-            }
-
-            // We did the best we could, have we committed successfully on enough slaves?
-            if ( !(successfulReplications >= replicationFactor) )
-            {
-                pushedToTooFewSlaveLogger.info( "Transaction " + txId + " couldn't commit on enough slaves, desired " +
-                        replicationFactor + ", but could only commit at " + successfulReplications );
-            }
+            Slave slave = slaveList.next();
+            Callable<Void> slaveCommitter = slaveCommitter( slave, txId, notifier );
+            committers.add( new ReplicationContext( slaveCommitters.submit( slaveCommitter ), slave ) );
         }
-        catch ( Throwable t )
+
+        // Wait for them and perhaps spawn new ones for failing committers until we're done
+        // or until we have no more slaves to try out.
+        Collection<ReplicationContext> toAdd = new ArrayList<>();
+        Collection<ReplicationContext> toRemove = new ArrayList<>();
+        while ( !committers.isEmpty() && successfulReplications < replicationFactor )
         {
-            log.error( "Unknown error commit master transaction at slave", t );
-        }
-        finally
-        {
-            // Cancel all ongoing committers in the executor
+            toAdd.clear();
+            toRemove.clear();
             for ( ReplicationContext context : committers )
             {
-                context.future.cancel( false );
+                if ( !context.future.isDone() )
+                {
+                    continue;
+                }
+
+                if ( isSuccessful( context ) )
+                // This committer was successful, increment counter
+                {
+                    successfulReplications++;
+                }
+                else if ( slaveList.hasNext() )
+                // This committer failed, spawn another one
+                {
+                    Slave newSlave = slaveList.next();
+                    Callable<Void> slaveCommitter;
+                    try
+                    {
+                        slaveCommitter = slaveCommitter( newSlave, txId, notifier );
+                    }
+                    catch ( Throwable t )
+                    {
+                        log.error( "Unknown error commit master transaction at slave", t );
+                        return desiredReplicationFactor /* missed them all :( */;
+                    }
+                    finally
+                    {
+                        // Cancel all ongoing committers in the executor
+                        for ( ReplicationContext committer : committers )
+                        {
+                            committer.future.cancel( false );
+                        }
+                    }
+
+                    toAdd.add( new ReplicationContext( slaveCommitters.submit( slaveCommitter ), newSlave ) );
+                }
+                toRemove.add( context );
+            }
+
+            // Incorporate the results into committers collection
+            if ( !toAdd.isEmpty() )
+            {
+                committers.addAll( toAdd );
+            }
+            if ( !toRemove.isEmpty() )
+            {
+                committers.removeAll( toRemove );
+            }
+
+            if ( !committers.isEmpty() )
+            // There are committers doing work right now, so go and wait for
+            // any of the committers to be done so that we can reevaluate
+            // the situation again.
+            {
+                notifier.waitForAnyCompletion();
             }
         }
+
+        // We did the best we could, have we committed successfully on enough slaves?
+        if ( successfulReplications < replicationFactor )
+        {
+            pushedToTooFewSlaveLogger
+                    .info( "Transaction " + txId + " couldn't commit on enough slaves, desired " + replicationFactor +
+                            ", but could only commit at " + successfulReplications );
+        }
+
+        return replicationFactor - successfulReplications;
     }
 
     private Iterator<Slave> filter( Iterator<Slave> slaves, final Integer externalAuthorServerId )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -27,12 +27,14 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.helpers.TransactionTemplate;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.ha.ClusterRule;
 
@@ -99,7 +101,11 @@ public class TxPushStrategyConfigIT
     {
         ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.round_robin );
 
-        long txId = getLastTx( cluster.getMaster() );
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        Monitors monitors = master.getDependencyResolver().resolveDependency( Monitors.class );
+        AtomicInteger totalMissedReplicas = new AtomicInteger();
+        monitors.addMonitorListener( (MasterTransactionCommitProcess.Monitor) totalMissedReplicas::addAndGet );
+        long txId = getLastTx( master );
         int count = 15;
         for ( int i = 0; i < count; i++ )
         {
@@ -115,11 +121,13 @@ public class TxPushStrategyConfigIT
         }
 
         assertEquals( txId + count, max );
-        assertTrue( "There should be members with transactions in the cluster", min != -1 );
-        assertTrue( "There should be members with transactions in the cluster", max != -1 );
+        assertTrue( "There should be members with transactions in the cluster", min != -1 && max != -1 );
+
+        int minLaggingBehindThreshold = 1 /* this is the value without errors */ +
+                totalMissedReplicas.get() /* let's consider the missed replications */;
         assertThat( "There should at most be a txId gap of 1 among the cluster members since the transaction pushing " +
-                "goes in a round robin fashion. min:" + min + ", max:" + max,
-                (int) (max - min), lessThanOrEqualTo( 1 ) );
+                        "goes in a round robin fashion. min:" + min + ", max:" + max, (int) (max - min),
+                lessThanOrEqualTo( minLaggingBehindThreshold ) );
     }
 
     @Test
@@ -194,7 +202,7 @@ public class TxPushStrategyConfigIT
         return cluster;
     }
 
-    private void mapMachineIds(final  ManagedCluster cluster )
+    private void mapMachineIds( ManagedCluster cluster )
     {
         machineIds = new InstanceId[cluster.size()];
         machineIds[0] = cluster.getServerId( cluster.getMaster() );


### PR DESCRIPTION
The test would fail whenever there are failure in the replication
attempt.  Indeed since the push factor is on a best effort mode in
reality we could be more far behind on slaves of what the test is
claiming.  This change will try to consider the failed replications
when asserting.  Such change should make the test more reliable.
