### PR TITLE
Enforce ListenSocketAddress and AdvertisedSocketAddress sameness.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.coreedge.core;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.function.Function;
 
@@ -49,8 +48,7 @@ public class CoreEdgeClusterSettings
         @Override
         public ListenSocketAddress apply( String value )
         {
-            String[] split = value.trim().split( ":" );
-            return new ListenSocketAddress( new InetSocketAddress( split[0], Integer.valueOf( split[1] ) ) );
+            return new ListenSocketAddress( value );
         }
 
         @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/AdvertisedSocketAddress.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/AdvertisedSocketAddress.java
@@ -20,9 +20,6 @@
 package org.neo4j.coreedge.messaging.address;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.Objects;
-import java.util.regex.Pattern;
 
 import org.neo4j.coreedge.core.state.storage.SafeChannelMarshal;
 import org.neo4j.coreedge.messaging.EndOfStreamException;
@@ -30,72 +27,12 @@ import org.neo4j.coreedge.messaging.marshalling.StringMarshal;
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.WritableChannel;
 
-import static java.lang.String.format;
-
-public class AdvertisedSocketAddress
+public class AdvertisedSocketAddress extends SocketAddress
 {
-    private final String address;
-    private static final Pattern pattern = Pattern.compile( "(.+):(\\d+)" );
 
     public AdvertisedSocketAddress( String address )
     {
-        this.address = validate( address );
-    }
-
-    private String validate( String address )
-    {
-        if ( address == null )
-        {
-            throw new IllegalArgumentException( "AdvertisedSocketAddress cannot be null" );
-        }
-
-        address = address.trim();
-
-        if ( address.contains( " " ) )
-        {
-            throw new IllegalArgumentException( format( "Cannot initialize AdvertisedSocketAddress for %s. Whitespace" +
-                    " characters cause unresolvable ambiguity.", address ) );
-        }
-
-        if ( !pattern.matcher( address ).matches() )
-        {
-            throw new IllegalArgumentException( format( "AdvertisedSocketAddress can only be created with " +
-                    "hostname:port. %s is not acceptable", address ) );
-        }
-
-        return address;
-    }
-
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-        AdvertisedSocketAddress that = (AdvertisedSocketAddress) o;
-        return Objects.equals( address, that.address );
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash( address );
-    }
-
-    public String toString()
-    {
-        return address;
-    }
-
-    public InetSocketAddress socketAddress()
-    {
-        String[] split = address.split( ":" );
-        return new InetSocketAddress( split[0], Integer.valueOf( split[1] ) );
+        super( address );
     }
 
     public static class AdvertisedSocketAddressChannelMarshal extends SafeChannelMarshal<AdvertisedSocketAddress>

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/ListenSocketAddress.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/ListenSocketAddress.java
@@ -19,47 +19,11 @@
  */
 package org.neo4j.coreedge.messaging.address;
 
