### PR TITLE
Uses RecordCursor in ReadNodeRecordsByCacheStep

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsByCacheStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsByCacheStep.java
@@ -57,7 +57,7 @@ public class ReadNodeRecordsByCacheStep extends AbstractStep<NodeRecord[]>
     public void start( int orderingGuarantees )
     {
         super.start( orderingGuarantees );
-        recordCursor.acquire( 0, RecordLoad.CHECK );
+        recordCursor.acquire( 0, RecordLoad.NORMAL );
     }
 
     @Override
@@ -95,8 +95,7 @@ public class ReadNodeRecordsByCacheStep extends AbstractStep<NodeRecord[]>
         @Override
         public void change( long nodeId, ByteArray array )
         {
-            boolean inUse = recordCursor.next( nodeId );
-            assert inUse;
+            recordCursor.next( nodeId );
             batch[cursor++] = recordCursor.get().clone();
             if ( cursor == batchSize )
             {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsByCacheStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsByCacheStep.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
@@ -40,16 +41,30 @@ public class ReadNodeRecordsByCacheStep extends AbstractStep<NodeRecord[]>
     private final boolean denseNodes;
     private final NodeRelationshipCache cache;
     private final int batchSize;
-    private final NodeStore nodeStore;
+    private final RecordCursor<NodeRecord> recordCursor;
 
     public ReadNodeRecordsByCacheStep( StageControl control, Configuration config,
             NodeStore nodeStore, NodeRelationshipCache cache, boolean denseNodes )
     {
         super( control, ">", config );
-        this.nodeStore = nodeStore;
         this.cache = cache;
         this.denseNodes = denseNodes;
         this.batchSize = config.batchSize();
+        this.recordCursor = nodeStore.newRecordCursor( nodeStore.newRecord() );
+    }
+
+    @Override
+    public void start( int orderingGuarantees )
+    {
+        super.start( orderingGuarantees );
+        recordCursor.acquire( 0, RecordLoad.CHECK );
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        recordCursor.close();
+        super.close();
     }
 
     @Override
@@ -80,7 +95,9 @@ public class ReadNodeRecordsByCacheStep extends AbstractStep<NodeRecord[]>
         @Override
         public void change( long nodeId, ByteArray array )
         {
-            batch[cursor++] = nodeStore.getRecord( nodeId, nodeStore.newRecord(), RecordLoad.CHECK );
+            boolean inUse = recordCursor.next( nodeId );
+            assert inUse;
+            batch[cursor++] = recordCursor.get().clone();
             if ( cursor == batchSize )
             {
                 send();


### PR DESCRIPTION
for more efficient reading of records.
