### PR TITLE
Reload changed auth files when modified on disk

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -66,7 +66,6 @@ class SessionRule implements TestRule
             @Override
             public void evaluate() throws Throwable
             {
-                Neo4jWithSocket.cleanupTemporaryTestFiles();
                 Map<Setting<?>,String> config = new HashMap<>();
                 config.put( GraphDatabaseSettings.auth_enabled, Boolean.toString( authEnabled ) );
                 gdb = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase( config );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -375,7 +375,6 @@ public class AuthenticationIT
     @Before
     public void setup() throws IOException
     {
-        Neo4jWithSocket.cleanupTemporaryTestFiles();
         this.client = cf.newInstance();
     }
 
@@ -386,7 +385,6 @@ public class AuthenticationIT
         {
             client.disconnect();
         }
-        Neo4jWithSocket.cleanupTemporaryTestFiles();
     }
 
     private void reconnect() throws Exception

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.commandline.admin;
 
+import org.neo4j.io.fs.FileSystemAbstraction;
+
 public interface OutsideWorld
 {
     void stdOutLine( String text );
@@ -28,4 +30,6 @@ public interface OutsideWorld
     void exit( int status );
 
     void printStacktrace( Exception exception );
+
+    FileSystemAbstraction fileSystem();
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
@@ -19,8 +19,13 @@
  */
 package org.neo4j.commandline.admin;
 
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
 class RealOutsideWorld implements OutsideWorld
 {
+    FileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction();
+
     @Override
     public void stdOutLine( String text )
     {
@@ -43,5 +48,11 @@ class RealOutsideWorld implements OutsideWorld
     public void printStacktrace( Exception exception )
     {
         exception.printStackTrace();
+    }
+
+    @Override
+    public FileSystemAbstraction fileSystem()
+    {
+        return fileSystemAbstraction;
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.fs.FileSystemAbstraction;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -211,6 +212,12 @@ public class AdminToolTest
         @Override
         public void printStacktrace( Exception exception )
         {
+        }
+
+        @Override
+        public FileSystemAbstraction fileSystem()
+        {
+            return null;
         }
     }
 

--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -33,6 +33,8 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -133,8 +135,13 @@ public class DefaultFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean renameFile( File from, File to ) throws IOException
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
     {
+        if ( copyOptions.length > 0 )
+        {
+            Files.move( from.toPath(), to.toPath(), copyOptions );
+            return true; // will throw if failure
+        }
         return FileUtils.renameFile( from, to );
     }
 
@@ -193,6 +200,12 @@ public class DefaultFileSystemAbstraction implements FileSystemAbstraction
     public void truncate( File path, long size ) throws IOException
     {
         FileUtils.truncateFile( path, size );
+    }
+
+    @Override
+    public long lastModifiedTime( File file )
+    {
+        return file.lastModified();
     }
 
     protected StoreFileChannel getStoreFileChannel( FileChannel channel )

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -30,6 +30,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -37,8 +38,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
  * This FileSystemAbstract implementation delegates all calls to a given {@link FileSystem} implementation.
@@ -165,9 +170,9 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean renameFile( File from, File to ) throws IOException
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
     {
-        Files.move( path( from ), path( to ) );
+        Files.move( path( from ), path( to ), copyOptions );
         return true;
     }
 
@@ -241,7 +246,7 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
                 else
                 {
                     Files.copy( sourcePath, targetPath,
-                            StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES );
+                            REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES );
                 }
             }
         }
@@ -270,5 +275,11 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
         {
             channel.truncate( size );
         }
+    }
+
+    @Override
+    public long lastModifiedTime( File file ) throws IOException
+    {
+        return Files.getLastModifiedTime( path( file ) ).toMillis();
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 import java.util.function.Function;
 import java.util.zip.ZipOutputStream;
 
@@ -57,7 +58,7 @@ public interface FileSystemAbstraction
 
     void deleteRecursively( File directory ) throws IOException;
 
-    boolean renameFile( File from, File to ) throws IOException;
+    boolean move( File from, File to, CopyOption... copyOptions ) throws IOException;
 
     File[] listFiles( File directory );
 
@@ -74,6 +75,8 @@ public interface FileSystemAbstraction
     <K extends ThirdPartyFileSystem> K getOrCreateThirdPartyFileSystem( Class<K> clazz, Function<Class<K>, K> creator );
 
     void truncate( File path, long size ) throws IOException;
+
+    long lastModifiedTime( File file ) throws IOException;
 
     interface ThirdPartyFileSystem extends Closeable
     {

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -68,10 +69,10 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         return AdversarialFileChannel.wrap( (StoreFileChannel) delegate.open( fileName, mode ), adversary );
     }
 
-    public boolean renameFile( File from, File to ) throws IOException
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, SecurityException.class );
-        return delegate.renameFile( from, to );
+        return delegate.move( from, to, copyOptions );
     }
 
     public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException
@@ -202,6 +203,14 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         adversary.injectFailure( FileNotFoundException.class, IOException.class, IllegalArgumentException.class,
                 SecurityException.class, NullPointerException.class );
         delegate.truncate( path, size );
+    }
+
+    @Override
+    public long lastModifiedTime( File file ) throws IOException
+    {
+        adversary.injectFailure( FileNotFoundException.class, IOException.class, SecurityException.class,
+                NullPointerException.class );
+        return delegate.lastModifiedTime( file );
     }
 
     private <K extends ThirdPartyFileSystem> ThirdPartyFileSystem adversarialProxy(

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.graphdb.mockfs;
 
-import java.awt.image.ConvolveOp;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.graphdb.mockfs;
 
+import java.awt.image.ConvolveOp;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -27,6 +28,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 import java.util.function.Function;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -79,9 +81,15 @@ public class DelegatingFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean renameFile( File from, File to ) throws IOException
+    public long lastModifiedTime( File file ) throws IOException
     {
-        return delegate.renameFile( from, to );
+        return delegate.lastModifiedTime( file );
+    }
+
+    @Override
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    {
+        return delegate.move( from, to, copyOptions );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -113,8 +113,9 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         }
     }
 
