### PR TITLE
3.1 specify auth realm

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -34,7 +34,6 @@ import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.kernel.api.security.AuthToken.NEW_CREDENTIALS;
 import static org.neo4j.kernel.api.security.AuthToken.PRINCIPAL;
-import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
 
 /**
  * Performs basic authentication with user name and password.
@@ -42,7 +41,6 @@ import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
 public class BasicAuthentication implements Authentication
 {
     private final AuthManager authManager;
-    private static final String SCHEME = "basic";
     private final Log log;
 
     public BasicAuthentication( AuthManager authManager, LogProvider logProvider )
@@ -54,7 +52,7 @@ public class BasicAuthentication implements Authentication
     @Override
     public AuthenticationResult authenticate( Map<String,Object> authToken ) throws AuthenticationException
     {
-        if ( !SCHEME.equals( authToken.get( SCHEME_KEY ) ) )
+        if ( !authManager.supports( authToken ) )
         {
             throw new AuthenticationException( Status.Security.Unauthorized, "Missing username and password" );
         }

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -54,7 +54,7 @@ public class BasicAuthentication implements Authentication
     {
         if ( !authManager.supports( authToken ) )
         {
-            throw new AuthenticationException( Status.Security.Unauthorized, "Missing username and password" );
+            throw new AuthenticationException( Status.Security.Unauthorized );
         }
 
         if ( authToken.containsKey( NEW_CREDENTIALS ) )

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -24,6 +24,10 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Map;
 
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AuthenticationResult;
@@ -38,6 +42,7 @@ import org.neo4j.time.FakeClock;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,6 +60,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class )  );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
@@ -74,6 +80,7 @@ public class BasicAuthenticationTest
         LogProvider logProvider = mock( LogProvider.class );
         when( logProvider.getLog( BasicAuthentication.class ) ).thenReturn( log );
         BasicAuthentication authentication = new BasicAuthentication( manager, logProvider );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
@@ -96,6 +103,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
@@ -114,6 +122,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
 
@@ -133,6 +142,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
@@ -150,6 +160,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
@@ -167,6 +178,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
@@ -187,6 +199,7 @@ public class BasicAuthenticationTest
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ) );
+        mockManagerSupportsScheme( manager, "basic" );
         when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
@@ -218,6 +231,18 @@ public class BasicAuthenticationTest
         // When
         authentication
                 .authenticate( map( "scheme", "basic", "principal", singletonList( "bob" ), "credentials", "secret" ) );
+    }
+
+    private void mockManagerSupportsScheme(BasicAuthManager manager, String expectedScheme) {
+        doAnswer(new Answer<Boolean>(){
+            @Override
+            public Boolean answer( InvocationOnMock invocation ) throws Throwable
+            {
+                final Object[] args = invocation.getArguments();
+                Map<String, Object> token = (Map<String, Object>)args[0];
+                return token.containsKey( "scheme" ) && token.get( "scheme" ).equals( expectedScheme );
+            }
+        }).when( manager ).supports( anyMap() );
     }
 
     private HasStatus hasStatus( Status status )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -42,6 +42,8 @@ public interface AuthManager extends Lifecycle
         public abstract AuthManager newInstance( Config config, LogProvider logProvider );
     }
 
+    boolean supports( Map<String, Object> authToken );
+
     /**
      * Log in using the provided authentication token
      * @param authToken The authentication token to login with. Typically contains principals and credentials.
@@ -73,6 +75,12 @@ public interface AuthManager extends Lifecycle
         @Override
         public void shutdown() throws Throwable
         {
+        }
+
+        @Override
+        public boolean supports( Map<String,Object> authToken )
+        {
+            return true;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -30,7 +30,11 @@ public interface AuthToken
     String SCHEME_KEY = "scheme";
     String PRINCIPAL = "principal";
     String CREDENTIALS = "credentials";
+    String REALM_KEY = "realm";
+    String PARAMETERS = "parameters";
     String NEW_CREDENTIALS = "new_credentials";
+    String BASIC_SCHEME = "basic";
+    String NATIVE_REALM = "native";
 
     static String safeCast( String key, Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
@@ -39,13 +43,33 @@ public interface AuthToken
         {
             throw new InvalidAuthTokenException(
                     "The value associated with the key `" + key + "` must be a String but was: " +
-                    (value == null ? "null" : value.getClass().getSimpleName()));
+                    (value == null ? "null" : value.getClass().getSimpleName()) );
         }
         return (String) value;
     }
 
     static Map<String,Object> newBasicAuthToken( String username, String password )
     {
-        return map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password );
+        return map( AuthToken.SCHEME_KEY, BASIC_SCHEME, AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS,
+                password );
+    }
+
+    static Map<String,Object> newBasicAuthToken( String username, String password, String realm )
+    {
+        return map( AuthToken.SCHEME_KEY, BASIC_SCHEME, AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password,
+                AuthToken.REALM_KEY, realm );
+    }
+
+    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String realm, String scheme )
+    {
+        return map( AuthToken.SCHEME_KEY, scheme, AuthToken.PRINCIPAL, principle, AuthToken.CREDENTIALS, credentials,
+                AuthToken.REALM_KEY, realm );
+    }
+
+    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String realm, String scheme,
+            Map<String,Object> parameters )
+    {
+        return map( AuthToken.SCHEME_KEY, scheme, AuthToken.PRINCIPAL, principle, AuthToken.CREDENTIALS, credentials,
+                AuthToken.REALM_KEY, realm, AuthToken.PARAMETERS, parameters );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.security;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class AuthTokenTest
+{
+    @Test
+    public void shouldMakeBasicAuthToken() throws Exception
+    {
+        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret" );
+        assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
+        assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
+        assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
+        assertThat("Should have no realm", token.get(AuthToken.REALM_KEY), nullValue());
+    }
+
+    @Test
+    public void shouldMakeBasicAuthTokenWithRealm() throws Exception
+    {
+        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret", "my realm" );
+        assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
+        assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
+        assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
+        assertThat("Should have correct realm", token.get(AuthToken.REALM_KEY), equalTo( "my realm" ));
+    }
+
+    @Test
+    public void shouldMakeCustomAuthTokenAndBasicScheme() throws Exception
+    {
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "basic" );
+        assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
+        assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
+        assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
+        assertThat("Should have correctno realm", token.get(AuthToken.REALM_KEY), equalTo( "my realm" ));
+    }
+
+    @Test
+    public void shouldMakeCustomAuthTokenAndCustomcScheme() throws Exception
+    {
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "my scheme" );
+        assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
+        assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
+        assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo("my scheme"));
+        assertThat("Should have correct realm", token.get(AuthToken.REALM_KEY), equalTo( "my realm" ));
+    }
+
+    @Test
+    public void shouldMakeCustomAuthTokenAndCustomcSchemeWithParameters() throws Exception
+    {
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "my scheme", map("a", "A", "b", "B") );
+        assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
+        assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
+        assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo("my scheme"));
+        assertThat("Should have correct realm", token.get(AuthToken.REALM_KEY), equalTo( "my realm" ));
+        assertThat("Should have correct parameters", token.get(AuthToken.PARAMETERS), equalTo( map("a", "A", "b", "B") ));
+    }
+}

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -33,6 +33,11 @@ import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
 
+import static org.neo4j.kernel.api.security.AuthToken.BASIC_SCHEME;
+import static org.neo4j.kernel.api.security.AuthToken.NATIVE_REALM;
+import static org.neo4j.kernel.api.security.AuthToken.REALM_KEY;
+import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
+
 /**
  * Manages server authentication and authorization.
  * <p>
@@ -87,6 +92,13 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     public void shutdown() throws Throwable
     {
         userRepository.shutdown();
+    }
+
+    @Override
+    public boolean supports( Map<String,Object> authToken )
+    {
+        return (!authToken.containsKey( SCHEME_KEY ) || BASIC_SCHEME.equals( authToken.get( SCHEME_KEY ) )) &&
+               (!authToken.containsKey( REALM_KEY ) || NATIVE_REALM.equals( authToken.get( REALM_KEY ) ));
     }
 
     @Override

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -97,7 +97,7 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     @Override
     public boolean supports( Map<String,Object> authToken )
     {
-        return (!authToken.containsKey( SCHEME_KEY ) || BASIC_SCHEME.equals( authToken.get( SCHEME_KEY ) )) &&
+        return authToken.containsKey( SCHEME_KEY ) && BASIC_SCHEME.equals( authToken.get( SCHEME_KEY ) ) &&
                (!authToken.containsKey( REALM_KEY ) || NATIVE_REALM.equals( authToken.get( REALM_KEY ) ));
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -194,7 +194,8 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
         {
             if ( token instanceof ShiroAuthToken )
             {
-                return ((ShiroAuthToken) token).getScheme().equals( "basic" );
+                ShiroAuthToken shiroAuthToken = (ShiroAuthToken) token;
+                return shiroAuthToken.getScheme().equals( "basic" ) && (shiroAuthToken.supportsRealm( "neo4j" ));
             }
             return false;
         }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -195,7 +195,8 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
             if ( token instanceof ShiroAuthToken )
             {
                 ShiroAuthToken shiroAuthToken = (ShiroAuthToken) token;
-                return shiroAuthToken.getScheme().equals( "basic" ) && (shiroAuthToken.supportsRealm( "neo4j" ));
+                return shiroAuthToken.getScheme().equals( AuthToken.BASIC_SCHEME ) &&
+                       (shiroAuthToken.supportsRealm( AuthToken.NATIVE_REALM ));
             }
             return false;
         }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -71,6 +71,13 @@ public class MultiRealmAuthManager implements EnterpriseAuthManager, UserManager
     }
 
     @Override
+    public boolean supports( final Map<String,Object> authToken )
+    {
+        final ShiroAuthToken token = new ShiroAuthToken( authToken );
+        return realms.stream().anyMatch( realm -> realm.supports( token ) );
+    }
+
+    @Override
     public EnterpriseAuthSubject login( Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
         ShiroSubject subject;

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -60,6 +60,9 @@ public class ShiroAuthToken implements AuthenticationToken
     /** returns true if token map does not specify a realm, or if it specifies the requested realm */
     public boolean supportsRealm( String realm )
     {
-        return !authToken.containsKey( AuthToken.REALM_KEY ) || authToken.get( AuthToken.REALM_KEY ).equals( realm );
+        return !authToken.containsKey( AuthToken.REALM_KEY ) ||
+               authToken.get( AuthToken.REALM_KEY ).toString().length() == 0 ||
+               authToken.get( AuthToken.REALM_KEY ).equals( "*" ) ||
+               authToken.get( AuthToken.REALM_KEY ).equals( realm );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
 public class ShiroAuthToken implements AuthenticationToken
 {
+    private static final String REALM_KEY = "realm";
     private final Map<String,Object> authToken;
 
     public ShiroAuthToken( Map<String,Object> authToken )
@@ -55,5 +56,11 @@ public class ShiroAuthToken implements AuthenticationToken
     Map<String,Object> getAuthTokenMap()
     {
         return authToken;
+    }
+
+    /** returns true if token map does not specify a realm, or if it specifies the requested realm */
+    public boolean supportsRealm( String realm )
+    {
+        return !authToken.containsKey( REALM_KEY ) || authToken.get( REALM_KEY ).equals( realm );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
 public class ShiroAuthToken implements AuthenticationToken
 {
-    private static final String REALM_KEY = "realm";
     private final Map<String,Object> authToken;
 
     public ShiroAuthToken( Map<String,Object> authToken )
@@ -61,6 +60,6 @@ public class ShiroAuthToken implements AuthenticationToken
     /** returns true if token map does not specify a realm, or if it specifies the requested realm */
     public boolean supportsRealm( String realm )
     {
-        return !authToken.containsKey( REALM_KEY ) || authToken.get( REALM_KEY ).equals( realm );
+        return !authToken.containsKey( AuthToken.REALM_KEY ) || authToken.get( AuthToken.REALM_KEY ).equals( realm );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -129,7 +129,7 @@ public class BoltInteraction implements NeoInteractionLevel<BoltInteraction.Bolt
         }
         subject.client.connect( address ).send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
                 .send( TransportTestUtil.chunk( InitMessage.init( "TestClient/1.1",
-                        map( "principal", username, "credentials", password, "scheme", "basic" ) ) ) );
+                        map( "realm", "neo4j", "principal", username, "credentials", password, "scheme", "basic" ) ) ) );
         assertThat( subject.client, TransportTestUtil.eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         subject.setLoginResult( TransportTestUtil.receiveOneResponseMessage( subject.client ) );
         return subject;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -55,6 +55,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.bolt.v1.messaging.message.ResetMessage.reset;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.security.AuthToken.BASIC_SCHEME;
+import static org.neo4j.kernel.api.security.AuthToken.CREDENTIALS;
+import static org.neo4j.kernel.api.security.AuthToken.NATIVE_REALM;
+import static org.neo4j.kernel.api.security.AuthToken.PRINCIPAL;
+import static org.neo4j.kernel.api.security.AuthToken.REALM_KEY;
+import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
 import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 
 public class BoltInteraction implements NeoInteractionLevel<BoltInteraction.BoltSubject>
@@ -129,7 +135,8 @@ public class BoltInteraction implements NeoInteractionLevel<BoltInteraction.Bolt
         }
         subject.client.connect( address ).send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
                 .send( TransportTestUtil.chunk( InitMessage.init( "TestClient/1.1",
-                        map( "realm", "neo4j", "principal", username, "credentials", password, "scheme", "basic" ) ) ) );
+                        map( REALM_KEY, NATIVE_REALM, PRINCIPAL, username, CREDENTIALS, password,
+                                SCHEME_KEY, BASIC_SCHEME ) ) ) );
         assertThat( subject.client, TransportTestUtil.eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         subject.setLoginResult( TransportTestUtil.receiveOneResponseMessage( subject.client ) );
         return subject;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import org.neo4j.kernel.api.security.AuthToken;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class ShiroAuthTokenTest
+{
+    private final String USERNAME = "myuser";
+    private final String PASSWORD = "mypw123";
+
+    @Test
+    public void shouldSupportBasicAuthToken() throws Exception
+    {
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME ) ) );
+        testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
+    }
+
+    @Test
+    public void shouldSupportBasicAuthTokenWithWildcardRealm() throws Exception
+    {
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, "*" ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "*" ) ) );
+        testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
+    }
+
+    @Test
+    public void shouldSupportBasicAuthTokenWithSpecificRealm() throws Exception
+    {
+        String realm = "ldap";
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, realm ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap" ) ) );
+        testTokenSupportsRealm( token, true, realm );
+        testTokenSupportsRealm( token, false, "unknown", "native" );
+    }
+
+    @Test
+    public void shouldSupportCustomAuthTokenWithSpecificRealm() throws Exception
+    {
+        String realm = "ldap";
+        ShiroAuthToken token =
+                new ShiroAuthToken( AuthToken.newCustomAuthToken( USERNAME, PASSWORD, realm, AuthToken.BASIC_SCHEME ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap" ) ) );
+        testTokenSupportsRealm( token, true, realm );
+        testTokenSupportsRealm( token, false, "unknown", "native" );
+    }
+
+    @Test
+    public void shouldSupportCustomAuthTokenWithSpecificRealmAndParameters() throws Exception
+    {
+        String realm = "ldap";
+        Map<String,Object> params = map( "a", "A", "b", "B" );
+        ShiroAuthToken token =
+                new ShiroAuthToken(
+                        AuthToken.newCustomAuthToken( USERNAME, PASSWORD, realm, AuthToken.BASIC_SCHEME, params ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap",
+                        "parameters", params ) ) );
+        testTokenSupportsRealm( token, true, realm );
+        testTokenSupportsRealm( token, false, "unknown", "native" );
+    }
+
+    private void testTokenSupportsRealm( ShiroAuthToken token, boolean supports, String... realms )
+    {
+        for ( String realm : realms )
+        {
+            assertThat( "Token should support '" + realm + "' realm", token.supportsRealm( realm ),
+                    equalTo( supports ) );
+        }
+    }
+
+    private void testBasicAuthToken( ShiroAuthToken token, String username, String password, String scheme )
+            throws InvalidAuthTokenException
+    {
+        assertThat( "Token should have basic scheme", token.getScheme(), equalTo( scheme ) );
+        assertThat( "Token have correct principal", token.getPrincipal(), equalTo( username ) );
+        assertThat( "Token have correct credentials", token.getCredentials(), equalTo( password ) );
+    }
+}


### PR DESCRIPTION
changelog: Support the ability for client applications to specify which authorizing realm to use when logging in
