### PR TITLE
Fixes a race in decorating input entities

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -70,6 +70,7 @@ import org.neo4j.unsafe.impl.batchimport.input.MissingRelationshipDataException;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 import org.neo4j.unsafe.impl.batchimport.input.csv.CsvInput;
 import org.neo4j.unsafe.impl.batchimport.input.csv.DataFactory;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Decorator;
 import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 
@@ -628,7 +629,7 @@ public class ImportTool
             @Override
             protected DataFactory<InputNode> underlyingObjectToObject( Option<File[]> input )
             {
-                Function<InputNode,InputNode> decorator = input.metadata() != null
+                Decorator<InputNode> decorator = input.metadata() != null
                         ? additiveLabels( input.metadata().split( ":" ) )
                         : NO_NODE_DECORATOR;
                 return data( decorator, encoding, input.value() );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
@@ -58,7 +58,7 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     {
         return batch -> new SimpleDataGeneratorBatch<>( nodeHeader, batch.getStart(), randomSeed + batch.getStart(),
                 nodeCount, labels, relationshipTypes,
-                new InputNodeDeserialization( SimpleDataGenerator.this, nodeHeader, groups, idType.idsAreExternal() ),
+                new InputNodeDeserialization( nodeHeader, SimpleDataGenerator.this, groups, idType.idsAreExternal() ),
                 new InputNode[batch.getSize()] ).get();
     }
 
@@ -66,7 +66,7 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     {
         return batch -> new SimpleDataGeneratorBatch<>( relationshipHeader, batch.getStart(),
                 randomSeed + batch.getStart(), nodeCount, labels, relationshipTypes,
-                new InputRelationshipDeserialization( SimpleDataGenerator.this, relationshipHeader, groups ),
+                new InputRelationshipDeserialization( relationshipHeader, SimpleDataGenerator.this, groups ),
                 new InputRelationship[batch.getSize()] ).get();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntity.java
@@ -55,6 +55,10 @@ public abstract class InputEntity implements SourceTraceability
         this.firstPropertyId = firstPropertyId;
     }
 
+    /**
+     * @return properties on this entity. Properties sits in one array with alternating keys (even indexes)
+     * and values (odd indexes).
+     */
     public Object[] properties()
     {
         return properties;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecorators.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityDecorators.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.input;
 import java.util.function.Function;
 
 import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Decorator;
 
 /**
  * Common {@link InputEntity} decorators, able to provide defaults or overrides.
@@ -31,11 +32,11 @@ public class InputEntityDecorators
     /**
      * Ensures that all {@link InputNode input nodes} will at least have the given set of labels.
      */
-    public static Function<InputNode,InputNode> additiveLabels( final String[] labelNamesToAdd )
+    public static Decorator<InputNode> additiveLabels( final String[] labelNamesToAdd )
     {
         if ( labelNamesToAdd == null || labelNamesToAdd.length == 0 )
         {
-            return value -> value;
+            return NO_NODE_DECORATOR;
         }
 
         return node -> {
@@ -57,7 +58,7 @@ public class InputEntityDecorators
      * Ensures that {@link InputRelationship input relationships} without a specified relationship type will get
      * the specified default relationship type.
      */
-    public static Function<InputRelationship,InputRelationship> defaultRelationshipType( final String defaultType )
+    public static Decorator<InputRelationship> defaultRelationshipType( final String defaultType )
     {
         if ( defaultType == null )
         {
@@ -86,6 +87,11 @@ public class InputEntityDecorators
         };
     }
 
-    public static final Function<InputNode,InputNode> NO_NODE_DECORATOR = value -> value;
-    public static final Function<InputRelationship,InputRelationship> NO_RELATIONSHIP_DECORATOR = value -> value;
+    public static final Decorator<InputNode> NO_NODE_DECORATOR = value -> value;
+    public static final Decorator<InputRelationship> NO_RELATIONSHIP_DECORATOR = value -> value;
+
+    public static <ENTITY extends InputEntity> Decorator<ENTITY> noDecorator()
+    {
+        return value -> value;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
@@ -69,11 +69,11 @@ public interface Configuration extends org.neo4j.csv.reader.Configuration
         }
     };
 
-    class Overriden extends org.neo4j.csv.reader.Configuration.Overridden implements Configuration
+    class Overridden extends org.neo4j.csv.reader.Configuration.Overridden implements Configuration
     {
         private final Configuration defaults;
 
-        public Overriden( Configuration defaults )
+        public Overridden( Configuration defaults )
         {
             super( defaults );
             this.defaults = defaults;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -32,6 +32,7 @@ import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
 
 /**
  * Provides {@link Input} from data contained in tabular/csv form. Expects factories for instantiating
@@ -107,11 +108,12 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputNode> iterator()
             {
-                return new InputGroupsDeserializer<>( nodeDataFactory.iterator(),
-                        nodeHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader, decorator) ->
+                DeserializerFactory<InputNode> factory = (dataStream, dataHeader, decorator, validator) ->
                         new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputNodeDeserialization( dataStream, dataHeader, groups, idType.idsAreExternal() ),
-                                decorator, Validators.<InputNode>emptyValidator(), badCollector ), InputNode.class );
+                                decorator, validator, badCollector );
+                return new InputGroupsDeserializer<>( nodeDataFactory.iterator(), nodeHeaderFactory, config,
+                        idType, maxProcessors, factory,Validators.<InputNode>emptyValidator(), InputNode.class );
             }
 
             @Override
@@ -130,11 +132,13 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputRelationship> iterator()
             {
-                return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(),
-                        relationshipHeaderFactory, config, idType, maxProcessors, (dataStream, dataHeader, decorator) ->
+                DeserializerFactory<InputRelationship> factory = (dataStream, dataHeader, decorator, validator) ->
                         new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputRelationshipDeserialization( dataStream, dataHeader, groups ),
-                                decorator, new InputRelationshipValidator(), badCollector ), InputRelationship.class );
+                                decorator, validator, badCollector );
+                return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(), relationshipHeaderFactory,
+                        config, idType, maxProcessors, factory, new InputRelationshipValidator(),
+                        InputRelationship.class );
             }
 
             @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -108,12 +108,15 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputNode> iterator()
             {
-                DeserializerFactory<InputNode> factory = (dataStream, dataHeader, decorator, validator) ->
-                        new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
-                                new InputNodeDeserialization( dataStream, dataHeader, groups, idType.idsAreExternal() ),
-                                decorator, validator, badCollector );
+                DeserializerFactory<InputNode> factory = (dataHeader, dataStream, decorator, validator) ->
+                {
+                        InputNodeDeserialization deserialization =
+                                new InputNodeDeserialization( dataHeader, dataStream, groups, idType.idsAreExternal() );
+                        return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
+                                deserialization, decorator, validator, badCollector );
+                };
                 return new InputGroupsDeserializer<>( nodeDataFactory.iterator(), nodeHeaderFactory, config,
-                        idType, maxProcessors, factory,Validators.<InputNode>emptyValidator(), InputNode.class );
+                        idType, maxProcessors, factory, Validators.<InputNode>emptyValidator(), InputNode.class );
             }
 
             @Override
@@ -132,10 +135,13 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputRelationship> iterator()
             {
-                DeserializerFactory<InputRelationship> factory = (dataStream, dataHeader, decorator, validator) ->
-                        new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
-                                new InputRelationshipDeserialization( dataStream, dataHeader, groups ),
-                                decorator, validator, badCollector );
+                DeserializerFactory<InputRelationship> factory = (dataHeader, dataStream, decorator, validator) ->
+                {
+                        InputRelationshipDeserialization deserialization =
+                                new InputRelationshipDeserialization( dataHeader, dataStream, groups );
+                        return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
+                                deserialization, decorator, validator, badCollector );
+                };
                 return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(), relationshipHeaderFactory,
                         config, idType, maxProcessors, factory, new InputRelationshipValidator(),
                         InputRelationship.class );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.neo4j.csv.reader.CharReadable;
@@ -58,7 +57,7 @@ public class DataFactories
      *
      * @return {@link DataFactory} that returns a {@link CharSeeker} over all the supplied {@code files}.
      */
-    public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
+    public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Decorator<ENTITY> decorator,
             final Charset charset, final File... files )
     {
         if ( files.length == 0 )
@@ -82,7 +81,7 @@ public class DataFactories
             }
 
             @Override
-            public Function<ENTITY,ENTITY> decorator()
+            public Decorator<ENTITY> decorator()
             {
                 return decorator;
             }
@@ -94,7 +93,7 @@ public class DataFactories
      * multiple times.
      * @return {@link DataFactory} that returns a {@link CharSeeker} over the supplied {@code readable}
      */
-    public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Function<ENTITY,ENTITY> decorator,
+    public static <ENTITY extends InputEntity> DataFactory<ENTITY> data( final Decorator<ENTITY> decorator,
             final Supplier<CharReadable> readable )
     {
         return config -> new Data<ENTITY>()
@@ -106,7 +105,7 @@ public class DataFactories
             }
 
             @Override
-            public Function<ENTITY,ENTITY> decorator()
+            public Decorator<ENTITY> decorator()
             {
                 return decorator;
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Decorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Decorator.java
@@ -19,17 +19,19 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
-import org.neo4j.csv.reader.CharReadable;
-import org.neo4j.csv.reader.CharSeeker;
+import java.util.function.Function;
+
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 
-/**
- * Produces a {@link CharSeeker} that can seek and extract values from a csv/tsv style data stream.
- * A decorator also comes with it which can specify global overrides/defaults of extracted input entities.
- */
-public interface Data<ENTITY extends InputEntity>
+public interface Decorator<ENTITY extends InputEntity> extends Function<ENTITY,ENTITY>
 {
-    CharReadable stream();
-
-    Decorator<ENTITY> decorator();
+    /**
+     * @return whether or not this decorator is mutable. This is important because a state-less decorator
+     * can be called from multiple parallel processing threads. A mutable decorator has to be called by
+     * a single thread and may incur a performance penalty.
+     */
+    default boolean isMutable()
+    {
+        return false;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -27,6 +27,7 @@ import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
 
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
 
 /**
  * Pulls in properties from an external CSV source and amends them to the "main" input nodes.
@@ -47,12 +48,15 @@ import static org.neo4j.csv.reader.CharSeekers.charSeeker;
  * <Pre>
  * Then properties {@code abc@somewhere} and {@code def@somewhere} will be amended to input node {@code 1}
  * and {@code ghi@someplace} to input node {@code 3}.
+ *
+ * NOTE that order the input data (where we key on ID) is assumed to be the same, there are no checks
+ * for trying to verify this constraint though.
  */
 public class ExternalPropertiesDecorator implements Decorator<InputNode>
 {
     private final InputEntityDeserializer<InputNode> deserializer;
     private final UpdateBehaviour updateBehaviour;
-    private volatile InputNode currentExternal;
+    private InputNode currentExternal;
 
     /**
      * @param headerFactory creates a {@link Header} that will specify which field is the {@link Type#ID id field}
@@ -65,8 +69,8 @@ public class ExternalPropertiesDecorator implements Decorator<InputNode>
         CharSeeker dataStream = charSeeker( data.create( config ).stream(), config, true );
         Header header = headerFactory.create( dataStream, config, idType );
         this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
-                new InputNodeDeserialization( dataStream, header, new Groups(), idType.idsAreExternal() ),
-                value -> value, Validators.<InputNode>emptyValidator(), badCollector );
+                new InputNodeDeserialization( header, dataStream, new Groups(), idType.idsAreExternal() ),
+                NO_NODE_DECORATOR, Validators.<InputNode>emptyValidator(), badCollector );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
-import java.util.function.Function;
-
 import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -50,11 +48,11 @@ import static org.neo4j.csv.reader.CharSeekers.charSeeker;
  * Then properties {@code abc@somewhere} and {@code def@somewhere} will be amended to input node {@code 1}
  * and {@code ghi@someplace} to input node {@code 3}.
  */
-public class ExternalPropertiesDecorator implements Function<InputNode,InputNode>
+public class ExternalPropertiesDecorator implements Decorator<InputNode>
 {
     private final InputEntityDeserializer<InputNode> deserializer;
-    private InputNode currentExternal;
     private final UpdateBehaviour updateBehaviour;
+    private volatile InputNode currentExternal;
 
     /**
      * @param headerFactory creates a {@link Header} that will specify which field is the {@link Type#ID id field}
@@ -108,5 +106,11 @@ public class ExternalPropertiesDecorator implements Function<InputNode,InputNode
     private void decorate( InputNode from )
     {
         from.updateProperties( updateBehaviour, currentExternal.properties() );
+    }
+
+    @Override
+    public boolean isMutable()
+    {
+        return true;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -55,7 +55,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
     @FunctionalInterface
     public interface DeserializerFactory<ENTITY extends InputEntity>
     {
-        InputEntityDeserializer<ENTITY> create( CharSeeker dataStream, Header dataHeader,
+        InputEntityDeserializer<ENTITY> create( Header dataHeader, CharSeeker dataStream,
                 Function<ENTITY,ENTITY> decorator, Validator<ENTITY> validator );
     }
 
@@ -94,7 +94,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
             Header dataHeader = headerFactory.create( dataStream, config, idType );
 
             InputEntityDeserializer<ENTITY> input =
-                    factory.create( dataStream, dataHeader, data.decorator(), validator );
+                    factory.create( dataHeader, dataStream, data.decorator(), validator );
             // It's important that we assign currentInput before calling initialize(), so that if something
             // goes wrong in initialize() and our close() is called we close it properly.
             currentInput = input;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -29,9 +29,12 @@ import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import static org.neo4j.csv.reader.CharSeekers.charSeeker;
 
 /**
- * Able to deserialize one input group. An input group is a list of one or more input files containing
- * its own header. An import can read multiple input groups. Each group is deserialized by
- * {@link InputEntityDeserializer}.
+ * Able to deserialize one input group. An input group is a list of one or more input files logically seen
+ * as one stream of data. The first line in this data stream defines the header, a header which applies to
+ * all data in its group.
+ *
+ * Depending on how the data is structured, see {@link Configuration#multilineFields()} data may or may not
+ * be parsed and processed in parallel for higher throughput.
  */
 class InputGroupsDeserializer<ENTITY extends InputEntity>
         extends NestingIterator<ENTITY,DataFactory<ENTITY>>

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
@@ -44,7 +44,7 @@ public class InputNodeDeserialization extends InputEntityDeserialization<InputNo
     private String[] labels = new String[10];
     private int labelsCursor;
 
-    public InputNodeDeserialization( SourceTraceability source, Header header, Groups groups, boolean idsAreExternal )
+    public InputNodeDeserialization( Header header, SourceTraceability source, Groups groups, boolean idsAreExternal )
     {
         super( source );
         this.header = header;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
@@ -39,7 +39,7 @@ public class InputRelationshipDeserialization extends InputEntityDeserialization
     private Object startNode;
     private Object endNode;
 
-    public InputRelationshipDeserialization( SourceTraceability source, Header header, Groups groups )
+    public InputRelationshipDeserialization( Header header, SourceTraceability source, Groups groups )
     {
         super( source );
         this.header = header;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -99,7 +99,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
                 // to cater for decorators which may be mutable and sensitive to ordering, while still putting
                 // the work of decorating and validating on the processing threads as to not affect performance.
                 InputEntityDeserializer<ENTITY> chunkDeserializer =
-                        factory.create( seeker, header, batchDecorator, batchValidator );
+                        factory.create( header, seeker, batchDecorator, batchValidator );
                 chunkDeserializer.initialize();
                 List<ENTITY> entities = new ArrayList<>();
                 while ( chunkDeserializer.hasNext() )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -33,6 +33,7 @@ import org.neo4j.csv.reader.SourceTraceability;
 import org.neo4j.csv.reader.Source.Chunk;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.impl.util.Validator;
 import org.neo4j.kernel.impl.util.collection.ContinuableArrayCursor;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
@@ -44,6 +45,8 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.Deser
 import org.neo4j.unsafe.impl.batchimport.staging.TicketedProcessing;
 
 import static org.neo4j.csv.reader.Source.singleChunk;
+import static org.neo4j.kernel.impl.util.Validators.emptyValidator;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.noDecorator;
 
 /**
  * Deserializes CSV into {@link InputNode} and {@link InputRelationship} and does so by reading characters
@@ -65,7 +68,8 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
 
     @SuppressWarnings( "unchecked" )
     public ParallelInputEntityDeserializer( Data<ENTITY> data, Header.Factory headerFactory, Configuration config,
-            IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory, Class<ENTITY> entityClass )
+            IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory,
+            Validator<ENTITY> validator, Class<ENTITY> entityClass )
     {
         // Reader of chunks, characters aligning to nearest newline
         source = new ProcessingSource( data.stream(), config.bufferSize(), maxProcessors );
@@ -81,9 +85,21 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
             Header dataHeader = headerFactory.create( firstSeeker, config, idType );
 
             // Initialize the processing logic for parsing the data in the first chunk, as well as in all other chunk
+            Decorator<ENTITY> decorator = data.decorator();
+
+            // Check if each individual processor can decorate-and-validate themselves or we have to
+            // defer that to the batch supplier below. We have to defer is decorator is mutable.
+            boolean deferredValidation = decorator.isMutable();
+            Decorator<ENTITY> batchDecorator = deferredValidation ? noDecorator() : decorator;
+            Validator<ENTITY> batchValidator = deferredValidation ? emptyValidator() : validator;
             processing = new TicketedProcessing<>( "Parallel input parser", maxProcessors, (seeker, header) ->
             {
-                InputEntityDeserializer<ENTITY> chunkDeserializer = factory.create( seeker, header, data.decorator() );
+                // Create a local deserializer for this chunk with NO decoration/validation,
+                // this will happen in an orderly fashion in our post-processor below and done like this
+                // to cater for decorators which may be mutable and sensitive to ordering, while still putting
+                // the work of decorating and validating on the processing threads as to not affect performance.
+                InputEntityDeserializer<ENTITY> chunkDeserializer =
+                        factory.create( seeker, header, batchDecorator, batchValidator );
                 chunkDeserializer.initialize();
                 List<ENTITY> entities = new ArrayList<>();
                 while ( chunkDeserializer.hasNext() )
@@ -96,7 +112,10 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
             () -> dataHeader.clone() /*We need to clone the stateful header to each processing thread*/ );
 
             // Utility cursor which takes care of moving over processed results from chunk to chunk
-            cursor = new ContinuableArrayCursor<>( rebaseBatches( processing ) );
+            Supplier<ENTITY[]> batchSupplier = rebaseBatches( processing );
+            batchSupplier = deferredValidation ?
+                    decorateAndValidate( batchSupplier, decorator, validator ) : batchSupplier;
+            cursor = new ContinuableArrayCursor<>( batchSupplier );
 
             // Start an asynchronous slurp of the chunks fed directly into the processors
             processing.slurp( seekers( firstSeeker, source, config ), true );
@@ -105,6 +124,25 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
         {
             throw new InputException( "Couldn't read first chunk from input", e );
         }
+    }
+
+    private Supplier<ENTITY[]> decorateAndValidate( Supplier<ENTITY[]> actual,
+            Decorator<ENTITY> decorator, Validator<ENTITY> validator )
+    {
+        return () ->
+        {
+            ENTITY[] entities = actual.get();
+            if ( entities != null )
+            {
+                for ( int i = 0; i < entities.length; i++ )
+                {
+                    ENTITY entity = decorator.apply( entities[i] );
+                    validator.validate( entity );
+                    entities[i] = entity;
+                }
+            }
+            return entities;
+        };
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -116,7 +116,7 @@ public class CsvInputBatchImportIT
     private org.neo4j.unsafe.impl.batchimport.input.csv.Configuration lowBufferSize(
             org.neo4j.unsafe.impl.batchimport.input.csv.Configuration actual )
     {
-        return new org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overriden( actual )
+        return new org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overridden( actual )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -795,7 +795,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputNode>> data = DataFactories.nodeData( CsvInputTest.<InputNode>data(
                 ":ID,one,two,three\n" +
                 "1,\"\",,value" ) );
-        Configuration config = config( new Configuration.Overriden( COMMAS )
+        Configuration config = config( new Configuration.Overridden( COMMAS )
         {
             @Override
             public boolean emptyQuotedStringsAsNull()
@@ -994,7 +994,7 @@ public class CsvInputTest
 
     private Configuration config( Configuration config )
     {
-        return new Configuration.Overriden( config )
+        return new Configuration.Overridden( config )
         {
             @Override
             public boolean multilineFields()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactoriesTest.java
@@ -283,7 +283,7 @@ public class DataFactoriesTest
 
     private static Configuration withBufferSize( Configuration config, final int bufferSize )
     {
-        return new Configuration.Overriden( config )
+        return new Configuration.Overridden( config )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import org.neo4j.csv.reader.CharReadable;
+import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.Input;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import static java.lang.String.valueOf;
+
+import static org.neo4j.csv.reader.Readables.wrap;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.data;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.nodeData;
+
+public class ExternalPropertiesDecoratorIT
+{
+    @Test
+    public void shouldDecorateExternalPropertiesInParallelProcessingCsvInput() throws Exception
+    {
+        // GIVEN
+        int processors = 5;
+        Collector collector = mock( Collector.class );
+        int count = 1000;
+        Configuration config = new Configuration.Overriden( Configuration.COMMAS )
+        {
+            @Override
+            public int bufferSize()
+            {
+                // Keep this low so that there will be many batches, to exercise the parallel processing
+                // 300 is empirically measured to roughly produce ~20 chunks
+                return 300;
+            }
+        };
+        IdType idType = IdType.STRING;
+        Decorator<InputNode> decorator = new ExternalPropertiesDecorator(
+                data( NO_NODE_DECORATOR, () -> decoratedData( count ) ),
+                defaultFormatNodeFileHeader(),
+                config, idType, UpdateBehaviour.ADD, collector );
+        Input input = new CsvInput(
+                nodeData( data( decorator, () -> mainData( count ) ) ), defaultFormatNodeFileHeader(),
+                null, null,
+                idType, config,
+                collector, processors );
+
+        // WHEN/THEN
+        try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
+        {
+            int i = 0;
+            for ( ; i < count; i++ )
+            {
+                assertTrue( nodes.hasNext() );
+                InputNode node = nodes.next();
+                // This property comes from decorator
+                assertHasProperty( node, "extra", node.id() + "-decorated" );
+                if ( i == 0 )
+                {
+                    nodes.processors( processors - nodes.processors( 0 ) );
+                }
+            }
+            assertEquals( count, i );
+            assertFalse( nodes.hasNext() );
+        }
+    }
+
+    private void assertHasProperty( InputNode node, String key, Object value )
+    {
+        Object[] properties = node.properties();
+        boolean found = false;
+        for ( int i = 0; i < properties.length; i++ )
+        {
+            if ( properties[i++].toString().equals( key ) )
+            {
+                assertFalse( found );
+                found = true;
+                assertEquals( value, properties[i] );
+            }
+        }
+        assertTrue( found );
+    }
+
+    String id( int i )
+    {
+        return valueOf( i );
+    }
+
+    private CharReadable decoratedData( int count )
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try ( PrintStream printer = new PrintStream( out ) )
+        {
+            printer.println( ":ID,extra" );
+            for ( int i = 0; i < count; i++ )
+            {
+                printer.println( id( i ) + "," + id( i ) + "-decorated" );
+            }
+        }
+        return wrap( new StringReader( out.toString() ) );
+    }
+
+    private CharReadable mainData( int count )
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try ( PrintStream printer = new PrintStream( out ) )
+        {
+            printer.println( ":ID" );
+            for ( int i = 0; i < count; i++ )
+            {
+                printer.println( id( i ) );
+            }
+        }
+        return wrap( new StringReader( out.toString() ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
@@ -53,7 +53,7 @@ public class ExternalPropertiesDecoratorIT
         int processors = 5;
         Collector collector = mock( Collector.class );
         int count = 1000;
-        Configuration config = new Configuration.Overriden( Configuration.COMMAS )
+        Configuration config = new Configuration.Overridden( Configuration.COMMAS )
         {
             @Override
             public int bufferSize()
@@ -86,6 +86,7 @@ public class ExternalPropertiesDecoratorIT
                 assertHasProperty( node, "extra", node.id() + "-decorated" );
                 if ( i == 0 )
                 {
+                    // This code is equal to nodes.setProcessors( processors ) (a method which doesn't exist)
                     nodes.processors( processors - nodes.processors( 0 ) );
                 }
             }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
@@ -31,7 +31,7 @@ import org.neo4j.csv.reader.Readables;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
-import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overriden;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.Overridden;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -131,9 +131,9 @@ public class ExternalPropertiesDecoratorTest
         return () -> Readables.wrap( new StringReader( data ) );
     }
 
-    private Overriden config()
+    private Overridden config()
     {
-        return new Configuration.Overriden( Configuration.COMMAS )
+        return new Configuration.Overridden( Configuration.COMMAS )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.function.Suppliers;
+import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 
 import static java.util.Arrays.asList;
@@ -51,7 +52,7 @@ public class InputGroupsDeserializerTest
         final AtomicReference<InputGroupsDeserializer<InputNode>> deserializerTestHack = new AtomicReference<>( null );
         InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<>(
                 data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS ), INTEGER,
-                Runtime.getRuntime().availableProcessors(), (stream,header,decorator) ->
+                Runtime.getRuntime().availableProcessors(), (stream,header,decorator,validator) ->
                 {
                     // This is the point where the currentInput field in InputGroupsDeserializer was null
                     // so ensure that's no longer the case, just by poking those source methods right here and now.
@@ -69,7 +70,7 @@ public class InputGroupsDeserializerTest
                     InputEntityDeserializer<InputNode> result = mock( InputEntityDeserializer.class );
                     when( result.sourceDescription() ).thenReturn( String.valueOf( flips.get() ) );
                     return result;
-                }, InputNode.class );
+                }, Validators.<InputNode>emptyValidator(), InputNode.class );
         deserializerTestHack.set( deserializer );
 
         // WHEN running through the iterator

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -52,7 +52,7 @@ public class InputGroupsDeserializerTest
         final AtomicReference<InputGroupsDeserializer<InputNode>> deserializerTestHack = new AtomicReference<>( null );
         InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<>(
                 data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS ), INTEGER,
-                Runtime.getRuntime().availableProcessors(), (stream,header,decorator,validator) ->
+                Runtime.getRuntime().availableProcessors(), (header,stream,decorator,validator) ->
                 {
                     // This is the point where the currentInput field in InputGroupsDeserializer was null
                     // so ensure that's no longer the case, just by poking those source methods right here and now.
@@ -82,7 +82,7 @@ public class InputGroupsDeserializerTest
 
     private Configuration lowBufferSize( Configuration conf )
     {
-        return new Configuration.Overriden( conf )
+        return new Configuration.Overridden( conf )
         {
             @Override
             public int bufferSize()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -55,7 +55,7 @@ public class ParallelInputEntityDeserializerTest
         // GIVEN
         int entities = 500;
         Data<InputNode> data = testData( entities );
-        Configuration config = new Configuration.Overriden( COMMAS )
+        Configuration config = new Configuration.Overridden( COMMAS )
         {
             @Override
             public int bufferSize()
@@ -68,13 +68,13 @@ public class ParallelInputEntityDeserializerTest
         Groups groups = new Groups();
         Set<Thread> observedProcessingThreads = new CopyOnWriteArraySet<>();
         int threads = 4;
-        DeserializerFactory<InputNode> deserializerFactory = (chunk,header,decorator,validator) ->
+        DeserializerFactory<InputNode> deserializerFactory = (header,chunk,decorator,validator) ->
         {
             observedProcessingThreads.add( Thread.currentThread() );
             // Make sure there will be 4 different processing threads doing this
             while ( observedProcessingThreads.size() < threads );
             return new InputEntityDeserializer<>( header, chunk, config.delimiter(),
-                    new InputNodeDeserialization( chunk, header, groups, idType.idsAreExternal() ), decorator,
+                    new InputNodeDeserialization( header, chunk, groups, idType.idsAreExternal() ), decorator,
                     validator, badCollector );
         };
         try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -25,13 +25,12 @@ import org.junit.Test;
 import java.io.StringReader;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.function.Function;
-
 import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.test.RandomRule;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
+import org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
 
@@ -69,17 +68,18 @@ public class ParallelInputEntityDeserializerTest
         Groups groups = new Groups();
         Set<Thread> observedProcessingThreads = new CopyOnWriteArraySet<>();
         int threads = 4;
-        DeserializerFactory<InputNode> deserializerFactory = (chunk,header,decorator) ->
+        DeserializerFactory<InputNode> deserializerFactory = (chunk,header,decorator,validator) ->
         {
             observedProcessingThreads.add( Thread.currentThread() );
             // Make sure there will be 4 different processing threads doing this
             while ( observedProcessingThreads.size() < threads );
             return new InputEntityDeserializer<>( header, chunk, config.delimiter(),
                     new InputNodeDeserialization( chunk, header, groups, idType.idsAreExternal() ), decorator,
-                    Validators.<InputNode>emptyValidator(), badCollector );
+                    validator, badCollector );
         };
         try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,
-                defaultFormatNodeFileHeader(), config, idType, threads, deserializerFactory, InputNode.class ) )
+                defaultFormatNodeFileHeader(), config, idType, threads, deserializerFactory,
+                Validators.<InputNode>emptyValidator(), InputNode.class ) )
         {
             deserializer.processors( threads );
 
@@ -127,9 +127,9 @@ public class ParallelInputEntityDeserializerTest
             }
 
             @Override
-            public Function<InputNode,InputNode> decorator()
+            public Decorator<InputNode> decorator()
             {
-                return item -> item;
+                return InputEntityDecorators.NO_NODE_DECORATOR;
             }
         };
     }


### PR DESCRIPTION
when parallel input processing was enabled. The decoration and validation
was done in each processing thread, which put constraints on decorators
and what they could do. Now decoration and validation is done in the
"groups" deserializer, i.e. right before returning to user.
