### PR TITLE
Tweak cost model constants

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -276,6 +276,7 @@ return p""")
 
   test("should be able to use index hints with STARTS WITH predicates") {
     // given
+    (1 to 50) foreach (i => createLabeledNode(Map("name" -> ("Robot" + i)), "Person"))
     val andres = createLabeledNode(Map("name" -> "Andres"), "Person")
     val jake = createLabeledNode(Map("name" -> "Jacob"), "Person")
     relate(andres, createNode())
@@ -430,18 +431,6 @@ return p""")
     // then
     result.toList should equal(List(Map("n" -> nodes(0)), Map("n" -> nodes(1))))
     result.executionPlanDescription().toString should include("NodeIndexScan")
-  }
-
-  test("should not use the index for property existence queries when cardinality does not prefer it") {
-    // given
-    val nodes = setupIndexScanTest()
-
-    // when
-    val result = executeWithCostPlannerOnly("MATCH (n:User) WHERE exists(n.name) RETURN n")
-
-    // then
-    result.toList.length should equal(100)
-    result.executionPlanDescription().toString should include("NodeByLabelScan")
   }
 
   test("should not use the index for property existence queries when property value predicate exists") {

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
@@ -89,7 +89,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val b = createNode("x")
     val r = relate(a, b)
 
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
+    val result = executeWithAllPlanners(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
     result.toSet should equal(Set(
       Map("r" -> r, "a" -> a, "b" -> b),
       Map("r" -> r, "a" -> b, "b" -> a)))

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModel.scala
@@ -39,19 +39,9 @@ object CardinalityCostModel extends CostModel {
   private def costPerRow(plan: LogicalPlan): CostPerRow = plan match {
 
     case  _: NodeByLabelScan |
-         _: ProjectEndpoints
+          _: NodeIndexScan |
+          _: ProjectEndpoints
     => FAST_STORE
-
-    case _: AllNodesScan => 1.2
-
-    case _: Expand |
-         _: VarExpand  => 2.0
-
-    case _: NodeUniqueIndexSeek |
-         _: NodeIndexSeek |
-         _: NodeIndexContainsScan |
-         _: NodeIndexEndsWithScan |
-         _: NodeIndexScan => 3.0
 
     // Filtering on labels and properties
     case Selection(predicates, _) if predicates.exists {
@@ -60,7 +50,19 @@ object CardinalityCostModel extends CostModel {
     }
     => FAST_STORE
 
-    case _: NodeByIdSeek  => 8.0
+    case _: AllNodesScan => 1.2
+
+    case _: Expand |
+         _: VarExpand  => 0.5
+
+    case _: NodeUniqueIndexSeek |
+         _: NodeIndexSeek |
+         _: NodeIndexContainsScan |
+         _: NodeIndexEndsWithScan => 1.9
+
+    case _: NodeByIdSeek |
+         _: DirectedRelationshipByIdSeek
+    => 6.2
 
     case _: NodeHashJoin |
          _: Aggregation |

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
@@ -39,7 +39,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
           )(solvedWithEstimation(10.0)), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r1")(solvedWithEstimation(100.0))
       )(solvedWithEstimation(10.0))
 
-    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(241))
+    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(231))
   }
 
   test("should introduce increase cost when estimating an eager operator and lazyness is preferred") {

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LeafPlanningIntegrationTest.scala
@@ -394,19 +394,6 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     }
   }
 
