### PR TITLE
Disable writes on followers

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -479,10 +479,12 @@ public interface Status
     enum Cluster implements Status
     {
         // transient errors
-        NoLeader( TransientError,
+        NoLeaderAvailable( TransientError,
                 "No leader available at the moment. Retrying your request at a later time may succeed." ),
 
-        ;
+        NotALeader( TransientError,
+                "The request cannot be processed by this server. Write requests can only be processed by the leader." ),
+                ;
 
         private final Code code;
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContextTest.scala
@@ -32,10 +32,12 @@ import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.graphdb.security.AuthorizationViolationException
 import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.security.AccessMode
 import org.neo4j.kernel.impl.api.{KernelStatement, KernelTransactionImplementation, StatementOperationParts}
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
+import org.neo4j.kernel.impl.factory.CanWrite
 import org.neo4j.kernel.impl.proc.Procedures
 import org.neo4j.kernel.impl.query.{Neo4jTransactionalContext, Neo4jTransactionalContextFactory, QuerySource}
 import org.neo4j.storageengine.api.StorageStatement
@@ -59,7 +61,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     when(kernelTransaction.mode()).thenReturn(AccessMode.Static.FULL)
     val storeStatement = mock[StorageStatement]
     val operations = mock[StatementOperationParts](RETURNS_DEEP_STUBS)
-    statement = new KernelStatement(kernelTransaction, null, storeStatement, new Procedures())
+    statement = new KernelStatement(kernelTransaction, null, storeStatement, new Procedures(), new CanWrite())
     statement.initialize(null, operations)
     statement.acquire()
   }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/WriteOperationsNotAllowedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/WriteOperationsNotAllowedException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.security;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+public class WriteOperationsNotAllowedException extends RuntimeException implements Status.HasStatus
+{
+    private final Status statusCode;
+
+    public WriteOperationsNotAllowedException( String msg, Status statusCode )
+    {
+        super( msg );
+        this.statusCode = statusCode;
+    }
+
+    /** The Neo4j status code associated with this exception type. */
+    @Override
+    public Status status()
+    {
+        return statusCode;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -76,6 +76,7 @@ import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -296,6 +297,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     private SchemaIndexProvider schemaIndexProvider;
     private File storeDir;
     private boolean readOnly;
+    private final AccessCapability accessCapability;
 
     private StorageEngine storageEngine;
     private TransactionLogModule transactionLogModule;
@@ -339,7 +341,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             Tracers tracers,
             Procedures procedures,
             IOLimiter ioLimiter,
-            Clock clock )
+            Clock clock,
+            AccessCapability accessCapability )
     {
         this.storeDir = storeDir;
         this.config = config;
@@ -372,6 +375,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         this.procedures = procedures;
         this.ioLimiter = ioLimiter;
         this.clock = clock;
+        this.accessCapability = accessCapability;
 
         readOnly = config.get( Configuration.read_only );
         msgLog = logProvider.getLog( getClass() );
@@ -780,7 +784,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         KernelTransactions kernelTransactions = life.add( new KernelTransactions( statementLocksFactory,
                 constraintIndexCreator, statementOperationContainer, schemaWriteGuard, transactionHeaderInformationFactory,
                 transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor, life,
-                tracers, storageEngine, procedures, transactionIdStore, clock ) );
+                tracers, storageEngine, procedures, transactionIdStore, clock, accessCapability ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, databaseHealth, transactionMonitor, procedures,
                 config );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.api.security.OverriddenAccessMode;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.TxState;
+import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -190,7 +191,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             Pool<KernelTransactionImplementation> pool,
                                             Clock clock,
                                             TransactionTracer tracer,
-                                            StorageEngine storageEngine )
+                                            StorageEngine storageEngine,
+                                            AccessCapability accessCapability )
     {
         this.operationContainer = operationContainer;
         this.schemaWriteGuard = schemaWriteGuard;
@@ -206,7 +208,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.clock = clock;
         this.tracer = tracer;
         this.storageStatement = storeLayer.newStatement();
-        this.currentStatement = new KernelStatement( this, this, storageStatement, procedures );
+        this.currentStatement = new KernelStatement( this, this, storageStatement, procedures, accessCapability );
         this.userMetaData = Collections.emptyMap();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionStateImpl;
+import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
@@ -84,6 +85,7 @@ public class KernelTransactions extends LifecycleAdapter
     private final StorageEngine storageEngine;
     private final Procedures procedures;
     private final TransactionIdStore transactionIdStore;
+    private final AccessCapability accessCapability;
     private final Supplier<LegacyIndexTransactionState> legacyIndexTxStateSupplier;
     private final Clock clock;
     private final ReentrantReadWriteLock newTransactionsLock = new ReentrantReadWriteLock();
@@ -118,7 +120,7 @@ public class KernelTransactions extends LifecycleAdapter
                                StorageEngine storageEngine,
                                Procedures procedures,
                                TransactionIdStore transactionIdStore,
-                               Clock clock )
+                               Clock clock, AccessCapability accessCapability )
     {
         this.statementLocksFactory = statementLocksFactory;
         this.constraintIndexCreator = constraintIndexCreator;
@@ -133,6 +135,7 @@ public class KernelTransactions extends LifecycleAdapter
         this.storageEngine = storageEngine;
         this.procedures = procedures;
         this.transactionIdStore = transactionIdStore;
+        this.accessCapability = accessCapability;
         this.legacyIndexTxStateSupplier = () -> new CachingLegacyIndexTransactionState(
                 new LegacyIndexTransactionStateImpl( indexConfigStore, legacyIndexProviderLookup ) );
         this.clock = clock;
@@ -150,7 +153,7 @@ public class KernelTransactions extends LifecycleAdapter
                     statementOperations, schemaWriteGuard, hooks, constraintIndexCreator, procedures,
                     transactionHeaderInformationFactory, transactionCommitProcess, transactionMonitor,
                     legacyIndexTxStateSupplier, localTxPool, clock, tracers.transactionTracer,
-                    storageEngine );
+                    storageEngine, accessCapability );
 
             allTransactions.add( tx );
             return tx;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/AccessCapability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/AccessCapability.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.factory;