-    private EphemeralFileSystemAbstraction( Set<File> directories, Map<File,EphemeralFileData> files )
+    private EphemeralFileSystemAbstraction( Set<File> directories, Map<File,EphemeralFileData> files, Clock clock )
     {
+        this.clock = clock;
         this.files = new ConcurrentHashMap<>( files );
         this.directories.addAll( directories );
         initCurrentWorkingDirectory();
@@ -517,7 +518,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         {
             copiedFiles.put( file.getKey(), file.getValue().copy() );
         }
-        return new EphemeralFileSystemAbstraction( directories, copiedFiles );
+        return new EphemeralFileSystemAbstraction( directories, copiedFiles, clock );
     }
 
     public void copyRecursivelyFromOtherFs( File from, FileSystemAbstraction fromFs, File to ) throws IOException

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -88,10 +89,10 @@ public class LimitedFilesystemAbstraction extends DelegatingFileSystemAbstractio
     }
 
     @Override
-    public boolean renameFile( File from, File to ) throws IOException
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
     {
         ensureHasSpace();
-        return super.renameFile( from, to );
+        return super.move( from, to, copyOptions );
     }
 
     public void runOutOfDiskSpace( boolean outOfSpace )

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
 import java.util.function.Function;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -125,9 +126,9 @@ public class SelectiveFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean renameFile( File from, File to ) throws IOException
+    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
     {
-        return chooseFileSystem( from ).renameFile( from, to );
+        return chooseFileSystem( from ).move( from, to, copyOptions );
     }
 
     @Override
@@ -177,6 +178,12 @@ public class SelectiveFileSystemAbstraction implements FileSystemAbstraction
     public void truncate( File path, long size ) throws IOException
     {
         chooseFileSystem( path ).truncate( path, size );
+    }
+
+    @Override
+    public long lastModifiedTime( File file ) throws IOException
+    {
+        return chooseFileSystem( file ).lastModifiedTime( file );
     }
 
     private FileSystemAbstraction chooseFileSystem( File file )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.security;
 
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -39,7 +40,7 @@ public interface AuthManager extends Lifecycle
             super( key, altKeys );
         }
 
-        public abstract AuthManager newInstance( Config config, LogProvider logProvider );
+        public abstract AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem );
     }
 
     boolean supports( Map<String, Object> authToken );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -23,6 +23,7 @@ import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.LogProvider;
 
@@ -40,7 +41,8 @@ public interface AuthManager extends Lifecycle
             super( key, altKeys );
         }
 
-        public abstract AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem );
+        public abstract AuthManager newInstance( Config config, LogProvider logProvider,
+                FileSystemAbstraction fileSystem, JobScheduler jobScheduler );
     }
 
     boolean supports( Map<String, Object> authToken );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -102,7 +102,9 @@ public class CommunityEditionModule extends EditionModule
         dependencies.satisfyDependency(
                 createKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem,
+                platformModule.jobScheduler )
+        ) );
 
         commitProcessFactory = new CommunityCommitProcessFactory();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -102,7 +102,7 @@ public class CommunityEditionModule extends EditionModule
         dependencies.satisfyDependency(
                 createKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
 
         commitProcessFactory = new CommunityCommitProcessFactory();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.factory;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
@@ -106,7 +107,7 @@ public abstract class EditionModule
         config.augment( singletonMap( Configuration.editionName.name(), databaseInfo.edition.toString() ) );
     }
 
-    public static AuthManager createAuthManager( Config config, LogService logging )
+    public static AuthManager createAuthManager( Config config, LogService logging, FileSystemAbstraction fileSystem )
     {
         boolean authEnabled = config.get( GraphDatabaseSettings.auth_enabled );
         if ( !authEnabled )
@@ -120,14 +121,14 @@ public abstract class EditionModule
             String candidateId = candidate.getKeys().iterator().next();
             if ( candidateId.equals( key ) )
             {
-                return candidate.newInstance( config, logging.getUserLogProvider() );
+                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem );
             }
             else if ( key.isEmpty() )
             {
                 // As a default use the available service for the configured build edition
                 logging.getInternalLog( GraphDatabaseFacadeFactory.class )
                         .info( "No auth manager implementation specified, defaulting to '" + candidateId + "'" );
-                return candidate.newInstance( config, logging.getUserLogProvider() );
+                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.internal.KernelDiagnostics;
 import org.neo4j.udc.UsageData;
@@ -107,7 +108,8 @@ public abstract class EditionModule
         config.augment( singletonMap( Configuration.editionName.name(), databaseInfo.edition.toString() ) );
     }
 
