### PR TITLE
`neo4j-backup` is now deprecated in favour of the new `neo4j-admin backup` command which provides the same functionality

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.commandline.admin;
 
+import java.io.PrintStream;
+
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 public interface OutsideWorld
@@ -32,4 +34,6 @@ public interface OutsideWorld
     void printStacktrace( Exception exception );
 
     FileSystemAbstraction fileSystem();
+
+    PrintStream errorStream();
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.commandline.admin;
 
+import java.io.PrintStream;
+
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
@@ -54,5 +56,11 @@ class RealOutsideWorld implements OutsideWorld
     public FileSystemAbstraction fileSystem()
     {
         return fileSystemAbstraction;
+    }
+
+    @Override
+    public PrintStream errorStream()
+    {
+        return System.err;
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.commandline.admin;
 
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -218,6 +219,12 @@ public class AdminToolTest
         public FileSystemAbstraction fileSystem()
         {
             return null;
+        }
+
+        @Override
+        public PrintStream errorStream()
+        {
+            throw new UnsupportedOperationException( "not implemented" );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
@@ -28,6 +28,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
+import org.neo4j.helpers.HostnamePort;
+
 public class Converters
 {
     public static <T> Function<String,T> mandatory()
@@ -102,5 +104,26 @@ public class Converters
     public static Function<String,Integer> toInt()
     {
         return Integer::new;
+    }
+
+    public static Function<String, HostnamePort> toHostnamePort( HostnamePort defaultAddress )
+    {
+        return from ->
+        {
+            if ( !from.contains( ":" ) )
+            {
+                from = from + ":" + defaultAddress.getPort();
+            }
+            if ( from.endsWith( ":" ) )
+            {
+                from = from + defaultAddress.getPort();
+            }
+            if ( from.startsWith( ":" ) )
+            {
+                from = defaultAddress.getHost() + from;
+            }
+            String[] parts = from.split( ":" );
+            return new HostnamePort( parts[0], Integer.parseInt( parts[1] ) );
+        };
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -58,7 +58,6 @@ public class BackupTool
     private static final String HOST = "host";
     private static final String PORT = "port";
 
-    @Deprecated // preferred -host and -port separately
     private static final String FROM = "from";
 
     private static final String VERIFY = "verify";
@@ -85,6 +84,9 @@ public class BackupTool
 
     public static void main( String[] args )
     {
+        System.err.println("WARNING: neo4j-backup is deprecated and support for it will be removed in a future " +
+                "version of Neo4j. Please use neo4j-admin backup.");
+
         BackupTool tool = new BackupTool( new BackupService(), System.out );
         try
         {
@@ -195,8 +197,9 @@ public class BackupTool
         return executeBackup( hostnamePort, new File( to ), consistencyCheck, tuningConfiguration, timeout, forensics );
     }
 
-    private BackupOutcome executeBackup( HostnamePort hostnamePort, File to, ConsistencyCheck consistencyCheck,
-            Config tuningConfiguration, long timeout, boolean forensics ) throws ToolFailureException
+    BackupOutcome executeBackup( HostnamePort hostnamePort, File to, ConsistencyCheck consistencyCheck,
+                                 Config tuningConfiguration, long timeout, boolean forensics )
+            throws ToolFailureException
     {
         try
         {
@@ -231,7 +234,7 @@ public class BackupTool
     }
 
     private BackupOutcome doBackup( HostnamePort hostnamePort, File to, ConsistencyCheck consistencyCheck,
-            Config config, long timeout, boolean forensics ) throws ToolFailureException
+                                    Config config, long timeout, boolean forensics ) throws ToolFailureException
     {
         try
         {
@@ -259,7 +262,7 @@ public class BackupTool
 
     private static Config readConfiguration( Args arguments ) throws ToolFailureException
     {
-        Map<String,String> specifiedConfig = stringMap();
+        Map<String, String> specifiedConfig = stringMap();
 
         String configFilePath = arguments.get( CONFIG, null );
         if ( configFilePath != null )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.consistency.ConsistencyCheckSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ConfigLoader;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.kernel.impl.util.Converters.mandatory;
+import static org.neo4j.kernel.impl.util.Converters.optional;
+import static org.neo4j.kernel.impl.util.Converters.toFile;
+import static org.neo4j.kernel.impl.util.Converters.toHostnamePort;
+import static org.neo4j.kernel.impl.util.Converters.toPath;
+import static org.neo4j.kernel.impl.util.Converters.withDefault;
+
+public class OnlineBackupCommand implements AdminCommand
+{
+
+    private static final String checkConsistencyArg = "check-consistency";
+
+    public static class Provider extends AdminCommand.Provider
+    {
+        public Provider()
+        {
+            super( "backup" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "[--from=<address>] --to=<backup-path> [--check-consistency] " +
+                    "[--additional-config=<config-file-path>] [--timeout=<timeout>]" );
+        }
+
+        @Override
+        public String description()
+        {
+            return "Perform a backup, over the network, from a running Neo4j server into a local copy of the " +
+                    "database store (the backup). Neo4j Server must be configured to run a backup service. See " +
+                    "http://neo4j.com/docs/operations-manual/current/backup/ for more details." +
+                    "\n\n" +
+                    "<address> is a <host>:<port> pair like neo4j.example.com:1234; the host defaults to localhost " +
+                    "and the port defaults to 6362, the default backup service port." +
+                    "\n\n" +
+                    "<backup-path> is a directory where the backup will be made; if there is already a backup " +
+                    "present an incremental backup will be made." +
+                    "\n\n" +
+                    "Consistency checking is enabled by default." +
+                    "\n\n" +
+                    "<timeout> is in the from <time>[ms|s|m|h]; the default is 20m; the default unit is seconds.";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new OnlineBackupCommand(
+                    new BackupTool( new BackupService(), outsideWorld.errorStream() ), homeDir, configDir );
+        }
+    }
+
+    private final BackupTool backupTool;
+    private final Path homeDir;
+    private final Path configDir;
+
+    public OnlineBackupCommand( BackupTool backupTool, Path homeDir, Path configDir )
+    {
+        this.backupTool = backupTool;
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        Args parsedArgs = Args.withFlags( checkConsistencyArg ).parse( args );
+        HostnamePort address;
+        File destination;
+        ConsistencyCheck consistencyCheck;
+        Optional<Path> additionalConfig;
+        long timeout;
+        try
+        {
+            address = parseAddress( parsedArgs );
+            destination = parseDestination( parsedArgs );
+            consistencyCheck = parseConsistencyCheck( parsedArgs );
+            additionalConfig = parseAdditionalConfig( parsedArgs );
+            timeout = parseTimeout( parsedArgs );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+
+        try
+        {
+            backupTool.executeBackup(
+                    address, destination, consistencyCheck, loadConfig( additionalConfig ), timeout, false );
+        }
+        catch ( BackupTool.ToolFailureException e )
+        {
+            throw new CommandFailed( "backup failed: " + e.getMessage(), e );
+        }
+    }
+
+    private HostnamePort parseAddress( Args args )
+    {
+        HostnamePort defaultAddress = new HostnamePort( "localhost", 6362 );
+        return args.interpretOption( "from", withDefault( defaultAddress ), toHostnamePort( defaultAddress ) );
+    }
+
+    private File parseDestination( Args parsedArgs )
+    {
+        return parsedArgs.interpretOption( "to", mandatory(), toFile() );
+    }
+
+    private ConsistencyCheck parseConsistencyCheck( Args args )
+    {
+        return args.getBoolean( checkConsistencyArg, true, true ) ? ConsistencyCheck.FULL : ConsistencyCheck.NONE;
+    }
+
+    private Optional<Path> parseAdditionalConfig( Args args )
+    {
+        return Optional.ofNullable( args.interpretOption( "additional-config", optional(), toPath() ) );
+    }
+
+    private long parseTimeout( Args parsedArgs )
+    {
+        return parsedArgs.getDuration( "timeout", TimeUnit.MINUTES.toMillis( 20 ) );
+    }
+
+    private Config loadConfig( Optional<Path> additionalConfig ) throws CommandFailed
+    {
+        //noinspection unchecked
+        return withAdditionalConfig( additionalConfig,
+                new ConfigLoader( asList( GraphDatabaseSettings.class, ConsistencyCheckSettings.class ) )
+                        .loadConfig(
+                                Optional.of( homeDir.toFile() ),
+                                Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) ) );
+    }
+
+    private Config withAdditionalConfig( Optional<Path> additionalConfig, Config config ) throws CommandFailed
+    {
+        if ( additionalConfig.isPresent() )
+        {
+            try
+            {
+                return config.with( MapUtil.load( additionalConfig.get().toFile() ) );
+            }
+            catch ( IOException e )
+            {
+                throw new CommandFailed( "Could not read additional config from " + additionalConfig.get(), e );
+            }
+        }
+        return config;
+    }
+}

--- a/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,1 +1,2 @@
+org.neo4j.backup.OnlineBackupCommand$Provider
 org.neo4j.restore.RestoreDatabaseCli$Provider

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.consistency.ConsistencyCheckSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cypher_planner;
+
+public class OnlineBackupCommandTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    private final BackupTool tool = mock( BackupTool.class );
+    private OnlineBackupCommand command;
+    private Path configDir;
+
+    public OnlineBackupCommandTest()
+    {
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        configDir = testDirectory.directory( "config-dir" ).toPath();
+        command = new OnlineBackupCommand( tool, Paths.get( "/some/path" ), configDir );
+    }
+
+    @Test
+    public void shouldNotRequestForensics() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--to=/" );
+
+        verify( tool )
+                .executeBackup( any(), any(), any(), any(), anyLong(), eq( false ) );
+    }
+
+    @Test
+    public void shouldDefaultFromToDefaultBackupAddress()
+            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--to=/" );
+
+        verify( tool ).executeBackup(
+                eq( new HostnamePort( "localhost", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldDefaultPortAndPassHost() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--from=foo.bar.server", "--to=/" );
+
+        verify( tool ).executeBackup(
+                eq( new HostnamePort( "foo.bar.server", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldAcceptAHostWithATrailingColon() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--from=foo.bar.server:", "--to=/" );
+
+        verify( tool ).executeBackup(
+                eq( new HostnamePort( "foo.bar.server", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldDefaultHostAndPassPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--from=:1234", "--to=/" );
+
+        verify( tool ).executeBackup(
+                eq( new HostnamePort( "localhost", 1234 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldPassHostAndPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--from=foo.bar.server:1234", "--to=/" );
+
+        verify( tool ).executeBackup(
+                eq( new HostnamePort( "foo.bar.server", 1234 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldPassDestination() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--to=/some/path/or/other" );
+
+        verify( tool ).executeBackup(
+                any(), eq( new File( "/some/path/or/other" ) ), any(), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldTreatToArgumentAsMandatory() throws CommandFailed
+    {
+        try
+        {
+            execute();
+            fail( "exception expected" );
+        }
+        catch ( IncorrectUsage incorrectUsage )
+        {
+            assertThat( incorrectUsage.getMessage(), containsString( "to" ) );
+        }
+    }
+
+    @Test
+    public void shouldNotAskForConsistencyCheckIfNotSpecified()
+            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--check-consistency=false", "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), eq( ConsistencyCheck.NONE ), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldAskForConsistencyCheckIfSpecified()
+            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        execute( "--check-consistency", "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), eq( ConsistencyCheck.FULL ), any(), anyLong(), anyBoolean() );
+    }
+
+    @Test
+    public void shouldIncludeGraphDatabaseSettings()
+            throws IOException, CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
+
+        execute( "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        assertThat( config.getValue().getSettingsClasses(), hasItem( GraphDatabaseSettings.class ) );
+    }
+
+    @Test
+    public void shouldIncludeConsistencyCheckSettings()
+            throws IOException, CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
+
+        execute( "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        assertThat( config.getValue().getSettingsClasses(), hasItem( ConsistencyCheckSettings.class ) );
+    }
+
+    @Test
+    public void shouldReadStandardConfig() throws IOException, CommandFailed, IncorrectUsage, BackupTool
+            .ToolFailureException
+
+    {
+        Files.write( configDir.resolve( "neo4j.conf" ), asList( cypher_planner.name() + "=RULE" ) );
+        ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
+
+        execute( "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        assertThat( config.getValue().get( cypher_planner ), is( "RULE" ) );
+    }
+
+    @Test
+    public void shouldAugmentConfig()
+            throws IOException, CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    {
+        Path extraConf = testDirectory.directory( "someOtherDir" ).toPath().resolve( "extra.conf" );
+        Files.write( extraConf, asList( cypher_planner.name() + "=RULE" ) );
+        ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
+
+        execute( "--additional-config=" + extraConf, "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        assertThat( config.getValue().get( cypher_planner ), is( "RULE" ) );
+    }
+
+    @Test
+    public void shouldDefaultTimeoutToTwentyMinutes()
+            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    {
+        execute( "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), any(), eq( MINUTES.toMillis( 20 ) ), anyBoolean() );
+    }
+
+    @Test
+    public void shouldInterpretAUnitlessTimeoutAsSeconds()
+            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    {
+        execute( "--timeout=10", "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), any(), eq( SECONDS.toMillis( 10 ) ), anyBoolean() );
+    }
+
+    @Test
+    public void shouldParseATimeoutWithUnits()
+            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    {
+        execute( "--timeout=10h", "--to=/" );
+
+        verify( tool ).executeBackup( any(), any(), any(), any(), eq( HOURS.toMillis( 10 ) ), anyBoolean() );
+    }
+
+    private void execute( String... args ) throws IncorrectUsage, CommandFailed
+    {
+        command.execute( args );
+    }
+}


### PR DESCRIPTION
changelog: Deprecated `neo4j-backup` 

The new `neo4j-admin backup` command provides the same functionality.
