### PR TITLE
Optimisations and asynchronous apply method for WorkSync

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
@@ -84,7 +84,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
         return transactionApplier;
     }
 
-    private void applyIndexUpdates()
+    private void applyIndexUpdates() throws Exception
     {
         if ( indexUpdates != null && indexUpdates.hasUpdates() )
         {
@@ -210,7 +210,14 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
                 // In that scenario the index would be created, populated and then fed the [this time duplicate]
                 // update for the node created before the index. The most straight forward solution is to
                 // apply pending index updates up to this point in this batch before index schema changes occur.
-                applyIndexUpdates();
+                try
+                {
+                    applyIndexUpdates();
+                }
+                catch ( Exception e )
+                {
+                    throw new IOException( "Failed to flush index updates prior to applying schema change", e );
+                }
 
                 switch ( command.getMode() )
                 {

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -34,20 +34,21 @@ import java.util.concurrent.locks.LockSupport;
 /**
  * Turns multi-threaded unary work into single-threaded stack work.
  * <p>
- *     The technique used here is inspired in part both by the Flat Combining
- *     concept from Hendler, Incze, Shavit &amp; Tzafrir, and in part by the
- *     wait-free linked queue design by Vyukov.
+ * The technique used here is inspired in part both by the Flat Combining
+ * concept from Hendler, Incze, Shavit &amp; Tzafrir, and in part by the
+ * wait-free linked queue design by Vyukov.
  * </p>
  * <p>
- *     In a sense, this turns many small, presumably concurrent, pieces of work
- *     into fewer, larger batches of work, that is then applied to the material
- *     under synchronisation.
+ * In a sense, this turns many small, presumably concurrent, pieces of work
+ * into fewer, larger batches of work, that is then applied to the material
+ * under synchronisation.
  * </p>
  * <p>
- *     Obviously this only makes sense for work that a) can be combined, and b)
- *     where the performance improvements from batching effects is large enough
- *     to overcome the overhead of collecting and batching up the work units.
+ * Obviously this only makes sense for work that a) can be combined, and b)
+ * where the performance improvements from batching effects is large enough
+ * to overcome the overhead of collecting and batching up the work units.
  * </p>
+ *
  * @see Work
  */
 public class WorkSync<Material, W extends Work<Material,W>>
@@ -60,6 +61,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
     /**
      * Create a new WorkSync that will synchronize the application of work to
      * the given material.
+     *
      * @param material The material we want to apply work to, in a thread-safe
      * way.
      */
@@ -75,6 +77,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
     /**
      * Apply the given work to the material in a thread-safe way, possibly by
      * combining it with other work.
+     *
      * @param work The work to be done.
      * @throws ExecutionException if this thread ends up performing the piled up work,
      * and any work unit in the pile throws an exception. Thus the current thread is not
@@ -454,6 +457,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
     private static final class FutureThrow extends FutureTask<Object>
     {
         private static final Callable<Object> NULL_CALLABLE = () -> null;
+
         FutureThrow( Throwable result )
         {
             super( NULL_CALLABLE );

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -83,7 +83,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
             tryCount++;
             try
             {
-                if ( lock.tryLock( tryCount < 10? 0 : 10, TimeUnit.MILLISECONDS ) )
+                if ( tryLock( tryCount, unit ) )
                 {
                     try
                     {
@@ -91,7 +91,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
                     }
                     finally
                     {
-                        lock.unlock();
+                        unlock();
                     }
                 }
             }
@@ -109,6 +109,16 @@ public class WorkSync<Material, W extends Work<Material,W>>
         {
             Thread.currentThread().interrupt();
         }
+    }
+
+    private boolean tryLock( int tryCount, WorkUnit<Material,W> unit ) throws InterruptedException
+    {
+        return lock.tryLock( tryCount < 10? 0 : 10, TimeUnit.MILLISECONDS );
+    }
+
+    private void unlock()
+    {
+        lock.unlock();
     }
 
     private void doSynchronizedWork()

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -350,15 +350,7 @@ public class WorkSync<Material, W extends Work<Material,W>>
         while ( batch != stackEnd )
         {
             batch.complete();
-            WorkUnit<Material,W> tmp = batch.next;
-            // The batch linked-list has been reversed, so oldest WorkUnits point to newer objects.
-            // Because of this, we null out the next reference here, to reduce the probability of
-            // ending up with a WorkUnit that has been promoted to the old-gen, that has a reference
-            // to objects in the new-gen. Old-gen objects are always considered live during new-gen
-            // collections, so a dead old-gen object can keep new-gen objects alive longer than
-            // necessary, causing a cascading premature promotion.
-            batch.next = null;
-            batch = tmp;
+            batch = batch.next;
         }
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -100,6 +100,27 @@ public class WorkSync<Material, W extends Work<Material,W>>
         while ( !unit.isDone() );
     }
 
+    /**
+     * Apply the given work to the material in a thread-safe way, possibly asynchronously
+     * if contention is observed with other threads, and possibly by combining it with other work.
+     * <p>
+     * The returned future can be cancelled while it is still enqueued to run, but cancellation
+     * may race with work combining and application, and have slightly weaker semantics than what
+     * the {@link Future} interface specifies. for instance, a unit of that is cancelled, and where
+     * the {@link Future#cancel(boolean)} cancel} method returns {@code true}, may still and up
+     * being applied.
+     * The reason for this departure from specification is implementation efficiency of the other
+     * {@code WorkSync} features, since the cancellation feature is likely rarely used.
+     * <p>
+     * The given unit of work may be done by this thread, or any other thread that is concurrently
+     * submitting work to the {@code WorkSync}. If this unit of work, or any of the other units of
+     * work, throws an exception, then the exception will surface in the thread that ends up doing
+     * the work. This may manifest itself as an {@link ExecutionException} thrown from one of the
+     * {@code get} methods of {@link Future}, or from the {@link #apply(Work)} method.
+     *
+     * @param work The work to be done.
+     * @return A {@link Future} representing the eventual completion of the work.
+     */
     public Future<?> applyAsync( W work )
     {
         // Schedule our work on the stack.

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/WorkSync.java
@@ -350,7 +350,15 @@ public class WorkSync<Material, W extends Work<Material,W>>
         while ( batch != stackEnd )
         {
             batch.complete();
-            batch = batch.next;
+            WorkUnit<Material,W> tmp = batch.next;
+            // The batch linked-list has been reversed, so oldest WorkUnits point to newer objects.
+            // Because of this, we null out the next reference here, to reduce the probability of
+            // ending up with a WorkUnit that has been promoted to the old-gen, that has a reference
+            // to objects in the new-gen. Old-gen objects are always considered live during new-gen
+            // collections, so a dead old-gen object can keep new-gen objects alive longer than
+            // necessary, causing a cascading premature promotion.
+            batch.next = null;
+            batch = tmp;
         }
     }
 

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -21,12 +21,17 @@ package org.neo4j.concurrent;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -76,8 +81,8 @@ public class WorkSyncTest
     {
         public void add( int delta )
         {
-            sum.getAndAdd( delta );
-            count.getAndIncrement();
+            sum.add( delta );
+            count.increment();
         }
     }
 
@@ -85,7 +90,7 @@ public class WorkSyncTest
     {
         private final AddWork addWork;
 
-        public RunnableWork( AddWork addWork )
+        RunnableWork( AddWork addWork )
         {
             this.addWork = addWork;
         }
@@ -97,8 +102,34 @@ public class WorkSyncTest
         }
     }
 
-    private AtomicInteger sum = new AtomicInteger();
-    private AtomicInteger count = new AtomicInteger();
+    private static class UnsynchronisedAdder
+    {
+        // The volatile modifier prevents hoisting and reordering optimisations that could *hide* races
+        private volatile long value;
+
+        public void add( long delta )
+        {
+            long v = value;
+            // Make sure other threads have a chance to run and race with our update
+            Thread.yield();
+            // Allow an up to ~50 micro-second window for racing and losing updates
+            usleep( ThreadLocalRandom.current().nextInt( 50 ) );
+            value = v + delta;
+        }
+
+        public void increment()
+        {
+            add( 1 );
+        }
+
+        public long sum()
+        {
+            return value;
+        }
+    }
+
+    private UnsynchronisedAdder sum = new UnsynchronisedAdder();
+    private UnsynchronisedAdder count = new UnsynchronisedAdder();
     private Adder adder = new Adder();
     private WorkSync<Adder,AddWork> sync = new WorkSync<>( adder );
 
@@ -106,10 +137,10 @@ public class WorkSyncTest
     public void mustApplyWork() throws Exception
     {
         sync.apply( new AddWork( 10 ) );
-        assertThat( sum.get(), is( 10 ) );
+        assertThat( sum.sum(), is( 10L ) );
 
         sync.apply( new AddWork( 20 ) );
-        assertThat( sum.get(), is( 30 ) );
+        assertThat( sum.sum(), is( 30L ) );
     }
 
     @Test
@@ -123,7 +154,7 @@ public class WorkSyncTest
         executor.shutdown();
         assertTrue( executor.awaitTermination( 2, TimeUnit.SECONDS ) );
 
-        assertThat( count.get(), lessThan( sum.get() ) );
+        assertThat( count.sum(), lessThan( sum.sum() ) );
     }
 
     @Test
@@ -133,7 +164,7 @@ public class WorkSyncTest
 
         sync.apply( new AddWork( 10 ) );
 
-        assertThat( sum.get(), is( 10 ) );
+        assertThat( sum.sum(), is( 10L ) );
         assertTrue( Thread.interrupted() );
     }
 