-    public static AuthManager createAuthManager( Config config, LogService logging, FileSystemAbstraction fileSystem )
+    public static AuthManager createAuthManager( Config config, LogService logging,
+            FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
         boolean authEnabled = config.get( GraphDatabaseSettings.auth_enabled );
         if ( !authEnabled )
@@ -121,14 +123,14 @@ public abstract class EditionModule
             String candidateId = candidate.getKeys().iterator().next();
             if ( candidateId.equals( key ) )
             {
-                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem );
+                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem, jobScheduler );
             }
             else if ( key.isEmpty() )
             {
                 // As a default use the available service for the configured build edition
                 logging.getInternalLog( GraphDatabaseFacadeFactory.class )
                         .info( "No auth manager implementation specified, defaulting to '" + candidateId + "'" );
-                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem );
+                return candidate.newInstance( config, logging.getUserLogProvider(), fileSystem, jobScheduler );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
@@ -264,7 +264,7 @@ public class IndexConfigStore extends LifecycleAdapter
         fileSystem.deleteFile( oldFile );
         try
         {
-            if ( fileSystem.fileExists( file ) && !fileSystem.renameFile( file, oldFile ) )
+            if ( fileSystem.fileExists( file ) && !fileSystem.move( file, oldFile ) )
             {
                 throw new RuntimeException( "Couldn't rename " + file + " -> " + oldFile );
             }
@@ -277,7 +277,7 @@ public class IndexConfigStore extends LifecycleAdapter
         // Rename the .tmp file to the current name
         try
         {
-            if ( !fileSystem.renameFile( tmpFile, this.file ) )
+            if ( !fileSystem.move( tmpFile, this.file ) )
             {
                 throw new RuntimeException( "Couldn't rename " + tmpFile + " -> " + file );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogs.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogs.java
@@ -175,7 +175,7 @@ public class LegacyLogs
             final String oldName = file.getName();
             final long version = getLegacyLogVersion( oldName );
             final String newName = DEFAULT_NAME + DEFAULT_VERSION_SUFFIX + version;
-            fs.renameFile( file, new File( file.getParent(), newName ) );
+            fs.move( file, new File( file.getParent(), newName ) );
         }
 
         deleteUnusedLogFiles( storeDir );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -166,6 +166,11 @@ public interface JobScheduler extends Lifecycle
          * Storage maintenance.
          */
         public static Group storageMaintenance = new Group( "StorageMaintenance", POOLED );
+
+        /**
+         * Native security.
+         */
+        public static Group nativeSecurity = new Group( "NativeSecurity", POOLED );
     }
 
     interface JobHandle

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
@@ -57,7 +57,7 @@ public class EditionModuleTest
         exception.expectMessage( "Auth enabled but no auth manager found. This is an illegal product configuration." );
 
         // When
-        EditionModule.createAuthManager( config, logService, null );
+        EditionModule.createAuthManager( config, logService, null, null );
 
         // Then
         verify( userLog ).error( anyString() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/EditionModuleTest.java
@@ -57,7 +57,7 @@ public class EditionModuleTest
         exception.expectMessage( "Auth enabled but no auth manager found. This is an illegal product configuration." );
 
         // When
-        EditionModule.createAuthManager( config, logService );
+        EditionModule.createAuthManager( config, logService, null );
 
         // Then
         verify( userLog ).error( anyString() );

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -296,7 +296,7 @@ public class LogTestUtils
         public void restore() throws IOException
         {
             fileSystem.deleteFile( file );
-            fileSystem.renameFile( backup, file );
+            fileSystem.move( backup, file );
         }
     }
 

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -197,7 +197,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
                 if ( fileSystem.fileExists( outputFile ) )
                 {
                     shiftArchivedOutputFiles();
-                    fileSystem.renameFile( outputFile, archivedOutputFile( 1 ) );
+                    fileSystem.move( outputFile, archivedOutputFile( 1 ) );
                 }
                 newStream = openOutputFile();
             }
@@ -252,7 +252,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
                 fileSystem.deleteFile( archive );
             } else
             {
-                fileSystem.renameFile( archive, archivedOutputFile( i + 1 ) );
+                fileSystem.move( archive, archivedOutputFile( i + 1 ) );
             }
         }
     }

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -279,7 +279,7 @@ public class RotatingFileOutputStreamSupplierTest
         OutputStream outputStream = supplier.get();
 
         IOException exception = new IOException( "text exception" );
-        doThrow( exception ).when( fs ).renameFile( any( File.class ), any( File.class ) );
+        doThrow( exception ).when( fs ).move( any( File.class ), any( File.class ) );
 
         write( outputStream, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/UsersCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/UsersCommand.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.commandline.admin.security;
 
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,8 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.DelegateFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.configuration.ConfigLoader;
@@ -217,7 +220,8 @@ public class UsersCommand implements AdminCommand
     {
         Config config = loadNeo4jConfig( homeDir, configDir );
         FileUserRepository userRepository =
-                BasicAuthManagerFactory.getUserRepository( config, NullLogProvider.getInstance() );
+                BasicAuthManagerFactory.getUserRepository( config,
+                        NullLogProvider.getInstance(), outsideWorld.fileSystem() );
         userRepository.start();
         return userRepository;
     }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
@@ -43,6 +43,13 @@ public abstract class AbstractUserRepository extends LifecycleAdapter implements
     private final Pattern usernamePattern = Pattern.compile( "^[a-zA-Z0-9_]+$" );
 
     @Override
+    public void clear()
+    {
+        users.clear();
+        usersByName.clear();
+    }
+
+    @Override
     public User getUserByName( String username )
     {
         return usersByName.get( username );
@@ -81,6 +88,13 @@ public abstract class AbstractUserRepository extends LifecycleAdapter implements
      * @throws IOException
      */
     protected abstract void saveUsers() throws IOException;
+
+    /**
+     * Override this in the implementing class to persist users
+     *
+     * @throws IOException
+     */
+    abstract void loadUsers() throws IOException;
 
     @Override
     public void update( User existingUser, User updatedUser )

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AbstractUserRepository.java
@@ -73,9 +73,9 @@ public abstract class AbstractUserRepository extends LifecycleAdapter implements
                 }
             }
 
-            persistUsers();
             users.add( user );
             usersByName.put( user.name(), user );
+            persistUsers();
         }
     }
 
@@ -135,10 +135,8 @@ public abstract class AbstractUserRepository extends LifecycleAdapter implements
             }
 
             users = newUsers;
-
-            persistUsers();
-
             usersByName.put( updatedUser.name(), updatedUser );
+            persistUsers();
         }
     }
 
@@ -163,10 +161,8 @@ public abstract class AbstractUserRepository extends LifecycleAdapter implements
         if ( foundUser )
         {
             users = newUsers;
-
-            persistUsers();
-
             usersByName.remove( user.name() );
+            persistUsers();
         }
         return foundUser;
     }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManagerFactory.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManagerFactory.java
@@ -28,6 +28,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.time.Clocks;
 
@@ -67,7 +68,8 @@ public class BasicAuthManagerFactory extends AuthManager.Factory
     }
 
     @Override
-    public AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem )
+    public AuthManager newInstance( Config config, LogProvider logProvider,
+            FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
         if ( !config.get( GraphDatabaseSettings.auth_enabled ) )
         {

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManagerFactory.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManagerFactory.java
@@ -24,6 +24,7 @@ import java.io.File;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -38,7 +39,8 @@ public class BasicAuthManagerFactory extends AuthManager.Factory
 {
     private static final String USER_STORE_FILENAME = "auth";
 
-    public static FileUserRepository getUserRepository( Config config, LogProvider logProvider )
+    public static FileUserRepository getUserRepository( Config config, LogProvider logProvider,
+            FileSystemAbstraction fileSystem )
     {
         // Resolve auth store file names
         File authStoreDir = config.get( DatabaseManagementSystemSettings.auth_store_directory );
@@ -50,7 +52,7 @@ public class BasicAuthManagerFactory extends AuthManager.Factory
         {
             userStoreFile = new File( authStoreDir, USER_STORE_FILENAME );
         }
-        return new FileUserRepository( userStoreFile.toPath(), logProvider );
+        return new FileUserRepository( fileSystem, userStoreFile, logProvider );
     }
 
     public interface Dependencies
@@ -65,7 +67,7 @@ public class BasicAuthManagerFactory extends AuthManager.Factory
     }
 
     @Override
-    public AuthManager newInstance( Config config, LogProvider logProvider )
+    public AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem )
     {
         if ( !config.get( GraphDatabaseSettings.auth_enabled ) )
         {
@@ -73,7 +75,7 @@ public class BasicAuthManagerFactory extends AuthManager.Factory
                     "configuration setting auth_enabled=false" );
         }
 
-        final UserRepository userRepository = getUserRepository( config, logProvider );
+        final UserRepository userRepository = getUserRepository( config, logProvider, fileSystem );
 
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
@@ -54,8 +54,12 @@ public class FileUserRepository extends AbstractUserRepository
     @Override
     public void start() throws Throwable
     {
-        users.clear();
-        usersByName.clear();
+        clear();
+        loadUsers();
+    }
+
+    void loadUsers() throws IOException
+    {
         if ( fileSystem.fileExists( authFile ) )
         {
             List<User> loadedUsers;
@@ -70,6 +74,7 @@ public class FileUserRepository extends AbstractUserRepository
                 throw new IllegalStateException( "Failed to read authentication file: " + authFile );
             }
 
+            clear();
             users = loadedUsers;
             for ( User user : users )
             {
@@ -82,5 +87,14 @@ public class FileUserRepository extends AbstractUserRepository
     protected void saveUsers() throws IOException
     {
         serialization.saveRecordsToFile( fileSystem, authFile, users );
+    }
+
+    @Override
+    public void reloadIfNeeded() throws IOException
+    {
+        if ( lastLoaded < fileSystem.lastModifiedTime( authFile ) )
+        {
+            loadUsers();
+        }
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/ListSnapshot.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/ListSnapshot.java
@@ -19,26 +19,16 @@
  */
 package org.neo4j.server.security.auth;
 
-import java.io.IOException;
+import java.util.List;
 
-/** A user repository implementation that just stores users in memory */
-public class InMemoryUserRepository extends AbstractUserRepository
+public class ListSnapshot<T>
 {
-    @Override
-    protected void persistUsers() throws IOException
-    {
-        // Nothing to do
-    }
+    public final long timestamp;
+    public final List<T> values;
 
-    @Override
-    protected ListSnapshot<User> readPersistedUsers() throws IOException
+    public ListSnapshot( long timestamp, List<T> values )
     {
-        return null;
-    }
-
-    @Override
-    public ListSnapshot<User> getPersistedSnapshot() throws IOException
-    {
-        return null;
+        this.timestamp = timestamp;
+        this.values = values;
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
@@ -52,6 +52,14 @@ public interface UserRepository extends Lifecycle
     void create( User user ) throws InvalidArgumentsException, IOException;
 
     /**
+     * Replaces the users in the repository with the given users.
+     * @param users the new users
+     * @throws InvalidArgumentsException if any username is not valid
+     * @throws IOException if the underlying storage for users fails
+     */
+    void setUsers( ListSnapshot<User> users ) throws InvalidArgumentsException, IOException;
+
+    /**
      * Update a user, given that the users token is unique.
      * @param existingUser the existing user object, which must match the current state in this repository
      * @param updatedUser the updated user object
@@ -77,5 +85,10 @@ public interface UserRepository extends Lifecycle
 
     Set<String> getAllUsernames();
 
-    void reloadIfNeeded() throws IOException;
+    /**
+     * Returns a snapshot of the current persisted user repository
+     * @return a snapshot of the current persisted user repository
+     * @throws IOException
+     */
+    ListSnapshot<User> getPersistedSnapshot() throws IOException;
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserRepository.java
@@ -31,6 +31,16 @@ import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
  */
 public interface UserRepository extends Lifecycle
 {
+    /**
+     * Clears all cached user data.
+     */
+    void clear();
+
+    /**
+     * Return the user associated with the given username.
+     * @param username the username
+     * @return the associated user, or null if no user exists
+     */
     User getUserByName( String username );
 
     /**
@@ -66,4 +76,6 @@ public interface UserRepository extends Lifecycle
     boolean isValidUsername( String username );
 
     Set<String> getAllUsernames();
+
+    void reloadIfNeeded() throws IOException;
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserSerialization.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserSerialization.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.security.auth;
 
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.server.security.auth.exception.FormatException;
 import org.neo4j.string.HexString;
 

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/CreateCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/CreateCommandTest.java
@@ -19,28 +19,19 @@
  */
 package org.neo4j.commandline.admin.security;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
-
-import java.io.File;
 
 import org.neo4j.commandline.admin.CommandFailed;
-import org.neo4j.commandline.admin.OutsideWorld;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class CreateCommandTest extends CommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Test
     public void shouldFailToCreateExistingUser() throws Throwable
     {
@@ -50,9 +41,6 @@ public class CreateCommandTest extends CommandTestBase
         // When - trying to create it again
         try
         {
-            File graphDir = testDir.graphDbDir();
-            File confDir = new File( graphDir, "conf" );
-            OutsideWorld out = mock( OutsideWorld.class );
             UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
             usersCommand.execute( new String[]{"create", "another", "abc"} );
             fail( "Should not have succeeded without exception" );
@@ -70,9 +58,6 @@ public class CreateCommandTest extends CommandTestBase
         // Given - no existing user
 
         // When - creating new user
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"create", "another", "abc"} );
 
@@ -90,9 +75,6 @@ public class CreateCommandTest extends CommandTestBase
         // Given - no existing user
 
         // When - creating new user with password change requirement
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"create", "another", "abc", "--requires-password-change=true"} );
 
@@ -110,9 +92,6 @@ public class CreateCommandTest extends CommandTestBase
         // Given - no existing user
 
         // When - creating new user with password change requirement
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"create", "--requires-password-change=true", "another", "abc"} );
 

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
@@ -23,16 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import java.io.File;
-
 import org.neo4j.commandline.admin.CommandFailed;
-import org.neo4j.commandline.admin.OutsideWorld;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -49,9 +45,6 @@ public class DeleteCommandTest extends CommandTestBase
         // When - trying to delete a user
         try
         {
-            File graphDir = testDir.graphDbDir();
-            File confDir = new File( graphDir, "conf" );
-            OutsideWorld out = mock( OutsideWorld.class );
             UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
             usersCommand.execute( new String[]{"delete", "another"} );
             fail( "Should not have succeeded without exception" );
@@ -70,9 +63,6 @@ public class DeleteCommandTest extends CommandTestBase
         createTestUser( "another", "abc" );
 
         // When - creating new user
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"delete", "another"} );
 

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/ListCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/ListCommandTest.java
@@ -23,16 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import java.io.File;
-
 import org.neo4j.commandline.admin.IncorrectUsage;
-import org.neo4j.commandline.admin.OutsideWorld;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -45,7 +41,7 @@ public class ListCommandTest extends CommandTestBase
     public void shouldFailWithoutSubcommand() throws Exception
     {
         UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), mock( OutsideWorld.class ) );
+                testDir.directory( "conf" ).toPath(), out );
 
         String[] arguments = {};
         try