+
+public interface AccessCapability
+{
+    void assertCanWrite();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CanWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CanWrite.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.factory;
+
+public class CanWrite implements AccessCapability
+{
+    @Override
+    public void assertCanWrite()
+    {
+        // no exception to throw as writes are permitted
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -85,6 +85,8 @@ public class CommunityEditionModule extends EditionModule
         LifeSupport life = platformModule.life;
         life.add( platformModule.dataSourceManager );
 
+        this.accessCapability = config.get( GraphDatabaseSettings.read_only )? new ReadOnly() : new CanWrite();
+
         GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
 
         lockManager = dependencies.satisfyDependency( createLockManager( config, logging ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -209,7 +209,7 @@ public class DataSourceModule
                 platformModule.tracers,
                 procedures,
                 editionModule.ioLimiter,
-                clock) );
+                clock, editionModule.accessCapability ) );
 
         dataSourceManager.register( neoStoreDataSource );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -107,6 +107,8 @@ public abstract class EditionModule
 
     public CoreAPIAvailabilityGuard coreAPIAvailabilityGuard;
 
+    public AccessCapability accessCapability;
+
     public IOLimiter ioLimiter;
 
     public IdReuseEligibility eligibleForIdReuse;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ReadOnly.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ReadOnly.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.factory;
+
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
+import org.neo4j.kernel.api.exceptions.Status;
+
+public class ReadOnly implements AccessCapability
+{
+    @Override
+    public void assertCanWrite()
+    {
+        throw new WriteOperationsNotAllowedException(
+                "No write operations are allowed on this database. This is a read only Neo4j instance.",
+                Status.General.ForbiddenOnReadOnlyDatabase );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocks;
@@ -86,7 +87,7 @@ public class KernelTransactionFactory
                 mock( Pool.class ),
                 Clocks.systemClock(),
                 NULL,
-                storageEngine );
+                storageEngine, new CanWrite() );
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -40,7 +41,7 @@ public class KernelStatementTest
         when( transaction.getReasonIfTerminated() ).thenReturn( Status.Transaction.Terminated );
         when( transaction.mode() ).thenReturn( AccessMode.Static.FULL );
 
-        KernelStatement statement = new KernelStatement( transaction, null, mock( StorageStatement.class ), null );
+        KernelStatement statement = new KernelStatement( transaction, null, mock( StorageStatement.class ), null, new CanWrite() );
         statement.acquire();
 
         statement.readOperations().nodeExists( 0 );
@@ -52,7 +53,7 @@ public class KernelStatementTest
         // given
         StorageStatement storeStatement = mock( StorageStatement.class );
         KernelStatement statement = new KernelStatement( mock( KernelTransactionImplementation.class ),
-                null, storeStatement, new Procedures() );
+                null, storeStatement, new Procedures(), new CanWrite() );
         statement.acquire();
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -361,7 +362,7 @@ public class KernelTransactionTerminationTest
                     mock( ConstraintIndexCreator.class ), new Procedures(), TransactionHeaderInformationFactory.DEFAULT,
                     mock( TransactionCommitProcess.class ), monitor, () -> mock( LegacyIndexTransactionState.class ),
                     mock( Pool.class ), Clocks.fakeClock(), TransactionTracer.NULL,
