### PR TITLE
Stop local services on a core when copying a store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -165,8 +165,8 @@ public class PlatformModule
         pageCache = dependencies.satisfyDependency( createPageCache( fileSystem, config, logging, tracers ) );
         life.add( new PageCacheLifecycle( pageCache ) );
 
-        diagnosticsManager = life.add( dependencies.satisfyDependency( new DiagnosticsManager( logging.getInternalLog(
-                DiagnosticsManager.class ) ) ) );
+        diagnosticsManager = life.add( dependencies
+                .satisfyDependency( new DiagnosticsManager( logging.getInternalLog( DiagnosticsManager.class ) ) ) );
 
         // TODO please fix the bad dependencies instead of doing this.
         // this was the place of the XaDataSourceManager. NeoStoreXaDataSource is create further down than
@@ -181,9 +181,7 @@ public class PlatformModule
 
         kernelExtensions = dependencies.satisfyDependency( new KernelExtensions(
                 new SimpleKernelContext( fileSystem, storeDir, databaseInfo, dependencies ),
-                externalDependencies.kernelExtensions(),
-                dependencies,
-                UnsatisfiedDependencyStrategies.fail() ) );
+                externalDependencies.kernelExtensions(), dependencies, UnsatisfiedDependencyStrategies.fail() ) );
 
         urlAccessRule = dependencies.satisfyDependency( URLAccessRules.combined( externalDependencies.urlAccessRules() ) );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/server/StartStopLife.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/server/StartStopLife.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.core.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class StartStopLife extends LifecycleAdapter
+{
+    private final List<Lifecycle> services = new ArrayList<>();
+
+    @Override
+    public synchronized void start() throws Throwable
+    {
+        for ( Lifecycle service : services )
+        {
+            service.start();
+        }
+    }
+
+    @Override
+    public synchronized void stop() throws Throwable
+    {
+        for ( Lifecycle service : services )
+        {
+            service.stop();
+        }
+    }
+
+    synchronized void register( Lifecycle lifecycle )
+    {
+        Objects.requireNonNull( lifecycle );
+        services.add( lifecycle );
+    }
+
+    synchronized void unregister( Lifecycle lifecycle )
+    {
+        Objects.requireNonNull( lifecycle );
+        services.remove( lifecycle );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloaderTest.java
@@ -30,6 +30,7 @@ import org.neo4j.coreedge.catchup.storecopy.CopiedStoreRecovery;
 import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
 import org.neo4j.coreedge.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.coreedge.catchup.storecopy.StoreFetcher;
+import org.neo4j.coreedge.core.server.StartStopLife;
 import org.neo4j.coreedge.core.state.CoreState;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.coreedge.identity.StoreId;
@@ -47,6 +48,7 @@ import static org.neo4j.coreedge.catchup.CatchupResult.SUCCESS;
 public class CoreStateDownloaderTest
 {
     private final LocalDatabase localDatabase = mock( LocalDatabase.class );
+    private final StartStopLife startStopLife = mock( StartStopLife.class );
     private final StoreFetcher storeFetcher = mock( StoreFetcher.class );
     private final CatchUpClient catchUpClient = mock( CatchUpClient.class );
     private final CopiedStoreRecovery recovery = mock( CopiedStoreRecovery.class );
@@ -59,8 +61,8 @@ public class CoreStateDownloaderTest
     private final File storeDir = new File( "graph.db" );
     private final File tempDir = new File( "graph.db/temp-copy" );
 
-    // DUT
-    private final CoreStateDownloader downloader = new CoreStateDownloader( localDatabase, storeFetcher, catchUpClient, logProvider, recovery );
+    private final CoreStateDownloader downloader =
+            new CoreStateDownloader( localDatabase, startStopLife, storeFetcher, catchUpClient, logProvider, recovery );
 
     @Before
     public void commonMocking()
@@ -96,8 +98,10 @@ public class CoreStateDownloaderTest
         downloader.downloadSnapshot( remoteMember, coreState );
 
         // then
+        verify( startStopLife ).stop();
         verify( localDatabase ).stop();
         verify( localDatabase ).start();
+        verify( startStopLife ).start();
     }
 
     @Test


### PR DESCRIPTION
While doing store copy we cannot server backup and/or catchup requests
so we need to stop those services and restart them after we have
completed the store copy.  In case a client was already performing a
backup/catchup it will be forced to handle the exception of a broken
connection.
