### PR TITLE
Add a file rename method to the PageCache interface

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -135,14 +135,9 @@ public class DefaultFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
-        if ( copyOptions.length > 0 )
-        {
-            Files.move( from.toPath(), to.toPath(), copyOptions );
-            return true; // will throw if failure
-        }
-        return FileUtils.renameFile( from, to );
+        Files.move( from.toPath(), to.toPath(), copyOptions );
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -38,11 +38,9 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
@@ -170,10 +168,9 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
         Files.move( path( from ), path( to ), copyOptions );
-        return true;
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -58,7 +58,7 @@ public interface FileSystemAbstraction
 
     void deleteRecursively( File directory ) throws IOException;
 
-    boolean move( File from, File to, CopyOption... copyOptions ) throws IOException;
+    void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException;
 
     File[] listFiles( File directory );
 

--- a/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
@@ -42,6 +42,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -120,7 +121,7 @@ public class FileUtils
      * Utility method that moves a file from its current location to the
      * new target location. If rename fails (for example if the target is
      * another disk) a copy/delete will be performed instead. This is not a rename,
-     * use {@link #renameFile(File, File)} instead.
+     * use {@link #renameFile(File, File, CopyOption...)} instead.
      *
      * @param toMove The File object to move.
      * @param target Target file to move to.
@@ -161,7 +162,7 @@ public class FileUtils
      * Utility method that moves a file from its current location to the
      * provided target directory. If rename fails (for example if the target is
      * another disk) a copy/delete will be performed instead. This is not a rename,
-     * use {@link #renameFile(File, File)} instead.
+     * use {@link #renameFile(File, File, CopyOption...)} instead.
      *
      * @param toMove The File object to move.
      * @param targetDirectory the destination directory
@@ -181,33 +182,9 @@ public class FileUtils
         return target;
     }
 
-    public static boolean renameFile( File srcFile, File renameToFile ) throws IOException
+    public static void renameFile( File srcFile, File renameToFile, CopyOption... copyOptions ) throws IOException
     {
-        if ( !srcFile.exists() )
-        {
-            throw new FileNotFoundException( "Source file[" + srcFile.getName() + "] not found" );
-        }
-        if ( renameToFile.exists() )
-        {
-            throw new FileNotFoundException( "Target file[" + renameToFile.getName() + "] already exists" );
-        }
-        if ( !renameToFile.getParentFile().isDirectory() )
-        {
-            throw new FileNotFoundException( "Target directory[" + renameToFile.getParent() + "] does not exists" );
-        }
-        int count = 0;
-        boolean renamed;
-        do
-        {
-            renamed = srcFile.renameTo( renameToFile );
-            if ( !renamed )
-            {
-                count++;
-                waitAndThenTriggerGC();
-            }
-        }
-        while ( !renamed && count <= WINDOWS_RETRY_COUNT );
-        return renamed;
+        Files.move( srcFile.toPath(), renameToFile.toPath(), copyOptions );
     }
 
     public static void truncateFile( SeekableByteChannel fileChannel, long position )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -97,12 +97,12 @@ public interface PageCache extends AutoCloseable
     int maxCachedPages();
 
     /**
-     * Rename source file to the given target file.
+     * Rename source file to the given target file, effectively moving the file from source to target.
      *
-     * Both files have to be unmapped when performing the move, otherwise an exception will be thrown.
+     * Both files have to be unmapped when performing the rename, otherwise an exception will be thrown.
      *
-     * @param sourceFile The name of the file to move.
-     * @param targetFile The new name of the file after the move.
+     * @param sourceFile The name of the file to rename.
+     * @param targetFile The new name of the file after the rename.
      * @param copyOptions Options to modify the behaviour of the move in possibly platform specific ways. In particular,
      * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any existing file at the
      * target path name, instead of throwing an exception.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
@@ -94,4 +95,17 @@ public interface PageCache extends AutoCloseable
 
     /** The max number of cached pages. */
     int maxCachedPages();
+
+    /**
+     * Move the file from the given source path, to the given target path.
+     *
+     * Both files have to be unmapped when performing the move, otherwise an exception will be thrown.
+     *
+     * @param sourceFile The name of the file to move.
+     * @param targetFile The new name of the file after the move.
+     * @param copyOptions Options to modify the behaviour of the move in possibly platform specific ways. In particular,
+     * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any existing file at the
+     * target path name, instead of throwing an exception.
+     */
+    void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -97,7 +97,7 @@ public interface PageCache extends AutoCloseable
     int maxCachedPages();
 
     /**
-     * Move the file from the given source path, to the given target path.
+     * Rename source file to the given target file.
      *
      * Both files have to be unmapped when performing the move, otherwise an exception will be thrown.
      *
@@ -107,5 +107,5 @@ public interface PageCache extends AutoCloseable
      * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any existing file at the
      * target path name, instead of throwing an exception.
      */
-    void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
+    void renameFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -101,18 +101,18 @@ public interface PageSwapperFactory
     void syncDevice() throws IOException;
 
     /**
-     * Rename the given source file given target file name, effectively moving the file from source to target.
+     * Rename the given source file to target file, effectively moving the file from source to target.
      *
      * The provided list of {@link CopyOption CopyOptions} can be used to modify and influence platform specific
      * behaviour. In particular, {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any
      * existing file at the target path name, instead of throwing an exception.
      *
-     * Implementors are free to assume that neither file name will be mapped by the page cache at the time of the move,
-     * and thus the move will see no interference from concurrent IO operations.
+     * Implementors are free to assume that neither file name will be mapped by the page cache at the time of the
+     * rename, and thus the rename will see no interference from concurrent IO operations.
      * @param sourceFile The existing file to rename.
-     * @param targetFile The desired new path of the source file. This file should not exist, unless
+     * @param targetFile The desired new name of the source file. This file should not exist, unless
      * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} is given as a {@code copyOption}.
-     * @param copyOptions Options to modify the behaviour of the move in possibly platform specific ways.
+     * @param copyOptions Options to modify the behaviour of the rename in possibly platform specific ways.
      * @see java.nio.file.Files#move(Path, Path, CopyOption...)
      */
     void renameUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -101,7 +101,7 @@ public interface PageSwapperFactory
     void syncDevice() throws IOException;
 
     /**
-     * Move the file by the given source file name, to the path indicated by the given target file name.
+     * Rename the given source file given target file name, effectively moving the file from source to target.
      *
      * The provided list of {@link CopyOption CopyOptions} can be used to modify and influence platform specific
      * behaviour. In particular, {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any
@@ -109,11 +109,11 @@ public interface PageSwapperFactory
      *
      * Implementors are free to assume that neither file name will be mapped by the page cache at the time of the move,
      * and thus the move will see no interference from concurrent IO operations.
-     * @param sourceFile The existing file to move.
+     * @param sourceFile The existing file to rename.
      * @param targetFile The desired new path of the source file. This file should not exist, unless
      * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} is given as a {@code copyOption}.
      * @param copyOptions Options to modify the behaviour of the move in possibly platform specific ways.
      * @see java.nio.file.Files#move(Path, Path, CopyOption...)
      */
-    void moveUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
+    void renameUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -21,6 +21,8 @@ package org.neo4j.io.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.CopyOption;
+import java.nio.file.Path;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 
@@ -97,4 +99,21 @@ public interface PageSwapperFactory
      * durable regardless of which method that does the forcing.
      */
     void syncDevice() throws IOException;
+
+    /**
+     * Move the file by the given source file name, to the path indicated by the given target file name.
+     *
+     * The provided list of {@link CopyOption CopyOptions} can be used to modify and influence platform specific
+     * behaviour. In particular, {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} may be used to overwrite any
+     * existing file at the target path name, instead of throwing an exception.
+     *
+     * Implementors are free to assume that neither file name will be mapped by the page cache at the time of the move,
+     * and thus the move will see no interference from concurrent IO operations.
+     * @param sourceFile The existing file to move.
+     * @param targetFile The desired new path of the source file. This file should not exist, unless
+     * {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} is given as a {@code copyOption}.
+     * @param copyOptions Options to modify the behaviour of the move in possibly platform specific ways.
+     * @see java.nio.file.Files#move(Path, Path, CopyOption...)
+     */
+    void moveUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException;
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CannotMoveMappedFileException.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CannotMoveMappedFileException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.impl;
+
+import java.io.File;
+import java.io.IOException;
+
+public class CannotMoveMappedFileException extends IOException
+{
+    public CannotMoveMappedFileException( File file )
+    {
+        super( "Cannot move mapped file: " + file );
+    }
+}

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -72,7 +72,7 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
     }
 
     @Override
-    public void moveUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
+    public void renameUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
     {
         fs.renameFile( sourceFile, targetFile, copyOptions );
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.NoSuchFileException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -68,6 +69,12 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
     public void syncDevice()
     {
         // Nothing do to, since we `fsync` files individually in `force()`.
+    }
+
+    @Override
+    public void moveUnopenedFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
+    {
+        fs.renameFile( sourceFile, targetFile, copyOptions );
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -400,7 +400,7 @@ public class MuninnPageCache implements PageCache
     }
 
     @Override
-    public synchronized void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions )
+    public synchronized void renameFile( File sourceFile, File targetFile, CopyOption... copyOptions )
             throws IOException
     {
         sourceFile = sourceFile.getCanonicalFile();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -407,7 +407,7 @@ public class MuninnPageCache implements PageCache
         targetFile = targetFile.getCanonicalFile();
         throwIfMapped( sourceFile );
         throwIfMapped( targetFile );
-        swapperFactory.moveUnopenedFile( sourceFile, targetFile, copyOptions );
+        swapperFactory.renameUnopenedFile( sourceFile, targetFile, copyOptions );
     }
 
     private void throwIfMapped( File file ) throws IOException

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -69,10 +69,10 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         return AdversarialFileChannel.wrap( (StoreFileChannel) delegate.open( fileName, mode ), adversary );
     }
 
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
         adversary.injectFailure( FileNotFoundException.class, SecurityException.class );
-        return delegate.move( from, to, copyOptions );
+        delegate.renameFile( from, to, copyOptions );
     }
 
     public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.CopyOption;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