@@ -66,7 +62,7 @@ public class ListCommandTest extends CommandTestBase
     public void shouldFailWithUnknownSubcommand() throws Exception
     {
         UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), mock( OutsideWorld.class ) );
+                testDir.directory( "conf" ).toPath(), out );
 
         String[] arguments = {"make-love-not-war"};
         try
@@ -87,9 +83,6 @@ public class ListCommandTest extends CommandTestBase
         createTestUser( "another", "abc" );
 
         // When - listing users
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand =
                 new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"list"} );
@@ -107,9 +100,6 @@ public class ListCommandTest extends CommandTestBase
         createTestUser( "another", "abc" );
 
         // When - listing users
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
-        OutsideWorld out = mock( OutsideWorld.class );
         UsersCommand usersCommand =
                 new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"list", "other"} );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -23,16 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import java.io.File;
-
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
-import org.neo4j.commandline.admin.OutsideWorld;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 public class SetPasswordCommandTest extends CommandTestBase
 {
@@ -43,8 +39,8 @@ public class SetPasswordCommandTest extends CommandTestBase
     @Test
     public void shouldFailSetPasswordWithNoArguments() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), mock( OutsideWorld.class ) );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
+                testDir.directory( "conf" ).toPath(),out );
 
         String[] arguments = {"set-password"};
         try
@@ -61,8 +57,8 @@ public class SetPasswordCommandTest extends CommandTestBase
     @Test
     public void shouldFailSetPasswordWithOnlyOneArgument() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), mock( OutsideWorld.class ) );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
+                testDir.directory( "conf" ).toPath(),out );
 
         String[] arguments = {"set-password", "neo4j"};
         try
@@ -79,8 +75,8 @@ public class SetPasswordCommandTest extends CommandTestBase
     @Test
     public void shouldFailSetPasswordWithNonExistingUser() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), mock( OutsideWorld.class ) );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
+                testDir.directory( "conf" ).toPath(), out );
 
         String[] arguments = {"set-password", "nosuchuser", "whatever"};
         try
@@ -100,10 +96,8 @@ public class SetPasswordCommandTest extends CommandTestBase
         // Given - no created user
 
         // When - the admin command sets the password
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
         UsersCommand usersCommand =
-                new UsersCommand( graphDir.toPath(), confDir.toPath(), mock( OutsideWorld.class ) );
+                new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"set-password", "neo4j", "abc"} );
 
         // Then - the default user does not require a password change
@@ -118,10 +112,8 @@ public class SetPasswordCommandTest extends CommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When - the admin command sets the password
-        File graphDir = testDir.graphDbDir();
-        File confDir = new File( graphDir, "conf" );
         UsersCommand usersCommand =
-                new UsersCommand( graphDir.toPath(), confDir.toPath(), mock( OutsideWorld.class ) );
+                new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
         usersCommand.execute( new String[]{"set-password", "another", "abc"} );
 
         // Then - the new user no longer requires a password change

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
@@ -23,15 +23,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import java.nio.file.Path;
-
 import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.commandline.admin.CommandLocator;
-import org.neo4j.commandline.admin.OutsideWorld;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -293,17 +289,14 @@ public class UsersCommandIT extends CommandTestBase
     private void assertFailedUserCommand( String command, String... errors )
     {
         // When running users command without a command or with incorrect command
-        Path homeDir = testDir.graphDbDir().toPath();
-        Path configDir = testDir.directory( "conf" ).toPath();
-        OutsideWorld out = mock( OutsideWorld.class );
         AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
         if ( command == null )
         {
-            tool.execute( homeDir, configDir, "users" );
+            tool.execute( graphDir.toPath(), confDir.toPath(), "users" );
         }
         else
         {
-            tool.execute( homeDir, configDir, "users", command );
+            tool.execute( graphDir.toPath(), confDir.toPath(), "users", command );
         }
 
         // Then we get the expected error
@@ -327,11 +320,9 @@ public class UsersCommandIT extends CommandTestBase
     private void assertFailedSubCommand( String command, String[] args, String... errors )
     {
         // When running set password on a failing case (missing user, or other error)
-        Path homeDir = testDir.graphDbDir().toPath();
-        Path configDir = testDir.directory( "conf" ).toPath();
-        OutsideWorld out = mock( OutsideWorld.class );
+        resetOutsideWorldMock();
         AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
-        tool.execute( homeDir, configDir, makeArgs( command, args ) );
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, args ) );
 
         // Then we get the expected error
         for ( String error : errors )
@@ -345,11 +336,9 @@ public class UsersCommandIT extends CommandTestBase
     private void assertSuccessfulSubCommand( String command, String[] args, String... messages )
     {
         // When running set password on a successful case (user exists)
-        Path homeDir = testDir.graphDbDir().toPath();
-        Path configDir = testDir.directory( "conf" ).toPath();
-        OutsideWorld out = mock( OutsideWorld.class );
+        resetOutsideWorldMock();
         AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
-        tool.execute( homeDir, configDir, makeArgs( command, args ));
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, args ));
 
         // Then we get the expected output messages
         for ( String message : messages )

--- a/community/security/src/test/java/org/neo4j/server/security/auth/InMemoryUserRepository.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/InMemoryUserRepository.java
@@ -29,4 +29,16 @@ public class InMemoryUserRepository extends AbstractUserRepository
     {
         // Nothing to do
     }
