### PR TITLE
Don't misleadingly report http port for https port conflict

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/PortBindException.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/PortBindException.java
@@ -32,4 +32,10 @@ public class PortBindException extends BindException
         super( String.format("Address %s is already in use, cannot bind to it.", address) );
         setStackTrace( original.getStackTrace() );
     }
+
+    public PortBindException( HostnamePort address, HostnamePort other, BindException original )
+    {
+        super( String.format("At least one of the addresses %s or %s is already in use, cannot bind to it.", address, other) );
+        setStackTrace( original.getStackTrace() );
+    }
 }

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -354,7 +354,14 @@ public class Jetty9WebServer implements WebServer
         }
         catch( BindException e )
         {
-            throw new PortBindException( jettyAddress, e );
+            if ( jettyHttpsAddress.isPresent() )
+            {
+                throw new PortBindException( jettyAddress, jettyHttpsAddress.get(), e );
+            }
+            else
+            {
+                throw new PortBindException( jettyAddress, e );
+            }
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -63,6 +63,7 @@ public class CommunityServerBuilder
 {
     protected final LogProvider logProvider;
     private HostnamePort address = new HostnamePort( "localhost", 7474 );
+    private HostnamePort httpsAddress = new HostnamePort( "localhost", 7473 );
     private String maxThreads = null;
     protected String dataDir = null;
     private String managementUri = "/db/manage/";
@@ -183,7 +184,7 @@ public class CommunityServerBuilder
         {
             properties.put( httpConnector("https").type.name(), "HTTP" );
             properties.put( httpConnector("https").enabled.name(), "true" );
-            properties.put( httpConnector("https").address.name(), "localhost:7473" );
+            properties.put( httpConnector("https").address.name(), httpsAddress.toString() );
             properties.put( httpConnector("https").encryption.name(), "TLS" );
         }
 
@@ -284,6 +285,12 @@ public class CommunityServerBuilder
     public CommunityServerBuilder onAddress( HostnamePort address )
     {
         this.address = address;
+        return this;
+    }
+
+    public CommunityServerBuilder onHttpsAddress( HostnamePort address )
+    {
+        this.httpsAddress = address;
         return this;
     }
 


### PR DESCRIPTION
When a server cannot start due to HTTPS port conflict, it reported the error was in HTTP port conflict. The code in question does not have an easy way to determine if the underlying jetty exception was due to http or https, so we just report both ports if https is set, and http only otherwise.

changelog: [server] Fixed misleading error message on https port conflict
