### PR TITLE
Retry count store lookup in case of concurrent state change.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -89,7 +89,7 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
             ProgressiveState<Key> originalState = this.state;
             try
             {
-                return lookup.value( !this.state.lookup( key, lookup ) );
+                return lookup.value( !originalState.lookup( key, lookup ) );
             }
             catch ( IllegalStateException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStore.java
@@ -49,7 +49,7 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
     private final Format format;
     final RotationStrategy rotationStrategy;
     private RotationTimerFactory rotationTimerFactory;
-    private volatile ProgressiveState<Key> state;
+    volatile ProgressiveState<Key> state;
     private DataInitializer<EntryUpdater<Key>> stateInitializer;
     final int keySize;
     final int valueSize;
@@ -84,7 +84,21 @@ public abstract class AbstractKeyValueStore<Key> extends LifecycleAdapter
     protected final <Value> Value lookup( Key key, Reader<Value> reader ) throws IOException
     {
         ValueLookup<Value> lookup = new ValueLookup<>( reader );
-        return lookup.value( !state.lookup( key, lookup ) );
+        while ( true )
+        {
+            ProgressiveState<Key> originalState = this.state;
+            try
+            {
+                return lookup.value( !this.state.lookup( key, lookup ) );
+            }
+            catch ( IllegalStateException e )
+            {
+                if ( originalState == this.state )
+                {
+                    throw e;
+                }
+            }
+        }
     }
 
     /** Introspective feature, not thread safe. */


### PR DESCRIPTION
Count store perform all lookup operation using current state without grabbing any kind of locks.
During any rotation that state will be substituted by new state and closed.
All new readers will use new state automatically.
The problem manifest itself when reader start lookup operation using state that was active when reader starts, but is already rotated and closed by count store rotation.
The most simple solution was chosen: we will retry lookup operation in case of IllegalStateException and state change.

Fixes #6787
