### PR TITLE
Replacing ClusterTopology with CoreTopology and EdgeTopology

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchUpClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchUpClient.java
@@ -110,7 +110,7 @@ public class CatchUpClient extends LifecycleAdapter
     private synchronized CatchUpChannel acquireChannel( MemberId memberId ) throws NoKnownAddressesException
     {
         AdvertisedSocketAddress catchUpAddress =
-                discoveryService.currentTopology().coreAddresses( memberId ).getCatchupServer();
+                discoveryService.coreServers().find( memberId ).getCatchupServer();
         CatchUpChannel channel = idleChannels.remove( catchUpAddress );
         if ( channel == null )
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/BindingProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/BindingProcess.java
@@ -22,7 +22,7 @@ package org.neo4j.coreedge.core.state;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.logging.Log;
 
@@ -37,7 +37,7 @@ class BindingProcess
         this.log = log;
     }
 
-    ClusterId attempt( ClusterTopology topology ) throws InterruptedException, TimeoutException, BindingException
+    ClusterId attempt( CoreTopology topology ) throws InterruptedException, TimeoutException, BindingException
     {
         ClusterId commonClusterId = topology.clusterId();
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/BindingService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/BindingService.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 import org.neo4j.coreedge.core.state.storage.SimpleStorage;
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.function.ThrowingAction;
@@ -84,7 +84,7 @@ class BindingService extends LifecycleAdapter
 
         long endTime = clock.millis() + timeoutMillis;
 
-        ClusterTopology topology = topologyService.currentTopology();
+        CoreTopology topology = topologyService.coreServers();
         ClusterId commonClusterId;
 
         while ( (commonClusterId = binder.attempt( topology )) == null )
@@ -92,7 +92,7 @@ class BindingService extends LifecycleAdapter
             if ( clock.millis() < endTime )
             {
                 retryWaiter.apply();
-                topology = topologyService.currentTopology();
+                topology = topologyService.coreServers();
             }
             else
             {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopology.java
@@ -20,44 +20,42 @@
 package org.neo4j.coreedge.discovery;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
 
-public class ClusterTopology
+public class CoreTopology
 {
-    private ClusterId clusterId;
-    private final Map<MemberId, CoreAddresses> coreMembers;
-    private final Set<EdgeAddresses> edgeAddresses;
-    private final boolean canBeBootstrapped;
+    public static CoreTopology EMPTY = new CoreTopology( null, false, Collections.emptyMap() );
 
-    public ClusterTopology( ClusterId clusterId, boolean canBeBootstrapped,
-            Map<MemberId,CoreAddresses> coreMembers,
-            Set<EdgeAddresses> edgeAddresses )
+    private final ClusterId clusterId;
+    private final boolean canBeBootstrapped;
+    private final Map<MemberId, CoreAddresses> coreMembers;
+
+    public CoreTopology( ClusterId clusterId, boolean canBeBootstrapped, Map<MemberId, CoreAddresses> coreMembers )
     {
+
         this.clusterId = clusterId;
         this.canBeBootstrapped = canBeBootstrapped;
-        this.edgeAddresses = edgeAddresses;
-        this.coreMembers = new HashMap<>( coreMembers );
+        this.coreMembers = coreMembers;
     }
 
-    public Set<MemberId> coreMembers()
+    public Set<MemberId> members()
     {
         return coreMembers.keySet();
     }
 
-    public Collection<CoreAddresses> coreMemberAddresses()
+    public ClusterId clusterId()
     {
-        return coreMembers.values();
+        return clusterId;
     }
 
-    public Collection<EdgeAddresses> edgeMemberAddresses()
+    public Collection<CoreAddresses> addresses()
     {
-        return edgeAddresses;
+        return coreMembers.values();
     }
 
     public boolean canBeBootstrapped()
@@ -65,7 +63,7 @@ public class ClusterTopology
         return canBeBootstrapped;
     }
 
-    public CoreAddresses coreAddresses( MemberId memberId ) throws NoKnownAddressesException
+    public CoreAddresses find( MemberId memberId ) throws NoKnownAddressesException
     {
         CoreAddresses coreAddresses = coreMembers.get( memberId );
         if ( coreAddresses == null )
@@ -78,12 +76,7 @@ public class ClusterTopology
     @Override
     public String toString()
     {
-        return String.format( "{coreMembers=%s, bootstrappable=%s, edgeMemberAddresses=%s}",
-                coreMembers.keySet(), canBeBootstrapped(), edgeAddresses );
+        return String.format( "{coreMembers=%s, bootstrappable=%s}", coreMembers.keySet(), canBeBootstrapped() );
     }
 
-    public ClusterId clusterId()
-    {
-        return clusterId;
-    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopologyListenerService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopologyListenerService.java
@@ -31,11 +31,11 @@ class CoreTopologyListenerService
         listeners.add( listener );
     }
 
-    void notifyListeners( ClusterTopology clusterTopology )
+    void notifyListeners( CoreTopology coreTopology )
     {
         for ( CoreTopologyService.Listener listener : listeners )
         {
-            listener.onCoreTopologyChange( clusterTopology );
+            listener.onCoreTopologyChange( coreTopology );
         }
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopologyService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopologyService.java
@@ -37,6 +37,6 @@ public interface CoreTopologyService extends TopologyService
 
     interface Listener
     {
-        void onCoreTopologyChange( ClusterTopology clusterTopology );
+        void onCoreTopologyChange( CoreTopology coreTopology );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeTopology.java
@@ -17,25 +17,29 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.coreedge.messaging.routing;
+package org.neo4j.coreedge.discovery;
 
-import org.neo4j.coreedge.discovery.CoreTopology;
-import org.neo4j.coreedge.discovery.TopologyService;
-import org.neo4j.coreedge.identity.MemberId;
+import java.util.Collections;
+import java.util.Set;
 
-public class AlwaysChooseFirstMember implements CoreMemberSelectionStrategy
+import org.neo4j.coreedge.identity.ClusterId;
+
+public class EdgeTopology
 {
-    private final TopologyService discoveryService;
+    public static EdgeTopology EMPTY = new EdgeTopology( null, Collections.emptySet() );
 
-    public AlwaysChooseFirstMember( TopologyService discoveryService)
+    private final ClusterId clusterId;
+    private final Set<EdgeAddresses> edgeMembers;
+
+    public EdgeTopology( ClusterId clusterId, Set<EdgeAddresses> edgeMembers )
     {
-        this.discoveryService = discoveryService;
+
+        this.clusterId = clusterId;
+        this.edgeMembers = edgeMembers;
     }
 
-    @Override
-    public MemberId coreMember() throws CoreMemberSelectionException
+    public Set<EdgeAddresses> members()
     {
-        CoreTopology coreTopology = discoveryService.coreServers();
-        return coreTopology.members().iterator().next();
+        return edgeMembers;
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClient.java
@@ -31,8 +31,6 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import static org.neo4j.coreedge.discovery.HazelcastClusterTopology.EDGE_SERVER_BOLT_ADDRESS_MAP_NAME;
@@ -61,18 +59,34 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     }
 
     @Override
-    public ClusterTopology currentTopology()
+    public EdgeTopology edgeServers()
     {
         try
         {
             return retry( ( hazelcastInstance ) ->
-                    HazelcastClusterTopology.getClusterTopology( hazelcastInstance, log ) );
+                    HazelcastClusterTopology.getEdgeTopology( hazelcastInstance, log ) );
         }
         catch ( Exception e )
         {
             log.info( "Failed to read cluster topology from Hazelcast. Continuing with empty (disconnected) topology. "
                     + "Connection will be reattempted on next polling attempt.", e );
-            return new ClusterTopology( null /* TODO */, false, emptyMap(), emptySet() );
+            return EdgeTopology.EMPTY;
+        }
+    }
+
+    @Override
+    public CoreTopology coreServers()
+    {
+        try
+        {
+            return retry( ( hazelcastInstance ) ->
+                    HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log ) );
+        }
+        catch ( Exception e )
+        {
+            log.info( "Failed to read cluster topology from Hazelcast. Continuing with empty (disconnected) topology. "
+                    + "Connection will be reattempted on next polling attempt.", e );
+            return CoreTopology.EMPTY;
         }
     }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
@@ -63,10 +63,27 @@ class HazelcastClusterTopology
     static final String RAFT_SERVER = "raft_server";
     static final String BOLT_SERVER = "bolt_server";
 
-    static ClusterTopology getClusterTopology( HazelcastInstance hazelcastInstance, Log log )
+    static EdgeTopology getEdgeTopology( HazelcastInstance hazelcastInstance, Log log )
+    {
+        Set<EdgeAddresses> edgeMembers = emptySet();
+        ClusterId clusterId = null;
+
+        if ( hazelcastInstance != null )
+        {
+            edgeMembers = edgeMembers( hazelcastInstance, log );
+            clusterId = getClusterId( hazelcastInstance );
+        }
+        else
+        {
+            log.info( "Cannot currently bind to distributed discovery service." );
+        }
+
+        return new EdgeTopology( clusterId, edgeMembers );
+    }
+
+    static CoreTopology getCoreTopology( HazelcastInstance hazelcastInstance, Log log )
     {
         Map<MemberId,CoreAddresses> coreMembers = emptyMap();
-        Set<EdgeAddresses> edgeMembers = emptySet();
         boolean canBeBootstrapped = false;
         ClusterId clusterId = null;
 
@@ -76,7 +93,6 @@ class HazelcastClusterTopology
             canBeBootstrapped = canBeBootstrapped( hzMembers );
 
             coreMembers = toCoreMemberMap( hzMembers, log );
-            edgeMembers = edgeMembers( hazelcastInstance, log );
 
             clusterId = getClusterId( hazelcastInstance );
         }
@@ -85,7 +101,7 @@ class HazelcastClusterTopology
             log.info( "Cannot currently bind to distributed discovery service." );
         }
 
-        return new ClusterTopology( clusterId, canBeBootstrapped, coreMembers, edgeMembers );
+        return new CoreTopology( clusterId, canBeBootstrapped, coreMembers );
     }
 
     private static ClusterId getClusterId( HazelcastInstance hazelcastInstance )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
@@ -67,7 +67,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     public void addCoreTopologyListener( Listener listener )
     {
         listenerService.addCoreTopologyListener( listener );
-        listener.onCoreTopologyChange( currentTopology() );
+        listener.onCoreTopologyChange( coreServers() );
     }
 
     @Override
@@ -80,16 +80,16 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     public void memberAdded( MembershipEvent membershipEvent )
     {
         log.info( "Core member added %s", membershipEvent );
-        log.info( "Current topology is %s", currentTopology() );
-        listenerService.notifyListeners(currentTopology());
+        log.info( "Current core topology is %s", coreServers() );
+        listenerService.notifyListeners( coreServers());
     }
 
     @Override
     public void memberRemoved( MembershipEvent membershipEvent )
     {
         log.info( "Core member removed %s", membershipEvent );
-        log.info( "Current topology is %s", currentTopology() );
-        listenerService.notifyListeners(currentTopology());
+        log.info( "Current core topology is %s", coreServers() );
+        listenerService.notifyListeners( coreServers());
     }
 
     @Override
@@ -103,7 +103,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         hazelcastInstance = createHazelcastInstance();
         log.info( "Cluster discovery service started" );
         membershipRegistrationId = hazelcastInstance.getCluster().addMembershipListener( this );
-        listenerService.notifyListeners(currentTopology());
+        listenerService.notifyListeners( coreServers());
     }
 
     @Override
@@ -165,8 +165,14 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     }
 
     @Override