+
+    @Override
+    void loadUsers() throws IOException
+    {
+        // Nothing to do
+    }
+
+    @Override
+    public void reloadIfNeeded()
+    {
+        // Nothing to do
+    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
@@ -215,7 +215,8 @@ public class EnterpriseCoreEditionModule extends EditionModule
                 createKernelData( platformModule.fileSystem, platformModule.pageCache, platformModule.storeDir,
                         config, platformModule.graphDatabaseFacade, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
+                platformModule.fileSystem, platformModule.jobScheduler ) ) );
 
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
@@ -215,7 +215,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
                 createKernelData( platformModule.fileSystem, platformModule.pageCache, platformModule.storeDir,
                         config, platformModule.graphDatabaseFacade, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
 
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -151,7 +151,8 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         life.add( dependencies.satisfyDependency(
                 new DefaultKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade ) ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
+                platformModule.fileSystem, platformModule.jobScheduler ) ) );
 
         headerInformationFactory = TransactionHeaderInformationFactory.DEFAULT;
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -151,7 +151,7 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         life.add( dependencies.satisfyDependency(
                 new DefaultKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade ) ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
 
         headerInformationFactory = TransactionHeaderInformationFactory.DEFAULT;
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -494,7 +494,7 @@ public class HighlyAvailableEditionModule
                 createKernelData( config, platformModule.graphDatabaseFacade, members, fs, platformModule.pageCache,
                         storeDir, lastUpdateTime, lastTxIdGetter, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
 
         commitProcessFactory = createCommitProcessFactory( dependencies, logging, monitors, config, paxosLife,
                 clusterClient, members, platformModule.jobScheduler, master, requestContextFactory,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -494,7 +494,8 @@ public class HighlyAvailableEditionModule
                 createKernelData( config, platformModule.graphDatabaseFacade, members, fs, platformModule.pageCache,
                         storeDir, lastUpdateTime, lastTxIdGetter, life ) );
 
-        life.add( dependencies.satisfyDependency( createAuthManager( config, logging, platformModule.fileSystem ) ) );
+        life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
+                platformModule.fileSystem, platformModule.jobScheduler ) ) );
 
         commitProcessFactory = createCommitProcessFactory( dependencies, logging, monitors, config, paxosLife,
                 clusterClient, members, platformModule.jobScheduler, master, requestContextFactory,

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
@@ -55,14 +56,14 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
     }
 
     @Override
-    public AuthManager newInstance( Config config, LogProvider logProvider )
+    public AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem )
     {
         StaticLoggerBinder.setNeo4jLogProvider( logProvider );
 
         List<Realm> realms = new ArrayList<>( 2 );
 
         // We always create the internal realm as it is our only UserManager implementation
-        InternalFlatFileRealm internalRealm = createInternalRealm( config, logProvider );
+        InternalFlatFileRealm internalRealm = createInternalRealm( config, logProvider, fileSystem );
 
         if ( config.get( SecuritySettings.internal_authentication_enabled ) ||
              config.get( SecuritySettings.internal_authorization_enabled ) )
@@ -89,16 +90,14 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
                 new ShiroCaffeineCache.Manager( Ticker.systemTicker(), ttl, maxCapacity ) );
     }
 
-    private static InternalFlatFileRealm createInternalRealm( Config config, LogProvider logProvider )
+    private static InternalFlatFileRealm createInternalRealm( Config config, LogProvider logProvider,
+            FileSystemAbstraction fileSystem )
     {
         // Resolve auth store and roles file names
         File authStoreDir = config.get( DatabaseManagementSystemSettings.auth_store_directory );
         File roleStoreFile = new File( authStoreDir, ROLE_STORE_FILENAME );
-        final UserRepository userRepository = getUserRepository( config, logProvider );
-
-        final RoleRepository roleRepository =
-                new FileRoleRepository( roleStoreFile.toPath(), logProvider );
-
+        final UserRepository userRepository = getUserRepository( config, logProvider, fileSystem );
+        final RoleRepository roleRepository = new FileRoleRepository( fileSystem, roleStoreFile, logProvider );
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
 
         AuthenticationStrategy authenticationStrategy = new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
@@ -32,6 +32,7 @@ import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
@@ -56,14 +57,15 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
     }
 
     @Override
-    public AuthManager newInstance( Config config, LogProvider logProvider, FileSystemAbstraction fileSystem )
+    public AuthManager newInstance( Config config, LogProvider logProvider,
+            FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
         StaticLoggerBinder.setNeo4jLogProvider( logProvider );
 
         List<Realm> realms = new ArrayList<>( 2 );
 
         // We always create the internal realm as it is our only UserManager implementation
-        InternalFlatFileRealm internalRealm = createInternalRealm( config, logProvider, fileSystem );
+        InternalFlatFileRealm internalRealm = createInternalRealm( config, logProvider, fileSystem, jobScheduler );
 
         if ( config.get( SecuritySettings.internal_authentication_enabled ) ||
              config.get( SecuritySettings.internal_authorization_enabled ) )
@@ -91,7 +93,7 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
     }
 
     private static InternalFlatFileRealm createInternalRealm( Config config, LogProvider logProvider,
-            FileSystemAbstraction fileSystem )
+            FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
         // Resolve auth store and roles file names
         File authStoreDir = config.get( DatabaseManagementSystemSettings.auth_store_directory );
@@ -104,6 +106,6 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
 
         return new InternalFlatFileRealm( userRepository, roleRepository, passwordPolicy, authenticationStrategy,
                 config.get( SecuritySettings.internal_authentication_enabled ),
-                config.get( SecuritySettings.internal_authorization_enabled ) );
+                config.get( SecuritySettings.internal_authorization_enabled ), jobScheduler );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRepository.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/RoleRepository.java
@@ -22,8 +22,8 @@ package org.neo4j.server.security.enterprise.auth;
 import java.io.IOException;
 import java.util.Set;
 