-                    mock( StorageEngine.class, RETURNS_MOCKS ) );
+                    mock( StorageEngine.class, RETURNS_MOCKS ), new CanWrite() );
 
             this.monitor = monitor;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
@@ -136,7 +137,7 @@ public class KernelTransactionTestBase
     {
         return new KernelTransactionImplementation( operationContainer, schemaWriteGuard,
                 hooks, null, null, headerInformationFactory, commitProcess, transactionMonitor, legacyIndexStateSupplier,
-                txPool, clock, TransactionTracer.NULL, storageEngine );
+                txPool, clock, TransactionTracer.NULL, storageEngine, new CanWrite() );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -40,6 +40,8 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.factory.AccessCapability;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocksFactory;
@@ -446,12 +448,12 @@ public class KernelTransactionsTest
             return new TestKernelTransactions( statementLocksFactory, null, statementOperationsContianer,
                     null, DEFAULT,
                     commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
-                    tracers, storageEngine, new Procedures(), transactionIdStore, Clocks.systemClock() );
+                    tracers, storageEngine, new Procedures(), transactionIdStore, Clocks.systemClock(), new CanWrite() );
         }
         return new KernelTransactions( statementLocksFactory,
                 null, statementOperationsContianer, null, DEFAULT,
                 commitProcess, null, null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
-                tracers, storageEngine, new Procedures(), transactionIdStore, Clocks.systemClock() );
+                tracers, storageEngine, new Procedures(), transactionIdStore, Clocks.systemClock(), new CanWrite() );
     }
 
     private static TransactionCommitProcess newRememberingCommitProcess( final TransactionRepresentation[] slot )
