### PR TITLE
Single active update puller

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterUpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterUpdatePuller.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+/**
+ * Masters implementation of update puller that does nothing since master should not pull updates.
+ */
+public class MasterUpdatePuller implements UpdatePuller
+{
+
+    public static final MasterUpdatePuller INSTANCE = new MasterUpdatePuller();
+
+    private MasterUpdatePuller()
+    {
+    }
+
+    @Override
+    public void start()
+    {
+        // no-op
+    }
+
+    @Override
+    public void stop()
+    {
+        // no-op
+    }
+
+    @Override
+    public void pullUpdates() throws InterruptedException
+    {
+        // no-op
+    }
+
+    @Override
+    public boolean tryPullUpdates() throws InterruptedException
+    {
+        return false;
+    }
+
+    @Override
+    public void pullUpdates( Condition condition, boolean assertPullerActive )
+            throws InterruptedException
+    {
+        // no-op
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/UpdatePuller.java
@@ -25,10 +25,9 @@ package org.neo4j.kernel.ha;
  * <p>
  * On a running instance of a store there should be only one active implementation of this interface.
  * <p>
- * Typically master instance should use {@link #NONE} implementation since master is owner of data in cluster env
- * and its up to slaves to pull updates.
  *
  * @see SlaveUpdatePuller
+ * @see MasterUpdatePuller
  */
 public interface UpdatePuller
 {
@@ -47,6 +46,16 @@ public interface UpdatePuller
      * @throws InterruptedException in case if interrupted while waiting for updates
      */
     boolean tryPullUpdates() throws InterruptedException;
+
+    /**
+     * Start update pulling
+     */
+    void start();
+
+    /**
+     * Terminate update pulling
+     */
+    void stop();
 
     /**
      * Pull updates and waits for the supplied condition to be
@@ -69,24 +78,4 @@ public interface UpdatePuller
         boolean evaluate( int currentTicket, int targetTicket );
     }
 
-    UpdatePuller NONE = new UpdatePuller()
-    {
-        @Override
-        public void pullUpdates() throws InterruptedException
-        {
-        }
-
-        @Override
-        public boolean tryPullUpdates() throws InterruptedException
-        {
-            return false;
-        }
-
-        @Override
-        public void pullUpdates( Condition condition, boolean assertPullerActive )
-                throws InterruptedException
-        {
-
-        }
-    };
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/AbstractComponentSwitcher.java
@@ -67,10 +67,17 @@ public abstract class AbstractComponentSwitcher<T> implements ComponentSwitcher
     private void updateDelegate( T newValue )
     {
         T oldDelegate = delegate.setDelegate( newValue );
-        shutdownDelegate( oldDelegate );
+        shutdownOldDelegate( oldDelegate );
+        startNewDelegate( newValue );
     }
 
-    protected void shutdownDelegate( T oldDelegate )
+    protected void startNewDelegate( T newValue )
     {
+        // no-op by default
+    }
+
+    protected void shutdownOldDelegate( T oldDelegate )
+    {
+        // no-op by default
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LockManagerSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/LockManagerSwitcher.java
@@ -72,7 +72,7 @@ public class LockManagerSwitcher extends AbstractComponentSwitcher<Locks>
     }
 
     @Override
-    protected void shutdownDelegate( Locks oldLocks )
+    protected void shutdownOldDelegate( Locks oldLocks )
     {
         if ( oldLocks != null )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/UpdatePullerSwitcher.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.ha.cluster.modeswitch;
 
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
+import org.neo4j.kernel.ha.MasterUpdatePuller;
 import org.neo4j.kernel.ha.PullerFactory;
 import org.neo4j.kernel.ha.SlaveUpdatePuller;
 import org.neo4j.kernel.ha.UpdatePuller;
@@ -44,26 +45,31 @@ public class UpdatePullerSwitcher extends AbstractComponentSwitcher<UpdatePuller
     @Override
     protected UpdatePuller getMasterImpl()
     {
-        return UpdatePuller.NONE;
+        return MasterUpdatePuller.INSTANCE;
     }
 
     @Override
     protected UpdatePuller getSlaveImpl()
     {
-        SlaveUpdatePuller slaveUpdatePuller = pullerFactory.createSlaveUpdatePuller();
-        slaveUpdatePuller.init();
-        slaveUpdatePuller.start();
-        return slaveUpdatePuller;
+        return pullerFactory.createSlaveUpdatePuller();
     }
 
     @Override
-    protected void shutdownDelegate( UpdatePuller updatePuller )
+    protected void shutdownOldDelegate( UpdatePuller updatePuller )
     {
-        if ( updatePuller != null && updatePuller instanceof SlaveUpdatePuller )
+        if ( updatePuller != null )
         {
-            SlaveUpdatePuller slaveUpdatePuller = (SlaveUpdatePuller) updatePuller;
-            slaveUpdatePuller.stop();
-            slaveUpdatePuller.shutdown();
+            updatePuller.stop();
         }
     }
+
+    @Override
+    protected void startNewDelegate( UpdatePuller updatePuller )
+    {
+        if ( updatePuller != null )
+        {
+            updatePuller.start();
+        }
+    }
+
 }


### PR DESCRIPTION
After introduction of detached state components lifecycle was change in a way that now it's possible to start new set of components while you still have old one active.
For case of update puller it mean that for some time we will have 2 update pullers active and they will try to apply transactions concurrently.
That is incorrect and causing errors during transactions apply phase.
This commit introduce new phase in component switch lifecycle, just after old component shutdown. And we will use this phase to start new update puller

@pair-with @lutovich

changelog: Update ha component lifecycle to make sure we have only one active update puller on slaves
