### PR TITLE
Fix Ephemeral fs not returning null when listing files for non existing directory

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -345,7 +345,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     @Override
     public File[] listFiles( File directory )
     {
-        if ( files.containsKey( directory ) )
+        if ( files.containsKey( directory ) || !directories.contains( directory ) )
         {
             // This means that you're trying to list files on a file, not a directory.
             return null;


### PR DESCRIPTION
It should now behave like DefaultFileSystemAbstraction
