### PR TITLE
Make `packaging` a default submodule

### DIFF
--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -6,7 +6,7 @@
     <version>3.1.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
-  <groupId>org.neo4j</groupId>
+
   <artifactId>neo4j-security-enterprise</artifactId>
   <version>3.1.0-SNAPSHOT</version>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -92,18 +92,6 @@ terms of the relevant Commercial Agreement.
           <version>${project.version}</version>
           <type>pom</type>
         </dependency>
-        <dependency>
-          <groupId>org.neo4j.doc</groupId>
-          <artifactId>neo4j-manual-parent</artifactId>
-          <version>${project.version}</version>
-          <type>pom</type>
-        </dependency>
-        <dependency>
-          <groupId>org.neo4j.doc</groupId>
-          <artifactId>neo4j-manual</artifactId>
-          <version>${project.version}</version>
-          <type>pom</type>
-        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -306,19 +306,6 @@
       <artifactId>neo4j-import-tool</artifactId>
       <version>${neo4j.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.neo4j.doc</groupId>
-      <artifactId>neo4j-manual</artifactId>
-      <version>${neo4j.version}</version>
-      <classifier>manpages</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.neo4j.doc</groupId>
-      <artifactId>neo4j-manual</artifactId>
-      <version>${neo4j.version}</version>
-      <classifier>manpagesenterprise</classifier>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -31,7 +31,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/community</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>keep</lineEnding>
       <filtered>true</filtered>
       <directoryMode>0755</directoryMode>
@@ -43,7 +43,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>lib/*.jar</include>
       </includes>
@@ -51,7 +51,7 @@
     <!-- filter and chmod 755 shell scripts -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -69,7 +69,7 @@
     <!-- configuration migrator -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>**/config-migrator.jar</include>
       </includes>
@@ -129,7 +129,6 @@
       <useStrictFiltering>true</useStrictFiltering>
       <excludes>
         <exclude>org.neo4j:*</exclude>
-        <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:*</exclude>
         <exclude>org.scala-lang:*</exclude>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -30,7 +30,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/community</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>dos</lineEnding>
       <filtered>true</filtered>
       <excludes>
@@ -40,7 +40,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>lib/*.jar</include>
       </includes>
@@ -48,7 +48,7 @@
     <!-- do not filter binaries -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>**/*.exe</include>
         <include>**/config-migrator.jar</include>
@@ -57,7 +57,7 @@
     <!-- filter text files -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.bat</include>
@@ -119,7 +119,6 @@
       <useStrictFiltering>true</useStrictFiltering>
       <excludes>
         <exclude>org.neo4j:*</exclude>
-        <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:*</exclude>
         <exclude>org.scala-lang:*</exclude>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -30,7 +30,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>keep</lineEnding>
       <filtered>true</filtered>
       <excludes>
@@ -43,7 +43,7 @@
     <!-- password files -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>unix</lineEnding>
       <filtered>true</filtered>
       <includes>
@@ -54,7 +54,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>lib/*.jar</include>
       </includes>
@@ -63,7 +63,7 @@
     <!-- filter and chmod 755 shell scripts -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -80,7 +80,7 @@
     <!-- configuration migrator -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>**/config-migrator.jar</include>
       </includes>
@@ -144,7 +144,6 @@
       <useStrictFiltering>true</useStrictFiltering>
       <excludes>
         <exclude>org.neo4j:*</exclude>
-        <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:*</exclude>
         <exclude>io.netty:netty</exclude>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -30,7 +30,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>dos</lineEnding>
       <filtered>true</filtered>
       <excludes>
@@ -40,7 +40,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>lib/*.jar</include>
       </includes>
@@ -48,7 +48,7 @@
     <!-- do not filter binaries -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <includes>
         <include>**/*.exe</include>
         <include>**/config-migrator.jar</include>
@@ -57,7 +57,7 @@
     <!-- filter text files -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory></outputDirectory>
+      <outputDirectory/>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.bat</include>
@@ -120,7 +120,6 @@
       <useStrictFiltering>true</useStrictFiltering>
       <excludes>
         <exclude>org.neo4j:*</exclude>
-        <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:*</exclude>
         <exclude>io.netty:netty</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -328,37 +328,6 @@
       </properties>
     </profile>
     <profile>
-      <id>neodev</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <attach-test-jar-phase>package</attach-test-jar-phase>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.neo4j.build.plugins</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <!-- inserting licenses is better than checking for them -->
-            <executions>
-              <execution>
-                <id>check-licenses</id>
-                <phase>none</phase>
-              </execution>
-              <execution>
-                <id>insert-licenses</id>
-                <phase>initialize</phase>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>neo-docs-build</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <module>integrationtests</module>
     <module>stresstests</module>
     <module>tools</module>
+    <module>packaging</module>
   </modules>
 
   <build>
@@ -305,7 +306,6 @@
       </activation>
       <modules>
         <module>manual</module>
-        <module>packaging</module>
         <module>packaging/installer-linux</module>
       </modules>
       <build>


### PR DESCRIPTION
The `packaging` module has only been incorporated as a proper submodule through activation of the `-DfullBuild` maven flag. This commit adds it to the list of default submodules, which also decouples it from the `manual` module, also activated by the mentioned flag.

I threw in removal of a profile that seems obsolete. That commit can be removed from this PR if it is inappropriate.