@@ -170,7 +201,54 @@ public class WorkSyncTest
         broken.set( false );
         sync.apply( new AddWork( 20 ) );
 
-        assertThat( sum.get(), is( 20 ) );
-        assertThat( count.get(), is( 1 ) );
+        assertThat( sum.sum(), is( 20L ) );
+        assertThat( count.sum(), is( 1L ) );
+    }
+
+    @Test
+    public void mustNotApplyWorkInParallelUnderStress() throws Exception
+    {
+        int workers = Runtime.getRuntime().availableProcessors() * 5;
+        int iterations = 1_000;
+        int incrementValue = 42;
+        CountDownLatch startLatch = new CountDownLatch( workers );
+        CountDownLatch endLatch = new CountDownLatch( workers );
+        ExecutorService executor = Executors.newFixedThreadPool( workers );
+        AtomicBoolean start = new AtomicBoolean();
+        Callable<Void> work = () ->
+        {
+            startLatch.countDown();
+            boolean spin;
+            do
+            {
+                spin = !start.get();
+            }
+            while ( spin );
+
+            for ( int i = 0; i < iterations; i++ )
+            {
+                sync.apply( new AddWork( incrementValue ) );
+            }
+
+            endLatch.countDown();
+            return null;
+        };
+
+        List<Future<Void>> futureList = new ArrayList<>();
+        for ( int i = 0; i < workers; i++ )
+        {
+            futureList.add( executor.submit( work ) );
+        }
+        startLatch.await();
+        start.set( true );
+        endLatch.await();
+
+        for ( Future<Void> future : futureList )
+        {
+            future.get(); // check for any exceptions
+        }
+
+        assertThat( count.sum(), lessThan( (long) (workers * iterations) ) );
+        assertThat( sum.sum(), is( (long) (incrementValue * workers * iterations) ) );
     }
 }

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -224,8 +224,11 @@ public class WorkSyncTest
         }
         catch ( TimeoutException ignore )
         {
+            while ( !semaphore.hasQueuedThreads() )
+            {
+                usleep( 1 );
+            }
             // good, the concurrent AddWork is now stuck on the semaphore
-            assertTrue( semaphore.hasQueuedThreads() );
         }
     }
 

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -192,7 +192,7 @@ public class WorkSyncTest
             executor.submit( new RunnableWork( new AddWork( 1 ) ) );
         }
         executor.shutdown();
