### PR TITLE
Update CheckStyle.XML for building on Windows

### DIFF
--- a/build/checkstyle.xml
+++ b/build/checkstyle.xml
@@ -23,7 +23,9 @@
   </module>
 
   <!-- Require new line at the end of file -->
-  <module name="NewlineAtEndOfFile"/>
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf_cr_crlf" />
+  </module>
 
   <!-- Prohibit trailing spaces -->
   <module name="RegexpSingleline">


### PR DESCRIPTION
Previously in commit 4fb90155be CheckStyle for java was enabled, in particular
the requirement for a newline at the end of files.  Unfortunately CheckStyle
uses the OS line endings instead of individual file type endings which results
in CheckStyle failing ~40 files when building Neo4j on Windows.  This is because
CheckStyle is expecting a CRLF however the offending files are using LF line
endings.

This commit modifies the CheckStyle.XML to expect any of the different types of
line endings: CRLF, CR and LF.

ref: http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile
