### PR TITLE
Cleanup git commit and branch info in kernel manifest file

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -111,8 +111,8 @@ the relevant Commercial Agreement.
               <packageName>org/neo4j/kernel</packageName>
             </manifest>
             <manifestEntries>
-              <!-- This becomes programmatically accessible from the org.neo4j.kernel Package instance -->
-              <Implementation-Version>${project.version},${git.commit.id.describe}</Implementation-Version>
+              <!-- This becomes programmatically accessible from the 'org.neo4j.kernel' java.lang.Package object -->
+              <Implementation-Version>${project.version},${git.commit}</Implementation-Version>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <hsqldb.version>2.3.2</hsqldb.version>
     <test.runner.jvm.settings>-Xmx2G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true -XX:-OmitStackTraceInFastThrow</test.runner.jvm.settings>
     <doclint-groups>reference</doclint-groups>
+    <git.commit>unknown-commit</git.commit>
   </properties>
 
   <modules>
@@ -236,23 +237,9 @@
      Git information extraction profiles.
      Activate by adding the required Git information to the environment, e.g. on *nix:
 
-     export GIT_BRANCH
      export GIT_COMMIT
-     GIT_BRANCH=$(git rev-parse - -abbrev-ref HEAD)
-     GIT_COMMIT=$(git rev-parse - -short HEAD)
+     GIT_COMMIT=$(git rev-parse HEAD)
     -->
-    <profile>
-      <id>attach-git-info-branch</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>env.GIT_BRANCH</name>
-        </property>
-      </activation>
-      <properties>
-        <git.commit.id.describe>${env.GIT_BRANCH}</git.commit.id.describe>
-      </properties>
-    </profile>
     <profile>
       <id>attach-git-info-commit</id>
       <activation>
@@ -262,7 +249,7 @@
         </property>
       </activation>
       <properties>
-        <git.commit.id.describe>${env.GIT_COMMIT}</git.commit.id.describe>
+        <git.commit>${env.GIT_COMMIT}</git.commit>
       </properties>
     </profile>
 


### PR DESCRIPTION
Added default `unknown-commit` value if env variable is not set, removed profile that exported git branch because value was never used.
