### PR TITLE
Extract channel pool from CatchUpClient.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchUpChannelPool.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchUpChannelPool.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.neo4j.coreedge.discovery.NoKnownAddressesException;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+class CatchUpChannelPool<CHANNEL extends CatchUpChannelPool.Channel>
+{
+    private final Map<AdvertisedSocketAddress, LinkedList<CHANNEL>> idleChannels = new HashMap<>();
+    private final Set<CHANNEL> activeChannels = new HashSet<>();
+    private final Function<AdvertisedSocketAddress, CHANNEL> factory;
+
+    CatchUpChannelPool( Function<AdvertisedSocketAddress, CHANNEL> factory )
+    {
+        this.factory = factory;
+    }
+
+    synchronized CHANNEL acquire( AdvertisedSocketAddress catchUpAddress ) throws NoKnownAddressesException
+    {
+        CHANNEL channel;
+        LinkedList<CHANNEL> channels = idleChannels.get( catchUpAddress );
+        if ( channels == null )
+        {
+            channel = factory.apply( catchUpAddress );
+        }
+        else
+        {
+            channel = channels.poll();
+            if ( channels.isEmpty() )
+            {
+                idleChannels.remove( catchUpAddress );
+            }
+        }
+
+        activeChannels.add( channel );
+        return channel;
+    }
+
+    synchronized void dispose( CHANNEL channel )
+    {
+        activeChannels.remove( channel );
+        channel.close();
+    }
+
+    synchronized void release( CHANNEL channel )
+    {
+        activeChannels.remove( channel );
+        idleChannels.computeIfAbsent( channel.destination(), (address) -> new LinkedList<>() ).add( channel );
+    }
+
+    synchronized void close()
+    {
+        idleChannels.values().stream().flatMap( Collection::stream )
+                .forEach( Channel::close );
+        activeChannels.forEach( Channel::close );
+    }
+
+    interface Channel
+    {
+        AdvertisedSocketAddress destination();
+
+        void close();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/CatchUpChannelPoolTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/CatchUpChannelPoolTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+
+import org.junit.Test;
+
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class CatchUpChannelPoolTest
+{
+    @Test
+    public void shouldReUseAChannelThatWasReleased() throws Exception
+    {
+        // given
+        CatchUpChannelPool<TestChannel> pool = new CatchUpChannelPool<>( TestChannel::new );
+
+        // when
+        TestChannel channelA = pool.acquire( localAddress( 1 ) );
+        pool.release( channelA );
+        TestChannel channelB = pool.acquire( localAddress( 1 ) );
+
+        // then
+        assertSame( channelA, channelB );
+    }
+
+    @Test
+    public void shouldCreateANewChannelIfFirstChannelIsDisposed() throws Exception
+    {
+        // given
+        CatchUpChannelPool<TestChannel> pool = new CatchUpChannelPool<>( TestChannel::new );
+
+        // when
+        TestChannel channelA = pool.acquire( localAddress( 1 ) );
+        pool.dispose( channelA );
+        TestChannel channelB = pool.acquire( localAddress( 1 ) );
+
+        // then
+        assertNotSame( channelA, channelB );
+    }
+
+    @Test
+    public void shouldCreateANewChannelIfFirstChannelIsStillActive() throws Exception
+    {
+        // given
+        CatchUpChannelPool<TestChannel> pool = new CatchUpChannelPool<>( TestChannel::new );
+
+        // when
+        TestChannel channelA = pool.acquire( localAddress( 1 ) );
+        TestChannel channelB = pool.acquire( localAddress( 1 ) );
+
+        // then
+        assertNotSame( channelA, channelB );
+    }
+
+    @Test
+    public void shouldCleanUpOnClose() throws Exception
+    {
+        // given
+        CatchUpChannelPool<TestChannel> pool = new CatchUpChannelPool<>( TestChannel::new );
+
+        TestChannel channelA = pool.acquire( localAddress( 1 ) );
+        TestChannel channelB = pool.acquire( localAddress( 1 ) );
+        TestChannel channelC = pool.acquire( localAddress( 1 ) );
+
+        pool.release( channelA );
+        pool.release( channelC );
+
+        TestChannel channelD = pool.acquire( localAddress( 2 ) );
+        TestChannel channelE = pool.acquire( localAddress( 2 ) );
+        TestChannel channelF = pool.acquire( localAddress( 2 ) );
+
+        // when
+        pool.close();
+
+        // then
+        assertTrue( channelA.closed );
+        assertTrue( channelB.closed );
+        assertTrue( channelC.closed );
+        assertTrue( channelD.closed );
+        assertTrue( channelE.closed );
+        assertTrue( channelF.closed );
+    }
+
+    private static class TestChannel implements CatchUpChannelPool.Channel
+    {
+        private final AdvertisedSocketAddress address;
+        private boolean closed;
+
+        TestChannel( AdvertisedSocketAddress address )
+        {
+            this.address = address;
+        }
+
+        @Override
+        public AdvertisedSocketAddress destination()
+        {
+            return address;
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+
+    private static AdvertisedSocketAddress localAddress( int port )
+    {
+        return new AdvertisedSocketAddress( "localhost", port );
+    }
+}


### PR DESCRIPTION
Also fix a leak where the pool could only store one channel per address.
