### PR TITLE
Properly handle transactions on ACK_FAILURE

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -390,16 +390,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     @Override
                     public State reset( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
-                        try
-                        {
-                            machine.ctx.statementProcessor.reset();
-                            return READY;
-                        }
-                        catch ( Throwable e )
-                        {
-                            fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
-                        }
+                        return resetMachine( machine );
                     }
                 },
 
@@ -419,16 +410,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     @Override
                     public State reset( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
-                        try
-                        {
-                            machine.ctx.statementProcessor.reset();
-                            return READY;
-                        }
-                        catch ( Throwable e )
-                        {
-                            fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
-                        }
+                        return resetMachine( machine );
                     }
 
                     @Override
@@ -436,9 +418,8 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     {
                         try
                         {
-                            machine.ctx.statementProcessor.streamResult( recordStream -> {
-                                machine.ctx.responseHandler.onRecords( recordStream, true );
-                            } );
+                            machine.ctx.statementProcessor.streamResult( recordStream ->
+                                    machine.ctx.responseHandler.onRecords( recordStream, true ) );
 
                             return READY;
                         }
@@ -454,9 +435,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     {
                         try
                         {
-                            machine.ctx.statementProcessor.streamResult( recordStream -> {
-                                machine.ctx.responseHandler.onRecords( recordStream, false );
-                            } );
+                            machine.ctx.statementProcessor.streamResult( recordStream -> machine.ctx.responseHandler.onRecords( recordStream, false ) );
 
                             return READY;
                         }
@@ -486,30 +465,13 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     @Override
                     public State reset( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
-                        try
-                        {
-                            machine.ctx.statementProcessor.reset();
-                            return READY;
-                        }
-                        catch ( Throwable e )
-                        {
-                            fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
-                        }
+                        return resetMachine( machine );
                     }
 
                     @Override
                     public State ackFailure( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
-                        try
-                        {
-                            return READY;
-                        }
-                        catch ( Throwable e )
-                        {
-                            fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
-                        }
+                        return READY;
                     }
 
                     @Override
@@ -557,16 +519,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             machine.ctx.markIgnored();
                             return INTERRUPTED;
                         }
-                        try
-                        {
-                            machine.ctx.statementProcessor.reset();
-                            return READY;
-                        }
-                        catch ( Throwable e )
-                        {
-                            fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
-                        }
+                        return resetMachine( machine );
                     }
 
                     @Override
@@ -643,6 +596,20 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
             String msg = "PULL_ALL cannot be handled by a session in the " + name() + " state.";
             fail( machine, new Neo4jError( Status.Request.Invalid, msg ) );
             throw new BoltConnectionFatality( msg );
+        }
+
+        State resetMachine( BoltStateMachine machine ) throws BoltConnectionFatality
+        {
+            try
+            {
+                machine.ctx.statementProcessor.reset();
+                return READY;
+            }
+            catch ( Throwable e )
+            {
+                fail( machine, Neo4jError.from( e ) );
+                throw new BoltConnectionFatality( e.getMessage() );
+            }
         }
 
     }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -245,7 +245,8 @@ public class TransactionStateMachine implements StatementProcessor
                     {
                         if ( statement.equalsIgnoreCase( BEGIN ) )
                         {
-                            return EXPLICIT_TRANSACTION;
+                            throw new QueryExecutionKernelException(
+                                    new InvalidSemanticsException( "Nested transactions are not supported." ) );
                         }
                         else if ( statement.equalsIgnoreCase( COMMIT ) )
                         {

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -21,8 +21,8 @@
 package org.neo4j.bolt.v1.runtime;
 
 import org.junit.Test;
+
 import org.neo4j.bolt.testing.BoltResponseRecorder;
-import org.neo4j.bolt.testing.NullResponseHandler;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -318,6 +318,24 @@ public class BoltStateMachineTest
 
         // When
         machine.run( "ROLLBACK", EMPTY_PARAMS, nullResponseHandler() );
+        machine.discardAll( nullResponseHandler() );
+
+        // Then
+        assertThat( machine, inState( FAILED ) );
+    }
+
+    @Test
+    public void testFailOnNestedTransactions() throws Throwable
+    {
+        // Given
+        BoltStateMachine machine = newMachine( READY );
+
+        // Given there is a running transaction
+        machine.run( "BEGIN", EMPTY_PARAMS, nullResponseHandler() );
+        machine.discardAll( nullResponseHandler() );
+
+        // When
+        machine.run( "BEGIN", EMPTY_PARAMS, nullResponseHandler() );
         machine.discardAll( nullResponseHandler() );
 
         // Then


### PR DESCRIPTION
In recent refactoring a bug was introduced in how we handle ACK_FAILURE on implicit transactions.
The scenario is when a driver acknowledges a failure it expects to be able to reuse the session.

```
C: RUN "INVALID" {}
C: PULL_ALL
S: FAILURE
S: IGNORED
C: ACK_FAILURE
C: RUN "RETURN 1" {}
C: PULL_ALL
```

This scenario was failing since the transaction wasn't properly closed on the first failure and consequently the last `PULL_ALL` created a state where the transaction had both succeeded and failed.
