### PR TITLE
Make enterprise built-in procedures work with auth disabled

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -276,14 +276,6 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
     private Authentication authentication( Config config, AuthManager authManager, LogService logService )
     {
-
-        if ( config.get( GraphDatabaseSettings.auth_enabled ) )
-        {
-            return new BasicAuthentication( authManager, logService.getInternalLogProvider() );
-        }
-        else
-        {
-            return Authentication.NONE;
-        }
+        return new BasicAuthentication( authManager, logService.getInternalLogProvider() );
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
@@ -44,9 +44,4 @@ public interface Authentication
      * @throws AuthenticationException If authentication failed.
      */
     AuthenticationResult authenticate( Map<String,Object> authToken ) throws AuthenticationException;
-
-    /**
-     * Allows all tokens to authenticate.
-     */
-    Authentication NONE = authToken -> AuthenticationResult.AUTH_DISABLED;
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -101,15 +101,7 @@ class SessionRule implements TestRule
 
     private Authentication authentication( Config config, AuthManager authManager, LogService logService )
     {
-
-        if ( config.get( GraphDatabaseSettings.auth_enabled ) )
-        {
-            return new BasicAuthentication( authManager, logService.getInternalLogProvider() );
-        }
-        else
-        {
-            return Authentication.NONE;
-        }
+        return new BasicAuthentication( authManager, logService.getInternalLogProvider() );
     }
 
     BoltStateMachine newMachine( String connectionDescriptor )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -137,7 +137,7 @@ public abstract class EditionModule
         boolean authEnabled = config.get( GraphDatabaseSettings.auth_enabled );
         if ( !authEnabled )
         {
-            return AuthManager.NO_AUTH;
+            return getAuthDisabledAuthManager();
         }
 
         String configuredKey = config.get( GraphDatabaseSettings.auth_manager );
@@ -174,6 +174,11 @@ public abstract class EditionModule
         }
 
         return authManager;
+    }
+
+    protected AuthManager getAuthDisabledAuthManager()
+    {
+        return AuthManager.NO_AUTH;
     }
 
     private AuthManager tryMakeInOrder( Config config, LogService logging, FileSystemAbstraction fileSystem,

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/EnterpriseCoreEditionModule.java
@@ -60,7 +60,9 @@ import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
@@ -335,4 +337,9 @@ public class EnterpriseCoreEditionModule extends EditionModule
         return new StandardBoltConnectionTracker();
     }
 