-    public ClusterTopology currentTopology()
+    public EdgeTopology edgeServers()
     {
-        return HazelcastClusterTopology.getClusterTopology( hazelcastInstance, log );
+        return HazelcastClusterTopology.getEdgeTopology( hazelcastInstance, log );
+    }
+
+    @Override
+    public CoreTopology coreServers()
+    {
+        return HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/RaftDiscoveryServiceConnector.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/RaftDiscoveryServiceConnector.java
@@ -41,8 +41,8 @@ public class RaftDiscoveryServiceConnector extends LifecycleAdapter implements C
     @Override
     public void start() throws BootstrapException
     {
-        ClusterTopology clusterTopology = discoveryService.currentTopology();
-        Set<MemberId> initialMembers = clusterTopology.coreMembers();
+        CoreTopology clusterTopology = discoveryService.coreServers();
+        Set<MemberId> initialMembers = clusterTopology.members();
 
         if ( clusterTopology.canBeBootstrapped() )
         {
@@ -53,9 +53,9 @@ public class RaftDiscoveryServiceConnector extends LifecycleAdapter implements C
     }
 
     @Override
-    public synchronized void onCoreTopologyChange( ClusterTopology clusterTopology )
+    public synchronized void onCoreTopologyChange( CoreTopology coreTopology )
     {
-        Set<MemberId> targetMembers = clusterTopology.coreMembers();
+        Set<MemberId> targetMembers = coreTopology.members();
         raftMachine.setTargetMembershipSet( targetMembers );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/TopologyService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/TopologyService.java
@@ -23,5 +23,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 
 public interface TopologyService extends Lifecycle
 {
-    ClusterTopology currentTopology();
+    EdgeTopology edgeServers();
+
+    CoreTopology coreServers();
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/AcquireEndpointsProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/AcquireEndpointsProcedure.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
-import org.neo4j.coreedge.discovery.ClusterTopology;
 import org.neo4j.coreedge.discovery.CoreAddresses;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.discovery.EdgeAddresses;
@@ -71,7 +70,7 @@ public class AcquireEndpointsProcedure extends CallableProcedure.BasicProcedure
         {
             MemberId leader = leaderLocator.getLeader();
             AdvertisedSocketAddress leaderAddress =
-                    discoveryService.currentTopology().coreAddresses( leader ).getBoltServer();
+                    discoveryService.coreServers().find( leader ).getBoltServer();
             writeEndpoints = writeEndpoints( leaderAddress );
         }
         catch ( NoLeaderFoundException | NoKnownAddressesException e )
@@ -101,11 +100,9 @@ public class AcquireEndpointsProcedure extends CallableProcedure.BasicProcedure
 
     private Set<ReadWriteEndPoint> readEndpoints()
     {
-        ClusterTopology clusterTopology = discoveryService.currentTopology();
-
-        Stream<AdvertisedSocketAddress> readEdge = clusterTopology.edgeMemberAddresses().stream()
+        Stream<AdvertisedSocketAddress> readEdge = discoveryService.edgeServers().members().stream()
                 .map( EdgeAddresses::getBoltAddress );
-        Stream<AdvertisedSocketAddress> readCore = clusterTopology.coreMemberAddresses().stream()
+        Stream<AdvertisedSocketAddress> readCore = discoveryService.coreServers().addresses().stream()
                 .map( CoreAddresses::getBoltServer );
 
         return Stream.concat( readEdge, readCore ).map( ReadWriteEndPoint::read )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.coreedge.core.consensus.LeaderLocator;
 import org.neo4j.coreedge.core.consensus.NoLeaderFoundException;
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.discovery.EdgeAddresses;
 import org.neo4j.coreedge.discovery.NoKnownAddressesException;
@@ -68,8 +68,8 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
-        ClusterTopology clusterTopology = discoveryService.currentTopology();
-        Set<MemberId> coreMembers = clusterTopology.coreMembers();
+        CoreTopology coreTopology = discoveryService.coreServers();
+        Set<MemberId> coreMembers = coreTopology.members();
         MemberId leader = null;
         try
         {
@@ -85,7 +85,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
             AdvertisedSocketAddress boltServerAddress = null;
             try
             {
-                boltServerAddress = clusterTopology.coreAddresses( memberId ).getBoltServer();
+                boltServerAddress = coreTopology.find( memberId ).getBoltServer();
             }
             catch ( NoKnownAddressesException e )
             {
@@ -94,7 +94,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
             Role role = memberId.equals( leader ) ? Role.LEADER : Role.FOLLOWER;
             endpoints.add( new ReadWriteEndPoint( boltServerAddress, role, memberId.getUuid() ) );
         }
-        for ( EdgeAddresses edgeAddresses : clusterTopology.edgeMemberAddresses() )
+        for ( EdgeAddresses edgeAddresses : discoveryService.edgeServers().members() )
         {
             endpoints.add( new ReadWriteEndPoint( edgeAddresses.getBoltAddress(), Role.READ_REPLICA ) );
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/DiscoverEndpointAcquisitionServersProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/DiscoverEndpointAcquisitionServersProcedure.java
@@ -23,8 +23,8 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
-import org.neo4j.coreedge.discovery.ClusterTopology;
 import org.neo4j.coreedge.discovery.CoreAddresses;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.messaging.address.AdvertisedSocketAddress;
 import org.neo4j.helpers.collection.Iterators;
@@ -66,8 +66,8 @@ public class DiscoverEndpointAcquisitionServersProcedure extends CallableProcedu
 
     private Stream<AdvertisedSocketAddress> findAddresses()
     {
-        ClusterTopology clusterTopology = discoveryService.currentTopology();
-        return clusterTopology.coreMemberAddresses().stream().map( CoreAddresses::getBoltServer );
+        CoreTopology coreTopology = discoveryService.coreServers();
+        return coreTopology.addresses().stream().map( CoreAddresses::getBoltServer );
     }
 
     private int noOfAddressesToReturn( Object[] input )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/RaftOutbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/RaftOutbound.java
@@ -57,7 +57,7 @@ public class RaftOutbound implements Outbound<MemberId, RaftMessage>
     {
         try
         {
-            CoreAddresses coreAddresses = discoveryService.currentTopology().coreAddresses( to );
+            CoreAddresses coreAddresses = discoveryService.coreServers().find( to );
             outbound.send( coreAddresses.getRaftServer(), decorateWithStoreId( message ) );
         }
         catch ( NoKnownAddressesException e )
@@ -71,7 +71,7 @@ public class RaftOutbound implements Outbound<MemberId, RaftMessage>
     {
         try
         {
-            CoreAddresses coreAddresses = discoveryService.currentTopology().coreAddresses( to );
+            CoreAddresses coreAddresses = discoveryService.coreServers().find( to );
             outbound.send( coreAddresses.getRaftServer(),
                     messages.stream().map( this::decorateWithStoreId ).collect( toList() ) );
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/routing/ConnectToRandomCoreMember.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/routing/ConnectToRandomCoreMember.java
@@ -22,7 +22,7 @@ package org.neo4j.coreedge.messaging.routing;
 import java.util.Iterator;
 import java.util.Random;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.TopologyService;
 import org.neo4j.coreedge.identity.MemberId;
 
@@ -39,16 +39,16 @@ public class ConnectToRandomCoreMember implements CoreMemberSelectionStrategy
     @Override
     public MemberId coreMember() throws CoreMemberSelectionException
     {
-        final ClusterTopology clusterTopology = discoveryService.currentTopology();
+        final CoreTopology coreTopology = discoveryService.coreServers();
 
-        if ( clusterTopology.coreMembers().size() == 0 )
+        if ( coreTopology.members().size() == 0 )
         {
             throw new CoreMemberSelectionException( "No core servers available" );
         }
 
-        int skippedServers = random.nextInt( clusterTopology.coreMembers().size() );
+        int skippedServers = random.nextInt( coreTopology.members().size() );
 
-        final Iterator<MemberId> iterator = clusterTopology.coreMembers().iterator();
+        final Iterator<MemberId> iterator = coreTopology.members().iterator();
 
         MemberId member;
         do

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/routing/NotMyselfSelectionStrategy.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/routing/NotMyselfSelectionStrategy.java
@@ -38,7 +38,7 @@ public class NotMyselfSelectionStrategy implements CoreMemberSelectionStrategy
     @Override
     public MemberId coreMember() throws CoreMemberSelectionException
     {
-        Optional<MemberId> member = discoveryService.currentTopology().coreMembers().stream()
+        Optional<MemberId> member = discoveryService.coreServers().members().stream()
                 .filter( coreMember -> !coreMember.equals( myself ) ).findFirst();
 
         if ( member.isPresent() )

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingProcessTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.UUID;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.logging.Log;
 
@@ -42,7 +42,7 @@ public class BindingProcessTest
     public void notBootstrappableShouldDoNothingWhenNoIdPublished() throws Exception
     {
         // given
-        ClusterTopology topology = new ClusterTopology( null, false, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( null, false, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( null, log );
 
@@ -58,7 +58,7 @@ public class BindingProcessTest
     {
         // given
         ClusterId commonClusterId = new ClusterId( UUID.randomUUID() );
-        ClusterTopology topology = new ClusterTopology( commonClusterId, false, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( commonClusterId, false, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( null, log );
 
@@ -77,7 +77,7 @@ public class BindingProcessTest
         ClusterId commonClusterId = new ClusterId( UUID.randomUUID() );
         ClusterId localClusterId = new ClusterId( commonClusterId.uuid() );
 
-        ClusterTopology topology = new ClusterTopology( commonClusterId, false, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( commonClusterId, false, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( localClusterId, log );
 
@@ -95,7 +95,7 @@ public class BindingProcessTest
         // given
         ClusterId localClusterId = new ClusterId( UUID.randomUUID() );
 
-        ClusterTopology topology = new ClusterTopology( null, false, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( null, false, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( localClusterId, log );
 
@@ -111,7 +111,7 @@ public class BindingProcessTest
     public void bootstrappableShouldGenerateNewId() throws Exception
     {
         // given
-        ClusterTopology topology = new ClusterTopology( null, true, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( null, true, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( null, log );
 
@@ -128,7 +128,7 @@ public class BindingProcessTest
     {
         // given
         ClusterId localClusterId = new ClusterId( UUID.randomUUID() );
-        ClusterTopology topology = new ClusterTopology( null, true, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( null, true, Collections.emptyMap() );
 
         BindingProcess binder = new BindingProcess( localClusterId, log );
 
@@ -146,7 +146,7 @@ public class BindingProcessTest
         // given
         ClusterId localClusterId = new ClusterId( UUID.randomUUID() );
         ClusterId commonClusterId = new ClusterId( UUID.randomUUID() );
-        ClusterTopology topology = new ClusterTopology( commonClusterId, false, Collections.emptyMap(), Collections.emptySet() );
+        CoreTopology topology = new CoreTopology( commonClusterId, false, Collections.emptyMap());
 
         // when
         BindingProcess binder = new BindingProcess( localClusterId, log );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingServiceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingServiceTest.java
@@ -100,7 +100,6 @@ public class BindingServiceTest
         // given
         CoreTopology topology = new CoreTopology( null, true, emptyMap() );
 
-
         when( topologyService.coreServers() ).thenReturn( topology );
         when( topologyService.casClusterId( any() ) ).thenReturn( true );
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingServiceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/BindingServiceTest.java
@@ -25,14 +25,14 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.neo4j.coreedge.core.state.storage.SimpleStorage;
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.time.Clocks;
 
 import static java.lang.Thread.sleep;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -51,9 +51,9 @@ public class BindingServiceTest
     public void shouldTimeoutEventually() throws Throwable
     {
         // given
-        ClusterTopology topology = new ClusterTopology( null, false, emptyMap(), emptySet() );
+        CoreTopology topology = new CoreTopology( null, false, emptyMap() );
 
-        when( topologyService.currentTopology() ).thenReturn( topology );
+        when( topologyService.coreServers() ).thenReturn( topology );
 
         BindingService bindingService = new BindingService( clusterIdStorage, topologyService,
                 getInstance(), Clocks.systemClock(), () -> sleep( 1 ), 50 );
@@ -76,10 +76,10 @@ public class BindingServiceTest
         // given
         ClusterId commonClusterId = new ClusterId( UUID.randomUUID() );
 
-        ClusterTopology topologyNOK = new ClusterTopology( null, false, emptyMap(), emptySet() );
-        ClusterTopology topologyOK = new ClusterTopology( commonClusterId, false, emptyMap(), emptySet() );
+        CoreTopology topologyNOK = new CoreTopology( null, false, emptyMap() );
+        CoreTopology topologyOK = new CoreTopology( commonClusterId, false, emptyMap() );
 
-        when( topologyService.currentTopology() ).thenReturn( topologyNOK, topologyNOK, topologyNOK, topologyOK );
+        when( topologyService.coreServers() ).thenReturn( topologyNOK, topologyNOK, topologyNOK, topologyOK );
         when( topologyService.casClusterId( any() ) ).thenReturn( true );
 
         BindingService bindingService = new BindingService( clusterIdStorage, topologyService,
@@ -98,9 +98,10 @@ public class BindingServiceTest
     public void shouldPublishNewId() throws Throwable
     {
         // given
-        ClusterTopology topology = new ClusterTopology( null, true, emptyMap(), emptySet() );
+        CoreTopology topology = new CoreTopology( null, true, emptyMap() );
 
-        when( topologyService.currentTopology() ).thenReturn( topology );
+
+        when( topologyService.coreServers() ).thenReturn( topology );
         when( topologyService.casClusterId( any() ) ).thenReturn( true );
 
         BindingService bindingService = new BindingService( clusterIdStorage, topologyService,
@@ -118,13 +119,13 @@ public class BindingServiceTest
     public void shouldPublishOldId() throws Throwable
     {
         // given
-        ClusterTopology topology = new ClusterTopology( null, true, emptyMap(), emptySet() );
+        CoreTopology topology = new CoreTopology( null, true, emptyMap() );
         ClusterId localClusterId = new ClusterId( UUID.randomUUID() );
 
         when( clusterIdStorage.exists() ).thenReturn( true );
         when( clusterIdStorage.readState() ).thenReturn( localClusterId );
 
-        when( topologyService.currentTopology() ).thenReturn( topology );
+        when( topologyService.coreServers() ).thenReturn( topology );
         when( topologyService.casClusterId( any() ) ).thenReturn( true );
 
         BindingService bindingService = new BindingService( clusterIdStorage, topologyService,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
@@ -293,7 +293,7 @@ public class Cluster
                 .filter( ( member ) -> member.database() != null ).findAny().get();
         CoreTopologyService coreTopologyService = aCoreGraphDb.database().getDependencyResolver()
                 .resolveDependency( CoreTopologyService.class );
-        return coreTopologyService.currentTopology().coreMembers().size();
+        return coreTopologyService.coreServers().members().size();
     }
 
     /**

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClientTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClientTest.java
@@ -117,10 +117,10 @@ public class HazelcastClientTest
         when( cluster.getMembers() ).thenReturn( members );
 
         // when
-        ClusterTopology topology = client.currentTopology();
+        CoreTopology topology = client.coreServers();
 
         // then
-        assertEquals( members.size(), topology.coreMembers().size() );
+        assertEquals( members.size(), topology.members().size() );
     }
 
     @Test
@@ -145,11 +145,11 @@ public class HazelcastClientTest
         when( cluster.getMembers() ).thenReturn( members );
 
         // when
-        ClusterTopology topology;
+        CoreTopology topology;
         for ( int i = 0; i < 5; i++ )
         {
-            topology = client.currentTopology();
-            assertEquals( members.size(), topology.coreMembers().size() );
+            topology = client.coreServers();
+            assertEquals( members.size(), topology.members().size() );
         }
 
         // then
@@ -181,9 +181,9 @@ public class HazelcastClientTest
         when( cluster.getMembers() ).thenReturn( members );
 
         // when
-        ClusterTopology topology = client.currentTopology();
+        CoreTopology topology = client.coreServers();
 
-        assertEquals( 0, topology.coreMembers().size() );
+        assertEquals( 0, topology.members().size() );
         verify( log ).info( startsWith( "Failed to read cluster topology from Hazelcast." ),
                 any( IllegalStateException.class ) );
     }
@@ -204,10 +204,10 @@ public class HazelcastClientTest
         when( hazelcastInstance.getCluster() ).thenThrow( new HazelcastInstanceNotActiveException() );
 
         // when
-        ClusterTopology topology = client.currentTopology();
+        CoreTopology topology = client.coreServers();
 
         // then
-        assertEquals( 0, topology.coreMembers().size() );
+        assertEquals( 0, topology.members().size() );
     }
 
     @Test
@@ -240,16 +240,16 @@ public class HazelcastClientTest
         when( cluster.getMembers() ).thenReturn( members );
 
         // when
-        ClusterTopology topology1 = client.currentTopology();
+        CoreTopology topology1 = client.coreServers();
 
         // then
-        assertEquals( members.size(), topology1.coreMembers().size() );
+        assertEquals( members.size(), topology1.members().size() );
 
         // when
-        ClusterTopology topology2 = client.currentTopology();
+        CoreTopology topology2 = client.coreServers();
 
         // then
-        assertEquals( members.size(), topology2.coreMembers().size() );
+        assertEquals( members.size(), topology2.members().size() );
         verify( connector, times( 2 ) ).connectToHazelcast();
     }
 
@@ -292,10 +292,10 @@ public class HazelcastClientTest
         renewableTimeoutService.invokeTimeout( REFRESH_EDGE );
 
         // when
-        ClusterTopology clusterTopology = hazelcastClient.currentTopology();
+        EdgeTopology clusterTopology = hazelcastClient.edgeServers();
 
         // then
-        assertEquals( 1, clusterTopology.edgeMemberAddresses().size() );
+        assertEquals( 1, clusterTopology.members().size() );
     }
 
     @Test
@@ -336,7 +336,7 @@ public class HazelcastClientTest
         hazelcastClient.start();
         renewableTimeoutService.invokeTimeout( REFRESH_EDGE );
 
-        int numberOfStartedEdgeServers = hazelcastClient.currentTopology().edgeMemberAddresses().size();
+        int numberOfStartedEdgeServers = hazelcastClient.edgeServers().members().size();
 
         // when
         hazelcastClient.stop();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryCoreClient.java
@@ -40,7 +40,8 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     private final Set<Listener> listeners = new LinkedHashSet<>();
     private final Log log;
 
-    private ClusterTopology clusterTopology;
+    private CoreTopology coreTopology;
+    private EdgeTopology edgeTopology;
 
     SharedDiscoveryCoreClient( SharedDiscoveryService sharedDiscoveryService, MemberId member, LogProvider logProvider, Config config )
     {
@@ -54,7 +55,7 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     public synchronized void addCoreTopologyListener( Listener listener )
     {
         listeners.add( listener );
-        listener.onCoreTopologyChange( clusterTopology );
+        listener.onCoreTopologyChange( coreTopology );
     }
 
     @Override
@@ -80,19 +81,31 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     }
 
     @Override
-    public synchronized ClusterTopology currentTopology()
+    public EdgeTopology edgeServers()
     {
-        return clusterTopology;
+        return edgeTopology;
     }
 
-    synchronized void onTopologyChange( ClusterTopology clusterTopology )
+    @Override
+    public CoreTopology coreServers()
     {
-        log.info( "Notified of topology change" );
-        this.clusterTopology = clusterTopology;
+        return coreTopology;
+    }
+
+    synchronized void onCoreTopologyChange( CoreTopology coreTopology )
+    {
+        log.info( "Notified of core topology change " + coreTopology );
+        this.coreTopology = coreTopology;
         for ( Listener listener : listeners )
         {
-            listener.onCoreTopologyChange( clusterTopology );
+            listener.onCoreTopologyChange( coreTopology );
         }
+    }
+
+    synchronized void onEdgeTopologyChange( EdgeTopology edgeTopology )
+    {
+        log.info( "Notified of edge topology change " + edgeTopology  );
+        this.edgeTopology = edgeTopology;
     }
 
     private static CoreAddresses extractAddresses( Config config )

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryEdgeClient.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryEdgeClient.java
@@ -52,10 +52,16 @@ class SharedDiscoveryEdgeClient extends LifecycleAdapter implements TopologyServ
     }
 
     @Override
-    public ClusterTopology currentTopology()
+    public EdgeTopology edgeServers()
     {
-        ClusterTopology topology = sharedDiscoveryService.currentTopology( null );
-        log.info( "Current topology is %s", topology );
+        return sharedDiscoveryService.edgeTopology();
+    }
+
+    @Override
+    public CoreTopology coreServers()
+    {
+        CoreTopology topology = sharedDiscoveryService.coreTopology( null );
+        log.info( "Core topology is %s", topology );
         return topology;
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/AcquireEndpointsProcedureTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/AcquireEndpointsProcedureTest.java
@@ -27,11 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
 import org.neo4j.coreedge.discovery.CoreAddresses;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.core.consensus.LeaderLocator;
 import org.neo4j.coreedge.core.consensus.NoLeaderFoundException;
+import org.neo4j.coreedge.discovery.EdgeTopology;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.logging.NullLogProvider;
@@ -59,8 +60,8 @@ public class AcquireEndpointsProcedureTest
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, DiscoverEndpointAcquisitionServersProcedureTest.coreAddresses( 0 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, DiscoverEndpointAcquisitionServersProcedureTest.addresses( 1 ) );
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( clusterId, DiscoverEndpointAcquisitionServersProcedureTest.addresses( 1 ) ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -88,8 +89,8 @@ public class AcquireEndpointsProcedureTest
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, DiscoverEndpointAcquisitionServersProcedureTest.coreAddresses( 0 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, DiscoverEndpointAcquisitionServersProcedureTest.addresses( 1, 2, 3 ) );
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( clusterId, DiscoverEndpointAcquisitionServersProcedureTest.addresses( 1, 2, 3 ) ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -113,9 +114,9 @@ public class AcquireEndpointsProcedureTest
         Map<MemberId, CoreAddresses> coreMembers = new HashMap<>();
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, DiscoverEndpointAcquisitionServersProcedureTest.coreAddresses( 0 ) );
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, DiscoverEndpointAcquisitionServersProcedureTest.addresses() );
 
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( clusterId, DiscoverEndpointAcquisitionServersProcedureTest.addresses() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -142,9 +143,8 @@ public class AcquireEndpointsProcedureTest
         Map<MemberId, CoreAddresses> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), DiscoverEndpointAcquisitionServersProcedureTest.coreAddresses( 0 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, DiscoverEndpointAcquisitionServersProcedureTest.addresses() );
-
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( clusterId, DiscoverEndpointAcquisitionServersProcedureTest.addresses() ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenThrow( new NoLeaderFoundException() );
@@ -169,9 +169,8 @@ public class AcquireEndpointsProcedureTest
         Map<MemberId, CoreAddresses> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), DiscoverEndpointAcquisitionServersProcedureTest.coreAddresses( 0 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, DiscoverEndpointAcquisitionServersProcedureTest.addresses() );
-
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( clusterId, DiscoverEndpointAcquisitionServersProcedureTest.addresses()) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( member( 1 ) );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -28,11 +28,12 @@ import java.util.UUID;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
 import org.neo4j.coreedge.discovery.CoreAddresses;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.discovery.EdgeAddresses;
 import org.neo4j.coreedge.core.consensus.LeaderLocator;
+import org.neo4j.coreedge.discovery.EdgeTopology;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.logging.NullLogProvider;
 
@@ -62,8 +63,8 @@ public class ClusterOverviewProcedureTest
 
         Set<EdgeAddresses> edges = addresses( 4, 5 );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( null, false, coreMembers, edges );
-        when( topologyService.currentTopology() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( null, false, coreMembers ) );
+        when( topologyService.edgeServers() ).thenReturn( new EdgeTopology( null, edges ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/DiscoverEndpointAcquisitionServersProcedureTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/DiscoverEndpointAcquisitionServersProcedureTest.java
@@ -29,8 +29,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.neo4j.coreedge.discovery.ClusterTopology;
 import org.neo4j.coreedge.discovery.CoreAddresses;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
 import org.neo4j.coreedge.discovery.EdgeAddresses;
 import org.neo4j.coreedge.identity.ClusterId;
@@ -62,8 +62,8 @@ public class DiscoverEndpointAcquisitionServersProcedureTest
         coreMembers.put( member( 1 ), coreAddresses( 1 ) );
         coreMembers.put( member( 2 ), coreAddresses( 2 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, addresses( 3, 4, 5 ) );
-        when( coreTopologyService.currentTopology() ).thenReturn( clusterTopology );
+        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
 
         final DiscoverEndpointAcquisitionServersProcedure proc =
                 new DiscoverEndpointAcquisitionServersProcedure( coreTopologyService, NullLogProvider.getInstance() );
@@ -87,8 +87,8 @@ public class DiscoverEndpointAcquisitionServersProcedureTest
         Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), coreAddresses( 0 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, addresses( 3, 4, 5 ) );
-        when( coreTopologyService.currentTopology() ).thenReturn( clusterTopology );
+        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
         final DiscoverEndpointAcquisitionServersProcedure proc =
                 new DiscoverEndpointAcquisitionServersProcedure( coreTopologyService, NullLogProvider.getInstance() );
 
@@ -110,8 +110,8 @@ public class DiscoverEndpointAcquisitionServersProcedureTest
         coreMembers.put( member( 1 ), coreAddresses( 1 ) );
         coreMembers.put( member( 2 ), coreAddresses( 2 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, addresses( 3, 4, 5) );
-        when( coreTopologyService.currentTopology() ).thenReturn( clusterTopology );
+        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
 
         final DiscoverEndpointAcquisitionServersProcedure proc =
                 new DiscoverEndpointAcquisitionServersProcedure( coreTopologyService, NullLogProvider.getInstance() );
@@ -134,8 +134,8 @@ public class DiscoverEndpointAcquisitionServersProcedureTest
         coreMembers.put( member( 1 ), coreAddresses( 1 ) );
         coreMembers.put( member( 2 ), coreAddresses( 2 ) );
 
-        final ClusterTopology clusterTopology = new ClusterTopology( clusterId, false, coreMembers, addresses( 3, 4, 5 ) );
-        when( coreTopologyService.currentTopology() ).thenReturn( clusterTopology );
+        final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
+        when( coreTopologyService.coreServers() ).thenReturn( clusterTopology );
 
         final DiscoverEndpointAcquisitionServersProcedure proc =
                 new DiscoverEndpointAcquisitionServersProcedure( coreTopologyService, NullLogProvider.getInstance() );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
@@ -30,7 +30,7 @@ import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
 import org.neo4j.coreedge.catchup.storecopy.StoreFetcher;
 import org.neo4j.coreedge.catchup.storecopy.StoreIdDownloadFailedException;
 import org.neo4j.coreedge.core.state.machines.tx.ConstantTimeRetryStrategy;
-import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.TopologyService;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.coreedge.identity.StoreId;
@@ -54,7 +54,7 @@ public class EdgeStartupProcessTest
     private StoreFetcher storeFetcher = mock( StoreFetcher.class );
     private LocalDatabase localDatabase = mock( LocalDatabase.class );
     private TopologyService hazelcastTopology = mock( TopologyService.class );
-    private ClusterTopology clusterTopology = mock( ClusterTopology.class );
+    private CoreTopology clusterTopology = mock( CoreTopology.class );
     private Lifecycle txPulling = mock( Lifecycle.class );
 
     private MemberId memberId = new MemberId( UUID.randomUUID() );
@@ -67,9 +67,10 @@ public class EdgeStartupProcessTest
     {
         when( localDatabase.storeDir() ).thenReturn( storeDir );
         when( localDatabase.storeId() ).thenReturn( localStoreId );
-        when( hazelcastTopology.currentTopology() ).thenReturn( clusterTopology );
-        when( clusterTopology.coreMembers() ).thenReturn( asSet( memberId ) );
+        when( hazelcastTopology.coreServers() ).thenReturn( clusterTopology );
+        when( clusterTopology.members() ).thenReturn( asSet( memberId ) );
     }
+
 
     @Test
     public void shouldReplaceEmptyStoreWithRemote() throws Throwable
@@ -100,6 +101,7 @@ public class EdgeStartupProcessTest
         when( localDatabase.isEmpty() ).thenReturn( false );
         when( storeFetcher.getStoreIdOf( any() ) ).thenReturn( otherStoreId );
 
+
         EdgeStartupProcess edgeStartupProcess = new EdgeStartupProcess( storeFetcher, localDatabase,
                 txPulling, new AlwaysChooseFirstMember( hazelcastTopology ),
                 new ConstantTimeRetryStrategy( 1, MILLISECONDS ), NullLogProvider.getInstance(), copiedStoreRecovery );
@@ -125,6 +127,7 @@ public class EdgeStartupProcessTest
         // given
         when( storeFetcher.getStoreIdOf( any() ) ).thenReturn( localStoreId );
         when( localDatabase.isEmpty() ).thenReturn( false );
+
 
         EdgeStartupProcess edgeStartupProcess = new EdgeStartupProcess( storeFetcher, localDatabase,
                 txPulling, new AlwaysChooseFirstMember( hazelcastTopology ),

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
@@ -71,7 +71,6 @@ public class EdgeStartupProcessTest
         when( clusterTopology.members() ).thenReturn( asSet( memberId ) );
     }
 
-
     @Test
     public void shouldReplaceEmptyStoreWithRemote() throws Throwable
     {
@@ -101,7 +100,6 @@ public class EdgeStartupProcessTest
         when( localDatabase.isEmpty() ).thenReturn( false );
         when( storeFetcher.getStoreIdOf( any() ) ).thenReturn( otherStoreId );
 
-
         EdgeStartupProcess edgeStartupProcess = new EdgeStartupProcess( storeFetcher, localDatabase,
                 txPulling, new AlwaysChooseFirstMember( hazelcastTopology ),
                 new ConstantTimeRetryStrategy( 1, MILLISECONDS ), NullLogProvider.getInstance(), copiedStoreRecovery );
@@ -127,7 +125,6 @@ public class EdgeStartupProcessTest
         // given
         when( storeFetcher.getStoreIdOf( any() ) ).thenReturn( localStoreId );
         when( localDatabase.isEmpty() ).thenReturn( false );
-
 
         EdgeStartupProcess edgeStartupProcess = new EdgeStartupProcess( storeFetcher, localDatabase,
                 txPulling, new AlwaysChooseFirstMember( hazelcastTopology ),

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.neo4j.coreedge.core.CoreGraphDatabase;
 import org.neo4j.coreedge.discovery.Cluster;
 import org.neo4j.coreedge.discovery.CoreClusterMember;
+import org.neo4j.coreedge.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.coreedge.ClusterRule;


### PR DESCRIPTION
We're doing this so that we don't make a call to HZ on the
Raft critical path.

It was previously looking up edge servers every time we sent
a message out which is pointless as we're never going to send
a Raft message to them anyway
