### PR TITLE
Added procedure to clear authentication and authorization cache

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
@@ -401,6 +401,13 @@ public class AuthProcedures
         }
     }
 
+    @Description( "Clears authentication and authorization cache." )
+    @Procedure( name = "dbms.security.clearAuthCache", mode = DBMS )
+    public void clearAuthenticationCache()
+    {
+        ensureAdminAuthSubject().clearAuthCache();
+    }
+
     // ----------------- helpers ---------------------
 
     protected void terminateTransactionsForValidUser( String username )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManager.java
@@ -24,4 +24,6 @@ import org.neo4j.kernel.api.security.AuthManager;
 public interface EnterpriseAuthManager extends AuthManager
 {
     EnterpriseUserManager getUserManager();
+
+    void clearAuthCache();
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -20,14 +20,19 @@
 package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.ExcessiveAttemptsException;
 import org.apache.shiro.authc.pam.ModularRealmAuthenticator;
 import org.apache.shiro.authc.pam.UnsupportedTokenException;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.cache.Cache;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.DefaultSessionStorageEvaluator;
 import org.apache.shiro.mgt.DefaultSubjectDAO;
 import org.apache.shiro.mgt.SubjectDAO;
+import org.apache.shiro.realm.AuthenticatingRealm;
+import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.realm.CachingRealm;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.util.Initializable;
@@ -188,5 +193,29 @@ class MultiRealmAuthManager implements EnterpriseAuthManager, UserManagerSupplie
     public EnterpriseUserManager getUserManager()
     {
         return userManager;
+    }
+
+    @Override
+    public void clearAuthCache()
+    {
+        for ( Realm realm : realms )
+        {
+            if ( realm instanceof AuthenticatingRealm )
+            {
+                Cache<Object,AuthenticationInfo> cache = ((AuthenticatingRealm) realm).getAuthenticationCache();
+                if ( cache != null )
+                {
+                    cache.clear();
+                }
+            }
+            if ( realm instanceof AuthorizingRealm )
+            {
+                Cache<Object,AuthorizationInfo> cache = ((AuthorizingRealm) realm).getAuthorizationCache();
+                if ( cache != null )
+                {
+                    cache.clear();
+                }
+            }
+        }
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -96,6 +96,11 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
         return authManager.getUserManager();
     }
 
+    public void clearAuthCache()
+    {
+        authManager.clearAuthCache();
+    }
+
     @Override
     public boolean isAdmin()
     {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
@@ -74,9 +74,8 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
                 }
                 return false;
             } );
-            assertThat( securityProcedures.count(), equalTo( 15L ) );
+            assertThat( securityProcedures.count(), equalTo( 16L ) );
         } );
-
     }
 
     //---------- Change own password -----------
@@ -869,6 +868,23 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
         testFailListRoleUsers( readSubject, ADMIN, PERMISSION_DENIED );
         testFailListRoleUsers( writeSubject, ADMIN, PERMISSION_DENIED );
         testFailListRoleUsers( schemaSubject, ADMIN, PERMISSION_DENIED );
+    }
+
+    //---------- clearing authentication cache -----------
+
+    @Test
+    public void shouldAllowClearAuthCacheIfAdmin() throws Exception
+    {
+        assertEmpty( adminSubject, "CALL dbms.security.clearAuthCache()" );
+    }
+
+    @Test
+    public void shouldNotClearAuthCacheIfNotAdmin() throws Exception
+    {
+        assertFail( pwdSubject, "CALL dbms.security.clearAuthCache()", CHANGE_PWD_ERR_MSG );
+        assertFail( readSubject, "CALL dbms.security.clearAuthCache()", PERMISSION_DENIED );
+        assertFail( writeSubject, "CALL dbms.security.clearAuthCache()", PERMISSION_DENIED );
+        assertFail( schemaSubject, "CALL dbms.security.clearAuthCache()", PERMISSION_DENIED );
     }
 
     //---------- permissions -----------

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -174,6 +174,29 @@ public class LdapCachingTest
         assertThat( "Test realm did not received a call", testRealm.takeAuthenticationFlag(), is( true ) );
     }
 
+    @Test
+    public void shouldInvalidateAuthenticationCacheOnDemand() throws InvalidAuthTokenException
+    {
+        // Given
+        Map<String,Object> mike = authToken( "mike", "123" );
+        authManager.login( mike );
+        assertThat( "Test realm did not receive a call", testRealm.takeAuthenticationFlag(), is( true ) );
+
+        // When
+        fakeTicker.advance( 2, TimeUnit.MILLISECONDS );
+        authManager.login( mike );
+
+        // Then
+        assertThat( "Test realm received a call", testRealm.takeAuthenticationFlag(), is( false ) );
+
+        // When
+        authManager.clearAuthCache();
+        authManager.login( mike );
+
+        // Then
+        assertThat( "Test realm did not receive a call", testRealm.takeAuthenticationFlag(), is( true ) );
+    }
+
     private class TestRealm extends LdapRealm
     {
         private boolean authenticationFlag = false;


### PR DESCRIPTION
Added procedure to allow an administrator to force clearing of all cached authentication and authorization information.

changelog: Added procedure to clear authentication and authorization cache so admin can accelerate changes from cached providers like LDAP