+    @Override
+    protected AuthManager getAuthDisabledAuthManager()
+    {
+        return EnterpriseAuthManager.NO_AUTH;
+    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -51,7 +51,9 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
 import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
@@ -275,5 +277,11 @@ public class EnterpriseEdgeEditionModule extends EditionModule
     protected BoltConnectionTracker createSessionTracker()
     {
         return new StandardBoltConnectionTracker();
+    }
+
+    @Override
+    protected AuthManager getAuthDisabledAuthManager()
+    {
+        return EnterpriseAuthManager.NO_AUTH;
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -63,8 +63,10 @@ import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.ha.BranchDetectingTxVerifier;
 import org.neo4j.kernel.ha.BranchedDataMigrator;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
@@ -870,5 +872,11 @@ public class HighlyAvailableEditionModule
     protected BoltConnectionTracker createSessionTracker()
     {
         return new StandardBoltConnectionTracker();
+    }
+
+    @Override
+    protected AuthManager getAuthDisabledAuthManager()
+    {
+        return EnterpriseAuthManager.NO_AUTH;
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.enterprise.api.security;
+
+import java.util.Map;
+
+import org.neo4j.kernel.api.security.AuthManager;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+
+public interface EnterpriseAuthManager extends AuthManager
+{
+    void clearAuthCache();
+
+    @Override
+    EnterpriseAuthSubject login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
+
+    /**
+     * Implementation that does no authentication.
+     */
+    EnterpriseAuthManager NO_AUTH = new EnterpriseAuthManager()
+    {
+        @Override
+        public EnterpriseAuthSubject login( Map<String,Object> authToken )
+        {
+            return EnterpriseAuthSubject.AUTH_DISABLED;
+        }
+
+        @Override
+        public void init() throws Throwable
+        {
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+        }
+
+        @Override
+        public void stop() throws Throwable
+        {
+        }
+
+        @Override
+        public void shutdown() throws Throwable
+        {
+        }
+
+        @Override
+        public void clearAuthCache()
+        {
+        }
+    };
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -22,7 +22,9 @@ package org.neo4j.kernel.impl.enterprise;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.enterprise.id.EnterpriseIdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.enterprise.transaction.log.checkpoint.ConfigurableIOLimiter;
@@ -105,5 +107,11 @@ public class EnterpriseEditionModule extends CommunityEditionModule
     protected Log authManagerLog()
     {
         return securityLog == null ? NullLog.getInstance() : securityLog;
+    }
+
+    @Override
+    protected AuthManager getAuthDisabledAuthManager()
+    {
+        return EnterpriseAuthManager.NO_AUTH;
     }
 }

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -61,6 +60,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.api.security.AccessMode.Static.FULL;
 
 public class QueryLoggerIT
@@ -94,10 +94,10 @@ public class QueryLoggerIT
     public void shouldLogCustomUserName() throws Throwable
     {
         // turn on query logging
-        final Map<Setting<?>, String> config = new HashMap<>( 2 );
-        config.put( GraphDatabaseSettings.logs_directory, logsDirectory.getPath() );
-        config.put( GraphDatabaseSettings.log_queries, Settings.TRUE );
-        EmbeddedInteraction db = new EmbeddedInteraction( config, databaseBuilder );
+        final Map<String, String> config = stringMap(
+            GraphDatabaseSettings.logs_directory.name(), logsDirectory.getPath(),
+            GraphDatabaseSettings.log_queries.name(), Settings.TRUE );
+        EmbeddedInteraction db = new EmbeddedInteraction( databaseBuilder, config );
 
         // create users
         db.getLocalUserManager().newUser( "mats", "neo4j", false );
@@ -132,7 +132,7 @@ public class QueryLoggerIT
         // turn on query logging
         databaseBuilder.setConfig( GraphDatabaseSettings.logs_directory, logsDirectory.getPath() );
         databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE );
-        EmbeddedInteraction db = new EmbeddedInteraction( Collections.emptyMap(), databaseBuilder );
+        EmbeddedInteraction db = new EmbeddedInteraction( databaseBuilder, Collections.emptyMap() );
         GraphDatabaseFacade graph = db.getLocalGraph();
 
         db.getLocalUserManager().setUserPassword( "neo4j", "123", false );

--- a/enterprise/security/src/main/java/org/neo4j/commandline/admin/security/RolesCommand.java
+++ b/enterprise/security/src/main/java/org/neo4j/commandline/admin/security/RolesCommand.java
@@ -42,7 +42,7 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.NullLog;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.configuration.ConfigLoader;
-import org.neo4j.server.security.enterprise.auth.EnterpriseAuthManager;
+import org.neo4j.server.security.enterprise.auth.EnterpriseAuthAndUserManager;
 import org.neo4j.server.security.enterprise.auth.EnterpriseAuthManagerFactory;
 import org.neo4j.server.security.enterprise.auth.RoleRepository;
 
@@ -86,7 +86,7 @@ public class RolesCommand implements AdminCommand
     private final Path configDir;
     private OutsideWorld outsideWorld;
     private JobScheduler jobScheduler;
-    private EnterpriseAuthManager authManager;
+    private EnterpriseAuthAndUserManager authManager;
 
     public RolesCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
@@ -194,14 +194,14 @@ public class RolesCommand implements AdminCommand
 
     private void createRole( String roleName ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().newRole( roleName );
         outsideWorld.stdOutLine( "Created new role '" + roleName + "'" );
     }
 
     private void deleteRole( String roleName ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().getRole( roleName ); // Will throw error on missing role
         if ( authManager.getUserManager().deleteRole( roleName ) )
         {
@@ -215,7 +215,7 @@ public class RolesCommand implements AdminCommand
 
     private void assignRole( String roleName, String username ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().getRole( roleName ); // Will throw error on missing role
         authManager.getUserManager().getUser( username ); // Will throw error on missing user
         for ( String name : authManager.getUserManager().getUsernamesForRole( roleName ) )
@@ -231,7 +231,7 @@ public class RolesCommand implements AdminCommand
 
     private void removeRole( String roleName, String username ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().getRole( roleName ); // Will throw error on missing role
         authManager.getUserManager().getUser( username ); // Will throw error on missing user
         for ( String name : authManager.getUserManager().getUsernamesForRole( roleName ) )
@@ -248,7 +248,7 @@ public class RolesCommand implements AdminCommand
 
     private void rolesFor( String username ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().getUser( username ); // Will throw error on missing user
         for ( String roleName : authManager.getUserManager().getRoleNamesForUser( username ) )
         {
@@ -258,7 +258,7 @@ public class RolesCommand implements AdminCommand
 
     private void usersFor( String roleName ) throws Throwable
     {
-        EnterpriseAuthManager authManager = getAuthManager();
+        EnterpriseAuthAndUserManager authManager = getAuthManager();
         authManager.getUserManager().getRole( roleName ); // Will throw error on missing role
         for ( String username : authManager.getUserManager().getUsernamesForRole( roleName ) )
         {
@@ -291,7 +291,7 @@ public class RolesCommand implements AdminCommand
         return repo;
     }
 
-    private EnterpriseAuthManager getAuthManager() throws Throwable
+    private EnterpriseAuthAndUserManager getAuthManager() throws Throwable
     {
         if ( this.authManager == null )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
-import org.neo4j.kernel.api.security.AuthManager;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.server.security.auth.UserManagerSupplier;
 
-public interface EnterpriseAuthManager extends AuthManager, UserManagerSupplier
+public interface EnterpriseAuthAndUserManager extends EnterpriseAuthManager, UserManagerSupplier
 {
     @Override
     EnterpriseUserManager getUserManager();
-
-    void clearAuthCache();
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
@@ -64,7 +64,7 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
     }
 
     @Override
-    public EnterpriseAuthManager newInstance( Config config, LogProvider logProvider, Log allegedSecurityLog,
+    public EnterpriseAuthAndUserManager newInstance( Config config, LogProvider logProvider, Log allegedSecurityLog,
             FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
 //        StaticLoggerBinder.setNeo4jLogProvider( logProvider );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -49,7 +49,7 @@ import org.neo4j.server.security.enterprise.auth.plugin.spi.RealmLifecycle;
 
 import static org.neo4j.helpers.Strings.escape;
 
-class MultiRealmAuthManager implements EnterpriseAuthManager
+class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
 {
     private final EnterpriseUserManager userManager;
     private final Collection<Realm> realms;

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -35,7 +35,7 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
     static final String READ_WRITE = "data:read,write";
     static final String READ = "data:read";
 
-    private final EnterpriseAuthManager authManager;
+    private final EnterpriseAuthAndUserManager authManager;
     private final ShiroSubject shiroSubject;
 
     public static StandardEnterpriseAuthSubject castOrFail( AuthSubject authSubject )
@@ -43,7 +43,7 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
         return EnterpriseAuthSubject.castOrFail( StandardEnterpriseAuthSubject.class, authSubject );
     }
 
-    public StandardEnterpriseAuthSubject( EnterpriseAuthManager authManager, ShiroSubject shiroSubject )
+    public StandardEnterpriseAuthSubject( EnterpriseAuthAndUserManager authManager, ShiroSubject shiroSubject )
     {
         this.authManager = authManager;
         this.shiroSubject = shiroSubject;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthenticationResult;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
@@ -93,9 +94,13 @@ class BoltInteraction implements NeoInteractionLevel<BoltInteraction.BoltSubject
     }
 
     @Override
-    public EnterpriseUserManager getLocalUserManager()
+    public EnterpriseUserManager getLocalUserManager() throws Exception
     {
-        return authManager.getUserManager();
+        if ( authManager instanceof EnterpriseAuthAndUserManager )
+        {
+            return ((EnterpriseAuthAndUserManager) authManager).getUserManager();
+        }
+        throw new Exception( "The used configuration does not have a user manager" );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
@@ -24,10 +24,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.graphdb.config.Setting;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -35,7 +33,7 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
 public interface NeoInteractionLevel<S>
 {
-    EnterpriseUserManager getLocalUserManager();
+    EnterpriseUserManager getLocalUserManager() throws Exception;
 
     GraphDatabaseFacade getLocalGraph();
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -39,7 +39,6 @@ import java.util.stream.Stream;
 import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;


### PR DESCRIPTION
Some built-in procedures in enterprise requires an enterprise auth subject to work (the concept of admin only exists in enterprise).
