### PR TITLE
Race conditions in ChunkedOutput

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -58,8 +58,10 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
         this.buffer = channel.alloc().buffer( this.bufferSize, this.bufferSize );
     }
 
+    //Flush can be called from a separate thread, we therefor need to synchronize
+    //on everything that touches the buffer
     @Override
-    public PackOutput flush() throws IOException
+    public synchronized PackOutput flush() throws IOException
     {
         if ( buffer != null && buffer.readableBytes() > 0 )
         {
@@ -186,7 +188,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
         chunkOpen = false;
     }
 
-    public void close()
+    public synchronized void close()
     {
         if(buffer != null)
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -79,7 +79,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeByte( byte value ) throws IOException
+    public synchronized PackOutput writeByte( byte value ) throws IOException
     {
         ensure(1);
         buffer.writeByte( value );
@@ -87,7 +87,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeShort( short value ) throws IOException
+    public synchronized PackOutput writeShort( short value ) throws IOException
     {
         ensure(2);
         buffer.writeShort( value );
@@ -95,7 +95,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeInt( int value ) throws IOException
+    public synchronized PackOutput writeInt( int value ) throws IOException
     {
         ensure(4);
         buffer.writeInt( value );
@@ -103,7 +103,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeLong( long value ) throws IOException
+    public synchronized PackOutput writeLong( long value ) throws IOException
     {
         ensure(8);
         buffer.writeLong( value );
@@ -111,7 +111,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeDouble( double value ) throws IOException
+    public synchronized PackOutput writeDouble( double value ) throws IOException
     {
         ensure(8);
         buffer.writeDouble( value );
@@ -119,7 +119,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public PackOutput writeBytes( ByteBuffer data ) throws IOException
+    public synchronized PackOutput writeBytes( ByteBuffer data ) throws IOException
     {
         // TODO: If data is larger than our chunk size or so, we're very likely better off just passing this ByteBuffer on rather than doing the copy here
         // TODO: *however* note that we need some way to find out when the data has been written (and thus the buffer can be re-used) if we take that approach
@@ -150,7 +150,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
         return writeBytes( ByteBuffer.wrap( data, offset, length ) );
     }
 
-    private void ensure( int size ) throws IOException
+    private synchronized void ensure( int size ) throws IOException
     {
         assert size <= maxChunkSize : size + " > " + maxChunkSize;
 
@@ -168,7 +168,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
         }
     }
 
-    private void closeChunkIfOpen()
+    private synchronized void closeChunkIfOpen()
     {
         if ( chunkOpen )
         {
@@ -198,7 +198,7 @@ public class ChunkedOutput implements PackOutput, MessageBoundaryHook
     }
 
     @Override
-    public void onMessageComplete() throws IOException
+    public synchronized void onMessageComplete() throws IOException
     {
         closeChunkIfOpen();
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
@@ -26,21 +26,23 @@ import io.netty.channel.ChannelPromise;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.bolt.v1.transport.ChunkedOutput;
 import org.neo4j.kernel.impl.util.HexPrinter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,9 +53,57 @@ public class ChunkedOutputTest
     private final ByteBuffer writtenData = ByteBuffer.allocate( 1024 );
     private ChunkedOutput out;
 
+
+    @Test
+    public void shouldNotNPE() throws Throwable
+    {
+        ExecutorService runner = Executors.newFixedThreadPool( 4 );
+        // When
+        runner.execute( () -> {
+            try
+            {
+                for ( int i = 0; i < 5; i++ )
+                {
+
+                    out.writeByte( (byte) 1 ).writeShort( (short) 2 );
+                    out.onMessageComplete();
+                    out.flush();
+                    Thread.sleep( ThreadLocalRandom.current().nextLong( 5 ) );
+
+                }
+            }
+            catch ( IOException | InterruptedException e )
+            {
+                throw new AssertionError( e );
+            }
+        } );
+        for ( int i = 0; i < 9; i++ )
+        {
+
+            runner.execute( () -> {
+                try
+                {
+                    for ( int j = 0; j < 5; j++ )
+                    {
+                        out.flush();
+                        Thread.sleep( ThreadLocalRandom.current().nextLong( 5 ) );
+                    }
+                }
+                catch ( IOException | InterruptedException e )
+                {
+                    throw new AssertionError( e );
+                }
+            } );
+        }
+
+        runner.awaitTermination( 2, TimeUnit.SECONDS );
+    }
+
     @Test
     public void shouldChunkSingleMessage() throws Throwable
     {
+        setupWriteAndFlush();
+
         // When
         out.writeByte( (byte) 1 ).writeShort( (short) 2 );
         out.onMessageComplete();
@@ -68,6 +118,8 @@ public class ChunkedOutputTest
     @Test
     public void shouldChunkMessageSpanningMultipleChunks() throws Throwable
     {
+        setupWriteAndFlush();
+
         // When
         out.writeLong( 1 ).writeLong( 2 ).writeLong( 3 );
         out.onMessageComplete();
@@ -83,6 +135,8 @@ public class ChunkedOutputTest
     @Test
     public void shouldReserveSpaceForChunkHeaderWhenWriteDataToNewChunk() throws IOException
     {
+        setupWriteAndFlush();
+
         // Given 2 bytes left in buffer + chunk is closed
         out.writeBytes( new byte[10], 0, 10 );  // 2 (header) + 10
         out.onMessageComplete();                // 2 (ending)
@@ -99,6 +153,8 @@ public class ChunkedOutputTest
     @Test
     public void shouldChunkDataWhoseSizeIsGreaterThanOutputBufferCapacity() throws IOException
     {
+        setupWriteAndFlush();
+
         // Given
         out.writeBytes( new byte[16], 0, 16 ); // 2 + 16 is greater than the default max size 16
         out.onMessageComplete();
@@ -113,6 +169,8 @@ public class ChunkedOutputTest
     @Test
     public void shouldNotThrowIfOutOfSyncFlush() throws Throwable
     {
+        setupWriteAndFlush();
+
         // When
         out.writeLong( 1 ).writeLong( 2 ).writeLong( 3 );
         out.onMessageComplete();
@@ -129,66 +187,105 @@ public class ChunkedOutputTest
     }
 
     @Test
-    public void shouldNotNPE() throws Throwable
+    public void shouldQueueWritesMadeWhileFlushing() throws Throwable
     {
-        ExecutorService runner = Executors.newFixedThreadPool( 10 );
-        // When
-        runner.execute( () -> {
-            try
-            {
-                for ( int i = 0; i < 10; i++ )
-                {
+        final CountDownLatch startLatch = new CountDownLatch( 1 );
+        final CountDownLatch finishLatch = new CountDownLatch( 1 );
+        final AtomicBoolean parallelException = new AtomicBoolean( false );
 
-                    out.writeByte( (byte) 1 ).writeShort( (short) 2 );
-                    out.onMessageComplete();
-                    out.flush();
-                    Thread.sleep( ThreadLocalRandom.current().nextLong( 10 ) );
-
-                }
-            }
-            catch ( IOException | InterruptedException e )
-            {
-                throw new AssertionError( e );
-            }
+        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).thenAnswer( invocation -> {
+            startLatch.countDown();
+            ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
+            writtenData.limit( writtenData.position() + byteBuf.readableBytes() );
+            byteBuf.readBytes( writtenData );
+            return null;
         } );
-        for ( int i = 0; i < 9; i++ )
-        {
 
-            runner.execute( () -> {
+        class ParallelWriter extends Thread
+        {
+            public void run()
+            {
                 try
                 {
-                    for ( int j = 0; j < 10; j++ )
-                    {
-                        out.flush();
-                        Thread.sleep( ThreadLocalRandom.current().nextLong( 10 ) );
-                    }
+                    startLatch.await();
+                    out.writeShort( (short) 2 );
+                    out.flush();
                 }
-                catch ( IOException | InterruptedException e )
+                catch ( Exception e )
                 {
-                    throw new AssertionError( e );
+                    e.printStackTrace( System.err );
+                    parallelException.set( true );
                 }
-            } );
+                finally
+                {
+                    finishLatch.countDown();
+                }
+            }
         }
+        new ParallelWriter().start();
 
-        runner.awaitTermination( 30, TimeUnit.SECONDS );
+        // When
+        out.writeShort( (short) 1 );
+        out.flush();
 
+        finishLatch.await();
+
+        // Then
+        assertFalse( parallelException.get() );
+        assertThat( writtenData.limit(), equalTo( 8 ) );
+        assertThat( HexPrinter.hex( writtenData, 0, 8 ), equalTo( "00 02 00 01 00 02 00 02" ) );
+    }
+
+    @Test
+    public void shouldNotBeAbleToWriteAfterClose() throws Throwable
+    {
+        // When
+        out.writeLong( 1 ).writeLong( 2 ).writeLong( 3 );
+        out.onMessageComplete();
+        out.flush();
+        out.close();
+        try
+        {
+            out.writeShort( (short) 42 );
+            fail( "Should have thrown IOException" );
+        }
+        catch ( IOException e )
+        {
+            // We've been expecting you Mr Bond.
+        }
+    }
+
+    @Test
+    public void shouldFlushOnClose() throws Throwable
+    {
+        setupWriteAndFlush();
+
+        // When
+        out.writeLong( 1 ).writeLong( 2 ).writeLong( 3 );
+        out.onMessageComplete();
+        out.close();
+
+        // Then
+        assertThat( writtenData.limit(), equalTo( 32 ) );
+        assertThat( HexPrinter.hex( writtenData, 0, 32 ),
+                equalTo( "00 08 00 00 00 00 00 00    00 01 00 08 00 00 00 00    " +
+                         "00 00 00 02 00 08 00 00    00 00 00 00 00 03 00 00" ) );
+    }
+
+    private void setupWriteAndFlush()
+    {
+        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).thenAnswer( invocation -> {
+            ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
+            writtenData.limit( writtenData.position() + byteBuf.readableBytes() );
+            byteBuf.readBytes( writtenData );
+            return null;
+        } );
     }
 
     @Before
     public void setup()
     {
         when( ch.alloc() ).thenReturn( UnpooledByteBufAllocator.DEFAULT );
-        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).thenAnswer( new Answer<Object>()
-        {
-            @Override
-            public Object answer( InvocationOnMock invocation ) throws Throwable
-            {
-                ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
-                writtenData.limit( writtenData.position() + byteBuf.readableBytes() );
-                byteBuf.readBytes( writtenData );
-                return null;
-            }
-        } );
         this.out = new ChunkedOutput( ch, 16 );
     }
 
@@ -197,5 +294,4 @@ public class ChunkedOutputTest
     {
         out.close();
     }
-
 }


### PR DESCRIPTION
`flush` is being called from the `SessionStateMachine` this can lead races where memory is leaked in the netty buffer and `NullPointerException` when one thread flushes the buffer just before the IO thread tries to write to the buffer.