-import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.server.security.auth.UserRepository;
 import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
 
 /**
@@ -34,6 +34,11 @@ public interface RoleRepository extends Lifecycle
     RoleRecord getRoleByName( String roleName );
 
     Set<String> getRoleNamesByUsername( String username );
+
+    /**
+     * Clears all cached role data.
+     */
+    void clear();
 
     /**
      * Create a role, given that the roles token is unique.
@@ -70,4 +75,8 @@ public interface RoleRepository extends Lifecycle
             throws ConcurrentModificationException, IOException;
 
     Set<String> getAllRoleNames();
+
+    void reloadIfNeeded() throws IOException;
+
+    boolean validateAgainst( UserRepository userRepository );
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactoryTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactoryTest.java
@@ -56,7 +56,7 @@ public class EnterpriseAuthManagerFactoryTest
         when( config.get( SecuritySettings.ldap_user_dn_template ) ).thenReturn( "prefix{0}" );
 
         // When
-        new EnterpriseAuthManagerFactory().newInstance( config, mockLogProvider );
+        new EnterpriseAuthManagerFactory().newInstance( config, mockLogProvider, null, null );
 
         // Then
         verify( mockLog, atLeastOnce() ).debug( anyString(), contains( "prefix" ), anyString() );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
@@ -21,24 +21,26 @@ package org.neo4j.server.security.enterprise.auth;
 
 import java.io.IOException;
 
+import org.neo4j.server.security.auth.ListSnapshot;
+
 /** A role repository implementation that just stores roles in memory */
 public class InMemoryRoleRepository extends AbstractRoleRepository
 {
     @Override
-    protected void saveRoles() throws IOException
+    protected void persistRoles() throws IOException
     {
         // Nothing to do
     }
 
     @Override
-    protected void loadRoles() throws IOException
+    protected ListSnapshot<RoleRecord> readPersistedRoles() throws IOException
     {
-        // Nothing to do
+        return null;
     }
 
     @Override
-    public void reloadIfNeeded()
+    public ListSnapshot<RoleRecord> getPersistedSnapshot()
     {
-        // Nothing to do
+        return null;
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InMemoryRoleRepository.java
@@ -29,4 +29,16 @@ public class InMemoryRoleRepository extends AbstractRoleRepository
     {
         // Nothing to do
     }
+
+    @Override
+    protected void loadRoles() throws IOException
+    {
+        // Nothing to do
+    }
+
+    @Override
+    public void reloadIfNeeded()
+    {
+        // Nothing to do
+    }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
@@ -116,8 +116,7 @@ public class InternalFlatFileRealmIT
                         "Carol:SHA-256,FE0056C37E,A543:\n" +
                         "Mia:SHA-256,0E1FFFC23E,34"
                 ,
-                "admin:Mia\n" +
-                        "publisher:Hanna,Carol\n" );
+                "THIS_WILL_NOT_BE_READ" );
 
         // now the roles file has non-existent users
         fs.addUserRoleFilePair(
@@ -187,7 +186,7 @@ public class InternalFlatFileRealmIT
         Runnable scheduledRunnable;
 
         @Override
-        public JobHandle scheduleRecurring( Group group, Runnable r, long delay, TimeUnit timeUnit )
+        public JobHandle scheduleRecurring( Group group, Runnable r, long initialDelay, long delay, TimeUnit timeUnit )
         {
             this.scheduledRunnable = r;
             return null;
@@ -219,6 +218,10 @@ public class InternalFlatFileRealmIT
             }
             if ( fileName.equals( roleStoreFile ) )
             {
+                if ( userStoreVersions.size() < roleStoreVersions.size() - 1 )
+                {
+                    roleStoreVersions.remove();
+                }
                 return new ByteArrayInputStream( roleStoreVersions.remove().getBytes( "UTF-8" ) );
             }
             return super.openAsInputStream( fileName );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystems;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.io.fs.DelegateFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.security.auth.AuthenticationStrategy;
+import org.neo4j.server.security.auth.BasicPasswordPolicy;
+import org.neo4j.server.security.auth.FileUserRepository;
+import org.neo4j.server.security.auth.PasswordPolicy;
+import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
+import org.neo4j.server.security.auth.UserRepository;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.time.Clocks;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class InternalFlatFileRealmIT
+{
+    File userStoreFile;
+    File roleStoreFile;
+
+    @Rule
+    public EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+
+    TestScheduledExecutorService executor = new TestScheduledExecutorService( 1 );
+    LogProvider logProvider = NullLogProvider.getInstance();
+    InternalFlatFileRealm realm;
+
+    @Before
+    public void setup() throws Throwable
+    {
+        userStoreFile = new File( "dbms", "auth" );
+        roleStoreFile = new File( "dbms", "roles" );
+        final UserRepository userRepository = new FileUserRepository( fsRule.get(), userStoreFile, logProvider );
+        final RoleRepository roleRepository = new FileRoleRepository( fsRule.get(), roleStoreFile, logProvider );
+        final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
+        AuthenticationStrategy authenticationStrategy = new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 );
+
+        realm = new InternalFlatFileRealm( userRepository, roleRepository, passwordPolicy, authenticationStrategy,
+                        true, true, executor );
+        realm.init();
+        realm.start();
+    }
+
+    @After
+    public void teardown() throws Throwable
+    {
+        realm.shutdown();
+    }
+
+    @Test
+    public void shouldReloadAuthFiles() throws Exception
+    {
+        overwrite( userStoreFile,
+                "Hanna:SHA-256,FE0056C37E,A543:\n" +
+                "Carol:SHA-256,FE0056C37E,A543:\n" +
+                "Mia:SHA-256,0E1FFFC23E,34A4:password_change_required\n"  );
+
+        overwrite( roleStoreFile,
+                "admin:Mia\n" +
+                "publisher:Hanna,Carol\n" );
+
+        executor.scheduledRunnable.run();
+
+        assertThat( realm.getAllUsernames(), containsInAnyOrder( "Hanna", "Carol", "Mia" ) );
+        assertThat( realm.getUsernamesForRole( "admin" ), containsInAnyOrder( "Mia" ) );
+        assertThat( realm.getUsernamesForRole( "publisher" ), containsInAnyOrder( "Hanna", "Carol" ) );
+    }
+
+    protected void overwrite( File file, String newContents ) throws IOException
+    {
+        FileSystemAbstraction fs = fsRule.get();
+
+        fs.deleteFile( file );
+        Writer w = fs.openAsWriter( file, Charset.defaultCharset(), false );
+        w.write( newContents );
+        w.close();
+    }
+
+    class TestScheduledExecutorService extends ScheduledThreadPoolExecutor
+    {
+        Runnable scheduledRunnable;
+
+        public TestScheduledExecutorService( int corePoolSize )
+        {
+            super( corePoolSize );
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate( Runnable r, long initialDelay, long delay, TimeUnit timeUnit )
+        {
+            this.scheduledRunnable = r;
+            return null;
+        }
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
@@ -24,10 +24,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
+import java.io.CharArrayReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
@@ -210,11 +211,11 @@ public class InternalFlatFileRealmIT
         }
 
         @Override
-        public InputStream openAsInputStream( File fileName ) throws IOException
+        public Reader openAsReader( File fileName, Charset charset ) throws IOException
         {
             if ( fileName.equals( userStoreFile ) )
             {
-                return new ByteArrayInputStream( userStoreVersions.remove().getBytes( "UTF-8" ) );
+                return new CharArrayReader( userStoreVersions.remove().toCharArray() );
             }
             if ( fileName.equals( roleStoreFile ) )
             {
@@ -222,9 +223,9 @@ public class InternalFlatFileRealmIT
                 {
                     roleStoreVersions.remove();
                 }
-                return new ByteArrayInputStream( roleStoreVersions.remove().getBytes( "UTF-8" ) );
+                return new CharArrayReader( roleStoreVersions.remove().toCharArray() );
             }
-            return super.openAsInputStream( fileName );
+            return super.openAsReader( fileName, charset );
         }
 
         @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
@@ -43,6 +44,7 @@ import org.neo4j.server.security.auth.UserRepository;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 import static org.neo4j.server.security.enterprise.auth.AuthTestUtil.listOf;
 
@@ -58,7 +60,8 @@ public class InternalFlatFileRealmTest
                         new InMemoryUserRepository(),
                         new InMemoryRoleRepository(),
                         new BasicPasswordPolicy(),
-                        new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ) );
+                        new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ),
+                        mock( JobScheduler.class ) );
 
         List<Realm> realms = listOf( testRealm );
 
