### PR TITLE
Write to STDERR for Powershell management scripts

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
@@ -64,6 +64,8 @@ Function Invoke-Neo4j
   {
     try 
     {
+      $HelpText = "Usage: neo4j { console | start | stop | restart | status | install-service | uninstall-service } < -Verbose >"
+
       # Determine the Neo4j Home Directory.  Uses the NEO4J_HOME enironment variable or a parent directory of this script
       $Neo4jHome = Get-Neo4jEnv 'NEO4J_HOME'
       if ( ($Neo4jHome -eq $null) -or (-not (Test-Path -Path $Neo4jHome)) ) {
@@ -85,9 +87,9 @@ Function Invoke-Neo4j
 
       switch ($Command.Trim().ToLower())
       {
-        "" {
-          Write-Host "Usage: neo4j { console | start | stop | restart | status | install-service | uninstall-service } < -Verbose >"
-          Return 1
+        "help" {
+          Write-Host $HelpText
+          Return 0
         }
         "console" {
           Write-Verbose "Console command specified"
@@ -121,8 +123,9 @@ Function Invoke-Neo4j
           Return [int](Uninstall-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
         }
         default {
-          Write-Host "Unknown command $Command"
-          Return 255
+          if ($Command -ne '') { Write-StdErr "Unknown command $Command" }
+          Write-StdErr $HelpText
+          Return 1
         }
       }
       # Should not get here!

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Write-StdErr.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Write-StdErr.ps1
@@ -1,0 +1,45 @@
+# Copyright (c) 2002-2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+<#
+.SYNOPSIS
+Writes a string to STDERR
+
+.DESCRIPTION
+Writes a string to STDERR.  Will use an appropriate function call depending on the Powershell Host.
+
+.PARAMETER Message
+A string to write
+
+.EXAMPLE
+Write-StdErr "This is a message"
+
+Outputs the string onto STDERR
+
+.NOTES
+This function is private to the powershell module
+
+#>
+Function Write-StdErr($Message) {
+  if ($Host.Name -eq 'ConsoleHost') { 
+    [Console]::Error.WriteLine($Message)
+  } else {
+    $host.UI.WriteErrorLine($Message)
+  }
+}


### PR DESCRIPTION
Previously the Powershell management scripts did not process the `help` command
correctly.  Also it would put the error message onto STDERR as is expected. This
commit changes the command behaviour to output the helptext and an exit code of
zero for the `help` command.  This commit also writes the error message for an
unknown command to STDERR instead of the default STDOUT.  This commit also
changes the exitcode for an unknown command from 255 to 1 to be more inline with
linux based management scripts.
