### PR TITLE
Enhance new execution guard possibilities and simplify migration.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -451,6 +451,7 @@ public abstract class GraphDatabaseSettings
             illegalValueMessage("has to be a valid kernel identifier", matches("[a-zA-Z0-9]*")));
 
     @Internal
+    @Deprecated
     public static final Setting<Boolean> execution_guard_enabled = setting("unsupported.dbms.executiontime_limit.enabled", BOOLEAN, FALSE );
 
     @Description("Amount of time in ms the GC monitor thread will wait before taking another measurement.")

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -53,5 +53,17 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
                 }
             }
         } );
+        add( new SpecificPropertyMigration("unsupported.dbms.executiontime_limit.time",
+                "unsupported.dbms.executiontime_limit.time has been replaced with dbms.transaction.timeout.")
+        {
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+                if ( StringUtils.isNotEmpty( value ) )
+                {
+                    rawConfiguration.putIfAbsent( GraphDatabaseSettings.transaction_timeout.name(), value );
+                }
+            }
+        } );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -356,12 +356,12 @@ public class DataSourceModule
     private Guard createGuard( Dependencies deps, Config config, Clock clock, LogService logging )
     {
         Boolean isGuardEnabled = config.get( GraphDatabaseSettings.execution_guard_enabled );
-        Guard guard = isGuardEnabled ? createTimeoutGuard( clock, logging ) : EmptyGuard.EMPTY_GUARD;
+        Guard guard = isGuardEnabled ? createGuard( clock, logging ) : EmptyGuard.EMPTY_GUARD;
         deps.satisfyDependency( guard );
         return guard;
     }
 
-    private TimeoutGuard createTimeoutGuard( Clock clock, LogService logging )
+    protected TimeoutGuard createGuard( Clock clock, LogService logging )
     {
         return new TimeoutGuard( clock, logging.getInternalLog( TimeoutGuard.class ) );
     }

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -46,6 +46,7 @@ import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
@@ -124,6 +125,11 @@ public interface ServerSettings
     Setting<Integer> webserver_max_threads = setting( "dbms.threads.worker_count", INTEGER,
             "" + Math.min( Runtime.getRuntime().availableProcessors(), 500 ),
             range( 1, JettyThreadCalculator.MAX_THREADS ) );
