### PR TITLE
Fix NPE in ServerBootstrapper

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -20,7 +20,6 @@
 package org.neo4j.server;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -52,7 +51,8 @@ public abstract class ServerBootstrapper implements Bootstrapper
     private NeoServer server;
     private Thread shutdownHook;
     private GraphDatabaseDependencies dependencies = GraphDatabaseDependencies.newDependencies();
-    private Log log;
+    // in case we have errors loading/validating the configuration log to stdout
+    private Log log = FormattedLogProvider.toOutputStream( System.out ).getLog( getClass() );
     private String serverAddress = "unknown address";
 
     public static int start( Bootstrapper boot, String... argv )
@@ -162,7 +162,6 @@ public abstract class ServerBootstrapper implements Bootstrapper
     }
 
     private Config createConfig( File homeDir, Optional<File> file, Pair<String, String>[] configOverrides )
-            throws IOException
     {
         return new ConfigLoader( this::settingsClasses ).loadConfig( Optional.of( homeDir ), file, configOverrides );
     }

--- a/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.test.SuppressOutput;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ServerBootstrapperTest
+{
+    @Rule
+    public final SuppressOutput suppress = SuppressOutput.suppress( SuppressOutput.System.out );
+
+    @Test
+    public void shouldNotThrowNullPointerExceptionIfConfigurationValidationFails() throws Exception
+    {
+        // given
+        ServerBootstrapper serverBootstrapper = new ServerBootstrapper()
+        {
+            @Override
+            protected NeoServer createNeoServer( Config config, GraphDatabaseDependencies dependencies,
+                    LogProvider userLogProvider )
+            {
+                return mock( NeoServer.class );
+            }
+
+            @Override
+            protected Iterable<Class<?>> settingsClasses( Map<String,String> settings )
+            {
+                // simulate validation failure
+                throw new IllegalArgumentException( "Missing mandatory setting" );
+            }
+        };
+
+        File dir = Files.createTempDirectory( "test-server-bootstrapper" ).toFile();
+        dir.deleteOnExit();
+
+        // when
+        serverBootstrapper.start( dir, Optional.empty() );
+
+        // then no exceptions are thrown and
+        assertThat( suppress.getOutputVoice().lines(), not( empty() ) );
+    }
+}


### PR DESCRIPTION
When there are validation failure in the configuration we have loaded
from disk a NPE is thrown when we try to log the exception because the
log is initialized later on.  This commit fixes this problems by
making sure that we have a simple log that simply prints to stdout if
the real log is not build yet.
