### PR TITLE
Fixes an issue with concurrently reading log during rotation

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
@@ -160,7 +160,8 @@ public class TargetDirectory
                     if ( e.getCause() != null &&
                             e.getCause() instanceof FileUtils.MaybeWindowsMemoryMappedFileReleaseProblem )
                     {
-                        System.err.println( "Failed to delete test directory, maybe due to Windows memory-mapped file problem" );
+                        System.err.println( "Failed to delete test directory, " +
+                                "maybe due to Windows memory-mapped file problem: " + e.getCause().getMessage() );
                     }
                     else
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/TransactionStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/TransactionStream.java
@@ -229,7 +229,7 @@ class TransactionStream
             this.file = file;
             try ( StoreChannel channel = fs.open( file, "r" ) )
             {
-                header = readLogHeader( buffer, channel, false );
+                header = readLogHeader( buffer, channel, false, file );
 
                 try ( IOCursor<LogEntry> cursor = logEntryCursor( logEntryReader, channel, header ) )
                 {
@@ -297,7 +297,7 @@ class TransactionStream
         StoreChannel channel = fs.open( file.file, "r" );
         try
         {
-            LogHeader header = readLogHeader( buffer, channel, false );
+            LogHeader header = readLogHeader( buffer, channel, false, file.file );
             if ( !header.equals( file.header ) )
             {
                 throw new IOException( "Files have changed on disk." );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigratorCheckPointer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigratorCheckPointer.java
@@ -66,7 +66,7 @@ public class StoreMigratorCheckPointer
         }
 
         try ( LogVersionedStoreChannel storeChannel =
-                      PhysicalLogFile.openForVersion( logFiles, fileSystem, logVersion ) )
+                      PhysicalLogFile.openForVersion( logFiles, fileSystem, logVersion, true ) )
         {
             long offset = storeChannel.size();
             storeChannel.position( offset );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryReader.java
@@ -63,7 +63,7 @@ class LegacyLogEntryReader
     {
         final StoreChannel rawChannel = fs.open( logFile, "r" );
 
-        final LogHeader header = readLogHeader( ByteBuffer.allocate( LOG_HEADER_SIZE ), rawChannel, false );
+        final LogHeader header = readLogHeader( ByteBuffer.allocate( LOG_HEADER_SIZE ), rawChannel, false, logFile );
         LogEntryReader<ReadableLogChannel> reader = readerFactory.apply( header );
 
         // this ensures that the last committed txId field in the header is initialized properly

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -91,7 +91,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
     {
         // Make sure at least a bare bones log file is available before recovery
         long lastLogVersionUsed = logVersionRepository.getCurrentLogVersion();
-        channel = openLogChannelForVersion( lastLogVersionUsed );
+        channel = createLogChannelForVersion( lastLogVersionUsed );
         channel.close();
     }
 
@@ -102,7 +102,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
         // Just read header and move to the end
 
         long lastLogVersionUsed = logVersionRepository.getCurrentLogVersion();
-        channel = openLogChannelForVersion( lastLogVersionUsed );
+        channel = createLogChannelForVersion( lastLogVersionUsed );
         // Move to the end
         channel.position( channel.size() );
 
@@ -142,6 +142,49 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
         writer.setChannel( channel );
     }
 
+    /**
+     * Rotates the current log file, continuing into next (version) log file.
+     * This method must be recovery safe, which means a crash at any point should be recoverable.
+     * Concurrent readers must also be able to parry for concurrent rotation.
+     * Concurrent writes will not be an issue since rotation and writing contends on the same monitor.
+     *
+     * Steps during rotation are:
+     * <ol>
+     * <li>1: Increment log version, {@link LogVersionRepository#incrementAndGetVersion()} (also flushes the store)</li>
+     * <li>2: Flush current log</li>
+     * <li>3: Create new log file</li>
+     * <li>4: Write header</li>
+     * </ol>
+     *
+     * Recovery: what happens if crash between:
+     * <ol>
+     * <li>1-2: New log version has been set, starting the writer will create the new log file idempotently.
+     * At this point there may have been half-written transactions in the previous log version,
+     * although they haven't been considered committed and so they will be truncated from log during recovery</li>
+     * <li>2-3: New log version has been set, starting the writer will create the new log file idempotently.
+     * At this point there may be complete transactions in the previous log version which may not have been
+     * acknowledged to be committed back to the user, but will be considered committed anyway.</li>
+     * <li>3-4: New log version has been set, starting the writer will see that the new file exists and
+     * will be forgiving when trying to read the header of it, so that if it isn't complete a fresh
+     * header will be set (TODO actually there's a problem here where the last committed tx from
+     * {@link TransactionIdStore} is read and placed in the new header before recovery is completed, which means
+     * that, reading (2-3), this number may be a lower number than what the previous log actually contains</li>
+     * </ol>
+     *
+     * Reading: what happens when rotation is between:
+     * <ol>
+     * <li>1-2: Reader bridge will see that there's a new version (when asking {@link LogVersionRepository}
+     * and try to open it. The log file doesn't exist yet though. The bridge can parry for this by catching
+     * {@link FileNotFoundException} and tell the reader that the stream has ended</li>
+     * <li>2-3: Same as (1-2)</li>
+     * <li>3-4: Here the new log file exists, but the header may not be fully written yet.
+     * TODO currently the reader will fail when trying to read the header since it's reading it strictly</li>
+     * </ol>
+     *
+     * @param currentLog current {@link LogVersionedStoreChannel channel} to flush and close.
+     * @return the channel of the newly opened/created log file.
+     * @throws IOException if an error regarding closing or opening log files occur.
+     */
     private PhysicalLogVersionedStoreChannel rotate( LogVersionedStoreChannel currentLog ) throws IOException
     {
         /*
@@ -164,16 +207,26 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
          * Note that by this point, rotation is done. The next few lines are
          * "simply overhead" for continuing to work with the new file.
          */
-        PhysicalLogVersionedStoreChannel newLog = openLogChannelForVersion( newLogVersion );
+        PhysicalLogVersionedStoreChannel newLog = createLogChannelForVersion( newLogVersion );
         currentLog.close();
         return newLog;
     }
 
-    private PhysicalLogVersionedStoreChannel openLogChannelForVersion( long forVersion ) throws IOException
+    /**
+     * Creates a new channel for the specified version, creating the backing file if it doesn't already exist.
+     * If the file exists then the header is verified to be of correct version. Having an existing file there
+     * could happen after a previous crash in the middle of rotation, where the new file was created,
+     * but the incremented log version changed hadn't made it to persistent storage.
+     *
+     * @param forVersion log version for the file/channel to create.
+     * @return {@link PhysicalLogVersionedStoreChannel} for newly created/opened log file.
+     * @throws IOException if there's any I/O related error.
+     */
+    private PhysicalLogVersionedStoreChannel createLogChannelForVersion( long forVersion ) throws IOException
     {
         File toOpen = logFiles.getLogFileForVersion( forVersion );
         StoreChannel storeChannel = fileSystem.open( toOpen, "rw" );
-        LogHeader header = readLogHeader( headerBuffer, storeChannel, false );
+        LogHeader header = readLogHeader( headerBuffer, storeChannel, false, toOpen );
         if ( header == null )
         {
             // Either the header is not there in full or the file was new. Don't care
@@ -196,14 +249,15 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
     @Override
     public ReadableLogChannel getReader( LogPosition position ) throws IOException
     {
-        PhysicalLogVersionedStoreChannel logChannel = openForVersion( logFiles, fileSystem, position.getLogVersion() );
+        PhysicalLogVersionedStoreChannel logChannel =
+                openForVersion( logFiles, fileSystem, position.getLogVersion(), false );
         logChannel.position( position.getByteOffset() );
         return new ReadAheadLogChannel( logChannel, readerLogVersionBridge );
     }
 
     public static PhysicalLogVersionedStoreChannel openForVersion( PhysicalLogFiles logFiles,
             FileSystemAbstraction fileSystem,
-            long version ) throws IOException
+            long version, boolean write ) throws IOException
     {
         final File fileToOpen = logFiles.getLogFileForVersion( version );
 
@@ -213,31 +267,45 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
                     fileToOpen.getCanonicalPath() ) );
         }
 
-        StoreChannel rawChannel;
+        StoreChannel rawChannel = null;
+        boolean successful = false;
         try
         {
-            rawChannel = fileSystem.open( fileToOpen, "rw" );
+            rawChannel = fileSystem.open( fileToOpen, write ? "rw" : "r" );
+
+            ByteBuffer buffer = ByteBuffer.allocate( LOG_HEADER_SIZE );
+            LogHeader header = readLogHeader( buffer, rawChannel, true, fileToOpen );
+            assert header != null && header.logVersion == version;
+            PhysicalLogVersionedStoreChannel result =
+                    new PhysicalLogVersionedStoreChannel( rawChannel, version, header.logFormatVersion );
+            successful = true;
+            return result;
         }
         catch ( FileNotFoundException cause )
         {
             throw Exceptions.withCause( new FileNotFoundException( String.format( "File could not be opened [%s]",
                     fileToOpen.getCanonicalPath() ) ), cause );
         }
-
-        ByteBuffer buffer = ByteBuffer.allocate( LOG_HEADER_SIZE );
-        LogHeader header = readLogHeader( buffer, rawChannel, true );
-        assert header != null && header.logVersion == version;
-
-        return new PhysicalLogVersionedStoreChannel( rawChannel, version, header.logFormatVersion );
+        finally
+        {
+            if (    // we managed to open the file
+                    rawChannel != null &&
+                    // but we didn't successfully do the rest, f.ex. reading the header
+                    !successful )
+            {
+                // then close the channel
+                rawChannel.close();
+                // ... and the exception causing us to not be successful will be thrown
+            }
+        }
     }
 
-
     public static PhysicalLogVersionedStoreChannel tryOpenForVersion( PhysicalLogFiles logFiles,
-            FileSystemAbstraction fileSystem, long version )
+            FileSystemAbstraction fileSystem, long version, boolean write )
     {
         try
         {
-            return openForVersion( logFiles, fileSystem, version );
+            return openForVersion( logFiles, fileSystem, version, write );
         }
         catch ( IOException ex )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReaderLogVersionBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReaderLogVersionBridge.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.log.entry.IncompleteLogHeaderException;
 
 import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.openForVersion;
 
@@ -47,10 +48,11 @@ public class ReaderLogVersionBridge implements LogVersionBridge
         PhysicalLogVersionedStoreChannel nextChannel;
         try
         {
-            nextChannel = openForVersion( logFiles, fileSystem, channel.getVersion() + 1 );
+            nextChannel = openForVersion( logFiles, fileSystem, channel.getVersion() + 1, false );
         }
-        catch ( FileNotFoundException e )
+        catch ( FileNotFoundException | IncompleteLogHeaderException e )
         {
+            // See PhysicalLogFile#rotate() for description as to why these exceptions are OK
             return channel;
         }
         channel.close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.transaction.log.entry;
 import java.io.File;
 import java.io.IOException;
 
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
+
 /**
  * Used to signal an incomplete log header, i.e. if file is smaller than the header.
  * This exception is still an {@link IOException}, but a specific subclass of it as to make possible
@@ -31,12 +33,22 @@ public class IncompleteLogHeaderException extends IOException
 {
     public IncompleteLogHeaderException( File file, int readSize )
     {
-        super( "Unable to read log version and last committed tx from '" + file.getAbsolutePath() + "', " +
-                "was only able to read " + readSize + " bytes" );
+        super( template( file, readSize ) );
     }
 
     public IncompleteLogHeaderException( int readSize )
     {
-        super( "Unable to read log version and last committed tx, was only able to read " + readSize + " bytes" );
+        super( template( null, readSize ) );
+    }
+
+    private static String template( File file, int readSize )
+    {
+        StringBuilder builder = new StringBuilder( "Unable to read log version and last committed tx" );
+        if ( file != null )
+        {
+            builder.append( " from '" + file.getAbsolutePath() + "'" );
+        }
+        builder.append( ". Was only able to read " + readSize + " bytes, but was expecting " + LOG_HEADER_SIZE );
+        return builder.toString();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/IncompleteLogHeaderException.java
@@ -17,29 +17,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.transaction;
+package org.neo4j.kernel.impl.transaction.log.entry;
 
-import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
+import java.io.File;
+import java.io.IOException;
 
-public class DeadSimpleLogVersionRepository implements LogVersionRepository
+/**
+ * Used to signal an incomplete log header, i.e. if file is smaller than the header.
+ * This exception is still an {@link IOException}, but a specific subclass of it as to make possible
+ * special handling.
+ */
+public class IncompleteLogHeaderException extends IOException
 {
-    private volatile long logVersion;
-
-    public DeadSimpleLogVersionRepository( long initialLogVersion )
+    public IncompleteLogHeaderException( File file, int readSize )
     {
-        this.logVersion = initialLogVersion;
+        super( "Unable to read log version and last committed tx from '" + file.getAbsolutePath() + "', " +
+                "was only able to read " + readSize + " bytes" );
     }
 
-    @Override
-    public long incrementAndGetVersion()
+    public IncompleteLogHeaderException( int readSize )
     {
-        logVersion++;
-        return logVersion;
-    }
-
-    @Override
-    public long getCurrentLogVersion()
-    {
-        return logVersion;
+        super( "Unable to read log version and last committed tx, was only able to read " + readSize + " bytes" );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
@@ -36,12 +36,28 @@ public class LogHeaderReader
     {
         try ( StoreChannel channel = fileSystem.open( file, "r" ) )
         {
-            return readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), channel, true );
+            return readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), channel, true, file );
         }
     }
 
