### PR TITLE
Introduces limit to the size of netty direct buffers

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/tx/ReplicatedTransactionFactory.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
+import org.neo4j.coreedge.messaging.MessageTooBigException;
 import org.neo4j.coreedge.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.coreedge.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
@@ -41,18 +41,25 @@ import org.neo4j.storageengine.api.StorageCommand;
 
 public class ReplicatedTransactionFactory
 {
+    private static final long MAX_SERIALIZED_TX_SIZE = 1024 * 1024 * 1024L; // 1 GB
+
     public static ReplicatedTransaction createImmutableReplicatedTransaction( TransactionRepresentation tx  )
     {
         ByteBuf transactionBuffer = Unpooled.buffer();
 
-        NetworkFlushableChannelNetty4 channel = new NetworkFlushableChannelNetty4( transactionBuffer );
+        NetworkFlushableChannelNetty4 channel = new NetworkFlushableChannelNetty4( transactionBuffer, MAX_SERIALIZED_TX_SIZE );
         try
         {
             TransactionSerializer.write( tx, channel );
         }
+        catch ( MessageTooBigException e )
+        {
+            throw new IllegalStateException( "Transaction size was too large to replicate across the cluster.", e );
+        }
         catch ( IOException e )
         {
-            // TODO: This should not happen. Not even the IOException, fix it.
+            // TODO: This should not happen. All operations are in memory, no IOException should be thrown
+            // Easier said than done though, we use the LogEntry handling routines which throw IOException
             throw new RuntimeException( e );
         }
 
@@ -77,7 +84,8 @@ public class ReplicatedTransactionFactory
         }
         catch ( IOException e )
         {
-            // TODO: This should not happen. Not even the IOException, fix it.
+            // TODO: This should not happen. All operations are in memory, no IOException should be thrown
+            // Easier said than done though, we use the LogEntry handling routines which throw IOException
             throw new RuntimeException( e );
         }
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/tx/ReplicatedTransactionFactory.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.coreedge.core.state.machines.tx;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import org.neo4j.coreedge.messaging.MessageTooBigException;
 import org.neo4j.coreedge.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.coreedge.messaging.NetworkReadableClosableChannelNetty4;
@@ -39,9 +40,11 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.storageengine.api.StorageCommand;
 
+import static org.neo4j.io.ByteUnit.gibiBytes;
+
 public class ReplicatedTransactionFactory
 {
-    private static final long MAX_SERIALIZED_TX_SIZE = 1024 * 1024 * 1024L; // 1 GB
+    private static final long MAX_SERIALIZED_TX_SIZE = gibiBytes( 1 );
 
     public static ReplicatedTransaction createImmutableReplicatedTransaction( TransactionRepresentation tx  )
     {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/MessageTooBigException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/MessageTooBigException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.messaging;
+
+import java.io.IOException;
+
+/**
+ * Throwing an instance of this exception indicates that the creation or handling of a message failed because of
+ * size restrictions.
+ */
+public class MessageTooBigException extends IOException
+{
+    public MessageTooBigException( String message )
+    {
+        super( message );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/NetworkFlushableChannelNetty4.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/messaging/NetworkFlushableChannelNetty4.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.coreedge.messaging;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.Flushable;
 
-import io.netty.buffer.ByteBuf;
 import org.neo4j.kernel.impl.transaction.log.FlushableChannel;
 
 import static java.lang.String.format;
+import static org.neo4j.io.ByteUnit.mebiBytes;
 
 public class NetworkFlushableChannelNetty4 implements FlushableChannel
 {
@@ -33,7 +35,7 @@ public class NetworkFlushableChannelNetty4 implements FlushableChannel
      * value for that should be sufficient for all replicated state except for transactions, the size of which
      * is unbounded.
      */
-    private static final long DEFAULT_SIZE_LIMIT = 2 * 1024 * 1024; // 2 MB
+    private static final long DEFAULT_SIZE_LIMIT = mebiBytes( 2 );
 
     private final ByteBuf delegate;
     private final int initialWriterIndex;

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/messaging/NetworkFlushableChannelNetty4Test.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/messaging/NetworkFlushableChannelNetty4Test.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.messaging;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class NetworkFlushableChannelNetty4Test
+{
+    @Test
+    public void shouldRespectSizeLimit() throws Exception
+    {
+        // Given
+        int sizeLimit = 100;
+        NetworkFlushableChannelNetty4 channel = new NetworkFlushableChannelNetty4( Unpooled.buffer(), sizeLimit );
+
+        // when
+        for ( int i = 0; i < sizeLimit; i++ )
+        {
+            channel.put( (byte) 1 );
+        }
+
+        try
+        {
+            channel.put( (byte) 1 );
+            fail("Should not allow more bytes than what the limit dictates");
+        }
+        catch( MessageTooBigException e )
+        {
+            // then
+        }
+    }
+
+    @Test
+    public void sizeLimitShouldWorkWithArrays() throws Exception
+    {
+        // Given
+        int sizeLimit = 100;
+        NetworkFlushableChannelNetty4 channel = new NetworkFlushableChannelNetty4( Unpooled.buffer(), sizeLimit );
+
+        // When
+        int padding = 10;
+        for ( int i = 0; i < sizeLimit - padding; i++ )
+        {
+            channel.put( (byte) 0 );
+        }
+
+        try
+        {
+            channel.put( new byte[padding * 2], padding * 2 );
+            fail("Should not allow more bytes than what the limit dictates");
+        }
+        catch( MessageTooBigException e )
+        {
+            // then
+        }
+    }
+
+    @Test
+    public void shouldNotCountBytesAlreadyInBuffer() throws Exception
+    {
+        // Given
+        int sizeLimit = 100;
+        ByteBuf buffer = Unpooled.buffer();
+
+        int padding = Long.BYTES;
+        buffer.writeLong( 0 );
+
+        NetworkFlushableChannelNetty4 channel = new NetworkFlushableChannelNetty4( buffer, sizeLimit );
+
+        // When
+        for ( int i = 0; i < sizeLimit - padding; i++ )
+        {
+            channel.put( (byte) 0 );
+        }
+        // then it should be ok
+        // again, when
+        for ( int i = 0; i < padding; i++ )
+        {
+            channel.put( (byte) 0 );
+        }
+        // then again, it should work
+        // finally, when we pass the limit
+        try
+        {
+            channel.put( (byte) 0 );
+            fail("Should not allow more bytes than what the limit dictates");
+        }
+        catch( MessageTooBigException e )
+        {
+            // then
+        }
+    }
+}


### PR DESCRIPTION
Unless a limit is set on the size of Netty buffers used for serializing
 and sending messages, they can grow to occupy all of the direct memory
 available, leading to unrecoverable errors. This change allows for
 setting a ceiling to how big a buffer can grow.
This currently affects transaction state serialization, effectively
 limiting how big a transaction can get and still be eligible for
 replication in a CE cluster.