+
+    @Description("If execution time limiting is enabled in the database, this configures the maximum request execution time.")
+    @Internal
+    @Deprecated
+    Setting<Long> webserver_limit_execution_time = setting( "unsupported.dbms.executiontime_limit.time", DURATION, NO_DEFAULT );
 
     @Internal
     Setting<List<String>> console_module_engines = setting(

--- a/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
@@ -40,10 +40,10 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.rest.web.ServerQuerySession;
 
+import static org.neo4j.server.web.HttpHeaderUtils.getTransactionTimeout;
+
 public class CypherExecutor extends LifecycleAdapter
 {
-    static final String MAX_EXECUTION_TIME_HEADER = "max-execution-time";
-
     private final Database database;
     private ExecutionEngine executionEngine;
     private GraphDatabaseQueryService service;
@@ -93,7 +93,7 @@ public class CypherExecutor extends LifecycleAdapter
     {
         if ( guardEnabled )
         {
-            long customTimeout = getTransactionTimeLimit( request );
+            long customTimeout = getTransactionTimeout( request, log );
             if ( customTimeout > 0 )
             {
                 return beginCustomTransaction( customTimeout );
@@ -110,23 +110,5 @@ public class CypherExecutor extends LifecycleAdapter
     private InternalTransaction beginDefaultTransaction()
     {
         return service.beginTransaction( KernelTransaction.Type.implicit, AccessMode.Static.FULL );
-    }
-
-    private long getTransactionTimeLimit( HttpServletRequest request )
-    {
-        String headerValue = request.getHeader( MAX_EXECUTION_TIME_HEADER );
-        if ( headerValue != null )
-        {
-            try
-            {
-                return Long.parseLong( headerValue );
-            }
-            catch ( NumberFormatException e )
-            {
-                log.error( String.format( "Fail to parse `%s` header with value: '%s'. Should be a positive number.",
-                        MAX_EXECUTION_TIME_HEADER, headerValue), e );
-            }
-        }
-        return -1;
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -65,10 +65,11 @@ public class TransactionFacade
         this.logProvider = logProvider;
     }
 
-    public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme, boolean implicitTransaction, AccessMode mode )
-            throws TransactionLifecycleException
+    public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme, boolean implicitTransaction,
+            AccessMode mode, long customTransactionTimeout ) throws TransactionLifecycleException
     {
-        return new TransactionHandle( kernel, engine, registry, uriScheme, implicitTransaction, mode, logProvider );
+        return new TransactionHandle( kernel, engine, registry, uriScheme, implicitTransaction, mode,
+                customTransactionTimeout, logProvider );
     }
 
     public TransactionHandle findTransactionHandle( long txId ) throws TransactionLifecycleException

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -46,9 +46,10 @@ public class TransitionalPeriodTransactionMessContainer
         this.txBridge = db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
     }
 
-    public TransitionalTxManagementKernelTransaction newTransaction( Type type, AccessMode mode )
+    public TransitionalTxManagementKernelTransaction newTransaction( Type type, AccessMode mode,
+            long customTransactionTimeout )
     {
-        return new TransitionalTxManagementKernelTransaction( db, type, mode, txBridge );
+        return new TransitionalTxManagementKernelTransaction( db, type, mode, customTransactionTimeout, txBridge );
     }
 
     public ThreadToStatementContextBridge getBridge()
@@ -56,9 +57,11 @@ public class TransitionalPeriodTransactionMessContainer
         return txBridge;
     }
 
-    public QuerySession create(  GraphDatabaseQueryService service, Type type, AccessMode mode, HttpServletRequest request )
+    public QuerySession create( GraphDatabaseQueryService service, Type type, AccessMode mode,
+            long customTransactionTimeout, HttpServletRequest request )
     {
-        InternalTransaction transaction = db.beginTransaction( type, mode );
+        InternalTransaction transaction = customTransactionTimeout > 0 ? db.beginTransaction( type, mode, customTransactionTimeout ) :
+                                          db.beginTransaction( type, mode);
         TransactionalContext context = new Neo4jTransactionalContext( service, transaction, txBridge.get(), locker );
         return new ServerQuerySession( request, context );
     }

--- a/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
+++ b/community/server/src/main/java/org/neo4j/server/web/HttpHeaderUtils.java
@@ -19,13 +19,18 @@
  */
 package org.neo4j.server.web;
 
-import javax.ws.rs.core.MediaType;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
+
+import org.neo4j.logging.Log;
 
 public class HttpHeaderUtils {
+
+    public static final String MAX_EXECUTION_TIME_HEADER = "max-execution-time";
 
     public static final Map<String, String> CHARSET = Collections.singletonMap("charset", StandardCharsets.UTF_8.name());
 
@@ -48,5 +53,31 @@ public class HttpHeaderUtils {
         Map<String, String> paramsWithCharset = new HashMap<String, String>(parameters);
         paramsWithCharset.putAll(CHARSET);
         return new MediaType(mediaType.getType(), mediaType.getSubtype(), paramsWithCharset);
+    }
+
+    /**
+     * Retrieve custom transaction timeout in milliseconds from numeric {@link #MAX_EXECUTION_TIME_HEADER} request
+     * header.
+     * If header is not set returns -1.
+     * @param request http request
+     * @param errorLog errors log for header parsing errors
+     * @return custom timeout if header set, -1 otherwise or when value is not a valid number.
+     */
+    public static long getTransactionTimeout( HttpServletRequest request, Log errorLog )
+    {
+        String headerValue = request.getHeader( MAX_EXECUTION_TIME_HEADER );
+        if ( headerValue != null )
+        {
+            try
+            {
+                return Long.parseLong( headerValue );
+            }
+            catch ( NumberFormatException e )
+            {
+                errorLog.error( String.format( "Fail to parse `%s` header with value: '%s'. Should be a positive number.",
+                        MAX_EXECUTION_TIME_HEADER, headerValue), e );
+            }
+        }
+        return -1;
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -35,6 +35,7 @@ import org.neo4j.test.DoubleLatch;
 import static javax.xml.bind.DatatypeConverter.parseLong;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,11 +48,11 @@ public class ConcurrentTransactionAccessTest
         TransactionRegistry registry =
                 new TransactionHandleRegistry( mock( Clock.class), 0, NullLogProvider.getInstance() );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
-        when(kernel.newTransaction( any( KernelTransaction.Type.class ), any( AccessMode.class ) ) )
+        when(kernel.newTransaction( any( KernelTransaction.Type.class ), any( AccessMode.class ), anyLong() ) )
                 .thenReturn( mock(TransitionalTxManagementKernelTransaction.class) );
         TransactionFacade actions = new TransactionFacade( kernel, null, registry, NullLogProvider.getInstance() );
 
-        final TransactionHandle transactionHandle = actions.newTransactionHandle( new DisgustingUriScheme(), true, AccessMode.Static.FULL );
+        final TransactionHandle transactionHandle = actions.newTransactionHandle( new DisgustingUriScheme(), true, AccessMode.Static.FULL, -1 );
 
         final DoubleLatch latch = new DoubleLatch();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -81,12 +81,11 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -111,19 +110,18 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
 
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         Result executionResult = mock( Result.class );
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -150,16 +148,15 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         QuerySession querySession = mock( QuerySession.class );
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         handle.execute( statements( new Statement( "query", map(), false, (ResultDataContent[]) null ) ), output,
@@ -200,15 +197,14 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( executionEngine.isPeriodicCommit( queryText) ).thenReturn( true );
         when( executionEngine.executeQuery( eq( queryText ), eq( map() ), eq( querySession ) ) )
                 .thenReturn( executionResult );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
         Statement statement = new Statement( queryText, map(), false, (ResultDataContent[]) null );
 
@@ -231,20 +227,20 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
 
         QueryExecutionEngine engine = mock( QueryExecutionEngine.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
 
         Result result = mock( Result.class );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( result );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         TransactionHandle handle = new TransactionHandle( kernel, engine, registry, uriScheme, false, FULL,
-                NullLogProvider.getInstance() );
+                anyLong(), NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -269,12 +265,12 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         TransactionHandle handle = new TransactionHandle( kernel, mock( QueryExecutionEngine.class ), registry,
-                uriScheme, true, FULL, NullLogProvider.getInstance() );
+                uriScheme, true, FULL, anyLong(), NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -304,11 +300,10 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, engine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, engine, registry );
 
         // then
         verifyZeroInteractions( kernel );
@@ -318,7 +313,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
 
         // then
-        verify( kernel ).newTransaction( any( Type.class ), any( AccessMode.class ) );
+        verify( kernel ).newTransaction( any( Type.class ), any( AccessMode.class ), anyLong() );
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
@@ -335,19 +330,18 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
 
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( executionEngine.executeQuery( "query", map(), querySession ) ).thenThrow( new NullPointerException() );
 
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -370,7 +364,7 @@ public class TransactionHandleTest
     {
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
-        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL );
+        TransitionalTxManagementKernelTransaction transactionContext = kernel.newTransaction( explicit, FULL, -1 );
         doThrow( new NullPointerException() ).when( transactionContext ).commit();
 
         LogProvider logProvider = mock( LogProvider.class );
@@ -383,11 +377,11 @@ public class TransactionHandleTest
         Result executionResult = mock( Result.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( engine.executeQuery( "query", map(), querySession ) ).thenReturn( executionResult );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         TransactionHandle handle =
-                new TransactionHandle( kernel, engine, registry, uriScheme, false, FULL, logProvider );
+                new TransactionHandle( kernel, engine, registry, uriScheme, false, FULL, -1, logProvider );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -415,14 +409,14 @@ public class TransactionHandleTest
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
         QuerySession querySession = mock( QuerySession.class );
         when( kernel.create( any( GraphDatabaseQueryService.class ), any( Type.class ), any( AccessMode.class ),
-                any( HttpServletRequest.class )) ).thenReturn( querySession );
+                anyLong(), any( HttpServletRequest.class )) ).thenReturn( querySession );
         when( executionEngine.executeQuery( "matsch (n) return n", map(), querySession ) )
                 .thenThrow( new QueryExecutionKernelException( new SyntaxException( "did you mean MATCH?" ) ) );
 
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, false, FULL,
-                NullLogProvider.getInstance() );
+                anyLong(),  NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -449,7 +443,7 @@ public class TransactionHandleTest
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         TransactionHandle handle = new TransactionHandle( mockKernel(), executionEngine, registry, uriScheme, false, FULL,
-                NullLogProvider.getInstance() );
+                anyLong(), NullLogProvider.getInstance() );
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
         // when
@@ -471,12 +465,11 @@ public class TransactionHandleTest
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
         TransitionalTxManagementKernelTransaction tx = mock( TransitionalTxManagementKernelTransaction.class );
-        when( kernel.newTransaction( any( Type.class ), any( AccessMode.class ) ) ).thenReturn( tx );
+        when( kernel.newTransaction( any( Type.class ), any( AccessMode.class ), anyLong() ) ).thenReturn( tx );
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337l );
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
-        TransactionHandle handle = new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
-                NullLogProvider.getInstance() );
+        TransactionHandle handle = getTransactionHandle( kernel, executionEngine, registry );
 
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
         Statement statement = new Statement( "MATCH (n) RETURN n", map(), false, (ResultDataContent[]) null );