@@ -520,19 +522,22 @@ public class KernelTransactionsTest
     private static class TestKernelTransactions extends KernelTransactions
     {
         public TestKernelTransactions( StatementLocksFactory statementLocksFactory,
-                ConstraintIndexCreator constraintIndexCreator,
-                StatementOperationContainer statementOperationsContianer, SchemaWriteGuard schemaWriteGuard,
-                TransactionHeaderInformationFactory txHeaderFactory,
-                TransactionCommitProcess transactionCommitProcess,
-                IndexConfigStore indexConfigStore,
-                LegacyIndexProviderLookup legacyIndexProviderLookup, TransactionHooks hooks,
-                TransactionMonitor transactionMonitor, LifeSupport dataSourceLife,
-                Tracers tracers, StorageEngine storageEngine, Procedures procedures,
-                TransactionIdStore transactionIdStore, Clock clock )
+                                       ConstraintIndexCreator constraintIndexCreator,
+                                       StatementOperationContainer statementOperationsContianer,
+                                       SchemaWriteGuard schemaWriteGuard,
+                                       TransactionHeaderInformationFactory txHeaderFactory,
+                                       TransactionCommitProcess transactionCommitProcess,
+                                       IndexConfigStore indexConfigStore,
+                                       LegacyIndexProviderLookup legacyIndexProviderLookup, TransactionHooks hooks,
+                                       TransactionMonitor transactionMonitor, LifeSupport dataSourceLife,
+                                       Tracers tracers, StorageEngine storageEngine, Procedures procedures,
+                                       TransactionIdStore transactionIdStore, Clock clock,
+                                       AccessCapability accessCapability )
         {
-            super( statementLocksFactory, constraintIndexCreator, statementOperationsContianer, schemaWriteGuard, txHeaderFactory,
-                    transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor,
-                    dataSourceLife, tracers, storageEngine, procedures, transactionIdStore, clock );
+            super( statementLocksFactory, constraintIndexCreator, statementOperationsContianer, schemaWriteGuard,
+                    txHeaderFactory, transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks,
+                    transactionMonitor, dataSourceLife, tracers, storageEngine, procedures, transactionIdStore, clock,
+                    accessCapability );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.api.state.TxState;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
@@ -73,7 +74,7 @@ public class LockingStatementOperationsTest
     private final KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
     private final TxState txState = new TxState();
     private final KernelStatement state = new KernelStatement( transaction, new SimpleTxStateHolder( txState ),
-            mock( StorageStatement.class ), new Procedures() );
+            mock( StorageStatement.class ), new Procedures(), new CanWrite() );
     private final SchemaStateOperations schemaStateOps;
 
     public LockingStatementOperationsTest()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -69,6 +70,6 @@ public class StatementLifecycleTest
     private KernelStatement getKernelStatement( KernelTransactionImplementation transaction,
             StorageStatement storageStatement )
     {
-        return new KernelStatement( transaction, null, storageStatement, new Procedures() );
+        return new KernelStatement( transaction, null, storageStatement, new Procedures(), new CanWrite() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -65,7 +66,7 @@ public abstract class DiskLayerTest
         db = (GraphDatabaseAPI) createGraphDatabase();
         DependencyResolver resolver = db.getDependencyResolver();
         this.disk = resolver.resolveDependency( StorageEngine.class ).storeReadLayer();
-        this.state = new KernelStatement( null, null, disk.newStatement(), new Procedures() );
+        this.state = new KernelStatement( null, null, disk.newStatement(), new Procedures(), new CanWrite() );
     }
 
     protected GraphDatabaseService createGraphDatabase()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.DbRepresentation;
@@ -69,10 +70,9 @@ public class TestReadOnlyNeo4j
 
             tx.success();
         }
-        catch ( TransactionFailureException e )
+        catch ( WriteOperationsNotAllowedException e )
         {
             // good
-            assertThat(e.getCause(), instanceOf( ReadOnlyDbException.class ));
         }
         readGraphDb.shutdown();
     }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocks;
@@ -120,7 +121,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new StandardConstraintSemantics(), monitors,
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
-                IOLimiter.unlimited(), Clock.systemUTC() );
+                IOLimiter.unlimited(), Clock.systemUTC(), new CanWrite() );
 
         return dataSource;
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -29,6 +29,7 @@ import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction.Type;
@@ -322,7 +323,8 @@ public class TransactionHandle implements TransactionTerminationHandle
                     output.statementResult( result, statement.includeStats(), statement.resultDataContents() );
                     output.notifications( result.getNotifications() );
                 }
