### PR TITLE
Log helpful message in user log when unable to bind to CE ports.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/ClusteringModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/ClusteringModule.java
@@ -29,6 +29,7 @@ import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.LogProvider;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
@@ -23,6 +23,7 @@ import org.neo4j.coreedge.core.consensus.schedule.DelayedRenewableTimeoutService
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.LogProvider;
 
 public interface DiscoveryServiceFactory

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
@@ -24,6 +24,7 @@ import org.neo4j.coreedge.core.consensus.schedule.DelayedRenewableTimeoutService
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.LogProvider;
 
 public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -20,7 +20,6 @@
 package org.neo4j.coreedge.edge;
 
 import java.io.File;
-import java.io.IOException;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -52,7 +51,6 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
 import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryService.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryService.java
@@ -35,6 +35,7 @@ import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.LogProvider;
 
 import static java.util.Collections.unmodifiableMap;
@@ -42,7 +43,7 @@ import static java.util.Collections.unmodifiableSet;
 
 public class SharedDiscoveryService implements DiscoveryServiceFactory
 {
-    private final Map<MemberId, CoreAddresses> coreMembers = new HashMap<>(  );
+    private final Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
     private final Set<EdgeAddresses> edgeAddresses = new HashSet<>();
     private final List<SharedDiscoveryCoreClient> coreClients = new ArrayList<>();
 
@@ -61,7 +62,9 @@ public class SharedDiscoveryService implements DiscoveryServiceFactory
     }
 
     @Override
-    public TopologyService edgeDiscoveryService( Config config, AdvertisedSocketAddress boltAddress, LogProvider logProvider, DelayedRenewableTimeoutService timeoutService, long edgeTimeToLiveTimeout, long edgeRefreshRate )
+    public TopologyService edgeDiscoveryService( Config config, AdvertisedSocketAddress boltAddress,
+            LogProvider logProvider, DelayedRenewableTimeoutService timeoutService, long edgeTimeToLiveTimeout,
+            long edgeRefreshRate )
     {
         return new SharedDiscoveryEdgeClient( this, boltAddress, logProvider );
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryServiceIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryServiceIT.java
@@ -38,6 +38,7 @@ import org.neo4j.coreedge.core.consensus.RaftMachine;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConnectionInfoIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConnectionInfoIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.neo4j.coreedge.catchup.CatchupServer;
+import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.core.state.CoreState;
+import org.neo4j.coreedge.discovery.CoreTopologyService;
+import org.neo4j.coreedge.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.coreedge.identity.MemberId;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.coreedge.ClusterRule;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.discovery_listen_address;
+import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.transaction_listen_address;
+import static org.neo4j.kernel.configuration.Config.defaults;
+
+public class ConnectionInfoIT
+{
+    private Socket testSocket;
+
+    @Rule
+    public final ClusterRule clusterRule =
+            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfEdgeMembers( 0 );
+
+    @After
+    public void teardown() throws IOException
+    {
+        if ( testSocket != null )
+        {
+            unbind( testSocket );
+        }
+    }
+
+    @Test
+    public void catchupServerMessage() throws Throwable
+    {
+        // given
+        testSocket = bindPort( "localhost", 4242 );
+
+        // when
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        AssertableLogProvider userLogProvider = new AssertableLogProvider();
+        Supplier mockSupplier = mock( Supplier.class );
+        CoreState coreState = mock( CoreState.class );
+        Config config = Config.defaults()
+                .with( singletonMap( transaction_listen_address.name(), ":" + testSocket.getLocalPort() ) );
+
+        CatchupServer catchupServer =
+                new CatchupServer( logProvider, userLogProvider, mockSupplier, mockSupplier, mockSupplier, mockSupplier,
+                        mockSupplier, coreState, config, new Monitors() );
+
+        //then
+        try
+        {
+            catchupServer.start();
+        }
+        catch ( Throwable throwable )
+        {
+            //expected.
+        }
+        logProvider.assertContainsMessageContaining( "Address is already bound for setting" );
+        userLogProvider.assertContainsMessageContaining( "Address is already bound for setting" );
+    }
+
+    @Test
+    public void hzTest() throws Throwable
+    {
+        // given
+        testSocket = bindPort( "0.0.0.0", 4243 );
+
+        //when
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        AssertableLogProvider userLogProvider = new AssertableLogProvider();
+
+        HazelcastDiscoveryServiceFactory hzFactory = new HazelcastDiscoveryServiceFactory();
+        Config config =
+                defaults().with( singletonMap( discovery_listen_address.name(), ":" + testSocket.getLocalPort() ) );
+        config.augment( singletonMap( CoreEdgeClusterSettings.initial_discovery_members.name(),
+                "localhost:" + testSocket.getLocalPort() ) );
+        config.augment( singletonMap( GraphDatabaseSettings.boltConnector( "bolt" ).enabled.name(), "true" ) );
+
+        CoreTopologyService coreTopologyService = hzFactory
+                .coreTopologyService( config, new MemberId( UUID.randomUUID() ), logProvider, userLogProvider );
+
+        try
+        {
+            coreTopologyService.init();
+            coreTopologyService.start();
+        }
+
+        //then
+        catch ( Throwable throwable )
+        {
+            //expected
+        }
+
+        logProvider.assertContainsMessageContaining( "Hazelcast was unable to start with setting" );
+        userLogProvider.assertContainsMessageContaining( "Hazelcast was unable to start with setting" );
+    }
+
+    private Socket bindPort( String address, int port ) throws IOException
+    {
+        Socket socket = new Socket();
+        socket.bind( new InetSocketAddress( address, port ) );
+        return socket;
+    }
+
+    private void unbind( Socket socket ) throws IOException
+    {
+        socket.close();
+    }
+}


### PR DESCRIPTION
Currently errors with binding to an address result in a stacktrace in
the internal log. We still do that, but also with a reasonable
message that says which port and which setting is the one with the bind
issue. This helps in debugging erros when setting up CE.
