### PR TITLE
DISCARD_ALL discards records not metadata

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
@@ -41,7 +41,7 @@ public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeExcep
     // while there are in-flight requests.
     private final MessageProcessingHandler initHandler;
     private final MessageProcessingHandler runHandler;
-    private final MessageProcessingHandler pullAllHandler;
+    private final MessageProcessingHandler resultHandler;
     private final MessageProcessingHandler defaultHandler;
 
     private BoltWorker worker;
@@ -51,7 +51,7 @@ public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeExcep
     {
         this.initHandler = new InitHandler( output, onEachCompletedRequest, log );
         this.runHandler = new RunHandler( output, onEachCompletedRequest, log );
-        this.pullAllHandler = new ResultHandler( output, onEachCompletedRequest, log );
+        this.resultHandler = new ResultHandler( output, onEachCompletedRequest, log );
         this.defaultHandler = new MessageProcessingHandler( output, onEachCompletedRequest, log );
 
         this.worker = worker;
@@ -86,13 +86,13 @@ public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeExcep
     @Override
     public void onDiscardAll()
     {
-        worker.enqueue( session -> session.discardAll( defaultHandler ) );
+        worker.enqueue( session -> session.discardAll( resultHandler ) );
     }
 
     @Override
     public void onPullAll()
     {
-        worker.enqueue( session -> session.pullAll( pullAllHandler ) );
+        worker.enqueue( session -> session.pullAll( resultHandler ) );
     }
 
     static class MessageProcessingHandler implements BoltResponseHandler

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -435,7 +435,8 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     {
                         try
                         {
-                            machine.ctx.statementProcessor.streamResult( recordStream -> machine.ctx.responseHandler.onRecords( recordStream, false ) );
+                            machine.ctx.statementProcessor.streamResult( recordStream ->
+                                    machine.ctx.responseHandler.onRecords( recordStream, false ) );
 
                             return READY;
                         }


### PR DESCRIPTION
A `DISCARD_ALL` should function just as a `PULL_ALL` except that it should
discard all records. However in the current implementation it also discards all
metadata which has never been the intention.
