### PR TITLE
Lock node without relationships during detach delete

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import org.apache.commons.lang3.mutable.MutableInt;
+
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.function.Consumer;
 import org.neo4j.function.Function;
@@ -266,7 +267,7 @@ public class LockingStatementOperations implements
     @Override
     public int nodeDetachDelete( final KernelStatement state, final long nodeId ) throws EntityNotFoundException
     {
-        final AtomicInteger count = new AtomicInteger(  );
+        final MutableInt count = new MutableInt(  );
         TwoPhaseNodeForRelationshipLocking locking = new TwoPhaseNodeForRelationshipLocking( entityReadDelegate,
                 new Consumer<Long>()
                 {
@@ -277,7 +278,7 @@ public class LockingStatementOperations implements
                         try
                         {
                             entityWriteDelegate.relationshipDelete( state, relId );
-                            count.incrementAndGet();
+                            count.increment();
                         }
                         catch ( EntityNotFoundException e )
                         {
@@ -289,7 +290,7 @@ public class LockingStatementOperations implements
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
         state.assertOpen();
         entityWriteDelegate.nodeDetachDelete( state, nodeId );
-        return count.get();
+        return count.intValue();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -28,10 +28,14 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import org.neo4j.function.Function;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.cursor.NodeItem;
+import org.neo4j.kernel.api.cursor.RelationshipItem;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -43,19 +47,26 @@ import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
+import org.neo4j.kernel.impl.api.state.StubCursors;
 import org.neo4j.kernel.impl.api.state.TxState;
+import org.neo4j.kernel.impl.api.store.CursorRelationshipIterator;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.api.store.StoreSingleNodeCursor;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
+import org.neo4j.kernel.impl.util.Cursors;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.neo4j.function.Functions.constant;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.schemaResource;
@@ -481,6 +492,60 @@ public class LockingStatementOperationsTest
         // then
         order.verify( locks, never() ).acquireExclusive( ResourceTypes.RELATIONSHIP, 123 );
         order.verify( entityWriteOps ).relationshipSetProperty( state, 123, property );
+    }
+
+    @Test
+    public void detachDeleteNodeWithoutRelationshipsExclusivelyLockNode() throws KernelException
+    {
+        long nodeId = 1L;
+
+        NodeItem nodeItem = mock( NodeItem.class );
+        when( nodeItem.getRelationships( Direction.BOTH ) ).thenReturn( RelationshipIterator.EMPTY );
+        StoreSingleNodeCursor nodeCursor = mock( StoreSingleNodeCursor.class );
+        when( nodeCursor.get() ).thenReturn( nodeItem );
+        when( entityReadOps.nodeCursorById( state, nodeId ) ).thenReturn( nodeCursor );
+
+        lockingOps.nodeDetachDelete( state, nodeId );
+
+        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
+        order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, nodeId );
+        order.verify( entityWriteOps ).nodeDetachDelete( state, nodeId );
+    }
+
+    @Test
+    public void detachDeleteNodeExclusivelyLockNodes() throws Exception
+    {
+        long startNodeId = 1L;
+        long endNodeId = 2L;
+
+        final RelationshipItem relationshipItem = StubCursors.asRelationship( 1L, 0, startNodeId, endNodeId, null );
+        CursorRelationshipIterator relationshipIterator =
+                new CursorRelationshipIterator( Cursors.cursor( relationshipItem ) );
+
+        NodeItem nodeItem = mock( NodeItem.class );
+        when( nodeItem.getRelationships( Direction.BOTH ) ).thenReturn( relationshipIterator );
+        StoreSingleNodeCursor nodeCursor = mock( StoreSingleNodeCursor.class );
+        when( nodeCursor.get() ).thenReturn( nodeItem );
+        when( entityReadOps.nodeCursorById( state, startNodeId ) ).thenReturn( nodeCursor );
+        doAnswer( new Answer()
+        {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable
+            {
+                RelationshipVisitor visitor = (RelationshipVisitor) invocation.getArguments()[2];
+                visitor.visit( relationshipItem.id(), relationshipItem.type(), relationshipItem.startNode(),
+                        relationshipItem.endNode() );
+                return null;
+            }
+        } ).when( entityReadOps ).relationshipVisit( eq(state), anyLong(), any(RelationshipVisitor.class) );
+
+        lockingOps.nodeDetachDelete( state, startNodeId );
+
+        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, startNodeId );
+        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, endNodeId );
+        order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, startNodeId );
+        order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, endNodeId );
+        order.verify( entityWriteOps ).nodeDetachDelete( state, startNodeId );
     }
 
     private static class SimpleTxStateHolder implements TxStateHolder

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -47,6 +47,8 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.IteratorUtil.set;
 
@@ -117,6 +119,19 @@ public class TwoPhaseNodeForRelationshipLockingTest
         inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
         inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
+    }
+
+    @Test
+    public void lockNodeWithoutRelationships() throws Exception
+    {
+        Collector collector = new Collector();
+        TwoPhaseNodeForRelationshipLocking locking = new TwoPhaseNodeForRelationshipLocking( ops, collector );
+        returnRelationships( nodeId, false );
+
+        locking.lockAllNodesAndConsumeRelationships( nodeId, state );
+
+        verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
+        verifyNoMoreInteractions( locks );
     }
 
     private void returnNodesForRelationship( final long relId, final long startNodeId, final long endNodeId )


### PR DESCRIPTION
Update node detach delete code to properly acquire node locks in case when node does not have any relationships.
Update test cases to cover this case.
Fixes: #7771 

<b> N.B. please null merge and use separate #7991 for 3.x versions </B>

changelog [2.3]
