### PR TITLE
Generate empty javadoc jar for deferred-locks module

### DIFF
--- a/enterprise/deferred-locks/pom.xml
+++ b/enterprise/deferred-locks/pom.xml
@@ -100,4 +100,39 @@
 
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>neo-full-build-with-javadoc</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>fullBuild</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-dummy-javadocs-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
The only package in this module is `org.neo4j.kernel.impl.locking` and all packages with `impl` in their name are excluded from javadoc generation. This means that no packages in deferred-locks module were eligible for javadoc generation and javadoc jar was not created at all.

This commit forces an empty javadoc jar generation.