@@ -103,6 +106,12 @@ public class InternalFlatFileRealmTest
         private boolean authenticationFlag = false;
         private boolean authorizationFlag = false;
 
+        public TestRealm( UserRepository userRepository, RoleRepository roleRepository, PasswordPolicy passwordPolicy,
+                AuthenticationStrategy authenticationStrategy, JobScheduler jobScheduler )
+        {
+            super( userRepository, roleRepository, passwordPolicy, authenticationStrategy, jobScheduler );
+        }
+
         boolean takeAuthenticationFlag()
         {
             boolean t = authenticationFlag;
@@ -115,12 +124,6 @@ public class InternalFlatFileRealmTest
             boolean t = authorizationFlag;
             authorizationFlag = false;
             return t;
-        }
-
-        TestRealm( UserRepository userRepository, RoleRepository roleRepository, PasswordPolicy passwordPolicy,
-                AuthenticationStrategy authenticationStrategy )
-        {
-            super( userRepository, roleRepository, passwordPolicy, authenticationStrategy );
         }
 
         @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
@@ -49,6 +50,7 @@ import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 import static org.neo4j.server.security.enterprise.auth.AuthTestUtil.listOf;
@@ -64,10 +66,11 @@ public class LdapCachingTest
     {
         InternalFlatFileRealm internalFlatFileRealm =
             new InternalFlatFileRealm(
-                    new InMemoryUserRepository(),
-                    new InMemoryRoleRepository(),
-                    new BasicPasswordPolicy(),
-                    new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 )
+                new InMemoryUserRepository(),
+                new InMemoryRoleRepository(),
+                new BasicPasswordPolicy(),
+                new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ),
+                mock( JobScheduler.class )
             );
 
         testRealm = new TestRealm( getLdapConfig(), NullLogProvider.getInstance() );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.InvalidArgumentsException;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.Credential;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
@@ -61,8 +62,10 @@ public class MultiRealmAuthManagerTest
         authStrategy = mock( AuthenticationStrategy.class );
 
         InternalFlatFileRealm internalFlatFileRealm =
-                new InternalFlatFileRealm( users, new InMemoryRoleRepository(), mock( PasswordPolicy.class ), authStrategy );
-        manager = new MultiRealmAuthManager( internalFlatFileRealm, Collections.singleton( internalFlatFileRealm ), new MemoryConstrainedCacheManager() );
+                new InternalFlatFileRealm( users, new InMemoryRoleRepository(), mock( PasswordPolicy.class ),
+                        authStrategy, mock( JobScheduler.class ) );
+        manager = new MultiRealmAuthManager( internalFlatFileRealm, Collections.singleton( internalFlatFileRealm ),
+                new MemoryConstrainedCacheManager() );
         manager.init();
         userManager = manager.getUserManager();
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -108,7 +108,6 @@ abstract class ProcedureInteractionTestBase<S>
     @Before
     public void setUp() throws Throwable
     {
-        Neo4jWithSocket.cleanupTemporaryTestFiles();
         neo = setUpNeoServer();
         neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class )
                 .register( ClassWithProcedures.class );
@@ -141,7 +140,6 @@ abstract class ProcedureInteractionTestBase<S>
     public void tearDown() throws Throwable
     {
         neo.tearDown();
-        Neo4jWithSocket.cleanupTemporaryTestFiles();
     }
 
     protected String[] with( String[] strs, String... moreStr )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/RoleSerializationTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/RoleSerializationTest.java
@@ -34,18 +34,17 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class RoleSerializationTest
 {
-
     private SortedSet<String> steveBob;
     private SortedSet<String> kellyMarie;
 
     @Before
     public void setUp()
     {
-        steveBob = new TreeSet<String>();
+        steveBob = new TreeSet<>();
         steveBob.add( "Steve" );
         steveBob.add( "Bob" );
 
-        kellyMarie = new TreeSet<String>();
+        kellyMarie = new TreeSet<>();
         kellyMarie.add( "Kelly" );
         kellyMarie.add( "Marie" );
     }


### PR DESCRIPTION
Every 5 seconds the auth and role files are checked for modifications, and reloaded if changed. This is to support clustered native auth, where the files are synchronized using rsync or similar.

changelog: Automatically reload auth files from disk every 5 seconds to enable external changes and externally driven cluster synchronisation