-                catch ( KernelException | CypherException | AuthorizationViolationException e )
+                catch ( KernelException | CypherException | AuthorizationViolationException |
+                        WriteOperationsNotAllowedException e )
                 {
                     errors.add( new Neo4jError( e.status(), e ) );
                     break;

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.server.NeoServer;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
@@ -187,6 +187,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
         this.relationshipTypeTokenHolder = coreStateMachinesModule.relationshipTypeTokenHolder;
         this.lockManager = coreStateMachinesModule.lockManager;
         this.commitProcessFactory = coreStateMachinesModule.commitProcessFactory;
+        this.accessCapability = new LeaderCanWrite( consensusModule.raftMachine() );
 
         CoreServerModule coreServerModule = new CoreServerModule( identityModule.myself(), platformModule, consensusModule,
                 coreStateMachinesModule, replicationModule, clusterStateDirectory, topologyService, localDatabase,
@@ -333,4 +334,5 @@ public class EnterpriseCoreEditionModule extends EditionModule
     {
         return new StandardBoltConnectionTracker();
     }
+
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/LeaderCanWrite.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/LeaderCanWrite.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.core;
+
+import org.neo4j.coreedge.core.consensus.RaftMachine;
+import org.neo4j.coreedge.core.consensus.roles.Role;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.factory.AccessCapability;
+
+class LeaderCanWrite implements AccessCapability
+{
+    private RaftMachine raftMachine;
+
+    LeaderCanWrite( RaftMachine raftMachine )
+    {
+        this.raftMachine = raftMachine;
+    }
+
+    @Override
+    public void assertCanWrite()
+    {
+        Role currentRole = raftMachine.currentRole();
+        if ( !currentRole.equals( Role.LEADER ) )
+        {
+            throw new WriteOperationsNotAllowedException(
+                    String.format( "No write operations are allowed on this database. Writes are only permitted on " +
+                            "the leader and the role of this server is: %s", currentRole ),
+                    Status.Cluster.NotALeader );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -70,6 +70,7 @@ import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.factory.EditionModule;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.factory.ReadOnly;
 import org.neo4j.kernel.impl.factory.StatementLocksFactorySelector;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -132,6 +133,8 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         File storeDir = platformModule.storeDir;
         LifeSupport life = platformModule.life;
         Monitors monitors = platformModule.monitors;
+
+        this.accessCapability = new ReadOnly();
 
         GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterShutdownIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterShutdownIT.java
@@ -35,6 +35,7 @@ import org.neo4j.coreedge.discovery.Cluster;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.test.coreedge.ClusterRule;
 
 import static java.util.Arrays.asList;
@@ -63,11 +64,18 @@ public class ClusterShutdownIT
     {
         Cluster cluster = clusterRule.startCluster();
 
-        for ( int victimId = 0; victimId < cluster.numberOfCoreMembersReportedByTopology(); victimId++ )
+        try
         {
-            assertTrue( cluster.getCoreMemberById( victimId ).database().isAvailable( 1000 ) );
-            shouldShutdownEvenThoughWaitingForLock0( cluster, victimId, shutdownOrder );
-            cluster.start();
+            for ( int victimId = 0; victimId < cluster.numberOfCoreMembersReportedByTopology(); victimId++ )
+            {
+                assertTrue( cluster.getCoreMemberById( victimId ).database().isAvailable( 1000 ) );
+                shouldShutdownEvenThoughWaitingForLock0( cluster, victimId, shutdownOrder );
+                cluster.start();
+            }
+        }
+        catch ( WriteOperationsNotAllowedException e )
+        {
+            // expected
         }
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreEdgeRolesIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreEdgeRolesIT.java
@@ -27,6 +27,7 @@ import org.neo4j.coreedge.discovery.Cluster;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.test.coreedge.ClusterRule;
 
 public class CoreEdgeRolesIT
@@ -46,12 +47,12 @@ public class CoreEdgeRolesIT
         Cluster cluster = clusterRule.startCluster();
         GraphDatabaseService db = cluster.findAnEdgeMember().database();
         Transaction tx = db.beginTx();
-        db.createNode();
 
         // then
-        exceptionMatcher.expect( TransactionFailureException.class );
+        exceptionMatcher.expect( WriteOperationsNotAllowedException.class );
 
         // when
+        db.createNode();
         tx.success();
         tx.close();
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
@@ -47,6 +47,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.PageCache;
@@ -111,7 +112,7 @@ public class EdgeServerReplicationIT
             node.addLabel( Label.label( "Foo" ) );
             tx.success();
         }
-        catch ( TransactionFailureException e )
+        catch ( WriteOperationsNotAllowedException e )
         {
             // expected
             transactionFailed = true;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -135,11 +135,13 @@ import org.neo4j.kernel.impl.enterprise.SecurityLog;
 import org.neo4j.kernel.impl.enterprise.StandardBoltConnectionTracker;
 import org.neo4j.kernel.impl.enterprise.id.EnterpriseIdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.enterprise.transaction.log.checkpoint.ConfigurableIOLimiter;
+import org.neo4j.kernel.impl.factory.CanWrite;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.factory.EditionModule;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.factory.ReadOnly;
 import org.neo4j.kernel.impl.factory.StatementLocksFactorySelector;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -218,6 +220,8 @@ public class HighlyAvailableEditionModule
         final Dependencies dependencies = platformModule.dependencies;
         final LogService logging = platformModule.logging;
         final Monitors monitors = platformModule.monitors;
+
+        this.accessCapability = config.get( GraphDatabaseSettings.read_only )? new ReadOnly() : new CanWrite();
 
         idTypeConfigurationProvider = new EnterpriseIdTypeConfigurationProvider( config );
 

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveTest.java
@@ -28,11 +28,13 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.read_only;
@@ -59,11 +61,11 @@ public class ReadOnlySlaveTest
         {
             readOnlySlave.createNode();
             tx.success();
+            fail( "Should have thrown exception" );
         }
-        catch ( TransactionFailureException ex )
+        catch ( WriteOperationsNotAllowedException ex )
         {
             // Then
-            assertThat( ex.getCause(), instanceOf( ReadOnlyDbException.class ) );
         }
     }
 
@@ -90,11 +92,11 @@ public class ReadOnlySlaveTest
             // Then
             slaveNode.setProperty( "foo", "bar" );
             tx.success();
+            fail( "Should have thrown exception" );
         }
-        catch ( TransactionFailureException ex )
+        catch ( WriteOperationsNotAllowedException ex )
         {
             // Ok!
-            assertThat( ex.getCause(), instanceOf( ReadOnlyDbException.class ) );
         }
     }
 
@@ -121,11 +123,11 @@ public class ReadOnlySlaveTest
             // Then
             slaveNode.addLabel( Label.label( "FOO" ) );
             tx.success();
+            fail( "Should have thrown exception" );
         }
-        catch ( TransactionFailureException ex )
+        catch ( WriteOperationsNotAllowedException ex )
         {
             // Ok!
-            assertThat( ex.getCause(), instanceOf( ReadOnlyDbException.class ) );
         }
     }
 
@@ -155,11 +157,11 @@ public class ReadOnlySlaveTest
             // Then
             slaveNode.createRelationshipTo( slaveNode2, RelationshipType.withName( "KNOWS" ) );
             tx.success();
+            fail( "Should have thrown exception" );
         }
-        catch ( TransactionFailureException ex )
+        catch ( WriteOperationsNotAllowedException ex )
         {
             // Ok!
-            assertThat( ex.getCause(), instanceOf( ReadOnlyDbException.class ) );
         }
     }
 }

--- a/manual/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
+++ b/manual/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
@@ -18,23 +18,20 @@
  */
 package org.neo4j.examples;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -85,10 +82,9 @@ public class ReadOnlyDocTest
             fail( "expected exception" );
         }
         // then
-        catch ( TransactionFailureException e )
+        catch ( WriteOperationsNotAllowedException e )
         {
             // ok
-            assertThat( e.getCause(), instanceOf( ReadOnlyDbException.class ) );
         }
     }
 }


### PR DESCRIPTION
This is a placeholder PR for disabling writes on followers in core-edge. At the moment you only get stopped from writing when you try to take a lock