-        assertTrue( executor.awaitTermination( 2, TimeUnit.SECONDS ) );
+        assertTrue( executor.awaitTermination( 10, TimeUnit.SECONDS ) );
 
         assertThat( adder.count(), lessThan( adder.sum() ) );
     }

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -74,7 +74,7 @@ public class WorkSyncTest
         while ( now < deadline );
     }
 
-    private static class AddWork implements Work<Adder, AddWork>
+    private static class AddWork implements Work<Adder,AddWork>
     {
         private int delta;
 
@@ -189,7 +189,7 @@ public class WorkSyncTest
         ExecutorService executor = Executors.newFixedThreadPool( 64 );
         for ( int i = 0; i < 1000; i++ )
         {
-            executor.submit( new RunnableWork( new AddWork( 1 )) );
+            executor.submit( new RunnableWork( new AddWork( 1 ) ) );
         }
         executor.shutdown();
         assertTrue( executor.awaitTermination( 2, TimeUnit.SECONDS ) );
@@ -390,7 +390,7 @@ public class WorkSyncTest
             usleep( 1000 );
             future.cancel( true );
             return null;
-        }) ;
+        } );
         spinwait( readyLatch );
         startLatch.set( true );
         assertGetThrowsCancellationException( future );
@@ -421,7 +421,7 @@ public class WorkSyncTest
             usleep( 1000 );
             future.cancel( true );
             return null;
-        }) ;
+        } );
         spinwait( readyLatch );
         startLatch.set( true );
         assertGetWithTimeoutThrowsCancellationException( future );

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -447,6 +447,15 @@ public class WorkSyncTest
     }
 
     @Test
+    public void cannotCancelApplyAsyncFutureThatIsAlreadyDone() throws Exception
+    {
+        Future<?> future = sync.applyAsync( new AddWork( 1 ) );
+        assertTrue( future.isDone() );
+        assertFalse( future.cancel( true ) );
+        assertFalse( future.isCancelled() );
+    }
+
+    @Test
     public void mustApplyWorkEvenWhenInterrupted() throws Exception
     {
         Thread.currentThread().interrupt();


### PR DESCRIPTION
These changes speed up the `WorkSync` mechanism. Quite noticeable in micro-benchmarks, but probably a negligible difference to the product as a whole. This also fixes a potential GC nepostism issue, where both the prior `tryLock` based locking mechanism, and the batch stack, could end up with prematurely promoted dead objects in the old-gen, that had "live" references to objects in the new-gen.

This also adds a `WorkSync.applyAsync` method, that may be useful for getting #7588 to a working state - specifically, the `TransactionPropagator` might have a use for it.
