### PR TITLE
Ensure security log is closed on LifeCycle.shutdown

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
@@ -228,6 +228,8 @@ public class EnterpriseCoreEditionModule extends EditionModule
         securityLog = SecurityLog.create( config, logging.getInternalLog( GraphDatabaseFacade.class ),
                 platformModule.fileSystem, platformModule.jobScheduler );
 
+        life.add( securityLog );
+
         life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
                 platformModule.fileSystem, platformModule.jobScheduler ) ) );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -155,6 +155,8 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         securityLog = SecurityLog.create( config, logging.getInternalLog( GraphDatabaseFacade.class ),
                 platformModule.fileSystem, platformModule.jobScheduler );
 
+        life.add( securityLog );
+
         life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
                 platformModule.fileSystem, platformModule.jobScheduler ) ) );
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -515,6 +515,8 @@ public class HighlyAvailableEditionModule
         securityLog = SecurityLog.create( config, logging.getInternalLog( GraphDatabaseFacade.class ),
                 platformModule.fileSystem, platformModule.jobScheduler );
 
+        life.add( securityLog );
+
         life.add( dependencies.satisfyDependency( createAuthManager( config, logging,
                 platformModule.fileSystem, platformModule.jobScheduler ) ) );
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -63,6 +63,10 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         platformModule.dependencies.satisfyDependency( new IdBasedStoreEntityCounters( this.idGeneratorFactory ) );
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
         platformModule.dependencies.satisfyDependency( createSessionTracker() );
+        if ( securityLog != null )
+        {
+            platformModule.life.add( securityLog );
+        }
     }
 
     @Override


### PR DESCRIPTION
There is a bug that only happens on windows, and can be seen in the StoreCopyClientTest when deleting log files, the security log cannot be deleted due to a lock.

There are many differences between the implementation of SecurityLog and the other logs. One that appears very relevant to this case is the fact that the debug.log is in LogService which implements LifeCycle, and when the shutdown() method is called, the LogService closes the OutputStream to the debug.log (See StoreLogService.java:195).

So I've implemented LifeCycle on SecurityLog and added calls to init and shutdown from the existing LifeCycle methods on the enterprise auth manager. We could have added SecurityLog to the lifecycle directly, as is done with debug.log in PlatformModule, but the edition differences make that messy, so it was easier to add these calls in the MultiRealmAuthManager where the security log is created and managed directly.

changelog: Fixed problem on windows with security log not being closed before backup is run, by tying it to the lifecycle shutdown
