### PR TITLE
Renames default_advertised_address to default_advertised_hostname

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -531,8 +531,8 @@ public abstract class GraphDatabaseSettings
     @Description("Default hostname or IP address the server uses to advertise itself to its connectors. " +
             "To advertise a specific hostname or IP address for a specific connector, " +
             "specify the +advertised_address+ property for the specific connector.")
-    public static final Setting<String> default_advertised_hostname =
-            setting( "dbms.connectors.default_advertised_hostname", STRING, "localhost" );
+    public static final Setting<String> default_advertised_address =
+            setting( "dbms.connectors.default_advertised_address", STRING, "localhost" );
 
     @Group("dbms.connector")
     public static class Connector

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -46,7 +46,7 @@ import org.neo4j.helpers.collection.Iterables;
 
 import static java.lang.Character.isDigit;
 import static java.lang.Integer.parseInt;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_advertised_hostname;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_advertised_address;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_listen_address;
 import static org.neo4j.io.fs.FileUtils.fixSeparatorsInPath;
 
@@ -575,7 +575,7 @@ public class Settings
             @Override
             public String getDefaultValue()
             {
-                return default_advertised_hostname.getDefaultValue() + ":" +
+                return default_advertised_address.getDefaultValue() + ":" +
                         LISTEN_SOCKET_ADDRESS.apply( listenAddressSetting.getDefaultValue() ).socketAddress().getPort();
             }
 
@@ -589,7 +589,7 @@ public class Settings
             public AdvertisedSocketAddress apply( Function<String, String> config )
             {
                 ListenSocketAddress listenSocketAddress = listenAddressSetting.apply( config );
-                String hostname = default_advertised_hostname.apply( config );
+                String hostname = default_advertised_address.apply( config );
                 int port = listenSocketAddress.socketAddress().getPort();
 
                 String name = name();

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -92,7 +92,7 @@ public class GraphDatabaseSettingsTest
         String hostname = "my_other_host";
         int port = 9999;
         Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.default_advertised_hostname.name(), hostname ) );
+        config.augment( stringMap( GraphDatabaseSettings.default_advertised_address.name(), hostname ) );
         String scoping = "bla";
         config.augment( stringMap( GraphDatabaseSettings.boltConnector( scoping ).advertised_address.name(), ":" + port ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/AdvertisedAddressSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/AdvertisedAddressSettingsTest.java
@@ -43,7 +43,7 @@ public class AdvertisedAddressSettingsTest
     {
         // given
         Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.default_advertised_hostname.name(), "server1.example.com" ) );
+        config.augment( stringMap( GraphDatabaseSettings.default_advertised_address.name(), "server1.example.com" ) );
         config.augment( stringMap( advertised_address_setting.name(), "server1.internal:4000" ) );
 
         // when
@@ -59,7 +59,7 @@ public class AdvertisedAddressSettingsTest
     {
         // given
         Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.default_advertised_hostname.name(), "server1.example.com" ) );
+        config.augment( stringMap( GraphDatabaseSettings.default_advertised_address.name(), "server1.example.com" ) );
 
         // when
         AdvertisedSocketAddress advertisedSocketAddress = config.get( advertised_address_setting );
@@ -74,7 +74,7 @@ public class AdvertisedAddressSettingsTest
     {
         // given
         Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.default_advertised_hostname.name(), "server1.example.com" ) );
+        config.augment( stringMap( GraphDatabaseSettings.default_advertised_address.name(), "server1.example.com" ) );
         config.augment( stringMap( advertised_address_setting.name(), ":4000" ) );
 
         // when

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/ConsensusModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/ConsensusModule.java
@@ -20,7 +20,6 @@
 package org.neo4j.coreedge.core.consensus;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
 import org.neo4j.coreedge.core.EnterpriseCoreEditionModule;
@@ -140,7 +139,7 @@ public class ConsensusModule
 
         life.add( new RaftDiscoveryServiceConnector( discoveryService, raftMachine ) );
 
-        life.add(logShipping);
+        life.add( logShipping );
     }
 
     private RaftLog createRaftLog( Config config, LifeSupport life, FileSystemAbstraction fileSystem,

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Election.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/roles/Election.java
@@ -30,7 +30,7 @@ import org.neo4j.logging.Log;
 
 public class Election
 {
-    public static  boolean start( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
+    public static boolean start( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
     {
         Set<MemberId> currentMembers = ctx.votingMembers();
         if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
@@ -69,7 +69,7 @@ public class CoreClusterMember implements ClusterMember
         String initialMembers = addresses.stream().map( AdvertisedSocketAddress::toString ).collect( joining( "," ) );
 
         config.put( "dbms.mode", "CORE" );
-        config.put( GraphDatabaseSettings.default_advertised_hostname.name(), "localhost" );
+        config.put( GraphDatabaseSettings.default_advertised_address.name(), "localhost" );
         config.put( CoreEdgeClusterSettings.initial_discovery_members.name(), initialMembers );
         config.put( CoreEdgeClusterSettings.discovery_listen_address.name(), "127.0.0.1:" + hazelcastPort );
         config.put( CoreEdgeClusterSettings.transaction_listen_address.name(), "127.0.0.1:" + txPort );

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
@@ -20,7 +20,7 @@ dbms.security.auth_enabled=true
 # Neo4j advertises the addresses its connectors.
 # To specify the hostname or IP address of this server used in the advertised addresses,
 # change this to the address of the network adapter you want to advertise.
-#dbms.connectors.default_advertised_hostname=localhost
+#dbms.connectors.default_advertised_address=localhost
 
 # You can also choose a specific advertised hostname or IP address, and
 # configure an advertised port for each connector, by setting their

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -55,7 +55,7 @@ dbms.directories.import=import
 # Neo4j advertises the addresses its connectors.
 # To specify the hostname or IP address of this server used in the advertised addresses,
 # change this to the address of the network adapter you want to advertise.
-#dbms.connectors.default_advertised_hostname=localhost
+#dbms.connectors.default_advertised_address=localhost
 
 # You can also choose a specific advertised hostname or IP address, and
 # configure an advertised port for each connector, by setting their

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -61,7 +61,7 @@ dbms.directories.import=import
 # Neo4j advertises the addresses its connectors.
 # To specify the hostname or IP address of this server used in the advertised addresses,
 # change this to the address of the network adapter you want to advertise.
-#dbms.connectors.default_advertised_hostname=localhost
+#dbms.connectors.default_advertised_address=localhost
 
 # You can also choose a specific advertised hostname or IP address, and
 # configure an advertised port for each connector, by setting their


### PR DESCRIPTION
This rename ensures the naming of the config parameters are consistently
 using "address" instead of "hostname".
