### PR TITLE
Decoupling Core Topology Lookup from Hazelcast

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
@@ -94,9 +94,9 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         membershipRegistrationId = hazelcastInstance.getCluster().addMembershipListener( new OurMembershipListener() );
         mapRegistrationId = hazelcastInstance.getMap( EDGE_SERVER_BOLT_ADDRESS_MAP_NAME )
                 .addEntryListener( new OurEntryListener(), true );
-        listenerService.notifyListeners( coreServers() );
         refreshCoreTopology();
         refreshEdgeTopology();
+        listenerService.notifyListeners( coreServers() );
     }
 
     @Override
@@ -189,6 +189,8 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     private void refreshCoreTopology()
     {
         latestCoreTopology = HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log );
+        log.info( "Current core topology is %s", coreServers() );
+        listenerService.notifyListeners( coreServers() );
     }
 
     private void refreshEdgeTopology()
@@ -211,8 +213,6 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         public void memberAdded( MembershipEvent membershipEvent )
         {
             log.info( "Core member added %s", membershipEvent );
-            log.info( "Current core topology is %s", coreServers() );
-            listenerService.notifyListeners( coreServers() );
             refreshCoreTopology();
         }
 
@@ -220,8 +220,6 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         public void memberRemoved( MembershipEvent membershipEvent )
         {
             log.info( "Core member removed %s", membershipEvent );
-            log.info( "Current core topology is %s", coreServers() );
-            listenerService.notifyListeners( coreServers() );
             refreshCoreTopology();
         }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastCoreTopologyService.java
@@ -24,7 +24,6 @@ import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
-import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastException;
@@ -63,6 +62,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
 
     private HazelcastInstance hazelcastInstance;
     private EdgeTopology latestEdgeTopology;
+    private CoreTopology latestCoreTopology;
 
     HazelcastCoreTopologyService( Config config, MemberId myself, LogProvider logProvider, LogProvider userLogProvider )
     {
@@ -92,8 +92,10 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         hazelcastInstance = createHazelcastInstance();
         log.info( "Cluster discovery service started" );
         membershipRegistrationId = hazelcastInstance.getCluster().addMembershipListener( new OurMembershipListener() );
-        mapRegistrationId = hazelcastInstance.getMap( EDGE_SERVER_BOLT_ADDRESS_MAP_NAME ).addEntryListener( new OurEntryListener(), true );
-        listenerService.notifyListeners( coreServers());
+        mapRegistrationId = hazelcastInstance.getMap( EDGE_SERVER_BOLT_ADDRESS_MAP_NAME )
+                .addEntryListener( new OurEntryListener(), true );
+        listenerService.notifyListeners( coreServers() );
+        refreshCoreTopology();
         refreshEdgeTopology();
     }
 
@@ -123,8 +125,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         TcpIpConfig tcpIpConfig = joinConfig.getTcpIpConfig();
         tcpIpConfig.setEnabled( true );
 
-        List<AdvertisedSocketAddress> initialMembers =
-                config.get( CoreEdgeClusterSettings.initial_discovery_members );
+        List<AdvertisedSocketAddress> initialMembers = config.get( CoreEdgeClusterSettings.initial_discovery_members );
         for ( AdvertisedSocketAddress address : initialMembers )
         {
             tcpIpConfig.addMember( address.toString() );
@@ -182,7 +183,12 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     @Override
     public CoreTopology coreServers()
     {
-        return HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log );
+        return latestCoreTopology;
+    }
+
+    private void refreshCoreTopology()
+    {
+        latestCoreTopology = HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log );
     }
 
     private void refreshEdgeTopology()
@@ -206,7 +212,8 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         {
             log.info( "Core member added %s", membershipEvent );
             log.info( "Current core topology is %s", coreServers() );
-            listenerService.notifyListeners( coreServers());
+            listenerService.notifyListeners( coreServers() );
+            refreshCoreTopology();
         }
 
         @Override
@@ -214,7 +221,8 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         {
             log.info( "Core member removed %s", membershipEvent );
             log.info( "Current core topology is %s", coreServers() );
-            listenerService.notifyListeners( coreServers());
+            listenerService.notifyListeners( coreServers() );
+            refreshCoreTopology();
         }
 
         @Override


### PR DESCRIPTION
We now refresh our local view of topology on topology change,
when asked, we now return that view.