-    public static LogHeader readLogHeader( ByteBuffer buffer, ReadableByteChannel channel, boolean strict )
-            throws IOException
+    /**
+     * Reads the header of a log. Data will be read from {@code channel} using supplied {@code buffer}
+     * as to allow more controlled allocation.
+     *
+     * @param buffer {@link ByteBuffer} to read into. Passed in to allow control over allocation.
+     * @param channel {@link ReadableByteChannel} to read from, typically a channel over a file containing the data.
+     * @param strict if {@code true} then will fail with {@link IncompleteLogHeaderException} on incomplete
+     * header, i.e. if there's not enough data in the channel to even read the header. If {@code false} then
+     * the return value will instead be {@code null}.
+     * @param fileForAdditionalErrorInformationOrNull when in {@code strict} mode the exception can be
+     * amended with information about which file the channel represents, if any. Purely for better forensics
+     * ability.
+     * @return {@link LogHeader} containing the log header data from the {@code channel}.
+     * @throws IOException if unable to read from {@code channel}
+     * @throws IncompleteLogHeaderException if {@code strict} and not enough data could be read
+     */
+    public static LogHeader readLogHeader( ByteBuffer buffer, ReadableByteChannel channel, boolean strict,
+            File fileForAdditionalErrorInformationOrNull ) throws IOException
     {
         buffer.clear();
         buffer.limit( LOG_HEADER_SIZE );
@@ -51,7 +67,11 @@ public class LogHeaderReader
         {
             if ( strict )
             {
-                throw new IOException( "Unable to read log version and last committed tx" );
+                if ( fileForAdditionalErrorInformationOrNull != null )
+                {
+                    throw new IncompleteLogHeaderException( fileForAdditionalErrorInformationOrNull, read );
+                }
+                throw new IncompleteLogHeaderException( read );
             }
             return null;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -59,7 +59,8 @@ public class LatestCheckPointFinder
         long oldestVersionFound = -1;
         while ( version >= INITIAL_LOG_VERSION )
         {
-            LogVersionedStoreChannel channel = PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem, version );
+            LogVersionedStoreChannel channel =
+                    PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem, version, false );
             if ( channel == null )
             {
                 return new LatestCheckPoint( null, false, oldestVersionFound );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogMatchers.java
@@ -59,10 +59,11 @@ public class LogMatchers
 {
     public static List<LogEntry> logEntries( FileSystemAbstraction fileSystem, String logPath ) throws IOException
     {
-        StoreChannel fileChannel = fileSystem.open( new File( logPath ), "r" );
+        File logFile = new File( logPath );
+        StoreChannel fileChannel = fileSystem.open( logFile, "r" );
 
         // Always a header
-        LogHeader header = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, true );
+        LogHeader header = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, true, logFile );
 
         // Read all log entries
         PhysicalLogVersionedStoreChannel versionedStoreChannel =

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
@@ -35,8 +35,8 @@ import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.ReaderLogVersionBridge;
-
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -67,7 +67,7 @@ public class ReaderLogVersionBridgeTest
         when( channel.getLogFormatVersion() ).thenReturn( CURRENT_LOG_VERSION );
         when( logFiles.getLogFileForVersion( version + 1 ) ).thenReturn( file );
         when( fs.fileExists( file ) ).thenReturn( true );
-        when( fs.open( file, "rw" ) ).thenReturn( newStoreChannel );
+        when( fs.open( file, "r" ) ).thenReturn( newStoreChannel );
         when( newStoreChannel.read( Matchers.<ByteBuffer>any() ) ).then( new Answer<Integer>()
         {
             @Override
@@ -98,7 +98,28 @@ public class ReaderLogVersionBridgeTest
 
         when( channel.getVersion() ).thenReturn( version );
         when( logFiles.getLogFileForVersion( version + 1 ) ).thenReturn( file );
-        when( fs.open( file, "rw" ) ).thenThrow( new FileNotFoundException() );
+        when( fs.open( file, "r" ) ).thenThrow( new FileNotFoundException() );
+
+        // when
+        final LogVersionedStoreChannel result = bridge.next( channel );
+
+        // then
+        assertEquals( channel, result );
+        verify( channel, never() ).close();
+    }
+
+    @Test
+    public void shouldReturnOldChannelWhenNextChannelHasntGottenCompleteHeaderYet() throws Exception
+    {
+        // given
+        final ReaderLogVersionBridge bridge = new ReaderLogVersionBridge( fs, logFiles );
+        final StoreChannel nextVersionWithIncompleteHeader = mock( StoreChannel.class );
+        when( nextVersionWithIncompleteHeader.read( any( ByteBuffer.class ) ) ).thenReturn( LOG_HEADER_SIZE / 2 );
+
+        when( channel.getVersion() ).thenReturn( version );
+        when( fs.fileExists( file ) ).thenReturn( true );
+        when( logFiles.getLogFileForVersion( version + 1 ) ).thenReturn( file );
+        when( fs.open( file, "r" ) ).thenReturn( nextVersionWithIncompleteHeader );
 
         // when
         final LogVersionedStoreChannel result = bridge.next( channel );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileRotateAndReadRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileRotateAndReadRaceIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.storageengine.api.ReadPastEndException;
+import org.neo4j.test.OtherThreadRule;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
+
+import static org.mockito.Mockito.mock;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.io.ByteUnit.kibiBytes;
+
+/**
+ * Tests an issue where writer would append data and sometimes rotate the log to new file. When rotating the log
+ * there's an intricate relationship between {@link LogVersionRepository}, creating the file and writing
+ * the header. Concurrent readers which scans the log stream will use {@link LogVersionBridge} to seemlessly
+ * jump over to new files, where the highest file is dictated by {@link LogVersionRepository#getCurrentLogVersion()}.
+ * There was this race where the log version was incremented, the new log file created and reader would get
+ * to this new file and try to read the header and fail before the header had been written.
+ *
+ * This test tries to reproduce this race. It will not produce false negatives, but sometimes false positives
+ * since it's non-deterministic.
+ */
+public class PhysicalLogFileRotateAndReadRaceIT
+{
+    private final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    private final LifeRule life = new LifeRule( true );
+    private final OtherThreadRule<Void> t2 = new OtherThreadRule<>( getClass().getName() + "-T2" );
+    @Rule
+    public final RuleChain rules = RuleChain.outerRule( directory ).around( life ).around( t2 );
+
+    // If any of these limits are reached the test ends, that or if there's a failure of course
+    private static final long LIMIT_TIME = SECONDS.toMillis( 5 );
+    private static final int LIMIT_ROTATIONS = 500;
+    private static final int LIMIT_READS = 1_000;
+
+    @Test
+    public void shouldNotSeeEmptyLogFileWhenReadingTransactionStream() throws Exception
+    {
+        // GIVEN
+        FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( directory.directory(), fileSystem );
+        LogVersionRepository logVersionRepository = new DeadSimpleLogVersionRepository( 0 );
+        PhysicalLogFile.Monitor monitor = mock( PhysicalLogFile.Monitor.class );
+        LogHeaderCache headerCache = new LogHeaderCache( 10 );
+        PhysicalLogFile logFile = life.add( new PhysicalLogFile( fileSystem, logFiles, kibiBytes( 1 ),
+                () -> 2L, logVersionRepository, monitor, headerCache ) );
+        FlushablePositionAwareChannel writer = logFile.getWriter();
+        LogPositionMarker startPosition = new LogPositionMarker();
+        writer.getCurrentPosition( startPosition );
+
+        // WHEN
+        AtomicBoolean end = new AtomicBoolean();
+        byte[] dataChunk = new byte[100];
+        // one thread constantly writing to and rotating the channel
+        AtomicInteger rotations = new AtomicInteger();
+        Future<Void> writeFuture = t2.execute( ignored ->
+        {
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            while ( !end.get() )
+            {
+                writer.put( dataChunk, random.nextInt( 1, dataChunk.length ) );
+                if ( logFile.rotationNeeded() )
+                {
+                    logFile.rotate();
+                    // Let's just close the gap to the reader so that it gets closer to the "hot zone"
+                    // where the rotation happens.
+                    writer.getCurrentPosition( startPosition );
+                    rotations.incrementAndGet();
+                }
+            }
+            return null;
+        } );
+        // one thread reading through the channel
+        long maxEndTime = currentTimeMillis() + LIMIT_TIME;
+        int reads = 0;
+        try
+        {
+            for ( ; currentTimeMillis() < maxEndTime &&
+                    reads < LIMIT_READS &&
+                    rotations.get() < LIMIT_ROTATIONS; reads++ )
+            {
+                try ( ReadableLogChannel reader = logFile.getReader( startPosition.newPosition() ) )
+                {
+                    deplete( reader );
+                }
+            }
+        }
+        finally
+        {
+            end.set( true );
+            writeFuture.get();
+        }
+
+        // THEN simply getting here means this was successful
+    }
+
+    private void deplete( ReadableLogChannel reader )
+    {
+        byte[] dataChunk = new byte[100];
+        try
+        {
+            while ( true )
+            {
+                reader.get( dataChunk, dataChunk.length );
+            }
+        }
+        catch ( ReadPastEndException e )
+        {
+            // This is OK, it means we've reached the end
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
@@ -24,13 +24,16 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
 import org.neo4j.kernel.impl.transaction.DeadSimpleTransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.Monitor;
+import org.neo4j.kernel.impl.transaction.log.entry.IncompleteLogHeaderException;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.test.TargetDirectory;
@@ -39,7 +42,14 @@ import org.neo4j.test.TargetDirectory.TestDirectory;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
@@ -195,6 +205,33 @@ public class PhysicalLogFileTest
         }, mark.newPosition() );
         assertTrue( called.get() );
         life.shutdown();
+    }
+
+    @Test
+    public void shouldCloseChannelInFailedAttemptToReadHeaderAfterOpen() throws Exception
+    {
+        // GIVEN a file which returns 1/2 log header size worth of bytes
+        File directory = new File( "/dir" );
+        FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( directory, fs );
+        int logVersion = 0;
+        File logFile = logFiles.getLogFileForVersion( logVersion );
+        StoreChannel channel = mock( StoreChannel.class );
+        when( channel.read( any( ByteBuffer.class ) ) ).thenReturn( LogHeader.LOG_HEADER_SIZE / 2 );
+        when( fs.fileExists( logFile ) ).thenReturn( true );
+        when( fs.open( eq( logFile ), anyString() ) ).thenReturn( channel );
+
+        // WHEN
+        try
+        {
+            PhysicalLogFile.openForVersion( logFiles, fs, logVersion, false );
+            fail( "Should have failed" );
+        }
+        catch ( IncompleteLogHeaderException e )
+        {
+            // THEN good
+            verify( channel ).close();
+        }
     }
 
     private byte[] readBytes( ReadableClosableChannel reader, int length ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
@@ -213,7 +213,8 @@ public class CheckPointerIntegrationTest
             List<CheckPoint> checkPoints = new ArrayList<>();
             for (; version >= INITIAL_LOG_VERSION; version-- )
             {
-                LogVersionedStoreChannel channel = PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem, version );
+                LogVersionedStoreChannel channel =
+                        PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem, version, false );
                 if ( channel == null )
                 {
                     break;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.transaction.log.InMemoryClosableChannel;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,7 +69,7 @@ public class LogHeaderReaderTest
         } );
 
         // when
-        final LogHeader result = readLogHeader( buffer, channel, true );
+        final LogHeader result = readLogHeader( buffer, channel, true, null );
 
         // then
         assertEquals( new LogHeader( CURRENT_LOG_VERSION, expectedLogVersion, expectedTxId ), result );
@@ -86,13 +87,12 @@ public class LogHeaderReaderTest
         try
         {
             // when
-            readLogHeader( buffer, channel, true );
+            readLogHeader( buffer, channel, true, null );
             fail( "should have thrown" );
         }
-        catch ( IOException ex )
+        catch ( IncompleteLogHeaderException ex )
         {
-            // then
-            assertEquals( "Unable to read log version and last committed tx", ex.getMessage() );
+            // then good
         }
     }
 
@@ -132,10 +132,10 @@ public class LogHeaderReaderTest
             readLogHeader( fs, file );
             fail( "should have thrown" );
         }
-        catch ( IOException ex )
+        catch ( IncompleteLogHeaderException ex )
         {
             // then
-            assertEquals( "Unable to read log version and last committed tx", ex.getMessage() );
+            assertTrue( ex.getMessage(), ex.getMessage().contains( file.getName() ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
@@ -52,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 public class TestLogPruning
 {
@@ -275,8 +273,8 @@ public class TestLogPruning
                     }
                 };
                 StoreChannel storeChannel = fs.open( files.getLogFileForVersion( version ), "r" );
-                LogVersionedStoreChannel versionedStoreChannel = PhysicalLogFile.openForVersion( files, fs, version );
-                        new PhysicalLogVersionedStoreChannel( storeChannel, -1 /* ignored */, CURRENT_LOG_VERSION );
+                LogVersionedStoreChannel versionedStoreChannel =
+                        PhysicalLogFile.openForVersion( files, fs, version, false );
                 try ( ReadableLogChannel channel =
                               new ReadAheadLogChannel( versionedStoreChannel, bridge, 1000 ) )
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/TransactionAppenderStressTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/TransactionAppenderStressTest.java
@@ -107,7 +107,7 @@ public class TransactionAppenderStressTest
 
     public static class TransactionIdChecker
     {
-        private File workingDirectory;
+        private final File workingDirectory;
 
         public TransactionIdChecker( File workingDirectory )
         {
@@ -136,7 +136,7 @@ public class TransactionAppenderStressTest
         private ReadableLogChannel openLogFile( FileSystemAbstraction fs, int version ) throws IOException
         {
             PhysicalLogFiles logFiles = new PhysicalLogFiles( workingDirectory, fs );
-            PhysicalLogVersionedStoreChannel channel = PhysicalLogFile.openForVersion( logFiles, fs, version );
+            PhysicalLogVersionedStoreChannel channel = PhysicalLogFile.openForVersion( logFiles, fs, version, false );
             return new ReadAheadLogChannel( channel, new ReaderLogVersionBridge( fs, logFiles ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
@@ -40,6 +40,8 @@ import org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,7 +65,7 @@ public class LatestCheckPointFinderTest
             File file = mock( File.class );
             when( logFiles.getLogFileForVersion( i ) ).thenReturn( file );
             StoreChannel channel = mock( StoreChannel.class );
-            when( fs.open( file, "rw" ) ).thenReturn( channel );
+            when( fs.open( eq( file ), anyString() ) ).thenReturn( channel );
             final int version = i;
             when( channel.read( any( ByteBuffer.class ) ) ).thenAnswer( invocationOnMock -> {
                 ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];

--- a/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/test/LogTestUtils.java
@@ -154,7 +154,7 @@ public class LogTestUtils
         {
             channel = fs.open( firstFile, "r" );
             ByteBuffer buffer = ByteBuffer.allocate( LogHeader.LOG_HEADER_SIZE );
-            LogHeader header = LogHeaderReader.readLogHeader( buffer, channel, true );
+            LogHeader header = LogHeaderReader.readLogHeader( buffer, channel, true, firstFile );
 
             PhysicalLogVersionedStoreChannel logVersionedChannel = new PhysicalLogVersionedStoreChannel( channel,
                     header.logVersion, header.logFormatVersion );
@@ -235,7 +235,7 @@ public class LogTestUtils
     private static LogHeader transferLogicalLogHeader( StoreChannel in, StoreChannel out, ByteBuffer buffer )
             throws IOException
     {
-        LogHeader header = readLogHeader( buffer, in, true );
+        LogHeader header = readLogHeader( buffer, in, true, null );
         writeLogHeader( buffer, header.logVersion, header.lastCommittedTxId );
         buffer.flip();
         out.write( buffer );

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
@@ -110,7 +110,7 @@ public class DumpLogicalLog
         LogHeader logHeader;
         try
         {
-            logHeader = readLogHeader( buffer, fileChannel, false );
+            logHeader = readLogHeader( buffer, fileChannel, false, firstFile );
         }
         catch ( IOException ex )
         {

--- a/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
+++ b/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
@@ -270,7 +270,7 @@ public class RsdrMain
     {
         File file = new File( neoStores.getStoreDir(), fname );
         StoreChannel fileChannel = files.open( file, "r" );
-        LogHeader logHeader = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, false );
+        LogHeader logHeader = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, false, file );
         console.printf( "Logical log version: %s with prev committed tx[%s]%n",
                 logHeader.logVersion, logHeader.lastCommittedTxId );
 

--- a/tools/src/main/java/org/neo4j/tools/rebuild/RebuildFromLogs.java
+++ b/tools/src/main/java/org/neo4j/tools/rebuild/RebuildFromLogs.java
@@ -186,7 +186,7 @@ class RebuildFromLogs
     private long findLastTransactionId( PhysicalLogFiles logFiles, long highestVersion ) throws IOException
     {
         ReadableLogChannel logChannel = new ReadAheadLogChannel(
-                PhysicalLogFile.openForVersion( logFiles, fs, highestVersion ), NO_MORE_CHANNELS );
+                PhysicalLogFile.openForVersion( logFiles, fs, highestVersion, false ), NO_MORE_CHANNELS );
 
         long lastTransactionId = -1;
 
@@ -233,7 +233,7 @@ class RebuildFromLogs
             PhysicalLogFiles logFiles = new PhysicalLogFiles( sourceDir, fs );
             int startVersion = 0;
             ReaderLogVersionBridge versionBridge = new ReaderLogVersionBridge( fs, logFiles );
-            PhysicalLogVersionedStoreChannel startingChannel = openForVersion( logFiles, fs, startVersion );
+            PhysicalLogVersionedStoreChannel startingChannel = openForVersion( logFiles, fs, startVersion, false );
             ReadableLogChannel channel = new ReadAheadLogChannel( startingChannel, versionBridge );
             long txId = BASE_TX_ID;
             TransactionQueue queue = new TransactionQueue( 10_000,


### PR DESCRIPTION
Problem was observed when reading transaction stream from
LogicalTransactionLog when all of a sudden an IOException saying
that log header couldn't be read was thrown. This happened since
there was a concurrent rotation, log version was incremented before
new log file was fully created. There was a guard for that in
the default log version bridge but the guard only guarded for
the file not being present, not for the header not yet having
been written.

Fix is to detect this state and treat it the same way as a missing
log file for that version. We do this by introducing a specific
IncompleteLogHeaderException (extending IOException) and letting
the ReaderLogVersionBridge catch it.

As a side-effect a lot of states and how recovery and concurrent
readers may parry for different states is now well documented in
PhysicalLogFile.

Another thing was that log readers always opened the files in
read/write mode even when purely reading, which was unnecessary.
This was changed to be specified from the outside.

PhysicalLogFileRotateAndReadRaceIT captures and showcases the issue.
