### PR TITLE
Exclude the store lock file from archives

### DIFF
--- a/community/common/src/main/java/org/neo4j/function/ThrowingAction.java
+++ b/community/common/src/main/java/org/neo4j/function/ThrowingAction.java
@@ -21,13 +21,22 @@ package org.neo4j.function;
 
 /**
  * An action that takes no parameters and returns no values, but may have a side-effect and may throw an exception.
+ *
  * @param <E> The type of exception this action may throw.
  */
 public interface ThrowingAction<E extends Exception>
 {
     /**
      * Apply the action for some or all of its side-effects to take place, possibly throwing an exception.
+     *
      * @throws E the exception that performing this action may throw.
      */
     void apply() throws E;
+
+    static <E extends Exception> ThrowingAction<E> noop()
+    {
+        return () ->
+        {
+        };
+    }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -166,7 +167,7 @@ public class DumpCommand implements AdminCommand
     {
         try
         {
-            dumper.dump( databaseDirectory, archive );
+            dumper.dump( databaseDirectory, archive, this::isStoreLock );
         }
         catch ( FileAlreadyExistsException e )
         {
@@ -184,6 +185,11 @@ public class DumpCommand implements AdminCommand
         {
             wrapIOException( e );
         }
+    }
+
+    private boolean isStoreLock( Path path )
+    {
+        return Objects.equals( path.getFileName().toString(), StoreLocker.STORE_LOCK_FILENAME );
     }
 
     private void wrapIOException( IOException e ) throws CommandFailed

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.function.Predicates;
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.util.Collections.emptySet;
@@ -53,7 +54,7 @@ public class DumperTest
         Files.write( archive, new byte[0] );
         try
         {
-            new Dumper().dump( directory, archive );
+            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( FileAlreadyExistsException e )
@@ -69,7 +70,7 @@ public class DumperTest
         Path archive = testDirectory.file( "the-archive.dump" ).toPath();
         try
         {
-            new Dumper().dump( directory, archive );
+            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
@@ -85,7 +86,7 @@ public class DumperTest
         Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
         try
         {
-            new Dumper().dump( directory, archive );
+            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
@@ -102,7 +103,7 @@ public class DumperTest
         Files.write( archive.getParent(), new byte[0] );
         try
         {
-            new Dumper().dump( directory, archive );
+            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( FileSystemException e )
@@ -121,7 +122,7 @@ public class DumperTest
         Files.createDirectories( archive.getParent() );
         try ( Closeable ignored = TestUtils.withPermissions( archive.getParent(), emptySet() ) )
         {
-            new Dumper().dump( directory, archive );
+            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( AccessDeniedException e )

--- a/community/io/src/main/java/org/neo4j/io/fs/FileVisitors.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileVisitors.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.fs;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.function.Predicate;
+
+import org.neo4j.function.ThrowingConsumer;
+
+public class FileVisitors
+{
+    public static FileVisitor<Path> onlyMatching( Predicate<Path> predicate, FileVisitor<Path> wrapped )
+    {
+        return new FileVisitor<Path>()
+        {
+            @Override
+            public FileVisitResult preVisitDirectory( Path dir, BasicFileAttributes attrs ) throws IOException
+            {
+                return predicate.test( dir ) ? wrapped.preVisitDirectory( dir, attrs ) : FileVisitResult.SKIP_SUBTREE;
+            }
+
+            @Override
+            public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException
+            {
+                return predicate.test( file ) ? wrapped.visitFile( file, attrs ) : FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed( Path file, IOException e ) throws IOException
+            {
+                return predicate.test( file ) ? wrapped.visitFileFailed( file, e ) : FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory( Path dir, IOException e ) throws IOException
+            {
+                return predicate.test( dir ) ? wrapped.postVisitDirectory( dir, e ) : FileVisitResult.CONTINUE;
+            }
+        };
+    }
+
+    public static FileVisitor<Path> throwExceptions( FileVisitor<Path> wrapped )
+    {
+        return new Decorator<Path>( wrapped )
+        {
+            @Override
+            public FileVisitResult visitFileFailed( Path file, IOException e ) throws IOException
+            {
+                if ( e != null )
+                {
+                    throw e;
+                }
+                return super.visitFileFailed( file, null );
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory( Path dir, IOException e ) throws IOException
+            {
+                if ( e != null )
+                {
+                    throw e;
+                }
+                return super.postVisitDirectory( dir, null );
+            }
+        };
+    }
+
+    public static FileVisitor<Path> onDirectory( ThrowingConsumer<Path, IOException> operation,
+                                                 FileVisitor<Path> wrapped )
+    {
+        return new Decorator<Path>( wrapped )
+        {
+            @Override
+            public FileVisitResult preVisitDirectory( Path dir, BasicFileAttributes attrs ) throws IOException
+            {
+                operation.accept( dir );
+                return super.preVisitDirectory( dir, attrs );
+            }
+        };
+    }
+
+    public static FileVisitor<Path> onFile( ThrowingConsumer<Path, IOException> operation, FileVisitor<Path> wrapped )
+    {
+        return new Decorator<Path>( wrapped )
+        {
+            @Override
+            public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException
+            {
+                operation.accept( file );
+                return super.visitFile( file, attrs );
+            }
+        };
+    }
+
+    public static FileVisitor<Path> justContinue()
+    {
+        return new FileVisitor<Path>()
+        {
+            @Override
+            public FileVisitResult preVisitDirectory( Path dir, BasicFileAttributes attrs ) throws IOException
+            {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile( Path file, BasicFileAttributes attrs ) throws IOException
+            {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed( Path file, IOException e ) throws IOException
+            {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory( Path dir, IOException e ) throws IOException
+            {
+                return FileVisitResult.CONTINUE;
+            }
+        };
+    }
+
+    public static class Decorator<T> implements FileVisitor<T>
+    {
+        private final FileVisitor<T> wrapped;
+
+        public Decorator( FileVisitor<T> wrapped )
+        {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory( T t, BasicFileAttributes attrs ) throws IOException
+        {
+            return wrapped.preVisitDirectory( t, attrs );
+        }
+
+        @Override
+        public FileVisitResult visitFile( T t, BasicFileAttributes attrs ) throws IOException
+        {
+            return wrapped.visitFile( t, attrs );
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed( T t, IOException e ) throws IOException
+        {
+            return wrapped.visitFileFailed( t, e );
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory( T t, IOException e ) throws IOException
+        {
+            return wrapped.postVisitDirectory( t, e );
+        }
+    }
+}


### PR DESCRIPTION
The behaviour of file locks on Windows is a constant source of
amazement (or bugs; and sometimes both). This code throws an exception
when reading:

```
File file = File.createTempFile("tmp", null);
file.deleteOnExit();
try (FileChannel channel = new RandomAccessFile(file, "rw").getChannel();
     FileLock lock = channel.tryLock()) {
    assert lock != null;
    new FileInputStream(file).read();
}
```

This is surprising to the casual reader of the Java API docs (to whit:
https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileLock.html);
but it is consistent with the locking semantics of the Win32 APIs
which specify, to anyone who cares to plumb their perlucid depths (so
far as this:
https://msdn.microsoft.com/en-us/library/windows/desktop/aa365202(v=vs.85).aspx),
that "[i]f the locking process opens the file a second time, it cannot
access the [locked] region through this second handle until it unlocks
the region". Caveat lockor.

Having locked the store lock for the duration of the archive process,
we must therefore avoid reading the contents of that file. This is no
great loss since the file is empty and there is nothing to be gained
(nor, it should be said, lost) from including it in the archive.