-  test("should not use indexes for large collections") {
-    // Index selectivity is 0.02, and label selectivity is 0.2.
-    // The OR query will use the formula A ∪ B = ¬ ( ¬ A ∩ ¬ B ) to calculate the selectivities,
-    // which gives us the formula:
-    // 1 - (1 - 0.02)^25 = 1 - .98^25 = 1 - .713702596 = 0.4 which is less selective than .2, so the index
-    // should not win
-    (new given {
-      indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25] RETURN n").plan should beLike {
-      case _: Selection => ()
-    }
-  }
-
   test("should use indexes for large collections if it is a unique index") {
     val result = new given {
       cost =  {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -22,11 +22,11 @@ package org.neo4j.cypher
 import org.neo4j.cypher.internal.compiler.v3_1.pipes.{IndexSeekByRange, UniqueIndexSeekByRange}
 
 /**
- * These tests are testing the actual index implementation, thus they should all check the actual result.
- * If you only want to verify that plans using indexes are actually planned, please use
- * [[org.neo4j.cypher.internal.compiler.v3_1.planner.logical.LeafPlanningIntegrationTest]]
- */
-class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport{
+  * These tests are testing the actual index implementation, thus they should all check the actual result.
+  * If you only want to verify that plans using indexes are actually planned, please use
+  * [[org.neo4j.cypher.internal.compiler.v3_1.planner.logical.LeafPlanningIntegrationTest]]
+  */
+class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
   test("should handle comparing large integers") {
     // Given
@@ -82,7 +82,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
   test("should perform prefix search in an update query") {
     createLabeledNode(Map("name" -> "London"), "Location")
     createLabeledNode(Map("name" -> "london"), "Location")
-    for (i <- 1 to 100) createLabeledNode("Location")
+    for (i <- 1 to 100) createLabeledNode(Map("name" -> ("City" + i)), "Location")
     graph.createIndex("Location", "name")
 
     val query =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
@@ -117,14 +117,14 @@ class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPla
         |RETURN m""".stripMargin
 
     // When
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     result.toList should equal(List(
       Map("m" -> n2),
       Map("m" -> n3)
     ))
-    result.executionPlanDescription().toString shouldNot include("Index")
+    result.executionPlanDescription().toString shouldNot include("IndexSeek")
     assertNoLockingHappened
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ActualCostCalculationTest.scala
@@ -286,22 +286,6 @@ class ActualCostCalculationTest extends CypherFunSuite {
     }
   }
 
-<<<<<<< HEAD
-  private def labelScan = NodeByLabelScanPipe("x", LazyLabel(LABEL.name()))()
-
-  private def labelScan(label: String) = NodeByLabelScanPipe("x", LazyLabel(label))()
-
-  private def hashJoin(l: Pipe, r: Pipe) = NodeHashJoinPipe(Set("x"), l, r)()
-
-  private def expand(l: Pipe, t: String) = ExpandAllPipe(l, "x", "r", "n", SemanticDirection.OUTGOING, LazyTypes(Seq(t)))()
-
-  private def allNodes = AllNodesScanPipe("x")()
-
-  private def nodeById(id: Long) = NodeByIdSeekPipe("x", SingleSeekArg(Literal(id)))()
-
-  private def relById(id: Long) = UndirectedRelationshipByIdSeekPipe("r", SingleSeekArg(Literal(id)), "to", "from")()
-
-=======
   private def labelScan(variable: String, label: String) = NodeByLabelScanPipe(variable, LazyLabel(label))()
 
   private def hashJoin(l: Pipe, r: Pipe) = NodeHashJoinPipe(Set("x"), l, r)()
@@ -314,16 +298,11 @@ class ActualCostCalculationTest extends CypherFunSuite {
 
   private def relById(id: Long) = UndirectedRelationshipByIdSeekPipe("r", SingleSeekArg(Literal(id)), "to", "from")()
 
->>>>>>> Tweak cost model constants
   private def eager(pipe: Pipe) = EagerPipe(pipe)()
 
   private def indexSeek(graph: GraphDatabaseQueryService) = {
     graph.withTx { tx =>
-<<<<<<< HEAD
       val transactionalContext = TransactionalContextWrapperv3_1(new Neo4jTransactionalContext(graph, tx, graph.statement, "X", Collections.emptyMap(), new PropertyContainerLocker))
-=======
-      val transactionalContext = TransactionalContextWrapperv3_1(new Neo4jTransactionalContext(graph, tx, graph.statement, new PropertyContainerLocker))
->>>>>>> Tweak cost model constants
       val ctx = new TransactionBoundPlanContext(transactionalContext)
       val literal = Literal(42)
 
@@ -338,11 +317,7 @@ class ActualCostCalculationTest extends CypherFunSuite {
 
   private def indexScan(graph: GraphDatabaseQueryService): NodeIndexScanPipe = {
     graph.withTx { tx =>
-<<<<<<< HEAD
       val transactionalContext = TransactionalContextWrapperv3_1(new Neo4jTransactionalContext(graph, tx, graph.statement, "X", Collections.emptyMap(), new PropertyContainerLocker))
-=======
-      val transactionalContext = TransactionalContextWrapperv3_1(new Neo4jTransactionalContext(graph, tx, graph.statement, new PropertyContainerLocker))
->>>>>>> Tweak cost model constants
       val ctx = new TransactionBoundPlanContext(transactionalContext)
 
       val labelId = ctx.getOptLabelId(LABEL.name()).get


### PR DESCRIPTION
Also updated `ActualCostCalculationTest` to add property filtering

Interesting changes:
- Index scans are as fast as label scans (from 3.0 to 1.0)
- Index seeks are tweaked from 3.0 to 1.9

Test output:

```
NodeIndexSeek: COST = 1.9243582552871088 * NROWS
NodeIndexScan: COST = 1.0081223395694658 * NROWS
NodeByID: COST = 6.183850510483064 * NROWS
AllNodeScan: COST = 1.207560834893734 * NROWS
RelByID: COST = 10.812422179582548 * NROWS
LabelScan followed by filter on property: COST = 1.9820059304920197 * NROWS
Expand: COST = 1.5051578949201065 * NROWS
NodeByLabelScan: COST = 1.0 * NROWS
```
