### PR TITLE
Removing a user should also remove it from all roles

### DIFF
--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -25,18 +25,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
-import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
-
-import static org.neo4j.kernel.api.security.AuthToken.BASIC_SCHEME;
-import static org.neo4j.kernel.api.security.AuthToken.NATIVE_REALM;
-import static org.neo4j.kernel.api.security.AuthToken.REALM_KEY;
-import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
 
 /**
  * Manages server authentication and authorization.
@@ -185,7 +180,7 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
         {
             User updatedUser = existingUser.augment()
                     .withCredentials( Credential.forPassword( password ) )
-                    .withRequiredPasswordChange( false )
+                    .withRequiredPasswordChange( requirePasswordChange )
                     .build();
             userRepository.update( existingUser, updatedUser );
         } catch ( ConcurrentModificationException e )

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/CommandTestBase.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/CommandTestBase.java
@@ -22,18 +22,16 @@ package org.neo4j.commandline.admin.security;
 import org.junit.Before;
 
 import java.io.File;
-import java.nio.file.FileSystems;
 
 import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.OutsideWorld;
-import org.neo4j.io.fs.DelegateFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.security.auth.Credential;
 import org.neo4j.server.security.auth.FileUserRepository;
 import org.neo4j.server.security.auth.User;
-import org.neo4j.test.rule.TestDirectory;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
@@ -45,8 +43,7 @@ import static org.mockito.Mockito.when;
 
 abstract class CommandTestBase
 {
-    protected TestDirectory testDir = TestDirectory.testDirectory();
-    protected FileSystemAbstraction fileSystem = new DelegateFileSystemAbstraction( FileSystems.getDefault() );
+    protected FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction( );
 
     File graphDir;
     File confDir;
@@ -57,22 +54,12 @@ abstract class CommandTestBase
     @Before
     public void setup()
     {
-        graphDir = testDir.graphDbDir();
-        confDir = ensureDir( "conf" );
-        homeDir = ensureDir( "home" );
+        graphDir = new File( "graph-db" );
+        confDir = new File( graphDir, "conf" );
+        homeDir = new File( graphDir, "home" );
         out = mock( OutsideWorld.class );
         resetOutsideWorldMock();
         tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
-    }
-
-    protected File ensureDir( String name )
-    {
-        File dir = new File( graphDir, name );
-        if ( !dir.exists() )
-        {
-            dir.mkdirs();
-        }
-        return dir;
     }
 
     protected void resetOutsideWorldMock()
@@ -83,7 +70,7 @@ abstract class CommandTestBase
 
     private File authFile()
     {
-        return new File( new File( new File( testDir.graphDbDir(), "data" ), "dbms" ), "auth" );
+        return new File( new File( new File( graphDir, "data" ), "dbms" ), "auth" );
     }
 
     User createTestUser( String username, String password ) throws Throwable

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/CommandTestBase.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/CommandTestBase.java
@@ -110,21 +110,26 @@ abstract class CommandTestBase
         return args;
     }
 
-    protected abstract String command();
-
-    protected String[] makeArgs( String subCommand, String... args )
+    protected String[] makeArgs( String command, String subCommand, String... args )
     {
-        String[] allArgs = new String[args.length + 2];
-        System.arraycopy( args, 0, allArgs, 2, args.length );
-        allArgs[0] = command();
-        allArgs[1] = subCommand;
+        String[] allArgs;
+        if ( subCommand.isEmpty() ) {
+            allArgs = new String[1];
+        }
+        else
+        {
+            allArgs = new String[args.length + 2];
+            System.arraycopy( args, 0, allArgs, 2, args.length );
+            allArgs[1] = subCommand;
+        }
+        allArgs[0] = command;
         return allArgs;
     }
 
-    void assertFailedSubCommand( String command, String[] args, String... errors )
+    void assertFailedSubCommand( String command, String subCommand, String[] args, String... errors )
     {
         resetOutsideWorldMock();
-        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, args ) );
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, subCommand, args ) );
 
         // Then we get the expected error
         for ( String error : errors )
@@ -135,10 +140,10 @@ abstract class CommandTestBase
         verify( out ).exit( 1 );
     }
 
-    void assertSuccessfulSubCommand( String command, String[] args, String... messages )
+    void assertSuccessfulSubCommand( String command, String subCommand, String[] args, String... messages )
     {
         resetOutsideWorldMock();
-        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, args ));
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( command, subCommand, args ));
 
         // Then we get the expected output messages
         for ( String message : messages )

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/CreateCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/CreateCommandTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.commandline.admin.security;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import org.neo4j.commandline.admin.CommandFailed;
 
@@ -34,9 +32,6 @@ import static org.mockito.Mockito.verify;
 
 public class CreateCommandTest extends UsersCommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Test
     public void shouldFailToCreateExistingUser() throws Throwable
     {

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/DeleteCommandTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.commandline.admin.security;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import org.neo4j.commandline.admin.CommandFailed;
 
@@ -34,9 +32,6 @@ import static org.mockito.Mockito.verify;
 
 public class DeleteCommandTest extends UsersCommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Test
     public void shouldFailToDeleteMissingUser() throws Throwable
     {

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/ListCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/ListCommandTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.commandline.admin.security;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import org.neo4j.commandline.admin.IncorrectUsage;
 
@@ -34,14 +32,10 @@ import static org.mockito.Mockito.verify;
 
 public class ListCommandTest extends UsersCommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Test
     public void shouldFailWithoutSubcommand() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), out );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(), confDir.toPath(), out );
 
         String[] arguments = {};
         try
@@ -61,8 +55,7 @@ public class ListCommandTest extends UsersCommandTestBase
     @Test
     public void shouldFailWithUnknownSubcommand() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( testDir.directory( "home" ).toPath(),
-                testDir.directory( "conf" ).toPath(), out );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(), confDir.toPath(), out );
 
         String[] arguments = {"make-love-not-war"};
         try

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetPasswordCommandTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.commandline.admin.security;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
@@ -32,15 +30,10 @@ import static org.junit.Assert.fail;
 
 public class SetPasswordCommandTest extends UsersCommandTestBase
 {
-
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Test
     public void shouldFailSetPasswordWithNoArguments() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
-                testDir.directory( "conf" ).toPath(),out );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(), confDir.toPath(),out );
 
         String[] arguments = {"set-password"};
         try
@@ -57,8 +50,7 @@ public class SetPasswordCommandTest extends UsersCommandTestBase
     @Test
     public void shouldFailSetPasswordWithOnlyOneArgument() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
-                testDir.directory( "conf" ).toPath(),out );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(), confDir.toPath(),out );
 
         String[] arguments = {"set-password", "neo4j"};
         try
@@ -75,8 +67,7 @@ public class SetPasswordCommandTest extends UsersCommandTestBase
     @Test
     public void shouldFailSetPasswordWithNonExistingUser() throws Exception
     {
-        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(),
-                testDir.directory( "conf" ).toPath(), out );
+        UsersCommand usersCommand = new UsersCommand( homeDir.toPath(), confDir.toPath(), out );
 
         String[] arguments = {"set-password", "nosuchuser", "whatever"};
         try
@@ -98,9 +89,10 @@ public class SetPasswordCommandTest extends UsersCommandTestBase
         // When - the admin command sets the password
         UsersCommand usersCommand =
                 new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
-        usersCommand.execute( new String[]{"set-password", "neo4j", "abc"} );
+        usersCommand.execute( new String[]{"set-password", "neo4j", "abc", "--requires-password-change=false"} );
 
         // Then - the default user does not require a password change
+        assertUsersPasswordMatches( "neo4j", "abc" );
         assertUserDoesNotRequirePasswordChange( "neo4j" );
     }
 
@@ -114,9 +106,10 @@ public class SetPasswordCommandTest extends UsersCommandTestBase
         // When - the admin command sets the password
         UsersCommand usersCommand =
                 new UsersCommand( graphDir.toPath(), confDir.toPath(), out );
-        usersCommand.execute( new String[]{"set-password", "another", "abc"} );
+        usersCommand.execute( new String[]{"set-password", "another", "abc", "--requires-password-change=false"} );
 
         // Then - the new user no longer requires a password change
+        assertUsersPasswordMatches( "another", "abc" );
         assertUserDoesNotRequirePasswordChange( "another" );
     }
 }

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
@@ -24,14 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import org.neo4j.commandline.admin.AdminTool;
-import org.neo4j.commandline.admin.CommandLocator;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.contains;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 public class UsersCommandIT extends UsersCommandTestBase
 {
     @Rule
@@ -45,7 +37,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // environment that the actual tested commands will encounter. In particular some auth state is created
         // on demand in both the UserCommand and in the real server. We want that state created before the tests
         // are run.
-        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( "list") );
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( "users", "list" ) );
         resetOutsideWorldMock();
     }
 
@@ -53,7 +45,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithNoSubCommand() throws Throwable
     {
         // When running 'users' with no subcommand, expect usage errors
-        assertFailedUserCommand( null,
+        assertFailedUserCommand( "", new String[0],
                 "Missing arguments: expected at least one sub-command as argument",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
@@ -69,7 +61,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given only default user
 
         // When running 'list', expect default user
-        assertSuccessfulSubCommand( "list", args(), "neo4j" );
+        assertSuccessfulUserCommand( "list", args(), "neo4j" );
     }
 
     @Test
@@ -79,7 +71,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'list', expect only new user (default not created if a new user is created first)
-        assertSuccessfulSubCommand( "list", args(), "another" );
+        assertSuccessfulUserCommand( "list", args(), "another" );
     }
 
     @Test
@@ -89,7 +81,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'list' with filter, expect specified user
-        assertSuccessfulSubCommand( "list", args("other"), "another" );
+        assertSuccessfulUserCommand( "list", args("other"), "another" );
     }
 
     //
@@ -100,7 +92,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithSetPasswordCommandAndNoArgs() throws Throwable
     {
         // When running 'set-password' with arguments, expect usage errors
-        assertFailedUserCommand( "set-password",
+        assertFailedUserCommand( "set-password", new String[0],
                 "Missing arguments: 'users set-password' expects username and password arguments",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
@@ -112,7 +104,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'set-password' with correct parameters, expect an error
-        assertFailedSubCommand( "set-password", args("another", "abc"), "User 'another' does not exist" );
+        assertFailedUserCommand( "set-password", args("another", "abc"), "User 'another' does not exist" );
     }
 
     @Test
@@ -121,7 +113,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulSubCommand( "set-password", args("neo4j", "abc"), "Changed password for user 'neo4j'" );
+        assertSuccessfulUserCommand( "set-password", args("neo4j", "abc"), "Changed password for user 'neo4j'" );
 
         // And the user no longer requires password change
         assertUserDoesNotRequirePasswordChange( "neo4j" );
@@ -135,7 +127,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulSubCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
 
         // And the user no longer requires password change
         assertUserDoesNotRequirePasswordChange( "another" );
@@ -149,13 +141,13 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulSubCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
 
         // And password change is no longer required
         assertUserDoesNotRequirePasswordChange( "another" );
 
         // Then when running another password set to same password expect error
-        assertFailedSubCommand( "set-password", args("another", "abc"), "Old password and new password cannot be the same" );
+        assertFailedUserCommand( "set-password", args("another", "abc"), "Old password and new password cannot be the same" );
     }
 
     @Test
@@ -166,13 +158,13 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulSubCommand( "set-password", args(args("another", "abc")), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args(args("another", "abc")), "Changed password for user 'another'" );
 
         // And password change is no longer required
         assertUserDoesNotRequirePasswordChange( "another" );
 
         // And then when changing to a different password, expect correct output
-        assertSuccessfulSubCommand( "set-password", args("another", "123"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args("another", "123"), "Changed password for user 'another'" );
     }
 
     //
@@ -183,7 +175,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithCreateCommandAndNoArgs() throws Throwable
     {
         // When running 'create' with arguments, expect usage errors
-        assertFailedUserCommand( "create",
+        assertFailedUserCommand( "create", new String[0],
                 "Missing arguments: 'users create' expects username and password arguments",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
@@ -195,7 +187,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulSubCommand( "create", args("another", "abc"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args("another", "abc"), "Created new user 'another'" );
 
         // And the user requires password change
         assertUserRequiresPasswordChange( "another" );
@@ -207,7 +199,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulSubCommand( "create", args("another", "abc", "--requires-password-change=true"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args("another", "abc", "--requires-password-change=true"), "Created new user 'another'" );
 
         // And the user requires password change
         assertUserRequiresPasswordChange( "another" );
@@ -219,7 +211,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulSubCommand( "create", args("another", "abc", "--requires-password-change=false"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args("another", "abc", "--requires-password-change=false"), "Created new user 'another'" );
 
         // And the user requires password change
         assertUserDoesNotRequirePasswordChange( "another" );
@@ -231,7 +223,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'create' with correct parameters, expect error
-        assertFailedSubCommand( "create", args("neo4j", "abc"), "The specified user 'neo4j' already exists" );
+        assertFailedUserCommand( "create", args("neo4j", "abc"), "The specified user 'neo4j' already exists" );
     }
 
     @Test
@@ -242,7 +234,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'create' with correct parameters, expect correct output
-        assertFailedSubCommand( "create", args("another", "abc"), "The specified user 'another' already exists" );
+        assertFailedUserCommand( "create", args("another", "abc"), "The specified user 'another' already exists" );
 
         // And the user still requires password change
         assertUserRequiresPasswordChange( "another" );
@@ -256,7 +248,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithDeleteCommandAndNoArgs() throws Throwable
     {
         // When running 'create' with arguments, expect usage errors
-        assertFailedUserCommand( "delete",
+        assertFailedUserCommand( "delete", new String[0],
                 "Missing arguments: 'users delete' expects username argument",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
@@ -268,7 +260,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedSubCommand( "delete", args("another"), "User 'another' does not exist" );
+        assertFailedUserCommand( "delete", args("another"), "User 'another' does not exist" );
     }
 
     @Test
@@ -277,7 +269,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedSubCommand( "delete", args("neo4j"), "Deleting the only remaining user 'neo4j' is not allowed" );
+        assertFailedUserCommand( "delete", args("neo4j"), "Deleting the only remaining user 'neo4j' is not allowed" );
     }
 
     @Test
@@ -287,7 +279,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'delete' with correct parameters, expect success
-        assertSuccessfulSubCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
+        assertSuccessfulUserCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
     }
 
     @Test
@@ -297,10 +289,10 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'delete' with correct parameters, expect success
-        assertSuccessfulSubCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
+        assertSuccessfulUserCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedSubCommand( "delete", args("another"), "Deleting the only remaining user 'another' is not allowed" );
+        assertFailedUserCommand( "delete", args("another"), "Deleting the only remaining user 'another' is not allowed" );
     }
 
     @Test
@@ -310,32 +302,20 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'create' with correct parameters, expect correct output
-        assertSuccessfulSubCommand( "delete", args("another"), "Deleted user 'another'" );
+        assertSuccessfulUserCommand( "delete", args("another"), "Deleted user 'another'" );
     }
 
     //
     // Utilities for testing AdminTool
     //
 
-    private void assertFailedUserCommand( String command, String... errors )
+    private void assertSuccessfulUserCommand( String subCommand, String[] args, String... messages )
     {
-        // When running users command without a command or with incorrect command
-        AdminTool tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
-        if ( command == null )
-        {
-            tool.execute( graphDir.toPath(), confDir.toPath(), "users" );
-        }
-        else
-        {
-            tool.execute( graphDir.toPath(), confDir.toPath(), "users", command );
-        }
+        assertSuccessfulSubCommand( "users", subCommand, args, messages );
+    }
 
-        // Then we get the expected error
-        for ( String error : errors )
-        {
-            verify( out ).stdErrLine( contains( error ) );
-        }
-        verify( out, times( 0 ) ).stdOutLine( anyString() );
-        verify( out ).exit( 1 );
+    private void assertFailedUserCommand( String subCommand, String[] args, String... messages )
+    {
+        assertFailedSubCommand( "users", subCommand, args, messages );
     }
 }

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandIT.java
@@ -20,15 +20,10 @@
 package org.neo4j.commandline.admin.security;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 public class UsersCommandIT extends UsersCommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Before
     public void setup()
     {
@@ -45,8 +40,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithNoSubCommand() throws Throwable
     {
         // When running 'users' with no subcommand, expect usage errors
-        assertFailedUserCommand( "", new String[0],
-                "Missing arguments: expected at least one sub-command as argument",
+        assertFailedUserCommand( "", new String[0], "Missing arguments: expected at least one sub-command as argument",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
     }
@@ -81,7 +75,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'list' with filter, expect specified user
-        assertSuccessfulUserCommand( "list", args("other"), "another" );
+        assertSuccessfulUserCommand( "list", args( "other" ), "another" );
     }
 
     //
@@ -104,7 +98,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'set-password' with correct parameters, expect an error
-        assertFailedUserCommand( "set-password", args("another", "abc"), "User 'another' does not exist" );
+        assertFailedUserCommand( "set-password", args( "another", "abc" ), "User 'another' does not exist" );
     }
 
     @Test
@@ -113,9 +107,38 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulUserCommand( "set-password", args("neo4j", "abc"), "Changed password for user 'neo4j'" );
+        assertSuccessfulUserCommand( "set-password", args( "neo4j", "abc" ), "Changed password for user 'neo4j'" );
 
-        // And the user no longer requires password change
+        // And the user requires password change
+        assertUsersPasswordMatches( "neo4j", "abc" );
+        assertUserRequiresPasswordChange( "neo4j" );
+    }
+
+    @Test
+    public void shouldSetPasswordWithPasswordChangeRequired() throws Throwable
+    {
+        // Given default state (only default user)
+
+        // When running 'set-password' with correct parameters, expect correct output
+        assertSuccessfulUserCommand( "set-password", args( "neo4j", "abc", "--requires-password-change=true" ),
+                "Changed password for user 'neo4j'" );
+
+        // And the user requires password change
+        assertUsersPasswordMatches( "neo4j", "abc" );
+        assertUserRequiresPasswordChange( "neo4j" );
+    }
+
+    @Test
+    public void shouldSetPasswordWithPasswordChangeRequiredFalse() throws Throwable
+    {
+        // Given no previously existing user
+
+        // When running 'create' with correct parameters, expect success
+        assertSuccessfulUserCommand( "set-password", args( "neo4j", "abc", "--requires-password-change=false" ),
+                "Changed password for user 'neo4j'" );
+
+        // And the user requires no password change
+        assertUsersPasswordMatches( "neo4j", "abc" );
         assertUserDoesNotRequirePasswordChange( "neo4j" );
     }
 
@@ -127,10 +150,11 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulUserCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args( "another", "abc" ), "Changed password for user 'another'" );
 
-        // And the user no longer requires password change
-        assertUserDoesNotRequirePasswordChange( "another" );
+        // And the user requires password change
+        assertUsersPasswordMatches( "another", "abc" );
+        assertUserRequiresPasswordChange( "another" );
     }
 
     @Test
@@ -141,13 +165,15 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulUserCommand( "set-password", args("another", "abc"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args( "another", "abc" ), "Changed password for user 'another'" );
 
-        // And password change is no longer required
-        assertUserDoesNotRequirePasswordChange( "another" );
+        // And password change is required
+        assertUsersPasswordMatches( "another", "abc" );
+        assertUserRequiresPasswordChange( "another" );
 
         // Then when running another password set to same password expect error
-        assertFailedUserCommand( "set-password", args("another", "abc"), "Old password and new password cannot be the same" );
+        assertFailedUserCommand( "set-password", args( "another", "abc" ),
+                "Old password and new password cannot be the same" );
     }
 
     @Test
@@ -158,13 +184,16 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'set-password' with correct parameters, expect correct output
-        assertSuccessfulUserCommand( "set-password", args(args("another", "abc")), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password",
+                args( args( "another", "abc", "--requires-password-change=false" ) ),
+                "Changed password for user 'another'" );
 
         // And password change is no longer required
+        assertUsersPasswordMatches( "another", "abc" );
         assertUserDoesNotRequirePasswordChange( "another" );
 
         // And then when changing to a different password, expect correct output
-        assertSuccessfulUserCommand( "set-password", args("another", "123"), "Changed password for user 'another'" );
+        assertSuccessfulUserCommand( "set-password", args( "another", "123" ), "Changed password for user 'another'" );
     }
 
     //
@@ -187,9 +216,10 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulUserCommand( "create", args("another", "abc"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args( "another", "abc" ), "Created new user 'another'" );
 
         // And the user requires password change
+        assertUsersPasswordMatches( "another", "abc" );
         assertUserRequiresPasswordChange( "another" );
     }
 
@@ -199,9 +229,11 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulUserCommand( "create", args("another", "abc", "--requires-password-change=true"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args( "another", "abc", "--requires-password-change=true" ),
+                "Created new user 'another'" );
 
         // And the user requires password change
+        assertUsersPasswordMatches( "another", "abc" );
         assertUserRequiresPasswordChange( "another" );
     }
 
@@ -211,9 +243,11 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'create' with correct parameters, expect success
-        assertSuccessfulUserCommand( "create", args("another", "abc", "--requires-password-change=false"), "Created new user 'another'" );
+        assertSuccessfulUserCommand( "create", args( "another", "abc", "--requires-password-change=false" ),
+                "Created new user 'another'" );
 
         // And the user requires password change
+        assertUsersPasswordMatches( "another", "abc" );
         assertUserDoesNotRequirePasswordChange( "another" );
     }
 
@@ -223,7 +257,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'create' with correct parameters, expect error
-        assertFailedUserCommand( "create", args("neo4j", "abc"), "The specified user 'neo4j' already exists" );
+        assertFailedUserCommand( "create", args( "neo4j", "abc" ), "The specified user 'neo4j' already exists" );
     }
 
     @Test
@@ -234,9 +268,10 @@ public class UsersCommandIT extends UsersCommandTestBase
         assertUserRequiresPasswordChange( "another" );
 
         // When running 'create' with correct parameters, expect correct output
-        assertFailedUserCommand( "create", args("another", "abc"), "The specified user 'another' already exists" );
+        assertFailedUserCommand( "create", args( "another", "abc" ), "The specified user 'another' already exists" );
 
         // And the user still requires password change
+        assertUsersPasswordMatches( "another", "neo4j" );
         assertUserRequiresPasswordChange( "another" );
     }
 
@@ -248,8 +283,7 @@ public class UsersCommandIT extends UsersCommandTestBase
     public void shouldGetUsageErrorsWithDeleteCommandAndNoArgs() throws Throwable
     {
         // When running 'create' with arguments, expect usage errors
-        assertFailedUserCommand( "delete", new String[0],
-                "Missing arguments: 'users delete' expects username argument",
+        assertFailedUserCommand( "delete", new String[0], "Missing arguments: 'users delete' expects username argument",
                 "neo4j-admin users <subcommand> [<username>] [<password>]",
                 "Runs several possible sub-commands for managing the native users" );
     }
@@ -260,7 +294,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given no previously existing user
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedUserCommand( "delete", args("another"), "User 'another' does not exist" );
+        assertFailedUserCommand( "delete", args( "another" ), "User 'another' does not exist" );
     }
 
     @Test
@@ -269,7 +303,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         // Given default state (only default user)
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedUserCommand( "delete", args("neo4j"), "Deleting the only remaining user 'neo4j' is not allowed" );
+        assertFailedUserCommand( "delete", args( "neo4j" ), "Deleting the only remaining user 'neo4j' is not allowed" );
     }
 
     @Test
@@ -279,7 +313,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'delete' with correct parameters, expect success
-        assertSuccessfulUserCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
+        assertSuccessfulUserCommand( "delete", args( "neo4j" ), "Deleted user 'neo4j'" );
     }
 
     @Test
@@ -289,10 +323,11 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'delete' with correct parameters, expect success
-        assertSuccessfulUserCommand( "delete", args("neo4j"), "Deleted user 'neo4j'" );
+        assertSuccessfulUserCommand( "delete", args( "neo4j" ), "Deleted user 'neo4j'" );
 
         // When running 'delete' with correct parameters, expect error
-        assertFailedUserCommand( "delete", args("another"), "Deleting the only remaining user 'another' is not allowed" );
+        assertFailedUserCommand( "delete", args( "another" ),
+                "Deleting the only remaining user 'another' is not allowed" );
     }
 
     @Test
@@ -302,7 +337,7 @@ public class UsersCommandIT extends UsersCommandTestBase
         createTestUser( "another", "neo4j" );
 
         // When running 'create' with correct parameters, expect correct output
-        assertSuccessfulUserCommand( "delete", args("another"), "Deleted user 'another'" );
+        assertSuccessfulUserCommand( "delete", args( "another" ), "Deleted user 'another'" );
     }
 
     //

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandTestBase.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandTestBase.java
@@ -24,6 +24,7 @@ import org.neo4j.server.security.auth.User;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 class UsersCommandTestBase extends CommandTestBase
 {
@@ -40,6 +41,12 @@ class UsersCommandTestBase extends CommandTestBase
         User user = getUser( username );
         assertThat( "User should not require password change", user.getFlags(),
                 not( hasItem( password_change_required ) ) );
+    }
+
+    void assertUsersPasswordMatches( String username, String password ) throws Throwable
+    {
+        User user = getUser( username );
+        assertTrue( "User password didn't match '" + password + "'", user.credentials().matchesPassword( password ) );
     }
 
 }

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandTestBase.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/UsersCommandTestBase.java
@@ -29,12 +29,6 @@ class UsersCommandTestBase extends CommandTestBase
 {
     protected static String password_change_required = "password_change_required";
 
-    @Override
-    protected String command()
-    {
-        return "users";
-    }
-
     void assertUserRequiresPasswordChange( String username ) throws Throwable
     {
         User user = getUser( username );

--- a/enterprise/security/src/main/java/org/neo4j/commandline/admin/security/RolesCommand.java
+++ b/enterprise/security/src/main/java/org/neo4j/commandline/admin/security/RolesCommand.java
@@ -296,101 +296,12 @@ public class RolesCommand implements AdminCommand
         if ( this.authManager == null )
         {
             Config config = loadNeo4jConfig( homeDir, configDir );
-            this.jobScheduler = new NoOpJobScheduler();
+            this.jobScheduler = new UsersCommand.NoOpJobScheduler();
             this.authManager = new EnterpriseAuthManagerFactory()
                     .newInstance( config, NullLogProvider.getInstance(),
                             NullLog.getInstance(), outsideWorld.fileSystem(), jobScheduler );
             this.authManager.start();    // required to setup default roles
         }
         return this.authManager;
-    }
-
-    public static class NoOpJobScheduler implements JobScheduler
-    {
-
-        @Override
-        public void init() throws Throwable
-        {
-
-        }
-
-        @Override
-        public void start() throws Throwable
-        {
-
-        }
-
-        @Override
-        public void stop() throws Throwable
-        {
-
-        }
-
-        @Override
-        public void shutdown() throws Throwable
-        {
-
-        }
-
-        @Override
-        public Executor executor( Group group )
-        {
-            return null;
-        }
-
-        @Override
-        public ThreadFactory threadFactory( Group group )
-        {
-            return null;
-        }
-
-        @Override
-        public JobHandle schedule( Group group, Runnable job )
-        {
-            return new NoOpJobHandle();
-        }
-
-        @Override
-        public JobHandle schedule( Group group, Runnable job, Map<String,String> metadata )
-        {
-            return new NoOpJobHandle();
-        }
-
-        @Override
-        public JobHandle schedule( Group group, Runnable runnable, long initialDelay,
-                TimeUnit timeUnit )
-        {
-            return new NoOpJobHandle();
-        }
-
-        @Override
-        public JobHandle scheduleRecurring( Group group, Runnable runnable, long period,
-                TimeUnit timeUnit )
-        {
-            return new NoOpJobHandle();
-        }
-
-        @Override
-        public JobHandle scheduleRecurring( Group group, Runnable runnable, long initialDelay,
-                long period, TimeUnit timeUnit )
-        {
-            return new NoOpJobHandle();
-        }
-
-        public static class NoOpJobHandle implements JobHandle
-        {
-
-            @Override
-            public void cancel( boolean mayInterruptIfRunning )
-            {
-
-            }
-
-            @Override
-            public void waitTermination() throws InterruptedException, ExecutionException
-            {
-
-            }
-        }
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
@@ -22,7 +22,6 @@ package org.neo4j.server.security.enterprise.auth;
 import com.github.benmanes.caffeine.cache.Ticker;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.realm.Realm;
-import org.slf4j.impl.StaticLoggerBinder;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -125,7 +124,7 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
         return orderedActiveRealms;
     }
 
-    private static InternalFlatFileRealm createInternalRealm( Config config, LogProvider logProvider,
+    public static InternalFlatFileRealm createInternalRealm( Config config, LogProvider logProvider,
             FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
         return new InternalFlatFileRealm(

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -42,9 +42,9 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
-import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
@@ -63,7 +63,7 @@ import static java.lang.String.format;
 /**
  * Shiro realm wrapping FileUserRepository and FileRoleRepository
  */
