### PR TITLE
Terminate bolt connections on auth expiration

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -31,6 +31,7 @@ import org.neo4j.bolt.v1.runtime.cypher.StatementMetadata;
 import org.neo4j.bolt.v1.runtime.cypher.StatementProcessor;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.graphdb.security.AuthExpirationException;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -366,13 +367,18 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                 {
                     @Override
                     public State run( BoltStateMachine machine, String statement,
-                                      Map<String, Object> params )
+                                      Map<String, Object> params ) throws BoltConnectionFatality
                     {
                         try
                         {
                             StatementMetadata statementMetadata = machine.ctx.statementProcessor.run( statement, params );
                             machine.ctx.onMetadata( "fields", statementMetadata.fieldNames() );
                             return STREAMING;
+                        }
+                        catch ( AuthExpirationException e )
+                        {
+                            fail( machine, Neo4jError.from( e ) );
+                            throw new BoltConnectionFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {
@@ -414,7 +420,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     }
 
                     @Override
-                    public State pullAll( BoltStateMachine machine )
+                    public State pullAll( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
                         try
                         {
@@ -422,6 +428,11 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                                     machine.ctx.responseHandler.onRecords( recordStream, true ) );
 
                             return READY;
+                        }
+                        catch ( AuthExpirationException e )
+                        {
+                            fail( machine, Neo4jError.from( e ) );
+                            throw new BoltConnectionFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {
@@ -431,7 +442,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     }
 
                     @Override
-                    public State discardAll( BoltStateMachine machine )
+                    public State discardAll( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
                         try
                         {
@@ -439,6 +450,11 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                                     machine.ctx.responseHandler.onRecords( recordStream, false ) );
 
                             return READY;
+                        }
+                        catch ( AuthExpirationException e )
+                        {
+                            fail( machine, Neo4jError.from( e ) );
+                            throw new BoltConnectionFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -378,7 +378,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                         catch ( AuthExpirationException e )
                         {
                             fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
+                            throw new BoltConnectionAuthFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {
@@ -432,7 +432,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                         catch ( AuthExpirationException e )
                         {
                             fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
+                            throw new BoltConnectionAuthFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {
@@ -454,7 +454,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                         catch ( AuthExpirationException e )
                         {
                             fail( machine, Neo4jError.from( e ) );
-                            throw new BoltConnectionFatality( e.getMessage() );
+                            throw new BoltConnectionAuthFatality( e.getMessage() );
                         }
                         catch ( Throwable e )
                         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -172,7 +172,7 @@ public class TransactionStateMachine implements StatementProcessor
                             throw new QueryExecutionKernelException(
                                     new InvalidSemanticsException( "No current transaction to rollback." ) );
                         }
-                        else if( spi.isPeriodicCommit( statement ) )
+                        else if ( spi.isPeriodicCommit( statement ) )
                         {
                             Result result = executeQuery( ctx, spi, statement, params );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.testing.BoltMatchers.canReset;
 import static org.neo4j.bolt.testing.BoltMatchers.failedWithStatus;
 import static org.neo4j.bolt.testing.BoltMatchers.hasNoTransaction;
@@ -417,7 +416,7 @@ public class BoltStateMachineTest
     {
         // Given
         TransactionStateMachine.SPI transactionSPI = mock( TransactionStateMachine.SPI.class );
-        doThrow( new AuthExpirationException( "Auth expired!" ) ).when( transactionSPI.beginTransaction( any() ) );
+        doThrow( new AuthExpirationException( "Auth expired!" ) ).when( transactionSPI ).beginTransaction( any() );
 
         BoltStateMachine machine = newMachineWithTransactionSPI( transactionSPI );
         machine.state = READY;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -417,7 +417,7 @@ public class BoltStateMachineTest
     {
         // Given
         TransactionStateMachine.SPI transactionSPI = mock( TransactionStateMachine.SPI.class );
-        when( transactionSPI.beginTransaction( any() ) ).thenThrow( new AuthExpirationException( "Auth expired!" ) );
+        doThrow( new AuthExpirationException( "Auth expired!" ) ).when( transactionSPI.beginTransaction( any() ) );
 
         BoltStateMachine machine = newMachineWithTransactionSPI( transactionSPI );
         machine.state = READY;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MachineRoom.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.neo4j.bolt.security.auth.AuthenticationException;
 import org.neo4j.bolt.security.auth.AuthenticationResult;
-import org.neo4j.bolt.testing.NullResponseHandler;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -63,6 +62,17 @@ public class MachineRoom
         init( machine );
         runBegin( machine );
         machine.state = state;
+        return machine;
+    }
+
+    public static BoltStateMachine newMachineWithTransactionSPI( TransactionStateMachine.SPI transactionSPI ) throws
+            AuthenticationException, BoltConnectionFatality
+    {
+        BoltStateMachine.SPI spi = mock( BoltStateMachine.SPI.class, RETURNS_MOCKS );
+        when( spi.transactionSpi() ).thenReturn( transactionSPI );
+
+        BoltStateMachine machine = new BoltStateMachine( spi, null, Clock.systemUTC() );
+        init( machine );
         return machine;
     }
 

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -409,7 +409,8 @@ public interface Status
         AuthenticationRateLimit( ClientError, "The client has provided incorrect authentication details too many times in a row." ),
         ModifiedConcurrently( TransientError, "The user was modified concurrently to this request." ),
         EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
-        Forbidden( ClientError, "An attempt was made to perform an unauthorized action." );
+        Forbidden( ClientError, "An attempt was made to perform an unauthorized action." ),
+        AuthorizationExpired( ClientError, "The stored authorization info has expired. Please reconnect." );
 
         private final Code code;
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthExpirationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthExpirationException.java
@@ -22,9 +22,7 @@ package org.neo4j.graphdb.security;
 import org.neo4j.kernel.api.exceptions.Status;
 
 /**
- * Thrown when the database is asked to perform an action that is not authorized based on the AccessMode settings.
- *
- * For instance, if attempting to write with READ_ONLY rights.
+ * Thrown when needed authorization or authentication info has expired in the neo4j auth cache
  */
 public class AuthExpirationException extends RuntimeException implements Status.HasStatus
 {

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthExpirationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthExpirationException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.security;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Thrown when the database is asked to perform an action that is not authorized based on the AccessMode settings.
+ *
+ * For instance, if attempting to write with READ_ONLY rights.
+ */
+public class AuthExpirationException extends RuntimeException implements Status.HasStatus
+{
+    private Status statusCode = Status.Security.AuthorizationExpired;
+
+    public AuthExpirationException( String msg )
+    {
+        super( msg );
+    }
+
+    /** The Neo4j status code associated with this exception type. */
+    @Override
+    public Status status()
+    {
+        return statusCode;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/assertion/Assert.java
+++ b/community/kernel/src/test/java/org/neo4j/test/assertion/Assert.java
@@ -47,6 +47,7 @@ public final class Assert
         try
         {
             f.apply();
+            fail( "Expected exception of type " + typeOfException + ", but no exception was thrown" );
         }
         catch ( Exception e )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -247,7 +247,7 @@ public class LdapRealm extends JndiLdapRealm
                         // Since we do not have the subject's credentials we cannot perform a new LDAP search
                         // for authorization info. Instead we need to fail with a special status,
                         // so that the client can react by re-authenticating.
-                        throw new AuthExpirationException( "The LDAP authorization info has expired." );
+                        throw new AuthExpirationException( "LDAP authorization info expired." );
                     }
                     return authorizationInfo;
                 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -57,6 +57,7 @@ import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.StartTlsRequest;
 import javax.naming.ldap.StartTlsResponse;
 
+import org.neo4j.graphdb.security.AuthExpirationException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
@@ -245,6 +246,7 @@ public class LdapRealm extends JndiLdapRealm
                         // TODO: Do a new LDAP search? But we need to cache the credentials for that...
                         // Or we need the resulting failure message to the client to contain some status
                         // so that the client can react by resending the auth token.
+                        throw new AuthExpirationException( "The LDAP authorization info has expired." );
                     }
                     return authorizationInfo;
                 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -243,9 +243,10 @@ public class LdapRealm extends JndiLdapRealm
                     AuthorizationInfo authorizationInfo = authorizationCache.get( username );
                     if ( authorizationInfo == null )
                     {
-                        // TODO: Do a new LDAP search? But we need to cache the credentials for that...
-                        // Or we need the resulting failure message to the client to contain some status
-                        // so that the client can react by resending the auth token.
+                        // The cached authorization info has expired.
+                        // Since we do not have the subject's credentials we cannot perform a new LDAP search
+                        // for authorization info. Instead we need to fail with a special status,
+                        // so that the client can react by re-authenticating.
                         throw new AuthExpirationException( "The LDAP authorization info has expired." );
                     }
                     return authorizationInfo;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAdminAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAdminAuthPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth.plugin;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.kernel.api.security.AuthToken;
+import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
+import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthInfo;
+import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthPlugin;
+import org.neo4j.server.security.enterprise.auth.plugin.spi.CacheableAuthInfo;
+
+public class TestCacheableAdminAuthPlugin extends AuthPlugin.CachingEnabledAdapter
+{
+    @Override
+    public String name()
+    {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public AuthInfo authenticateAndAuthorize( Map<String,Object> authToken )
+    {
+        getAuthInfoCallCount.incrementAndGet();
+
+        String principal = (String) authToken.get( AuthToken.PRINCIPAL );
+        String credentials = (String) authToken.get( AuthToken.CREDENTIALS );
+
+        if ( principal.equals( "neo4j" ) && credentials.equals( "neo4j" ) )
+        {
+            return CacheableAuthInfo.of( "neo4j", "neo4j".getBytes(),
+                    Collections.singleton( PredefinedRoles.ADMIN ) );
+        }
+        return null;
+    }
+
+    // For testing purposes
+    public static AtomicInteger getAuthInfoCallCount = new AtomicInteger( 0 );
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCacheableAuthenticationPlugin.java
@@ -63,6 +63,5 @@ public class TestCacheableAuthenticationPlugin extends AuthenticationPlugin.Cach
         return null;
     }
 
-    // For testing purposes
     public static AtomicInteger getAuthenticationInfoCallCount = new AtomicInteger( 0 );
 }

--- a/enterprise/security/src/test/resources/META-INF/services/org.neo4j.server.security.enterprise.auth.plugin.spi.AuthPlugin
+++ b/enterprise/security/src/test/resources/META-INF/services/org.neo4j.server.security.enterprise.auth.plugin.spi.AuthPlugin
@@ -1,3 +1,4 @@
 org.neo4j.server.security.enterprise.auth.plugin.TestAuthPlugin
 org.neo4j.server.security.enterprise.auth.plugin.TestCacheableAuthPlugin
+org.neo4j.server.security.enterprise.auth.plugin.TestCacheableAdminAuthPlugin
 org.neo4j.server.security.enterprise.auth.plugin.LdapGroupHasUsersAuthPlugin


### PR DESCRIPTION
If the authorization info expires where credentials will be needed to renew it, the server side bolt state machine will send one final failure message and terminate the connection. This functionality uses a new status `Status.Security.AuthorizationExpired`.

Builds on https://github.com/neo4j/neo4j/pull/7974

changelog: Terminate Bolt connection on authorization expiration with specific status code so client apps can differentiate between cache expiry and invalid credentials
