### PR TITLE
Fix secure caching of authentication info

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
@@ -19,9 +19,13 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleRole;
+import org.apache.shiro.authz.permission.RolePermissionResolver;
 import org.apache.shiro.authz.permission.WildcardPermission;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -57,6 +61,23 @@ public class PredefinedRolesBuilder implements RolesBuilder
 
         return roles;
     }
+
+    public static final RolePermissionResolver rolePermissionResolver = new RolePermissionResolver()
+    {
+        @Override
+        public Collection<Permission> resolvePermissionsInRole( String roleString )
+        {
+            SimpleRole role = roles.get( roleString );
+            if ( role != null )
+            {
+                return role.getPermissions();
+            }
+            else
+            {
+                return Collections.emptyList();
+            }
+        }
+    };
 
     @Override
     public Map<String,SimpleRole> buildRoles()

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
@@ -100,6 +100,19 @@ public class SecuritySettings
     public static final Setting<String> ldap_user_dn_template =
             setting( "dbms.security.realms.ldap.user_dn_template", STRING, "uid={0},ou=users,dc=example,dc=com" );
 
+    @Description( "Determines if the result of authentication via the LDAP server should be cached or not. " +
+                  "Caching is used to limit the number of LDAP requests that have to be made over the network " +
+                  "for users that have already been authenticated successfully. A user can be authenticated against " +
+                  "an existing cache entry (instead of via an LDAP server) as long as it is alive " +
+                  "(see `dbms.security.realms.auth_cache_ttl`).\n" +
+                  "An important consequence of setting this to `true` than needs to be well understood, is that " +
+                  "Neo4j then needs to cache a hashed version of the credentials in order to perform credentials " +
+                  "matching. This hashing is done using a cryptographic hash function together with a random salt. " +
+                  "Preferably a conscious decision should be made if this method is considered acceptable by " +
+                  "the security standards of the organization in which this Neo4j instance is deployed." )
+    public static final Setting<Boolean> ldap_authentication_cache_enabled =
+            setting( "dbms.security.realms.ldap.authentication_cache_enabled", BOOLEAN, "true" );
+
     @Description( "Perform LDAP search for authorization info using a system account." )
     public static final Setting<Boolean> ldap_authorization_use_system_account =
             setting( "dbms.security.realms.ldap.authorization.use_system_account", BOOLEAN, "false" );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
@@ -21,13 +21,12 @@ package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.util.ByteSource;
 
 import org.neo4j.kernel.api.security.AuthenticationResult;
+import org.neo4j.server.security.auth.Credential;
 
-import static org.neo4j.kernel.api.security.AuthenticationResult.FAILURE;
-import static org.neo4j.kernel.api.security.AuthenticationResult.PASSWORD_CHANGE_REQUIRED;
-import static org.neo4j.kernel.api.security.AuthenticationResult.SUCCESS;
-import static org.neo4j.kernel.api.security.AuthenticationResult.TOO_MANY_ATTEMPTS;
+import static org.neo4j.kernel.api.security.AuthenticationResult.*;
 
 public class ShiroAuthenticationInfo extends SimpleAuthenticationInfo
 {
@@ -39,11 +38,17 @@ public class ShiroAuthenticationInfo extends SimpleAuthenticationInfo
         this.authenticationResult = AuthenticationResult.FAILURE;
     }
 
-    public ShiroAuthenticationInfo( Object principal, Object credentials, String realmName,
+    public ShiroAuthenticationInfo( Object principal, String credentials, String realmName,
             AuthenticationResult authenticationResult )
     {
-        super( principal, credentials, realmName );
+        super( principal, null, realmName );
         this.authenticationResult = authenticationResult;
+        if ( credentials != null )
+        {
+            Credential hashedCredentials = Credential.forPassword( credentials );
+            setCredentials( hashedCredentials.passwordHash() );
+            setCredentialsSalt( ByteSource.Util.bytes( hashedCredentials.salt() ) );
+        }
     }
 
     public AuthenticationResult getAuthenticationResult()

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
@@ -83,6 +83,7 @@ public class LdapRealmTest
 
         when( config.get( SecuritySettings.ldap_authentication_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.ldap_authorization_enabled ) ).thenReturn( true );
+        when( config.get( SecuritySettings.ldap_authentication_cache_enabled ) ).thenReturn( false );
     }
 
     @Test


### PR DESCRIPTION
When caching the result of LDAP authentication, the credentials needs to be
stored in order to perform credentials matching against the cached
authentication info. This is done by hashing the credentials with a random salt.
- Use HashedCredentialsMatcher in LdapRealm
- Adds new setting dbms.security.realms.ldap.authentication_cache_enabled
- Move rolePermissionResolver to PredefinedRolesBuilder

This fixes a serious bug where you could previously authenticate against an
existing user's cached authentication result without supplying correct
credentials.
