### PR TITLE
Proper namespace resolution

### DIFF
--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/FunctionInvocation.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/FunctionInvocation.scala
@@ -36,7 +36,7 @@ object FunctionInvocation {
 
 case class FunctionInvocation(namespace: Namespace, functionName: FunctionName, distinct: Boolean, args: IndexedSeq[Expression])
                              (val position: InputPosition) extends Expression {
-  val name = functionName.name
+  val name = (namespace.parts :+ functionName.name).mkString(".")
   val function = Function.lookup.getOrElse(name.toLowerCase, UnresolvedFunction)
 
   def semanticCheck(ctx: SemanticContext) = function.semanticCheckHook(ctx, this)

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
 
 /**
  * Utility for constructing and starting Neo4j for test purposes.
@@ -101,7 +102,7 @@ public interface TestServerBuilder
 
     /**
      * Pre-populate the server with a database copied from the specified directory
-     * @param sourceDirectory
+     * @param sourceDirectory the directory to copy from
      * @return this builder instance
      */
     TestServerBuilder copyFrom( File sourceDirectory );
@@ -115,4 +116,14 @@ public interface TestServerBuilder
      * @return this builder instance
      */
     TestServerBuilder withProcedure( Class<?> procedureClass );
+
+    /**
+     * Configure the server to load the specified function definition class. The class should contain one or more
+     * methods annotated with {@link UserFunction}, these will become available to call through
+     * cypher.
+     *
+     * @param functionClass a class containing one or more function definitions
+     * @return this builder instance
+     */
+    TestServerBuilder withFunction( Class<?> functionClass );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -255,7 +255,7 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
     /**
      * A kernel extension used to ensure we load user-registered procedures
      * after other kernel extensions have initialized, since kernel extensions
-     * can addProcedure custom injectables that procedures need.
+     * can add custom injectables that procedures need.
      */
     private static class Neo4jHarnessExtensions extends KernelExtensionFactory<Neo4jHarnessExtensions.Dependencies>
     {

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -196,7 +196,14 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
     @Override
     public TestServerBuilder withProcedure( Class<?> procedureClass )
     {
-        procedures.add( procedureClass );
+        procedures.addProcedure( procedureClass );
+        return this;
+    }
+
+    @Override
+    public TestServerBuilder withFunction( Class<?> functionClass )
+    {
+        procedures.addFunction( functionClass );
         return this;
     }
 
@@ -248,7 +255,7 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
     /**
      * A kernel extension used to ensure we load user-registered procedures
      * after other kernel extensions have initialized, since kernel extensions
-     * can add custom injectables that procedures need.
+     * can addProcedure custom injectables that procedures need.
      */
     private static class Neo4jHarnessExtensions extends KernelExtensionFactory<Neo4jHarnessExtensions.Dependencies>
     {

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/HarnessRegisteredProcs.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/HarnessRegisteredProcs.java
@@ -28,10 +28,16 @@ import org.neo4j.kernel.impl.proc.Procedures;
 public class HarnessRegisteredProcs
 {
     private final List<Class<?>> procs = new LinkedList<>();
+    private final List<Class<?>> functions = new LinkedList<>();
 
-    public void add( Class<?> procedureClass )
+    public void addProcedure( Class<?> procedureClass )
     {
         this.procs.add( procedureClass );
+    }
+
+    public void addFunction( Class<?> functionClass )
+    {
+        this.functions.add( functionClass );
     }
 
     @SuppressWarnings( "deprecation" )
@@ -40,6 +46,11 @@ public class HarnessRegisteredProcs
         for ( Class<?> cls : procs )
         {
             procedures.registerProcedure( cls );
+        }
+
+        for ( Class<?> cls : functions )
+        {
+            procedures.registerFunction( cls );
         }
     }
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.harness.junit;
 
-import java.io.File;
-import java.net.URI;
-import java.util.function.Function;
-
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.net.URI;
+import java.util.function.Function;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Configuration;
@@ -144,6 +144,13 @@ public class Neo4jRule implements TestRule, TestServerBuilder
     public Neo4jRule withProcedure( Class<?> procedureClass )
     {
         builder = builder.withProcedure( procedureClass );
+        return this;
+    }
+
+    @Override
+    public Neo4jRule withFunction( Class<?> functionClass )
+    {
+        builder = builder.withFunction( functionClass );
         return this;
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTest.java
@@ -65,7 +65,7 @@ public class JavaFunctionsTest
         @Context
         public SomeService service;
 
-        @UserFunction("my.hello")
+        @UserFunction( "my.hello" )
         public String hello()
         {
             return service.hello();
@@ -77,7 +77,7 @@ public class JavaFunctionsTest
         @Context
         public MyCoreAPI myCoreAPI;
 
-        @UserFunction( value = "my.willFail")
+        @UserFunction( value = "my.willFail" )
         public long willFail() throws ProcedureException
         {
             return myCoreAPI.makeNode( "Test" );
@@ -94,11 +94,14 @@ public class JavaFunctionsTest
     public void shouldLaunchWithDeclaredFunctions() throws Exception
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class ).newServer())
+        try ( ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class )
+                .newServer() )
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
-                    quotedJson( "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.myFunc() AS someNumber' } ] }" ) );
+                    quotedJson(
+                            "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.myFunc() AS someNumber' } ] " +
+                            "}" ) );
 
             JsonNode result = response.get( "results" ).get( 0 );
             assertEquals( "someNumber", result.get( "columns" ).get( 0 ).asText() );
@@ -111,14 +114,19 @@ public class JavaFunctionsTest
     public void shouldGetHelpfulErrorOnProcedureThrowsException() throws Exception
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class ).newServer())
+        try ( ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class )
+                .newServer() )
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
-                    quotedJson( "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.funcThatThrows()' } ] }" ) );
+                    quotedJson(
+                            "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.funcThatThrows()' } ] }" ) );
 
             String error = response.get( "errors" ).get( 0 ).get( "message" ).asText();
