### PR TITLE
Ignore redundant ACK_FAILURE messages

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -392,6 +392,14 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     {
                         return resetMachine( machine );
                     }
+
+                    @Override
+                    public State ackFailure( BoltStateMachine machine ) throws BoltConnectionFatality
+                    {
+                        machine.ctx.markIgnored();
+                        return READY;
+                    }
+
                 },
 
         /**
@@ -411,6 +419,13 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                     public State reset( BoltStateMachine machine ) throws BoltConnectionFatality
                     {
                         return resetMachine( machine );
+                    }
+
+                    @Override
+                    public State ackFailure( BoltStateMachine machine ) throws BoltConnectionFatality
+                    {
+                        machine.ctx.markIgnored();
+                        return STREAMING;
                     }
 
                     @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/testing/BoltMatchers.java
@@ -225,7 +225,7 @@ public class BoltMatchers
             @Override
             public void describeTo( Description description )
             {
-                description.appendText( "can reset" );
+                description.appendText( "in state " + state.name() );
             }
         };
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -45,6 +45,7 @@ import static org.neo4j.bolt.testing.NullResponseHandler.nullResponseHandler;
 import static org.neo4j.bolt.v1.runtime.BoltStateMachine.State.CONNECTED;
 import static org.neo4j.bolt.v1.runtime.BoltStateMachine.State.FAILED;
 import static org.neo4j.bolt.v1.runtime.BoltStateMachine.State.READY;
+import static org.neo4j.bolt.v1.runtime.BoltStateMachine.State.STREAMING;
 import static org.neo4j.bolt.v1.runtime.MachineRoom.EMPTY_PARAMS;
 import static org.neo4j.bolt.v1.runtime.MachineRoom.USER_AGENT;
 import static org.neo4j.bolt.v1.runtime.MachineRoom.newMachine;
@@ -200,6 +201,36 @@ public class BoltStateMachineTest
 
         // Then the transaction should still be open
         assertThat( machine, hasTransaction() );
+    }
+
+    @Test
+    public void shouldIgnoreAckFailureWhenInReadyState() throws Throwable
+    {
+        // Given a ready machine
+        final BoltStateMachine machine = newMachine( READY );
+
+        // When
+        BoltResponseRecorder recorder = new BoltResponseRecorder();
+        machine.ackFailure( recorder );
+
+        // Then
+        assertThat( recorder.nextResponse(), wasIgnored() );
+        assertThat( machine, inState( READY ) );
+    }
+
+    @Test
+    public void shouldIgnoreAckFailureWhenInStreamingState() throws Throwable
+    {
+        // Given a streaming machine
+        final BoltStateMachine machine = newMachine( STREAMING );
+
+        // When
+        BoltResponseRecorder recorder = new BoltResponseRecorder();
+        machine.ackFailure( recorder );
+
+        // Then
+        assertThat( recorder.nextResponse(), wasIgnored() );
+        assertThat( machine, inState( STREAMING ) );
     }
 
     @Test


### PR DESCRIPTION
This addresses a complexity around dealing with multithreading within
drivers by making the server more tolerant of ACK_FAILURE messages that
may not be required. In a failed scenario where the driver sends both a
RESET and an ACK_FAILURE from separate threads (due to a manual
interrupt request) it is hard to guarantee that the ACK_FAILURE will be
processed by the server before the RESET. This change forgives a late
ACK_FAILURE by simply ignoring it.
