### PR TITLE
Disallow deleting final user in neo4j-admin to match server behaviour

### DIFF
--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/UsersCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/UsersCommand.java
@@ -183,6 +183,10 @@ public class UsersCommand implements AdminCommand
     {
         BasicAuthManager authManager = getAuthManager();
         authManager.getUser( username );    // Will throw error on missing user
+        if ( authManager.getAllUsernames().size() == 1 )
+        {
+            throw new IllegalArgumentException( "Deleting the only remaining user '" + username + "' is not allowed" );
+        }
         if ( authManager.deleteUser( username ) )
         {
             outsideWorld.stdOutLine( "Deleted user '" + username + "'" );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
@@ -57,9 +57,29 @@ public class DeleteCommandTest extends UsersCommandTestBase
     }
 
     @Test
+    public void shouldNotDeleteDefaultUser() throws Throwable
+    {
+        // Given - default user
+        createTestUser( "neo4j", "abc" );
+
+        // When
+        try
+        {
+            UsersCommand usersCommand = new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
+            usersCommand.execute( new String[]{"delete", "neo4j"} );
+        }
+        catch ( CommandFailed e )
+        {
+            // Expect failure message
+            assertThat( e.getMessage(), containsString( "Deleting the only remaining user 'neo4j' is not allowed" ) );
+        }
+    }
+
+    @Test
     public void shouldDeleteExistingUser() throws Throwable
     {
         // Given - existing user
+        createTestUser( "neo4j", "abc" );
         createTestUser( "another", "abc" );
 
         // When - creating new user


### PR DESCRIPTION
 The server does not allow you to delete yourself. In neo4j-admin the running user is not identified, but the logged in user is assumed to be the admin. The closest role to match server behaviour is to disallow deleting the last user.