-            assertEquals( "Failed to invoke function `org.neo4j.harness.funcThatThrows`: Caused by: java.lang.RuntimeException: This is an exception", error );
+            assertEquals(
+                    "Failed to invoke function `org.neo4j.harness.funcThatThrows`: Caused by: java.lang" +
+                    ".RuntimeException: This is an exception",
+                    error );
         }
     }
 
@@ -126,7 +134,8 @@ public class JavaFunctionsTest
     public void shouldWorkWithInjectableFromKernelExtension() throws Throwable
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctionsUsingMyService.class ).newServer())
+        try ( ServerControls server = TestServerBuilders.newInProcessBuilder()
+                .withFunction( MyFunctionsUsingMyService.class ).newServer() )
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaFunctionsTest.java
@@ -23,13 +23,9 @@ import org.codehaus.jackson.JsonNode;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.stream.Stream;
-
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.procedure.Context;
-import org.neo4j.procedure.Mode;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.server.HTTP;
@@ -39,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
-public class JavaProceduresTest
+public class JavaFunctionsTest
 {
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
@@ -47,89 +43,62 @@ public class JavaProceduresTest
     @Rule
     public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
 
-    public static class MyProcedures
+    public static class MyFunctions
     {
-        public static class OutputRecord
+
+        @UserFunction
+        public long myFunc()
         {
-            public long someNumber = 1337;
+            return 1337L;
         }
 
-        @Procedure
-        public Stream<OutputRecord> myProc()
-        {
-            return Stream.of( new OutputRecord() );
-        }
-
-        @Procedure
-        public Stream<OutputRecord> procThatThrows()
+        @UserFunction
+        public long funcThatThrows()
         {
             throw new RuntimeException( "This is an exception" );
         }
     }
 
-    public static class MyProceduresUsingMyService
+    public static class MyFunctionsUsingMyService
     {
-        public static class OutputRecord
-        {
-            public String result;
-        }
 
         @Context
         public SomeService service;
 
-        @Procedure("hello")
-        public Stream<OutputRecord> hello()
+        @UserFunction("my.hello")
+        public String hello()
         {
-            OutputRecord t = new OutputRecord();
-            t.result = service.hello();
-            return Stream.of( t );
+            return service.hello();
         }
     }
 
-    public static class MyProceduresUsingMyCoreAPI
+    public static class MyFunctionsUsingMyCoreAPI
     {
-        public static class LongResult
-        {
-            public Long value;
-        }
-
         @Context
         public MyCoreAPI myCoreAPI;
 
-        @Procedure( value = "makeNode", mode = Mode.WRITE )
-        public Stream<LongResult> makeNode( @Name( "label" ) String label ) throws ProcedureException
+        @UserFunction( value = "my.willFail")
+        public long willFail() throws ProcedureException
         {
-            LongResult t = new LongResult();
-            t.value = myCoreAPI.makeNode( label );
-            return Stream.of( t );
+            return myCoreAPI.makeNode( "Test" );
         }
 
-        @Procedure( value = "willFail", mode = Mode.READ )
-        public Stream<LongResult> willFail() throws ProcedureException
+        @UserFunction( "my.countNodes" )
+        public long countNodes()
         {
-            LongResult t = new LongResult();
-            t.value = myCoreAPI.makeNode( "Test" );
-            return Stream.of( t );
-        }
-
-        @Procedure( "countNodes" )
-        public Stream<LongResult> countNodes()
-        {
-            LongResult t = new LongResult();
-            t.value = myCoreAPI.countNodes();
-            return Stream.of( t );
+            return myCoreAPI.countNodes();
         }
     }
 
     @Test
-    public void shouldLaunchWithDeclaredProcedures() throws Exception
+    public void shouldLaunchWithDeclaredFunctions() throws Exception
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withProcedure( MyProcedures.class ).newServer())
+        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class ).newServer())
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
-                    quotedJson( "{ 'statements': [ { 'statement': 'CALL org.neo4j.harness.myProc' } ] }" ) );
+                    quotedJson( "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.myFunc() AS someNumber' } ] }" ) );
 
             JsonNode result = response.get( "results" ).get( 0 );
             assertEquals( "someNumber", result.get( "columns" ).get( 0 ).asText() );
