### PR TITLE
Returns index partitions in sorted order

### DIFF
--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,9 @@ import org.neo4j.test.TargetDirectory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class PartitionedIndexStorageTest
@@ -163,6 +167,44 @@ public class PartitionedIndexStorageTest
         List<File> folders = storage.listFolders();
 
         assertEquals( asSet( folder1, folder2 ), new HashSet<>( folders ) );
+    }
+
+    @Test
+    public void shouldListIndexPartitionsSorted() throws Exception
+    {
+        // GIVEN
+        FileSystemAbstraction scramblingFs = new DefaultFileSystemAbstraction()
+                {
+                    @Override
+                    public File[] listFiles( File directory )
+                    {
+                        List<File> files = asList( super.listFiles( directory ) );
+                        Collections.shuffle( files );
+                        return files.toArray( new File[files.size()] );
+                    }
+                };
+        PartitionedIndexStorage myStorage = new PartitionedIndexStorage( getOrCreateDirFactory( scramblingFs ),
+                scramblingFs, testDir.graphDbDir(), INDEX_ID, false );
+        File parent = myStorage.getIndexFolder();
+        int directoryCount = 10;
+        for ( int i = 0; i < directoryCount; i++ )
+        {
+            scramblingFs.mkdirs( new File( parent, String.valueOf( i + 1 ) ) );
+        }
+
+        // WHEN
+        Map<File,Directory> directories = myStorage.openIndexDirectories();
+
+        // THEN
+        assertEquals( directoryCount, directories.size() );
+        int previous = 0;
+        for ( Map.Entry<File,Directory> directory : directories.entrySet() )
+        {
+            int current = parseInt( directory.getKey().getName() );
+            assertTrue( "Wanted directory " + current + " to have higher id than previous " + previous,
+                    current > previous );
+            previous = current;
+        }
     }
 
     private void createRandomFilesAndFolders( File rootFolder ) throws IOException


### PR DESCRIPTION
when opening a multi-partition index. This is important since the index state,
i.e. ONLINE/POPULATING is set and check in the first one.

changelog: Fixes an issue where multi-partition indexes would, during startup, sometimes not be recognized as ONLINE when in fact they were. This would result in an unnecessary full population of the index
