### PR TITLE
Handle equivalence of collections containing null

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Equivalent.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Equivalent.scala
@@ -127,7 +127,7 @@ object Equivalent {
     if (it.isEmpty) return (e1, e2, e3)
 
     it.foldLeft(ArrayBuffer(e1, e2, e3)) {
-      case (acc, element: T) => acc += eager(element)
+      case (acc, element) => acc += eager(element)
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/EquivalentTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/EquivalentTest.scala
@@ -130,6 +130,7 @@ class EquivalentTest extends CypherFunSuite {
   shouldMatch(Array[Int](1, 2, 3), asList(1, 2, 3))
 
   shouldMatch(asList(1, 2, 3), asList(1L, 2L, 3L))
+  shouldMatch(asList(1, 2, 3, null), asList(1L, 2L, 3L, null))
   shouldMatch(Array[Int](1, 2, 3), asList(1L, 2L, 3L))
   shouldMatch(Array[Int](1, 2, 3), asList(1.0D, 2.0D, 3.0D))
   shouldMatch(Array[Any](1, Array[Int](2, 2), 3), asList(1.0D, asList(2.0D, 2.0D), 3.0D))


### PR DESCRIPTION
 The code was expecting all elements to be of the same base class, but `null` does
 not follow this rule.
