### PR TITLE
Moved reflective procedure compilation to init phase of lifecycle

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -69,9 +69,6 @@ public abstract class EditionModule
 {
     public void registerProcedures( Procedures procedures ) throws KernelException
     {
-        // hack to force IBM JDK 8 to load all classes before reflective procedure compilation
-        Service.load( ProceduresProvider.class );
-
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInProcedures.class );
         registerProceduresFromProvider( "auth-procedures-provider", procedures );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
@@ -46,6 +46,8 @@ import static java.util.stream.Collectors.toList;
  */
 public class OutputMappers
 {
+    private final TypeMappers typeMappers;
+
     public OutputMappers( TypeMappers typeMappers )
     {
         this.typeMappers = typeMappers;
@@ -124,9 +126,6 @@ public class OutputMappers
         }
     }
 
-    private final Lookup lookup = MethodHandles.lookup();
-    private final TypeMappers typeMappers;
-
     /**
      * Build an output mapper for the return type of a given method.
      *
@@ -177,6 +176,8 @@ public class OutputMappers
     public OutputMapper mapper( Class<?> userClass ) throws ProcedureException
     {
         assertIsValidRecordClass( userClass );
+
+        final Lookup lookup = MethodHandles.lookup();
 
         List<Field> fields = instanceFields( userClass );
         FieldSignature[] signature = new FieldSignature[fields.size()];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -45,13 +45,14 @@ import org.neo4j.logging.NullLog;
  */
 public class Procedures extends LifecycleAdapter
 {
+    private final Log log;
     private final ProcedureRegistry registry = new ProcedureRegistry();
     private final TypeMappers typeMappers = new TypeMappers();
     private final ComponentRegistry components = new ComponentRegistry();
-    private final ReflectiveProcedureCompiler compiler;
+    private final ReflectiveProcedureCompiler compiler =
+            new ReflectiveProcedureCompiler(typeMappers, components, this::getLog);
     private final ThrowingConsumer<Procedures, ProcedureException> builtin;
     private final File pluginDir;
-    private final Log log;
 
     public Procedures()
     {
@@ -63,7 +64,11 @@ public class Procedures extends LifecycleAdapter
         this.builtin = builtin;
         this.pluginDir = pluginDir;
         this.log = log;
-        this.compiler = new ReflectiveProcedureCompiler(typeMappers, components, log);
+    }
+
+    private Log getLog()
+    {
+        return this.log;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -59,7 +59,6 @@ import static org.neo4j.helpers.collection.Iterators.asRawIterator;
  */
 public class ReflectiveProcedureCompiler
 {
-    private final MethodHandles.Lookup lookup = MethodHandles.lookup();
     private final OutputMappers outputMappers;
     private final MethodSignatureCompiler inputSignatureDeterminer;
     private final FieldInjections fieldInjections;
@@ -68,8 +67,8 @@ public class ReflectiveProcedureCompiler
 
     public ReflectiveProcedureCompiler( TypeMappers typeMappers, ComponentRegistry components, Supplier<Log> log )
     {
-        inputSignatureDeterminer = new MethodSignatureCompiler( typeMappers );
-        outputMappers = new OutputMappers( typeMappers );
+        this.inputSignatureDeterminer = new MethodSignatureCompiler( typeMappers );
+        this.outputMappers = new OutputMappers( typeMappers );
         this.fieldInjections = new FieldInjections( components );
         this.log = log;
         this.typeMappers = typeMappers;
@@ -152,7 +151,7 @@ public class ReflectiveProcedureCompiler
 
         List<FieldSignature> inputSignature = inputSignatureDeterminer.signatureFor( method );
         OutputMapper outputMapper = outputMappers.mapper( method );
-        MethodHandle procedureMethod = lookup.unreflect( method );
+        MethodHandle procedureMethod = MethodHandles.lookup().unreflect( method );
         List<FieldInjections.FieldSetter> setters = fieldInjections.setters( procDefinition );
 
         Optional<String> description = description( method );
@@ -198,7 +197,7 @@ public class ReflectiveProcedureCompiler
         List<FieldSignature> inputSignature = inputSignatureDeterminer.signatureFor( method );
         Class<?> returnType = method.getReturnType();
         TypeMappers.NeoValueConverter valueConverter = typeMappers.converterFor( returnType );
-        MethodHandle procedureMethod = lookup.unreflect( method );
+        MethodHandle procedureMethod = MethodHandles.lookup().unreflect( method );
         List<FieldInjections.FieldSetter> setters = fieldInjections.setters( procDefinition );
 
         Optional<String> description = description( method );
@@ -262,7 +261,7 @@ public class ReflectiveProcedureCompiler
     {
         try
         {
-            return lookup.unreflectConstructor( procDefinition.getConstructor() );
+            return MethodHandles.lookup().unreflectConstructor( procDefinition.getConstructor() );
         }
         catch ( IllegalAccessException | NoSuchMethodException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -63,10 +63,10 @@ public class ReflectiveProcedureCompiler
     private final OutputMappers outputMappers;
     private final MethodSignatureCompiler inputSignatureDeterminer;
     private final FieldInjections fieldInjections;
-    private final Log log;
+    private final Supplier<Log> log;
     private final TypeMappers typeMappers;
 
-    public ReflectiveProcedureCompiler( TypeMappers typeMappers, ComponentRegistry components, Log log )
+    public ReflectiveProcedureCompiler( TypeMappers typeMappers, ComponentRegistry components, Supplier<Log> log )
     {
         inputSignatureDeterminer = new MethodSignatureCompiler( typeMappers );
         outputMappers = new OutputMappers( typeMappers );
@@ -223,7 +223,7 @@ public class ReflectiveProcedureCompiler
         }
         else if ( !deprecatedBy.isEmpty() )
         {
-            log.warn( warning );
+            log.get().warn( warning );
             deprecated = Optional.of( deprecatedBy );
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -57,7 +57,7 @@ public class ProcedureJarLoaderTest
 
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
-                    NullLog.getInstance() ), NullLog.getInstance() );
+                    () -> NullLog.getInstance() ), NullLog.getInstance() );
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -66,7 +66,7 @@ public class ReflectiveProcedureTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, () -> NullLog.getInstance() );
     }
 
     @Test
@@ -271,7 +271,8 @@ public class ReflectiveProcedureTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log );
+        ReflectiveProcedureCompiler procedureCompiler =
+                new ReflectiveProcedureCompiler( new TypeMappers(), components, () -> log );
 
         // When
         List<CallableProcedure> procs = procedureCompiler.compileProcedure( ProcedureWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -214,6 +214,10 @@ public class ReflectiveProcedureWithArgumentsTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), NullLog.getInstance() ).compileProcedure( clazz );
+        return new ReflectiveProcedureCompiler(
+                new TypeMappers(),
+                new ComponentRegistry(),
+                () -> NullLog.getInstance()
+            ).compileProcedure( clazz );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -65,7 +65,7 @@ public class ReflectiveUserFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, () -> NullLog.getInstance() );
     }
 
     @Test
@@ -249,7 +249,8 @@ public class ReflectiveUserFunctionTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log );
+        ReflectiveProcedureCompiler procedureCompiler =
+                new ReflectiveProcedureCompiler( new TypeMappers(), components, () -> log );
 
         // When
         List<CallableUserFunction> funcs = procedureCompiler.compileFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -128,6 +128,7 @@ public class ResourceInjectionTest
     {
         ComponentRegistry components = new ComponentRegistry();
         components.register( MyAwesomeAPI.class, (ctx) -> new MyAwesomeAPI() );
-        return new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() ).compileProcedure( clazz );
+        return new ReflectiveProcedureCompiler( new TypeMappers(), components, () -> NullLog.getInstance() )
+                .compileProcedure( clazz );
     }
 }


### PR DESCRIPTION
Attempting to fix broken IBM JDK 8 builds. Probably related to different class loading combined with the reflective procedure compiler.