@@ -142,14 +111,14 @@ public class JavaProceduresTest
     public void shouldGetHelpfulErrorOnProcedureThrowsException() throws Exception
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withProcedure( MyProcedures.class ).newServer())
+        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctions.class ).newServer())
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
-                    quotedJson( "{ 'statements': [ { 'statement': 'CALL org.neo4j.harness.procThatThrows' } ] }" ) );
+                    quotedJson( "{ 'statements': [ { 'statement': 'RETURN org.neo4j.harness.funcThatThrows()' } ] }" ) );
 
             String error = response.get( "errors" ).get( 0 ).get( "message" ).asText();
-            assertEquals( "Failed to invoke procedure `org.neo4j.harness.procThatThrows`: Caused by: java.lang.RuntimeException: This is an exception", error );
+            assertEquals( "Failed to invoke function `org.neo4j.harness.funcThatThrows`: Caused by: java.lang.RuntimeException: This is an exception", error );
         }
     }
 
@@ -157,11 +126,11 @@ public class JavaProceduresTest
     public void shouldWorkWithInjectableFromKernelExtension() throws Throwable
     {
         // When
-        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withProcedure( MyProceduresUsingMyService.class ).newServer())
+        try(ServerControls server = TestServerBuilders.newInProcessBuilder().withFunction( MyFunctionsUsingMyService.class ).newServer())
         {
             // Then
             HTTP.Response response = HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
-                    quotedJson( "{ 'statements': [ { 'statement': 'CALL hello' } ] }" ) );
+                    quotedJson( "{ 'statements': [ { 'statement': 'RETURN my.hello() AS result' } ] }" ) );
 
             assertEquals( "[]", response.get( "errors" ).toString() );
             JsonNode result = response.get( "results" ).get( 0 );
