### PR TITLE
Final format for GetServersProcedure

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
@@ -59,7 +59,9 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
                 .out( "id", Neo4jTypes.NTString ).out( "address", Neo4jTypes.NTString )
-                .out( "role", Neo4jTypes.NTString ).build() );
+                .out( "role", Neo4jTypes.NTString )
+                .description( "Overview of all currently accessible cluster members and their roles." )
+                .build() );
         this.discoveryService = discoveryService;
         this.leaderLocator = leaderLocator;
         this.log = logProvider.getLog( getClass() );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/RoleProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/RoleProcedure.java
@@ -37,7 +37,9 @@ abstract class RoleProcedure extends CallableProcedure.BasicProcedure
     RoleProcedure()
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
-                .out( OUTPUT_NAME, Neo4jTypes.NTString ).build() );
+                .out( OUTPUT_NAME, Neo4jTypes.NTString )
+                .description( "The role of a specific instance in the cluster." )
+                .build() );
     }
 
     @Override


### PR DESCRIPTION
Change the format of the returned data to:

`C: RUN "CALL dbms.cluster.routing.getServers" {}
   PULL_ALL
S: SUCCESS {"fields": ["ttl", "servers"]}
   RECORD [9223372036854775807, [
{"role: "WRITE", "addresses": ["127.0.0.1:9001"]},
{"role": "READ", "addresses": ["127.0.0.1:9002", "127.0.0.1:9003"]},
{"role": "ROUTE", "addresses": ["127.0.0.1:9001", "127.0.0.1:9002", "127.0.0.1:9003"]}
]]`