@@ -499,7 +492,7 @@ public class TransactionHandleTest
                 .thenThrow( new DeadlockDetectedException( "deadlock" ) );
 
         TransactionHandle handle = new TransactionHandle( mockKernel(), executionEngine,
-                mock( TransactionRegistry.class ), uriScheme, true, FULL, NullLogProvider.getInstance() );
+                mock( TransactionRegistry.class ), uriScheme, true, FULL, anyLong(), NullLogProvider.getInstance() );
 
         ExecutionResultSerializer output = mock( ExecutionResultSerializer.class );
 
@@ -530,8 +523,15 @@ public class TransactionHandleTest
     {
         TransitionalTxManagementKernelTransaction context = mock( TransitionalTxManagementKernelTransaction.class );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
-        when( kernel.newTransaction( any( Type.class ), any( AccessMode.class ) ) ).thenReturn( context );
+        when( kernel.newTransaction( any( Type.class ), any( AccessMode.class ), anyLong() ) ).thenReturn( context );
         return kernel;
+    }
+
+    private TransactionHandle getTransactionHandle( TransitionalPeriodTransactionMessContainer kernel,
+            QueryExecutionEngine executionEngine, TransactionRegistry registry )
+    {
+        return new TransactionHandle( kernel, executionEngine, registry, uriScheme, true, FULL,
+                anyLong(), NullLogProvider.getInstance() );
     }
 
     private static Matcher<Iterable<Neo4jError>> hasNoErrors()

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.GraphDatabaseQueryService;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransitionalPeriodTransactionMessContainerTest
+{
+
+    private GraphDatabaseFacade databaseFacade = mock( GraphDatabaseFacade.class );
+    private GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+    private HttpServletRequest request = mock( HttpServletRequest.class );
+    private DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+    private ThreadToStatementContextBridge bridge = mock( ThreadToStatementContextBridge.class );
+    private InternalTransaction internalTransaction = mock( InternalTransaction.class );
+    private KernelTransaction.Type type = KernelTransaction.Type.implicit;
+    private AccessMode.Static accessMode = AccessMode.Static.FULL;
+
+    @Before
+    public void setUp()
+    {
+        when( internalTransaction.transactionType() ).thenReturn( type );
+        when( internalTransaction.mode() ).thenReturn( accessMode );
+        when( databaseFacade.getDependencyResolver() ).thenReturn( dependencyResolver );
+        when( queryService.getDependencyResolver() ).thenReturn( dependencyResolver );
+        when( dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ) ).thenReturn( bridge );
+    }
+
+    @Test
+    public void startTransactionWithCustomTimeout() throws Exception
+    {
+        when( databaseFacade.beginTransaction( type, accessMode, 10 ) ).thenReturn( internalTransaction );
+
+        TransitionalPeriodTransactionMessContainer transactionMessContainer =
+                new TransitionalPeriodTransactionMessContainer( databaseFacade );
+        transactionMessContainer.create( queryService, type, accessMode, 10, request );
+
+        verify( databaseFacade ).beginTransaction( type, accessMode, 10 );
+    }
+
+    @Test
+    public void startDefaultTransactionWhenTimeoutNotSpecified()
+    {
+        when( databaseFacade.beginTransaction( type, accessMode ) ).thenReturn( internalTransaction );
+
+        TransitionalPeriodTransactionMessContainer transactionMessContainer =
+                new TransitionalPeriodTransactionMessContainer( databaseFacade );
+        transactionMessContainer.create( queryService, type, accessMode, 0, request );
+
+        verify( databaseFacade ).beginTransaction( type, accessMode );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TransitionalTxManagementKernelTransactionTest
+{
+
+    private GraphDatabaseFacade databaseFacade = mock( GraphDatabaseFacade.class );
+    private ThreadToStatementContextBridge contextBridge = mock( ThreadToStatementContextBridge.class );
+    private AccessMode.Static accessMode = AccessMode.Static.READ;
+    private KernelTransaction.Type type = KernelTransaction.Type.implicit;
+
+    @Test
+    public void reopenStartTransactionWithCustomTimeoutIfSpecified() throws Exception
+    {
+        TransitionalTxManagementKernelTransaction managementKernelTransaction =
+                new TransitionalTxManagementKernelTransaction( databaseFacade, type, accessMode, 10, contextBridge );
+
+        managementKernelTransaction.reopenAfterPeriodicCommit();
+
+        verify( databaseFacade, times( 2 ) ).beginTransaction( type, accessMode, 10);
+    }
+
+    @Test
+    public void reopenStartDefaultTransactionIfTimeoutNotSpecified()
+    {
+        TransitionalTxManagementKernelTransaction managementKernelTransaction =
+                new TransitionalTxManagementKernelTransaction( databaseFacade, type, accessMode, -1, contextBridge );
+
+        managementKernelTransaction.reopenAfterPeriodicCommit();
+
+        verify( databaseFacade, times( 2 ) ).beginTransaction( type, accessMode );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/HttpHeaderUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.web;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class HttpHeaderUtilsTest
+{
+    @Rule
+    public AssertableLogProvider logProvider = new AssertableLogProvider( true );
+    private HttpServletRequest request;
+
+    @Before
+    public void setUp()
+    {
+        request = Mockito.mock( HttpServletRequest.class );
+    }
+
+    @Test
+    public void retrieveCustomTransactionTimeout() throws Exception
+    {
+        when( request.getHeader( HttpHeaderUtils.MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "100" );
+        Log log = logProvider.getLog( HttpServletRequest.class );
+        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        assertEquals( "Transaction timeout should be retrieved.", 100, transactionTimeout );
+        logProvider.assertNoLoggingOccurred();
+    }
+
+    @Test
+    public void defaultValueWhenCustomTransactionTimeoutNotSpecified()
+    {
+        Log log = logProvider.getLog( HttpServletRequest.class );
+        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        assertEquals( "Transaction timeout not specified.", -1, transactionTimeout );
+        logProvider.assertNoLoggingOccurred();
+    }
+
+    @Test
+    public void defaultValueWhenCustomTransactionTimeoutNotANumber()
+    {
+        when( request.getHeader( HttpHeaderUtils.MAX_EXECUTION_TIME_HEADER ) ).thenReturn( "aa" );
+        Log log = logProvider.getLog( HttpServletRequest.class );
+        long transactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
+        assertEquals( "Transaction timeout not specified.", -1, transactionTimeout );
+        logProvider.assertContainsMessageContaining("Fail to parse `max-execution-time` header with value: 'aa'. Should be a positive number.");
+    }
+}


### PR DESCRIPTION
Add support for custom timeout in REST transactional endpoint.
Provide migration for internal settings 'unsupported.dbms.executiontime_limit.time' to make user migration as smooth as possible.
Additional test for periodic commit queries.

**Please note it should be null merged into 3.1**