-import java.net.InetSocketAddress;
-import java.util.Objects;
-
-public class ListenSocketAddress
+public class ListenSocketAddress extends SocketAddress
 {
-    private final InetSocketAddress address;
 
-    public ListenSocketAddress( InetSocketAddress address )
+    public ListenSocketAddress( String address )
     {
-        this.address = address;
-    }
-
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-        ListenSocketAddress that = (ListenSocketAddress) o;
-        return Objects.equals( address, that.address );
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash( address );
-    }
-
-    public InetSocketAddress socketAddress()
-    {
-        return address;
-    }
-
-    @Override
-    public String toString()
-    {
-        return address.getHostName() + ":" + address.getPort();
+        super( address );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/SocketAddress.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/address/SocketAddress.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.messaging.address;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+public abstract class SocketAddress
+{
+    final String address;
+    private static final Pattern pattern = Pattern.compile( "(.+):(\\d+)" );
+
+    public SocketAddress( String address )
+    {
+        this.address = validate( address );
+    }
+
+    private String validate( String address )
+    {
+        if ( address == null )
+        {
+            throw new IllegalArgumentException( getClass().getSimpleName() + " cannot be null" );
+        }
+
+        address = address.trim();
+
+        if ( address.contains( " " ) )
+        {
+            throw new IllegalArgumentException( format( "Cannot initialize "+ getClass().getSimpleName() +" for %s. " +
+                    "Whitespace" +
+                    " characters cause unresolvable ambiguity.", address ) );
+        }
+
+        if ( !pattern.matcher( address ).matches() )
+        {
+            throw new IllegalArgumentException( format( getClass().getSimpleName() + " can only be created with " +
+                    "hostname:port. %s is not acceptable", address ) );
+        }
+
+        return address;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        SocketAddress that = (AdvertisedSocketAddress) o;
+        return Objects.equals( address, that.address );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( address );
+    }
+
+    public String toString()
+    {
+        return address;
+    }
+
+    public InetSocketAddress socketAddress()
+    {
+        String[] split = address.split( ":" );
+        return new InetSocketAddress( split[0], Integer.valueOf( split[1] ) );
+    }
+}
+

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/messaging/address/SocketAddressTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/messaging/address/SocketAddressTest.java
@@ -20,21 +20,42 @@
 package org.neo4j.coreedge.messaging.address;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static java.lang.String.format;
-
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
-public class AdvertisedSocketAddressTest
+@RunWith( value = Parameterized.class )
+public class SocketAddressTest
 {
+    private Class instanceOf;
+
+    public SocketAddressTest( Class instanceOf )
+    {
+        this.instanceOf = instanceOf;
+    }
+
+    @Parameterized.Parameters
+    public static Collection getParameters()
+    {
+        Object[] parameters = new Object[]{AdvertisedSocketAddress.class, ListenSocketAddress.class};
+        return Arrays.asList( parameters );
+    }
+
     @Test
     public void shouldCreateAdvertisedSocketAddressWithLeadingWhitespace() throws Exception
     {
         // given
-        AdvertisedSocketAddress address = new AdvertisedSocketAddress( whitespace( 1 ) + "localhost:9999" );
+        SocketAddress address = instanceOf == AdvertisedSocketAddress.class ?
+                                new AdvertisedSocketAddress( whitespace( 1 ) + "localhost:9999" ) :
+                                new ListenSocketAddress( whitespace( 1 ) + "localhost:9999" );
 
         // when
         String string = address.toString();
@@ -47,7 +68,9 @@ public class AdvertisedSocketAddressTest
     public void shouldCreateAdvertisedSocketAddressWithTrailingWhitespace() throws Exception
     {
         // given
-        AdvertisedSocketAddress address = new AdvertisedSocketAddress( "localhost:9999" + whitespace( 1 ) );
+        SocketAddress address = instanceOf == AdvertisedSocketAddress.class ?
+                                new AdvertisedSocketAddress( "localhost:9999" + whitespace( 1 ) ) :
+                                new ListenSocketAddress( "localhost:9999" + whitespace( 1 ) );
 
         // when
         String string = address.toString();
@@ -62,14 +85,16 @@ public class AdvertisedSocketAddressTest
         String address = "localhost:" + whitespace( 1 ) + "9999";
         try
         {
-            new AdvertisedSocketAddress( address );
+            SocketAddress socketAddress =
+                    instanceOf == AdvertisedSocketAddress.class ? new AdvertisedSocketAddress( address )
+                                                                : new ListenSocketAddress( address );
             fail( "Should have thrown an exception" );
         }
         catch ( IllegalArgumentException e )
         {
-            assertThat( e.getMessage(),
-                    containsString( format( "Cannot initialize AdvertisedSocketAddress for %s. Whitespace " +
-                            "characters cause unresolvable ambiguity.", address ) ) );
+            assertThat( e.getMessage(), containsString(
+                    format( "Cannot initialize %s for %s. Whitespace " +
+                            "characters cause unresolvable ambiguity.", instanceOf.getSimpleName(), address ) ) );
         }
     }
 
@@ -79,14 +104,16 @@ public class AdvertisedSocketAddressTest
         String address = "localhost:";
         try
         {
-            new AdvertisedSocketAddress( address );
+            SocketAddress socketAddress =
+                    instanceOf == AdvertisedSocketAddress.class ? new AdvertisedSocketAddress( address )
+                                                                : new ListenSocketAddress( address );
             fail( "Should have thrown an exception" );
         }
         catch ( IllegalArgumentException e )
         {
-            assertThat( e.getMessage(),
-                    containsString( format( "AdvertisedSocketAddress can only be created with hostname:port. " +
-                            "%s is not acceptable", address ) ) );
+            assertThat( e.getMessage(), containsString(
+                    format( "%s can only be created with hostname:port. " + "%s is not acceptable",
+                            instanceOf.getSimpleName(), address ) ) );
         }
     }
 


### PR DESCRIPTION
These classes are kept apart so we can follow instantiations while
debugging. They have the exact same contract and implementation,
therefore this commit makes that more concrete by making them
extend from the same superclass.
