### PR TITLE
Retry Edge Server startup if failed on download from core server.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFetcher.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFetcher.java
@@ -82,7 +82,8 @@ public class StoreFetcher
         }
     }
 
-    public void copyStore( MemberId from, StoreId expectedStoreId, File destDir ) throws StoreCopyFailedException
+    public void copyStore( MemberId from, StoreId expectedStoreId, File destDir )
+            throws StoreCopyFailedException, StreamingTransactionsFailedException
     {
         try
         {
@@ -98,7 +99,7 @@ public class StoreFetcher
             CatchupResult catchupResult = pullTransactions( from, expectedStoreId, destDir, pullTxIndex );
             if ( catchupResult != SUCCESS )
             {
-                throw new StoreCopyFailedException( "Failed to pull transactions: " + catchupResult );
+                throw new StreamingTransactionsFailedException( "Failed to pull transactions: " + catchupResult );
             }
         }
         catch ( IOException e )
@@ -109,36 +110,6 @@ public class StoreFetcher
 
     public StoreId getStoreIdOf( MemberId from ) throws StoreIdDownloadFailedException
     {
-        String operation = "get store id from " + from;
-        long retryInterval = 5_000;
-        int attempts = 0;
-
-        while ( attempts++ < 5 )
-        {
-            log.info( "Attempt #%d to %s.", attempts, operation );
-
-            try
-            {
-                return storeCopyClient.fetchStoreId( from );
-            }
-            catch ( StoreIdDownloadFailedException e )
-            {
-                log.info( "Attempt #%d to %s failed.", attempts, operation );
-            }
-
-            try
-            {
-                log.info( "Next attempt to %s in %d ms.", operation, retryInterval );
-                Thread.sleep( retryInterval );
-                retryInterval = retryInterval * 2;
-            }
-            catch ( InterruptedException e )
-            {
-                Thread.interrupted();
-                throw new StoreIdDownloadFailedException( e );
-            }
-        }
-
-        throw new StoreIdDownloadFailedException( "Failed to " + operation + " after " + (attempts - 1) + " attempts" );
+        return storeCopyClient.fetchStoreId( from );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StreamingTransactionsFailedException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StreamingTransactionsFailedException.java
@@ -17,11 +17,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.coreedge.discovery;
+package org.neo4j.coreedge.catchup.storecopy;
 
-public class NoKnownAddressesException extends Exception
+public class StreamingTransactionsFailedException extends Exception
 {
-    public NoKnownAddressesException( String message )
+    StreamingTransactionsFailedException( String message )
     {
         super( message );
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloader.java
@@ -29,6 +29,7 @@ import org.neo4j.coreedge.catchup.storecopy.CopiedStoreRecovery;
 import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
 import org.neo4j.coreedge.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.coreedge.catchup.storecopy.StoreFetcher;
+import org.neo4j.coreedge.catchup.storecopy.StreamingTransactionsFailedException;
 import org.neo4j.coreedge.catchup.storecopy.TemporaryStoreDirectory;
 import org.neo4j.coreedge.core.state.CoreState;
 import org.neo4j.coreedge.identity.MemberId;
@@ -133,7 +134,8 @@ public class CoreStateDownloader
         }
     }
 
-    private void copyWholeStoreFrom( MemberId source, StoreId expectedStoreId, StoreFetcher storeFetcher ) throws IOException, StoreCopyFailedException
+    private void copyWholeStoreFrom( MemberId source, StoreId expectedStoreId, StoreFetcher storeFetcher )
+            throws IOException, StoreCopyFailedException, StreamingTransactionsFailedException
     {
         TemporaryStoreDirectory tempStore = new TemporaryStoreDirectory( localDatabase.storeDir() );
         storeFetcher.copyStore( source, expectedStoreId, tempStore.storeDir() );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreTopology.java
@@ -68,7 +68,7 @@ public class CoreTopology
         CoreAddresses coreAddresses = coreMembers.get( memberId );
         if ( coreAddresses == null )
         {
-            throw new NoKnownAddressesException();
+            throw new NoKnownAddressesException( "Unable to find address mapping for member: " + memberId );
         }
         return coreAddresses;
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EdgeStartupProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EdgeStartupProcess.java
@@ -105,12 +105,12 @@ class EdgeStartupProcess implements Lifecycle
             try
             {
                 Thread.sleep( retryInterval );
-                retryInterval = retryInterval * 2;
+                retryInterval = Math.min( 60_000, retryInterval * 2 );
             }
             catch ( InterruptedException e )
             {
                 Thread.interrupted();
-                throw new RuntimeException( "Interrupted while trying to start edge server. Shutting down.", e );
+                throw new RuntimeException( "Interrupted while trying to start edge server.", e );
             }
         }
         throw new Exception( "Failed to start edge server after " + (attempts - 1) + " attempts" );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
@@ -109,9 +109,9 @@ public class EdgeStartupProcessTest
             edgeStartupProcess.start();
             fail( "should have thrown" );
         }
-        catch ( IllegalStateException ex )
+        catch ( Exception ex )
         {
-            // expected
+            //expected.
         }
 
         // then

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/edge/EdgeStartupProcessTest.java
@@ -39,11 +39,12 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -112,6 +113,9 @@ public class EdgeStartupProcessTest
         catch ( Exception ex )
         {
             //expected.
+            assertThat( ex.getMessage(), containsString(
+                    "This edge machine cannot join the cluster. The local database is not empty and has a " +
+                            "mismatching storeId" ) );
         }
 
         // then

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.coreedge.scenarios;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -29,16 +32,13 @@ import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
 
-import org.junit.Rule;
-import org.junit.Test;
-
+import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.core.CoreGraphDatabase;
+import org.neo4j.coreedge.core.consensus.log.segmented.FileNames;
+import org.neo4j.coreedge.core.consensus.roles.Role;
 import org.neo4j.coreedge.discovery.Cluster;
 import org.neo4j.coreedge.discovery.CoreClusterMember;
 import org.neo4j.coreedge.discovery.EdgeClusterMember;
-import org.neo4j.coreedge.core.consensus.log.segmented.FileNames;
-import org.neo4j.coreedge.core.consensus.roles.Role;
-import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
-import org.neo4j.coreedge.core.CoreGraphDatabase;
 import org.neo4j.coreedge.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.coreedge.edge.EdgeGraphDatabase;
 import org.neo4j.function.ThrowingSupplier;
@@ -67,7 +67,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -77,7 +76,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.coreedge.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.coreedge.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
 import static org.neo4j.function.Predicates.awaitEx;
@@ -203,7 +201,7 @@ public class EdgeServerReplicationIT
         {
             // Lifecycle should throw exception, server should not start.
             assertThat( required.getCause(), instanceOf( LifecycleException.class ) );
-            assertThat( required.getCause().getCause(), instanceOf( IllegalStateException.class ) );
+            assertThat( required.getCause().getCause(), instanceOf( Exception.class ) );
             assertThat( required.getCause().getCause().getMessage(),
                     containsString( "This edge machine cannot join the cluster. " +
                             "The local database is not empty and has a mismatching storeId:" ) );


### PR DESCRIPTION
Previously we would retry when attempting to get the store Id. This change will cause us to retry on any error when starting up an edge server. Each retry attempt will randomly pick a core server to try to download from. 