@@ -175,14 +144,14 @@ public class JavaProceduresTest
     {
         // When
         try ( ServerControls server = TestServerBuilders.newInProcessBuilder()
-                .withProcedure( MyProceduresUsingMyCoreAPI.class ).newServer() )
+                .withFunction( MyFunctionsUsingMyCoreAPI.class ).newServer() )
         {
+            HTTP.POST( server.httpURI().resolve( "db/data/transaction/commit" ).toString(),
+                    quotedJson( "{ 'statements': [ { 'statement': 'CREATE (), (), ()' } ] }" ) );
+
             // Then
-            assertQueryGetsValue( server, "CALL makeNode(\\'Test\\')", 0L );
-            assertQueryGetsValue( server, "CALL makeNode(\\'Test\\')", 1L );
-            assertQueryGetsValue( server, "CALL makeNode(\\'Test\\')", 2L );
-            assertQueryGetsValue( server, "CALL countNodes", 3L );
-            assertQueryGetsError( server, "CALL willFail", "Write operations are not allowed" );
+            assertQueryGetsValue( server, "RETURN my.countNodes() AS value", 3L );
+            assertQueryGetsError( server, "RETURN my.willFail() AS value", "Write operations are not allowed" );
         }
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness;
+
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+public class MyCoreAPI
+{
+    private final GraphDatabaseAPI graph;
+    private final ThreadToStatementContextBridge txBridge;
+    private final Log log;
+
+    public MyCoreAPI( GraphDatabaseAPI graph, ThreadToStatementContextBridge txBridge, Log log )
+    {
+        this.graph = graph;
+        this.txBridge = txBridge;
+        this.log = log;
+    }
+
+    public long makeNode( String label ) throws ProcedureException
+    {
+        long result;
+        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AccessMode.Static.WRITE ) )
+        {
+            Statement statement = this.txBridge.get();
+            DataWriteOperations writeOps = statement.dataWriteOperations();
+            long nodeId = writeOps.nodeCreate();
+            int labelId = writeOps.labelGetOrCreateForName( label );
+            writeOps.nodeAddLabel( nodeId, labelId );
+            result = nodeId;
+            tx.success();
+        }
+        catch ( Exception e )
+        {
+            log.error( "Failed to create node: " + e.getMessage() );
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
+                    "Failed to create node: " + e.getMessage(), e );
+        }
+        return result;
+    }
+
+    public long countNodes()
+    {
+        long result;
+        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AccessMode.Static.READ ) )
+        {
+            Statement statement = this.txBridge.get();
+            result = statement.readOperations().countsForNode( -1 );
+            tx.success();
+        }
+        return result;
+    }
+}

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness;
+
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+// Similar to the MyExtensionThatAddsInjectable, this demonstrates a
+// non-public mechanism for adding new context components, but in this
+// case the goal is to provide alternative Core API's and as such it wraps
+// the old Core API.
+public class MyExtensionThatAddsAlternativeCoreAPI
+        extends KernelExtensionFactory<MyExtensionThatAddsAlternativeCoreAPI.Dependencies>
+{
+    public MyExtensionThatAddsAlternativeCoreAPI()
+    {
+        super( "my-ext" );
+    }
+
+    @Override
+    public Lifecycle newInstance( KernelContext context,
+            Dependencies dependencies ) throws Throwable
+    {
+        dependencies.procedures().registerComponent( MyCoreAPI.class,
+                ( ctx ) -> new MyCoreAPI( dependencies.getGraphDatabaseAPI(), dependencies.txBridge(),
+                        dependencies.logService().getUserLog( MyCoreAPI.class ) ) );
+        return new LifecycleAdapter();
+    }
+
+    public interface Dependencies
+    {
+        LogService logService();
+
+        Procedures procedures();
+
+        GraphDatabaseAPI getGraphDatabaseAPI();
+
+        ThreadToStatementContextBridge txBridge();
+
+    }
+}

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness;
+
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+// This ensures a non-public mechanism for adding new context components
+// to Procedures is testable via Harness. While this is not public API,
+// this is a vital mechanism to cover use cases Procedures need to cover,
+// and is in place as an approach that should either eventually be made
+// public, or the relevant use cases addressed in other ways.
+public class MyExtensionThatAddsInjectable
+        extends KernelExtensionFactory<MyExtensionThatAddsInjectable.Dependencies>
+{
+    public MyExtensionThatAddsInjectable()
+    {
+        super( "my-ext" );
+    }
+
+    @Override
+    public Lifecycle newInstance( KernelContext context,
+            Dependencies dependencies ) throws Throwable
+    {
+        dependencies.procedures().registerComponent( SomeService.class, ( ctx ) -> new SomeService() );
+        return new LifecycleAdapter();
+    }
+
+    public interface Dependencies
+    {
+        Procedures procedures();
+    }
+}

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/SomeService.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/SomeService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.harness;
+
+public class SomeService
+{
+    public String hello()
+    {
+        return "world";
+    }
+}

