### PR TITLE
Change the format of the returned data to:

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedure.java
@@ -59,7 +59,9 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
                 .out( "id", Neo4jTypes.NTString ).out( "address", Neo4jTypes.NTString )
-                .out( "role", Neo4jTypes.NTString ).build() );
+                .out( "role", Neo4jTypes.NTString )
+                .description( "Overview of all currently accessible cluster members and their roles." )
+                .build() );
         this.discoveryService = discoveryService;
         this.leaderLocator = leaderLocator;
         this.log = logProvider.getLog( getClass() );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/RoleProcedure.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/procedures/RoleProcedure.java
@@ -37,7 +37,9 @@ abstract class RoleProcedure extends CallableProcedure.BasicProcedure
     RoleProcedure()
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
-                .out( OUTPUT_NAME, Neo4jTypes.NTString ).build() );
+                .out( OUTPUT_NAME, Neo4jTypes.NTString )
+                .description( "The role of a specific instance in the cluster." )
+                .build() );
     }
 
     @Override

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterDiscoveryIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterDiscoveryIT.java
@@ -19,7 +19,11 @@
  */
 package org.neo4j.coreedge.scenarios;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,9 +67,16 @@ public class ClusterDiscoveryIT
         {
             currentMembers = getMembers( cluster.getCoreMemberById( i ).database() );
 
-            assertEquals(1, currentMembers.stream().filter( x -> x[1].equals( "WRITE" ) ).count());
-            assertEquals(4, currentMembers.stream().filter( x -> x[1].equals( "READ" ) ).count());
-            assertEquals(3, currentMembers.stream().filter( x -> x[1].equals( "ROUTE" ) ).count());
+            List<Map<String,Object>> members = (List<Map<String, Object>>) currentMembers.get( 0 )[1];
+
+            assertEquals( 1, members.stream().filter( x -> x.get( "role" ).equals( "WRITE" ) )
+                    .flatMap( x -> Arrays.stream( (Object[]) x.get( "addresses" ) ) ).count() );
+
+            assertEquals( 4, members.stream().filter( x -> x.get( "role" ).equals( "READ" ) )
+                    .flatMap( x -> Arrays.stream( (Object[]) x.get( "addresses" ) ) ).count() );
+
+            assertEquals( 3, members.stream().filter( x -> x.get( "role" ).equals( "ROUTE" ) )
+                    .flatMap( x -> Arrays.stream( (Object[]) x.get( "addresses" ) ) ).count() );
         }
     }
 


### PR DESCRIPTION
C: RUN "CALL dbms.cluster.routing.getServers" {}
   PULL_ALL
S: SUCCESS {"fields": ["ttl", "servers"]}
   RECORD [9223372036854775807, [
{"role: "WRITE", "addresses": ["127.0.0.1:9001"]},
{"role": "READ", "addresses": ["127.0.0.1:9002", "127.0.0.1:9003"]},
{"role": "ROUTE", "addresses": ["127.0.0.1:9001", "127.0.0.1:9002", "127.0.0.1:9003"]}
]]
