### PR TITLE
Improved message when store upgrade can't be done

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -456,7 +456,7 @@ public class ImportTool
             Collection<Option<File[]>> relationshipsFiles,
             org.neo4j.unsafe.impl.batchimport.Configuration configuration )
     {
-        System.out.println( "Neo4j version: " + Version.getKernel().getReleaseVersion() );
+        System.out.println( "Neo4j version: " + Version.getNeo4jVersion() );
         System.out.println( "Importing the contents of these files into " + storeDir + ":" );
         printInputFiles( "Nodes", nodesFiles );
         printInputFiles( "Relationships", relationshipsFiles );
@@ -547,7 +547,7 @@ public class ImportTool
     private static String manualReference( ManualPage page, Anchor anchor )
     {
         // Docs are versioned major.minor-suffix, so drop the patch version.
-        String[] versionParts = Version.getKernel().getReleaseVersion().split("-");
+        String[] versionParts = Version.getNeo4jVersion().split("-");
         versionParts[0] = versionParts[0].substring(0, 3);
         String docsVersion = String.join("-", versionParts);
 

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -1107,7 +1107,7 @@ public class ImportToolTest
     @Test
     public void shouldPrintReferenceLinkOnDataImportErrors() throws Exception
     {
-        String[] versionParts = Version.getKernel().getReleaseVersion().split("-");
+        String[] versionParts = Version.getNeo4jVersion().split("-");
         versionParts[0] = versionParts[0].substring(0, 3);
         String docsVersion = String.join("-", versionParts);
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -376,7 +376,7 @@ public class DataSourceModule
         Log internalLog = platform.logging.getInternalLog( Procedures.class );
 
         Procedures procedures = new Procedures(
-                new BuiltInProcedures( Version.getKernel().getReleaseVersion(),  platform.databaseInfo.edition.toString()),
+                new BuiltInProcedures( Version.getNeo4jVersion(),  platform.databaseInfo.edition.toString()),
                 pluginDir,  internalLog );
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -193,8 +193,8 @@ public class PlatformModule
 
     private void publishPlatformInfo( UsageData sysInfo )
     {
-        sysInfo.set( UsageDataKeys.version, Version.getKernel().getReleaseVersion() );
-        sysInfo.set( UsageDataKeys.revision, Version.getKernel().getVersion() );
+        sysInfo.set( UsageDataKeys.version, Version.getNeo4jVersion() );
+        sysInfo.set( UsageDataKeys.revision, Version.getKernelVersion() );
     }
 
     public LifeSupport createLife()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
-import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -172,8 +171,7 @@ public class NeoStores implements AutoCloseable
             String actualStoreVersion = versionLongToString( getRecord( pageCache, neoStoreFileName, STORE_VERSION ) );
             if ( !expectedStoreVersion.equals( actualStoreVersion ) )
             {
-                throw new StoreUpgrader.UnexpectedUpgradingStoreVersionException( neoStoreFileName.getName(),
-                        actualStoreVersion );
+                throw new UnexpectedStoreVersionException( actualStoreVersion, expectedStoreVersion );
             }
         }
         catch ( NoSuchFileException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnexpectedStoreVersionException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/UnexpectedStoreVersionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+public class UnexpectedStoreVersionException extends StoreFailureException
+{
+    private static final String MESSAGE = "Unable to open store with version '%s', expected store version '%s'.";
+
+    public UnexpectedStoreVersionException( String actualStoreVersion, String expectedStoreVersion )
+    {
+        super( String.format( MESSAGE, actualStoreVersion, expectedStoreVersion ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor.Section;
 import org.neo4j.kernel.impl.util.CustomIOConfigValidator;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
@@ -318,11 +319,22 @@ public class StoreUpgrader
 
     public static class UnexpectedUpgradingStoreVersionException extends UnableToUpgradeException
     {
-        protected static final String MESSAGE = "'%s' has a store version '%s' that we cannot upgrade from.";
+        protected static final String MESSAGE =
+                "Not possible to upgrade a store with version '%s' to current store version `%s` (Neo4j %s).";
 
-        public UnexpectedUpgradingStoreVersionException( String filename, String actualVersion )
+        public UnexpectedUpgradingStoreVersionException( String fileVersion, String currentVersion )
         {
-            super( String.format( MESSAGE, filename, actualVersion ) );
+            super( String.format( MESSAGE, fileVersion, currentVersion, Version.getNeo4jVersion() ) );
+        }
+    }
+
+    public static class AttemptedDowngradeException extends UnableToUpgradeException
+    {
+        protected static final String MESSAGE = "Downgrading stores are not supported.";
+
+        public AttemptedDowngradeException()
+        {
+            super( MESSAGE );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
@@ -60,7 +60,7 @@ public class StoreVersionCheck
         String storeVersion = MetaDataStore.versionLongToString( record );
         if ( !expectedVersion.equals( storeVersion ) )
         {
-            return new Result( Outcome.unexpectedUpgradingStoreVersion, storeVersion, neostoreFile.getName() );
+            return new Result( Outcome.unexpectedStoreVersion, storeVersion, neostoreFile.getName() );
         }
 
         return new Result( Outcome.ok, null, neostoreFile.getName() );
@@ -84,7 +84,8 @@ public class StoreVersionCheck
             ok( true ),
             missingStoreFile( false ),
             storeVersionNotFound( false ),
-            unexpectedUpgradingStoreVersion( false ),
+            unexpectedStoreVersion( false ),
+            attemptedStoreDowngrade( false ),
             storeNotCleanlyShutDown( false );
 
             private final boolean success;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
@@ -103,7 +103,7 @@ public class UpgradableDatabase
             if ( fromFormat.generation() > format.generation() )
             {
                 // Tried to downgrade, that isn't supported
-                result = new Result( Outcome.unexpectedUpgradingStoreVersion, fromFormat.storeVersion(),
+                result = new Result( Outcome.attemptedStoreDowngrade, fromFormat.storeVersion(),
                         new File( storeDirectory, MetaDataStore.DEFAULT_NAME ).getAbsolutePath() );
             }
             else
@@ -119,7 +119,7 @@ public class UpgradableDatabase
         }
         catch ( IllegalArgumentException e )
         {
-            result = new Result( Outcome.unexpectedUpgradingStoreVersion, result.actualVersion, result.storeFilename );
+            result = new Result( Outcome.unexpectedStoreVersion, result.actualVersion, result.storeFilename );
         }
 
         switch ( result.outcome )
@@ -129,9 +129,10 @@ public class UpgradableDatabase
         case storeVersionNotFound:
             throw new StoreUpgrader.UpgradingStoreVersionNotFoundException(
                     getPathToStoreFile( storeDirectory, result ) );
-        case unexpectedUpgradingStoreVersion:
-            throw new StoreUpgrader.UnexpectedUpgradingStoreVersionException(
-                    getPathToStoreFile( storeDirectory, result ), result.actualVersion );
+        case attemptedStoreDowngrade:
+            throw new StoreUpgrader.AttemptedDowngradeException();
+        case unexpectedStoreVersion:
+            throw new StoreUpgrader.UnexpectedUpgradingStoreVersionException( result.actualVersion, format.storeVersion() );
         case storeNotCleanlyShutDown:
             throw new StoreUpgrader.DatabaseNotCleanlyShutDownException();
         default:
@@ -193,7 +194,8 @@ public class UpgradableDatabase
         case missingStoreFile: // let's assume the db is empty
             return true;
         case storeVersionNotFound:
-        case unexpectedUpgradingStoreVersion:
+        case unexpectedStoreVersion:
+        case attemptedStoreDowngrade:
             return false;
         default:
             throw new IllegalArgumentException( "Unknown outcome: " + result.outcome.name() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyStoreVersionCheck.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyStoreVersionCheck.java
@@ -64,7 +64,7 @@ public class LegacyStoreVersionCheck
             String actualVersion = readVersion( fileChannel, expectedVersionBytes.length );
             if ( !expectedVersion.equals( actualVersion ) )
             {
-                return new Result( Outcome.unexpectedUpgradingStoreVersion, actualVersion, storeFilename );
+                return new Result( Outcome.unexpectedStoreVersion, actualVersion, storeFilename );
             }
         }
         catch ( IOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/Version.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/Version.java
@@ -36,6 +36,11 @@ public class Version extends Service
         return getKernel().getVersion();
     }
 
+    public static String getNeo4jVersion()
+    {
+        return getKernel().getReleaseVersion();
+    }
+
     private final String artifactId;
     private final String title;
     private final String vendor;
@@ -73,7 +78,7 @@ public class Version extends Service
 
     /**
      * @return a detailed version string, including source control revision information if that is available, suitable
-     *         for internal use, logging and debugging.
+     * for internal use, logging and debugging.
      */
     public final String getVersion()
     {
@@ -86,37 +91,6 @@ public class Version extends Service
     public String getReleaseVersion()
     {
         return releaseVersion;
-    }
-
-    /**
-     * @return the source control revision information, if that is available
-     */
-    public final String getRevision()
-    {
-        StringBuilder result = new StringBuilder( getReleaseVersion() );
-        result.append( ':' ).append( getBranchName() ).append( ':' );
-        String build = getBuildNumber();
-        if ( !(build.startsWith( "${" ) || build.startsWith( "{" )) )
-        {
-            result.append( build ).append( '/' );
-        }
-        result.append( getCommitId() );
-        return result.toString();
-    }
-
-    protected String getBuildNumber()
-    {
-        return "{BuildNumber}";
-    }
-
-    protected String getCommitId()
-    {
-        return "{CommitId}";
-    }
-
-    protected String getBranchName()
-    {
-        return "{BranchName}";
     }
 
     protected Version( String artifactId, String version )
@@ -146,7 +120,7 @@ public class Version extends Service
         );
 
         Matcher matcher = pattern.matcher( fullVersion );
-        if(matcher.matches())
+        if ( matcher.matches() )
         {
             return matcher.group( 1 );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.builtinprocs.ListIndexesProcedure;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.server.security.auth.AuthSubject;
 
 import static java.util.Collections.singletonList;
@@ -284,6 +285,7 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
                 readOperationsInNewTransaction().procedureCallRead( procedureName( "dbms", "components" ), new Object[0] );
 
         // Then
-        assertThat( asList( stream ), contains( equalTo( new Object[]{"Neo4j Kernel", singletonList("dev"), "community"} ) ) );
+        assertThat( asList( stream ), contains(
+                equalTo( new Object[]{"Neo4j Kernel", singletonList( Version.getNeo4jVersion() ), "community"} ) ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -222,7 +222,7 @@ public class MigrationTestUtils
             File file = new File( dir, storeFile.storeFileName() );
             StoreVersionCheck.Result result =
                     legacyStoreVersionCheck.hasVersion( file, StandardV3_0.STORE_VERSION, storeFile.isOptional() );
-            success &= result.outcome == Outcome.unexpectedUpgradingStoreVersion ||
+            success &= result.outcome == Outcome.unexpectedStoreVersion ||
                        result.outcome == Outcome.storeVersionNotFound;
         }
         return success;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheckTest.java
@@ -96,7 +96,7 @@ public class StoreVersionCheckTest
 
         // then
         assertFalse( result.outcome.isSuccessful() );
-        assertEquals( StoreVersionCheck.Result.Outcome.unexpectedUpgradingStoreVersion, result.outcome );
+        assertEquals( StoreVersionCheck.Result.Outcome.unexpectedStoreVersion, result.outcome );
         assertEquals( "V1", result.actualVersion );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabaseTest.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStoreVersionCheck;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.string.UTF8;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
@@ -261,8 +262,8 @@ public class UpgradableDatabaseTest
             {
                 // then
                 assertFalse( StoreVersion.isEnterpriseStoreVersion( version ) );
-                File expectedFile = new File( workingDirectory, neostoreFilename ).getAbsoluteFile();
-                assertEquals( String.format( MESSAGE, expectedFile, version ), e.getMessage() );
+                assertEquals( String.format( MESSAGE, version, upgradableDatabase.currentVersion(),
+                        Version.getNeo4jVersion() ), e.getMessage() );
             }
             catch ( StoreUpgrader.UnexpectedUpgradingStoreFormatException e )
             {

--- a/community/neo4j/src/test/java/db/DatabaseStartupTest.java
+++ b/community/neo4j/src/test/java/db/DatabaseStartupTest.java
@@ -37,9 +37,7 @@ import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -120,8 +118,6 @@ public class DatabaseStartupTest
             // then
             assertTrue( ex.getCause() instanceof LifecycleException );
             assertTrue( ex.getCause().getCause() instanceof StoreUpgrader.UnexpectedUpgradingStoreVersionException );
-            assertThat( ex.getCause().getCause().getMessage(),
-                    containsString( "has a store version '" + badStoreVersion + "' that we cannot upgrade from." ) );
         }
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/DatabaseRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/DatabaseRepresentation.java
@@ -64,6 +64,6 @@ public class DatabaseRepresentation extends MappingRepresentation implements Ext
         serializer.putUri( "constraints", PATH_SCHEMA_CONSTRAINT );
         serializer.putUri( "transaction", PATH_TRANSACTION );
         serializer.putUri( "node_labels", PATH_LABELS );
-        serializer.putString( "neo4j_version", Version.getKernel().getReleaseVersion() );
+        serializer.putString( "neo4j_version", Version.getNeo4jVersion() );
     }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/StartClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/StartClient.java
@@ -188,7 +188,7 @@ public class StartClient
         if ( version )
         {
             String edition = StringUtils.capitalize( factory.getEdition().toLowerCase() );
-            out.printf( "Neo4j %s, version %s", edition, Version.getKernelVersion() );
+            out.printf( "Neo4j %s, version %s", edition, Version.getNeo4jVersion() );
         }
         else if ( (path != null && (port != null || name != null || host != null || pid != null))
              || (pid != null && host != null) )

--- a/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
@@ -30,8 +30,6 @@ import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.ShellServer;
 
-import static org.neo4j.kernel.internal.Version.getKernel;
-
 /**
  * Can replace the prompt string (PS1) with common Bash variable interpretation,
  * f.ex. "\h [\t] \W $ " would result in "shell [10:05:30] 1243 $"
@@ -51,8 +49,8 @@ public class BashVariableInterpreter
         STATIC_REPLACERS.put( "@", new DateReplacer( "KK:mm aa" ) );
         STATIC_REPLACERS.put( "A", new DateReplacer( "HH:mm" ) );
         STATIC_REPLACERS.put( "u", new StaticReplacer( "user" ) );
-        STATIC_REPLACERS.put( "v", new StaticReplacer( getKernel().getReleaseVersion() ) );
-        STATIC_REPLACERS.put( "V", new StaticReplacer( getKernel().getVersion() ) );
+        STATIC_REPLACERS.put( "v", new StaticReplacer( Version.getNeo4jVersion() ) );
+        STATIC_REPLACERS.put( "V", new StaticReplacer( Version.getKernelVersion() ) );
     }
 
     private final Map<String, Replacer> localReplacers = new HashMap<String, Replacer>();

--- a/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/BashVariableInterpreter.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 import org.neo4j.shell.ShellServer;

--- a/integrationtests/src/test/java/org/neo4j/kernel/VersionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/VersionIT.java
@@ -23,13 +23,13 @@ import org.junit.Test;
 
 import org.neo4j.kernel.internal.Version;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 public class VersionIT
 {
     @Test
     public void canGetKernelRevision() throws Exception
     {
-        assertFalse( "Kernel revision not specified", "".equals( Version.getKernelVersion() ) );
+        assertNotEquals( "Kernel revision not specified", "", Version.getKernelVersion() );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -61,7 +61,6 @@ import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
-import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
@@ -332,7 +331,7 @@ public class StoreUpgradeIntegrationTest
             {
                 assertTrue( ex.getCause() instanceof LifecycleException );
                 Throwable realException = ex.getCause().getCause();
-                assertTrue( Exceptions.contains( realException, MetaDataStore.DEFAULT_NAME,
+                assertTrue( "Unexpected exception", Exceptions.contains( realException,
                         StoreUpgrader.UnexpectedUpgradingStoreVersionException.class ) );
             }
         }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/model/DesktopModel.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/model/DesktopModel.java
@@ -68,7 +68,7 @@ public class DesktopModel
 
     public String getNeo4jVersion()
     {
-        return format( "%s", Version.getKernel().getReleaseVersion() );
+        return format( "%s", Version.getNeo4jVersion() );
     }
 
     public HostnamePort getServerAddress()


### PR DESCRIPTION
Before, this was printed

```
/home/jonas/workspace/neo4j/community/kernel/target/test-data/org.neo4j.kernel.impl.storemigration.UpgradableDatabaseTest$UnsupportedVersions/E1F262ADB34943A5536165FFEF6AEC90/graph-db/neostore' has a store version 'v0.A.4' that we cannot upgrade from
```

After, this is printed instead

```
Unable to upgrade. Cannot open store with version 'v0.A.4'. Current version is `v0.A.7` (Neo4j 3.0.7-SNAPSHOT).
```

This message is thrown when the version is unknown, e.g. it is
jibberish (not sure if that would ever happen), or more likely, it's a
version that is part of a later version of Neo4j which this version has
no knowledge of. Printing the current version (as well as Neo4j version)
makes it as clear as is possible, that he has screwed up his database versions.