--- a/community/neo4j-harness/src/test/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
+++ b/community/neo4j-harness/src/test/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
@@ -1,2 +1,2 @@
-org.neo4j.harness.JavaProceduresTest$MyExtensionThatAddsInjectable
-org.neo4j.harness.JavaProceduresTest$MyExtensionThatAddsAlternativeCoreAPI
+org.neo4j.harness.MyExtensionThatAddsInjectable
+org.neo4j.harness.MyExtensionThatAddsAlternativeCoreAPI

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -679,12 +679,15 @@ public class UserFunctionIT
         assertFalse( res.hasNext() );
     }
 
+    /**
+     * NOTE: this test tests user-defined functions added in this file {@link ClassWithFunctions}. These are not
+     * built-in functions in any shape or form.
+     */
     @Test
-    public void shouldListAllFunctions() throws Throwable
+    public void shouldListAllUserDefinedFunctions() throws Throwable
     {
         //Given/When
         Result res = db.execute( "CALL dbms.functions()" );
-
 
         String expected =
         "+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+" + lineSeparator() +
@@ -713,9 +716,9 @@ public class UserFunctionIT
         "| 'org.neo4j.procedure.simpleArgument'                | 'org.neo4j.procedure.simpleArgument(someValue :: INTEGER?) :: (INTEGER?)'                                                                                    | ''                      |" + lineSeparator() +
         "| 'org.neo4j.procedure.squareDouble'                  | 'org.neo4j.procedure.squareDouble(someValue :: FLOAT?) :: (FLOAT?)'                                                                                          | ''                      |" + lineSeparator() +
         "| 'org.neo4j.procedure.squareLong'                    | 'org.neo4j.procedure.squareLong(someValue :: INTEGER?) :: (INTEGER?)'                                                                                        | ''                      |" + lineSeparator() +
-        "| 'org.neo4j.procedure.sum'                           | 'org.neo4j.procedure.sum(numbers :: LIST? OF NUMBER?) :: (NUMBER?)'                                                                                          | ''                      |" + lineSeparator() +
         "| 'org.neo4j.procedure.throwsExceptionInStream'       | 'org.neo4j.procedure.throwsExceptionInStream() :: (INTEGER?)'                                                                                                | ''                      |" + lineSeparator() +
         "| 'org.neo4j.procedure.unsupportedFunction'           | 'org.neo4j.procedure.unsupportedFunction() :: (STRING?)'                                                                                                     | ''                      |" + lineSeparator() +
+        "| 'this.is.test.only.sum'                             | 'this.is.test.only.sum(numbers :: LIST? OF NUMBER?) :: (NUMBER?)'                                                                                            | ''                      |" + lineSeparator() +
         "+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+" + lineSeparator() +
         "26 rows" + lineSeparator();
 
@@ -726,10 +729,10 @@ public class UserFunctionIT
     public void shouldCallFunctionWithSameNameAsBuiltIn() throws Throwable
     {
         //Given/When
-        Result res = db.execute( "RETURN org.neo4j.procedure.sum([1337, 2.718281828, 3.1415]) AS result");
+        Result res = db.execute( "RETURN this.is.test.only.sum([1337, 2.718281828, 3.1415]) AS result" );
 
         // Then
-        assertThat( res.next().get("result"), equalTo( 1337 +  2.718281828 + 3.1415 ) );
+        assertThat( res.next().get( "result" ), equalTo( 1337 + 2.718281828 + 3.1415 ) );
         assertFalse( res.hasNext() );
     }
 
@@ -910,7 +913,7 @@ public class UserFunctionIT
             return 1337L;
         }
 
-        @UserFunction
+        @UserFunction("this.is.test.only.sum")
         public Number sum(@Name("numbers") List<Number> numbers)
         {
          return numbers.stream().mapToDouble( Number::doubleValue ).sum();


### PR DESCRIPTION
It should be possible to use the names of the built-in functions as long
as you put the function in a separate namespace. The lookup was erroneously
using only the name of the function when doing lookup which lead to that
user-defined functions were shadowed by the built-in function with the same name.

Also added capability to test functions in `neo4j-harness`.
