### PR TITLE
Add deprecation warning for neo4j-wrapper in Powershell management scripts

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jServer.ps1
@@ -148,6 +148,10 @@ Function Get-Neo4jServer
     if ( (Get-Neo4jEnv 'NEO4J_CONF') -eq $null) { Set-Neo4jEnv "NEO4J_CONF" $ConfDir }
     if ( (Get-Neo4jEnv 'NEO4J_HOME') -eq $null) { Set-Neo4jEnv "NEO4J_HOME" $Neo4jHome }
 
+    # Any deprecation warnings
+    $WrapperPath = Join-Path -Path $ConfDir -ChildPath 'neo4j-wrapper.conf'
+    If (Test-Path -Path $WrapperPath) { Write-Warning "$WrapperPath is deprecated and support for it will be removed in a future version of Neo4j; please move all your settings to neo4j.conf" }
+
     Write-Output $serverObject
   }
 

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jServer.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jServer.Tests.ps1
@@ -130,5 +130,17 @@ InModuleScope Neo4j-Management {
          Assert-MockCalled Set-Neo4jEnv -Times 0 -ParameterFilter { $Name -eq 'NEO4J_HOME' }
       }
     }
+
+    Context "Deprecation warning if a neo4j-wrapper.conf file is found" {
+      global:New-MockNeo4jInstall -RootDir 'TestDrive:\neo4j'
+      Mock Write-Warning
+ 
+      '# Mock File' | Out-File 'TestDrive:\neo4j\conf\neo4j-wrapper.conf'
+
+      It "Should raise a warning if conf\neo4j-wrapper.conf exists" {
+         $neoServer = Get-Neo4jServer -Neo4jHome 'TestDrive:\neo4j\' -ErrorAction Stop
+         Assert-MockCalled Write-Warning -Times 1
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously the Powershell Management scripts would silently accept any settings
in the `conf\neo4j-wrapper.conf` file.  This commit now writes a deprecation
warning whenever the powershell management scripts are run.  This is due to
`Get-Neo4jServer` being a primaary entrypoint for all management.  This commit
also adds a unit test to ensure the behaviour.  Note a similar warning was added
for the linux based scripts in commit 4cb3c97825772b35da98bed92c83f71589148308.
