### PR TITLE
Includes reason for master replying NOT_LOCKED

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -336,7 +336,7 @@ class SlaveLocksClient implements Locks.Client
             case DEAD_LOCKED:
                 throw new DeadlockDetectedException( result.getMessage() );
             case NOT_LOCKED:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException( result.toString() );
             case OK_LOCKED:
                 break;
             default:


### PR DESCRIPTION
when failing to lock a resource requested from slave