-class InternalFlatFileRealm extends AuthorizingRealm implements RealmLifecycle, EnterpriseUserManager
+public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLifecycle, EnterpriseUserManager
 {
     /**
      * This flag is used in the same way as User.PASSWORD_CHANGE_REQUIRED, but it's

--- a/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/EnterpriseUsersCommandIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/EnterpriseUsersCommandIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin.security;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.security.enterprise.auth.FileRoleRepository;
+import org.neo4j.server.security.enterprise.auth.RoleRecord;
+
+import static org.junit.Assert.assertThat;
+
+public class EnterpriseUsersCommandIT extends UsersCommandIT
+{
+
+    @Before
+    public void setup()
+    {
+        super.setup();
+        // the following line ensures that the test setup code (like creating test users) works on the same initial
+        // environment that the actual tested commands will encounter. In particular some auth state is created
+        // on demand in both the UserCommand and in the real server. We want that state created before the tests
+        // are run.
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( "users", "list" ) );
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( "roles", "list" ) );
+        resetOutsideWorldMock();
+    }
+
+    @Test
+    public void shouldRemoveUserFromRoleWhenRemovingUser() throws Throwable
+    {
+        // given
+        createTestRole( "test_role" );
+        createTestUser( "another", "abc" );
+        assertSuccessfulSubCommand( "roles", "assign", args( "test_role", "another" ),
+                "Assigned role 'test_role' to user 'another'" );
+        assertSuccessfulSubCommand( "roles", "users", args( "test_role" ), "another" );
+
+        // when
+        assertSuccessfulSubCommand( "users", "delete", args( "another" ), "Deleted user 'another'" );
+
+        // then
+        assertThat( getRole( "test_role" ).users(), org.hamcrest.core.IsEqual.equalTo( Collections.emptySortedSet() ) );
+    }
+
+    private File rolesFile()
+    {
+        return new File( new File( new File( graphDir, "data" ), "dbms" ), "roles" );
+    }
+
+    private RoleRecord createTestRole( String roleName ) throws Throwable
+    {
+        FileRoleRepository roles = new FileRoleRepository( fileSystem, rolesFile(), NullLogProvider.getInstance() );
+        roles.start();
+        RoleRecord role = new RoleRecord.Builder().withName( roleName ).build();
+        roles.create( role );
+        return role;
+    }
+
+    private RoleRecord getRole( String roleName ) throws Throwable
+    {
+        FileRoleRepository roles = new FileRoleRepository( fileSystem, rolesFile(), NullLogProvider.getInstance() );
+        roles.start();
+        return roles.getRoleByName( roleName );
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandIT.java
@@ -20,22 +20,12 @@
 package org.neo4j.commandline.admin.security;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
-import java.nio.file.Path;
 import java.util.stream.Stream;
-
-import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.NullLog;
-import org.neo4j.logging.NullLogProvider;
-import org.neo4j.server.security.enterprise.auth.EnterpriseAuthManagerFactory;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Stream.concat;
-import static org.mockito.Mockito.mock;
-import static org.neo4j.commandline.admin.security.RolesCommand.loadNeo4jConfig;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ADMIN;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
@@ -43,21 +33,16 @@ import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRol
 
 public class RolesCommandIT extends RolesCommandTestBase
 {
-    @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( testDir );
-
     @Before
     public void setUp() throws Throwable
     {
-        Path homeDir = testDir.graphDbDir().toPath();
-        Path configDir = testDir.directory( "conf" ).toPath();
-
-        JobScheduler jobScheduler = mock(JobScheduler.class);
-
-        // create default roles
-        new EnterpriseAuthManagerFactory().newInstance(
-                loadNeo4jConfig( homeDir, configDir ), NullLogProvider.getInstance(),
-                NullLog.getInstance(), fileSystem, jobScheduler ).start();
+        super.setup();
+        // the following line ensures that the test setup code (like creating test users) works on the same initial
+        // environment that the actual tested commands will encounter. In particular some auth state is created
+        // on demand in both the RolesCommand and in the real server. We want that state created before the tests
+        // are run.
+        tool.execute( graphDir.toPath(), confDir.toPath(), makeArgs( "roles", "list" ) );
+        resetOutsideWorldMock();
     }
 
     @Test

--- a/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandTestBase.java
@@ -41,10 +41,4 @@ class RolesCommandTestBase extends CommandTestBase
         roles.create( role );
         return role;
     }
-
-    @Override
-    protected String command()
-    {
-        return "roles";
-    }
 }

--- a/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/commandline/admin/security/RolesCommandTestBase.java
@@ -30,7 +30,7 @@ class RolesCommandTestBase extends CommandTestBase
 
     private File rolesFile()
     {
-        return new File( new File( new File( testDir.graphDbDir(), "data" ), "dbms" ), "roles" );
+        return new File( new File( new File( graphDir, "data" ), "dbms" ), "roles" );
     }
 
     RoleRecord createTestRole( String roleName ) throws Throwable


### PR DESCRIPTION
If a user was assigned a role and later removed, it wasn't removed from the roles. This would make it so that if a new user was created with the same name, it would have the roles that the old user had.

This also fixes a bug where the `BasicAuthManager` ignored the requires-password-change flag and always cleared it on `setUserPassword`.
