### PR TITLE
Fix termination of transactions in restricted access mode

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
@@ -49,6 +49,11 @@ public interface AuthSubject extends AccessMode
     boolean allowsProcedureWith( String[] roleNames ) throws InvalidArgumentsException;
 
     /**
+     * @return A string representing the primary principal of this subject
+     */
+    String username();
+
+    /**
      * Implementation to use when authentication has not yet been performed. Allows nothing.
      */
     AuthSubject ANONYMOUS = new AuthSubject()
@@ -112,6 +117,12 @@ public interface AuthSubject extends AccessMode
         {
             return "<anonymous>";
         }
+
+        @Override
+        public String username()
+        {
+            return ""; // Should never clash with a valid username
+        }
     };
 
     /**
@@ -153,6 +164,12 @@ public interface AuthSubject extends AccessMode
         public String name()
         {
             return "<auth disabled>";
+        }
+
+        @Override
+        public String username()
+        {
+            return ""; // Should never clash with a valid username
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.security;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.api.security.AuthSubject;
 
 public class OverriddenAccessMode implements AccessMode
 {
@@ -76,6 +77,27 @@ public class OverriddenAccessMode implements AccessMode
         else
         {
             return originalMode.name() + " restricted to " + overriddenMode.name();
+        }
+    }
+
+    public String username()
+    {
+        return getUsernameFromAccessMode( originalMode );
+    }
+
+    public static String getUsernameFromAccessMode( AccessMode accessMode )
+    {
+        if ( accessMode instanceof AuthSubject )
+        {
+            return ((AuthSubject) accessMode).username();
+        }
+        else if ( accessMode instanceof OverriddenAccessMode )
+        {
+            return ((OverriddenAccessMode) accessMode).username();
+        }
+        else
+        {
+            return ""; // Should never clash with a valid username
         }
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
@@ -148,6 +148,12 @@ public class BasicAuthSubject implements AuthSubject
     @Override
     public String name()
     {
+        return username();
+    }
+
+    @Override
+    public String username()
+    {
         return user.name();
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
@@ -146,6 +146,17 @@ public class EnterpriseAuthSubject implements AuthSubject
     @Override
     public String name()
     {
+        String username = username();
+        if ( username.isEmpty() )
+        {
+            return "<missing_principal>";
+        }
+        return username;
+    }
+
+    @Override
+    public String username()
+    {
         Object principal = shiroSubject.getPrincipal();
         if ( principal != null )
         {
@@ -153,7 +164,7 @@ public class EnterpriseAuthSubject implements AuthSubject
         }
         else
         {
-            return "<missing_principal>";
+            return ""; // Should never clash with a valid username
         }
     }
 


### PR DESCRIPTION
- Fix issue that we could miss terminating transactions while they were
  executing in a restricted access mode (e.g. procedure call, query planning)