@@ -33,6 +35,7 @@ import org.neo4j.adversaries.Adversary;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.impl.CannotMoveMappedFileException;
 
 /**
  * A {@linkplain PageCache page cache} that wraps another page cache and an {@linkplain Adversary adversary} to provide
@@ -111,5 +114,14 @@ public class AdversarialPageCache implements PageCache
     public int maxCachedPages()
     {
         return delegate.maxCachedPages();
+    }
+
+    @Override
+    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions )
+            throws IOException
+    {
+        adversary.injectFailure( CannotMoveMappedFileException.class, FileAlreadyExistsException.class,
+                IOException.class, SecurityException.class );
+        delegate.moveFile( sourceFile, targetFile, copyOptions );
     }
 }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -117,11 +117,11 @@ public class AdversarialPageCache implements PageCache
     }
 
     @Override
-    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions )
+    public void renameFile( File sourceFile, File targetFile, CopyOption... copyOptions )
             throws IOException
     {
         adversary.injectFailure( CannotMoveMappedFileException.class, FileAlreadyExistsException.class,
                 IOException.class, SecurityException.class );
-        delegate.moveFile( sourceFile, targetFile, copyOptions );
+        delegate.renameFile( sourceFile, targetFile, copyOptions );
     }
 }

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -86,9 +86,9 @@ public class DelegatingFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
-        return delegate.move( from, to, copyOptions );
+        delegate.renameFile( from, to, copyOptions );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
@@ -89,10 +89,10 @@ public class LimitedFilesystemAbstraction extends DelegatingFileSystemAbstractio
     }
 
     @Override
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
         ensureHasSpace();
-        return super.move( from, to, copyOptions );
+        super.renameFile( from, to, copyOptions );
     }
 
     public void runOutOfDiskSpace( boolean outOfSpace )

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
@@ -126,9 +126,9 @@ public class SelectiveFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
-    public boolean move( File from, File to, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
     {
-        return chooseFileSystem( from ).move( from, to, copyOptions );
+        chooseFileSystem( from ).renameFile( from, to, copyOptions );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.OpenOption;
 import java.util.Optional;
 
@@ -57,6 +58,13 @@ public class DelegatingPageCache implements PageCache
     public int maxCachedPages()
     {
         return delegate.maxCachedPages();
+    }
+
+    @Override
+    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions )
+            throws IOException
+    {
+        delegate.moveFile( sourceFile, targetFile, copyOptions );
     }
 
     public void flushAndForce( IOLimiter limiter ) throws IOException

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -61,10 +61,10 @@ public class DelegatingPageCache implements PageCache
     }
 
     @Override
-    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions )
+    public void renameFile( File sourceFile, File targetFile, CopyOption... copyOptions )
             throws IOException
     {
-        delegate.moveFile( sourceFile, targetFile, copyOptions );
+        delegate.renameFile( sourceFile, targetFile, copyOptions );
     }
 
     public void flushAndForce( IOLimiter limiter ) throws IOException

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -4702,7 +4702,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
         try ( PagedFile ignore = pageCache.map( a, filePageSize ) )
         {
-            pageCache.moveFile( a, b );
+            pageCache.renameFile( a, b );
         }
     }
 
@@ -4714,7 +4714,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
         try ( PagedFile ignore = pageCache.map( b, filePageSize ) )
         {
-            pageCache.moveFile( a, b );
+            pageCache.renameFile( a, b );
         }
     }
 
@@ -4724,7 +4724,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         File a = file( "a" );
         File b = existingFile( "b" );
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
     }
 
     @Test
@@ -4735,8 +4735,8 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
         try
         {
-            pageCache.moveFile( a, b );
-            fail( "pageCache.moveFile should have thrown" );
+            pageCache.renameFile( a, b );
+            fail( "pageCache.renameFile should have thrown" );
         }
         catch ( NoSuchFileException e )
         {
@@ -4750,7 +4750,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         File a = file( "doesNotExist" );
         File b = file( "b" );
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
     }
 
     @Test
@@ -4759,7 +4759,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         File a = file( "a" );
         File b = file( "b" );
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
         pageCache.map( b, filePageSize ).close();
     }
 
@@ -4769,7 +4769,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         File a = file( "a" );
         File b = file( "b" );
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
         pageCache.map( a, filePageSize );
         fail( "pageCache.map should have thrown" );
     }
@@ -4781,7 +4781,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         File b = file( "b" );
         generateFileWithRecords( a, recordCount, recordSize );
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
         verifyRecordsInFile( b, recordCount );
     }
 
@@ -4810,7 +4810,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         }
 
         // Do the move
-        pageCache.moveFile( a, b, REPLACE_EXISTING );
+        pageCache.renameFile( a, b, REPLACE_EXISTING );
 
         // Then verify that the old random data we put in 'b' has been replaced with the contents of 'a'
         verifyRecordsInFile( b, recordCount );
@@ -4824,7 +4824,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
         // File 'a' should canonicalise from 'a/poke/..' to 'a', which is a file that exists.
         // Thus, this should not throw a NoSuchFileException.
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
     }
 
     @Test
@@ -4835,6 +4835,6 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
         // File 'b' should canonicalise from 'b/poke/..' to 'b', which is a file that doesn't exists.
         // Thus, this should not throw a FileAlreadyExistsException.
-        pageCache.moveFile( a, b );
+        pageCache.renameFile( a, b );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
@@ -264,9 +264,9 @@ public class IndexConfigStore extends LifecycleAdapter
         fileSystem.deleteFile( oldFile );
         try
         {
-            if ( fileSystem.fileExists( file ) && !fileSystem.move( file, oldFile ) )
+            if ( fileSystem.fileExists( file ) )
             {
-                throw new RuntimeException( "Couldn't rename " + file + " -> " + oldFile );
+                fileSystem.renameFile( file, oldFile );
             }
         }
         catch ( IOException e )
@@ -277,10 +277,7 @@ public class IndexConfigStore extends LifecycleAdapter
         // Rename the .tmp file to the current name
         try
         {
-            if ( !fileSystem.move( tmpFile, this.file ) )
-            {
-                throw new RuntimeException( "Couldn't rename " + tmpFile + " -> " + file );
-            }
+            fileSystem.renameFile( tmpFile, this.file );
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogs.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogs.java
@@ -175,7 +175,7 @@ public class LegacyLogs
             final String oldName = file.getName();
             final long version = getLegacyLogVersion( oldName );
             final String newName = DEFAULT_NAME + DEFAULT_VERSION_SUFFIX + version;
-            fs.move( file, new File( file.getParent(), newName ) );
+            fs.renameFile( file, new File( file.getParent(), newName ) );
         }
 
         deleteUnusedLogFiles( storeDir );

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -296,7 +296,7 @@ public class LogTestUtils
         public void restore() throws IOException
         {
             fileSystem.deleteFile( file );
-            fileSystem.move( backup, file );
+            fileSystem.renameFile( backup, file );
         }
     }
 

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -197,7 +197,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
                 if ( fileSystem.fileExists( outputFile ) )
                 {
                     shiftArchivedOutputFiles();
-                    fileSystem.move( outputFile, archivedOutputFile( 1 ) );
+                    fileSystem.renameFile( outputFile, archivedOutputFile( 1 ) );
                 }
                 newStream = openOutputFile();
             }
@@ -252,7 +252,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
                 fileSystem.deleteFile( archive );
             } else
             {
-                fileSystem.move( archive, archivedOutputFile( i + 1 ) );
+                fileSystem.renameFile( archive, archivedOutputFile( i + 1 ) );
             }
         }
     }

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -279,7 +279,7 @@ public class RotatingFileOutputStreamSupplierTest
         OutputStream outputStream = supplier.get();
 
         IOException exception = new IOException( "text exception" );
-        doThrow( exception ).when( fs ).move( any( File.class ), any( File.class ) );
+        doThrow( exception ).when( fs ).renameFile( any( File.class ), any( File.class ) );
 
         write( outputStream, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );

--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileRepositorySerializer.java
@@ -78,7 +78,7 @@ public abstract class FileRepositorySerializer<S>
         try
         {
             writeToFile( fileSystem, tempFile, serialize( records ) );
-            fileSystem.move( tempFile, recordsFile, ATOMIC_MOVE, REPLACE_EXISTING );
+            fileSystem.renameFile( tempFile, recordsFile, ATOMIC_MOVE, REPLACE_EXISTING );
         }
         catch ( Throwable e )
         {

--- a/community/security/src/test/java/org/neo4j/server/security/auth/FileUserRepositoryTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/FileUserRepositoryTest.java
@@ -157,13 +157,13 @@ public class FileUserRepositoryTest
         FileSystemAbstraction craschingFileSystem =
             new DelegatingFileSystemAbstraction( fs ) {
                 @Override
-                public boolean move( File oldLocation, File newLocation, CopyOption... copyOptions ) throws IOException
+                public void renameFile( File oldLocation, File newLocation, CopyOption... copyOptions ) throws IOException
                 {
                     if ( authFile.getName().equals( newLocation.getName().toString() ) )
                     {
                         throw exception;
                     }
-                    return super.move( oldLocation, newLocation, copyOptions );
+                    super.renameFile( oldLocation, newLocation, copyOptions );
                 }
             };
 

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -21,6 +21,7 @@ package org.neo4j.com.storecopy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.OpenOption;
 import java.util.Map;
 import java.util.Optional;
@@ -96,6 +97,12 @@ public class ExternallyManagedPageCache implements PageCache
     public int maxCachedPages()
     {
         return delegate.maxCachedPages();
+    }
+
+    @Override
+    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
+    {
+        delegate.moveFile( sourceFile, targetFile, copyOptions );
     }
 
     /**

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -100,9 +100,9 @@ public class ExternallyManagedPageCache implements PageCache
     }
 
     @Override
-    public void moveFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
+    public void renameFile( File sourceFile, File targetFile, CopyOption... copyOptions ) throws IOException
     {
-        delegate.moveFile( sourceFile, targetFile, copyOptions );
+        delegate.renameFile( sourceFile, targetFile, copyOptions );
     }
 
     /**

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -307,7 +307,7 @@ public class TestBranchedData
             String fileName = file.getName();
             if ( !fileName.equals( StoreLogService.INTERNAL_LOG_NAME ) && !file.getName().startsWith( "branched-" ) )
             {
-                assertTrue( FileUtils.renameFile( file, new File( branchDir, file.getName() ) ) );
+                FileUtils.renameFile( file, new File( branchDir, file.getName() ) );
             }
         }
         return timestamp;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/FileRoleRepositoryTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/FileRoleRepositoryTest.java
@@ -162,14 +162,14 @@ public class FileRoleRepositoryTest
         FileSystemAbstraction craschingFileSystem =
                 new DelegatingFileSystemAbstraction( fs ) {
                     @Override
-                    public boolean move( File oldLocation, File newLocation, CopyOption... copyOptions ) throws
+                    public void renameFile( File oldLocation, File newLocation, CopyOption... copyOptions ) throws
                             IOException
                     {
                         if ( roleFile.getName().equals( newLocation.getName().toString() ) )
                         {
                             throw exception;
                         }
-                        return super.move( oldLocation, newLocation, copyOptions );
+                        super.renameFile( oldLocation, newLocation, copyOptions );
                     }
                 };
 


### PR DESCRIPTION
We need this since only the page cache is aware of any custom IO subsystem configurations we might have, and renaming files is an operation that is used in a fair number of places.

Co-authored with @burqen 
