### PR TITLE
Make `CALL` possible inside `FOREACH`

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/InQueryProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/InQueryProcedureCallAcceptanceTest.scala
@@ -26,6 +26,18 @@ import org.neo4j.kernel.api.proc.Neo4jTypes
 
 class InQueryProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest {
 
+  test("should work inside FOREACH") {
+    val query = """WITH [1, 2, 3] AS list
+                  |FOREACH (i IN list |
+                  |  CALL db.labels() YIELD label
+                  |)
+                """.stripMargin
+
+    val result = execute(query)
+
+    result.toList shouldBe empty
+  }
+
   test("should be able to find labels from built-in-procedure") {
     // Given
     createLabeledNode("A")


### PR DESCRIPTION
`FOREACH` only allows instances of `UpdateClause` to exist in its
inner scope. `CALL` may have side effects, and may be very useful
in a `FOREACH` construct, so this commit makes it an `UpdateClause`
to support it inside `FOREACH`.
