### PR TITLE
Promote the getId() from the Node/Relationship to the PropertyContainer interface

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/IdentifiablePropertyContainer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/IdentifiablePropertyContainer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+public interface IdentifiablePropertyContainer extends PropertyContainer {
+
+    /**
+     * Returns the unique id of this {@link PropertyContainer}. Id's are garbage
+     * collected over time so they are only guaranteed to be unique during a
+     * specific time span: if the {@link PropertyContainer} is deleted, it's
+     * likely that a new {@link PropertyContainer} at some point will get the old
+     * id. <b>Note</b>: this makes {@link PropertyContainer} id's brittle as
+     * public APIs.
+     *
+     * @return The id of this {@link PropertyContainer}
+     */
+     long getId();
+
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/IdentifiablePropertyContainer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/IdentifiablePropertyContainer.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.graphdb;
 
-public interface IdentifiablePropertyContainer extends PropertyContainer {
-
+/**
+ * Provides the ability to obtain the unique id of the implementing
+ * {@link PropertyContainer}.
+ */
+public interface IdentifiablePropertyContainer extends PropertyContainer
+{
     /**
      * Returns the unique id of this {@link PropertyContainer}. Id's are garbage
      * collected over time so they are only guaranteed to be unique during a

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -52,8 +52,18 @@ package org.neo4j.graphdb;
  * when nodes and relationships are deleted, which means it's bad practice to
  * refer to them this way. Instead, use application generated ids.
  */
-public interface Node extends PropertyContainer
+public interface Node extends IdentifiablePropertyContainer
 {
+    /**
+     * Returns the unique id of this node. Ids are garbage collected over time
+     * so they are only guaranteed to be unique during a specific time span: if
+     * the node is deleted, it's likely that a new node at some point will get
+     * the old id. <b>Note</b>: this makes node ids brittle as public APIs.
+     *
+     * @return the id of this node
+     */
+    long getId();
+
     /**
      * Deletes this node if it has no relationships attached to it. If
      * <code>delete()</code> is invoked on a node with relationships, an

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -58,7 +58,7 @@ public interface Node extends IdentifiablePropertyContainer
      * Returns the unique id of this node. Ids are garbage collected over time
      * so they are only guaranteed to be unique during a specific time span: if
      * the node is deleted, it's likely that a new node at some point will get
-     * the old id. <b>Note</b>: this makes node ids brittle as public APIs.
+     * the old id. <b>Note</b>: This makes node ids brittle as public APIs.
      *
      * @return the id of this node
      */

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -55,16 +55,6 @@ package org.neo4j.graphdb;
 public interface Node extends PropertyContainer
 {
     /**
-     * Returns the unique id of this node. Ids are garbage collected over time
-     * so they are only guaranteed to be unique during a specific time span: if
-     * the node is deleted, it's likely that a new node at some point will get
-     * the old id. <b>Note</b>: this makes node ids brittle as public APIs.
-     *
-     * @return the id of this node
-     */
-    long getId();
-
-    /**
      * Deletes this node if it has no relationships attached to it. If
      * <code>delete()</code> is invoked on a node with relationships, an
      * unchecked exception will be raised when the transaction is committing.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
@@ -145,15 +145,4 @@ public interface PropertyContainer
      * @return all properties on this property container
      */
     Map<String, Object> getAllProperties();
-
-    /**
-     * Returns the unique id of this <code>PropertyContainer</code>. Ids are garbage collected over time
-     * so they are only guaranteed to be unique during a specific time span: if
-     * the  <code>PropertyContainer</code> is deleted, it's likely that a new
-     * <code>PropertyContainer</code> at some point will get the old id. <b>Note</b>: this makes
-     * <code>PropertyContainer</code> ids brittle as public APIs.
-     *
-     * @return The id of this  <code>PropertyContainer</code>.
-     */
-    long getId();
 }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PropertyContainer.java
@@ -145,4 +145,15 @@ public interface PropertyContainer
      * @return all properties on this property container
      */
     Map<String, Object> getAllProperties();
+
+    /**
+     * Returns the unique id of this <code>PropertyContainer</code>. Ids are garbage collected over time
+     * so they are only guaranteed to be unique during a specific time span: if
+     * the  <code>PropertyContainer</code> is deleted, it's likely that a new
+     * <code>PropertyContainer</code> at some point will get the old id. <b>Note</b>: this makes
+     * <code>PropertyContainer</code> ids brittle as public APIs.
+     *
+     * @return The id of this  <code>PropertyContainer</code>.
+     */
+    long getId();
 }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -63,7 +63,7 @@ package org.neo4j.graphdb;
  * {@link #getOtherNode(Node)} and {@link #getNodes()} are guaranteed to always
  * return valid, non-null nodes.
  * <p>
- * A node's id is unique, but note the following: Neo4j reuses its internal ids
+ * A relationship's id is unique, but note the following: Neo4j reuses its internal ids
  * when nodes and relationships are deleted, which means it's bad practice to
  * refer to them this way. Instead, use application generated ids.
  */
@@ -73,10 +73,10 @@ public interface Relationship extends IdentifiablePropertyContainer
      * Returns the unique id of this relationship. Ids are garbage collected
      * over time so they are only guaranteed to be unique during a specific time
      * span: if the relationship is deleted, it's likely that a new relationship
-     * at some point will get the old id. <b>Note</b>: This makes node ids
-     * brittle as public APIs.
+     * at some point will get the old id. <b>Note</b>: This makes relationship
+     * ids brittle as public APIs.
      *
-     * @return the id of this relationship
+     * @return The id of this relationship
      */
      long getId();
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -73,10 +73,10 @@ public interface Relationship extends IdentifiablePropertyContainer
      * Returns the unique id of this relationship. Ids are garbage collected
      * over time so they are only guaranteed to be unique during a specific time
      * span: if the relationship is deleted, it's likely that a new relationship
-     * at some point will get the old id. This makes relationship ids brittle as
-     * public APIs.
+     * at some point will get the old id. <b>Note</b>: This makes node ids
+     * brittle as public APIs.
      *
-     * @return the id of this node
+     * @return the id of this relationship
      */
      long getId();
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -67,8 +67,19 @@ package org.neo4j.graphdb;
  * when nodes and relationships are deleted, which means it's bad practice to
  * refer to them this way. Instead, use application generated ids.
  */
-public interface Relationship extends PropertyContainer
+public interface Relationship extends IdentifiablePropertyContainer
 {
+    /**
+     * Returns the unique id of this relationship. Ids are garbage collected
+     * over time so they are only guaranteed to be unique during a specific time
+     * span: if the relationship is deleted, it's likely that a new relationship
+     * at some point will get the old id. This makes relationship ids brittle as
+     * public APIs.
+     *
+     * @return the id of this node
+     */
+     long getId();
+
     /**
      * Deletes this relationship. Invoking any methods on this relationship
      * after <code>delete()</code> has returned is invalid and will lead to

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -70,17 +70,6 @@ package org.neo4j.graphdb;
 public interface Relationship extends PropertyContainer
 {
     /**
-     * Returns the unique id of this relationship. Ids are garbage collected
-     * over time so they are only guaranteed to be unique during a specific time
-     * span: if the relationship is deleted, it's likely that a new relationship
-     * at some point will get the old id. This makes relationship ids brittle as
-     * public APIs.
-     *
-     * @return the id of this node
-     */
-     long getId();
-
-    /**
      * Deletes this relationship. Invoking any methods on this relationship
      * after <code>delete()</code> has returned is invalid and will lead to
      * {@link NotFoundException} being thrown.


### PR DESCRIPTION
The Node and Relationship objects each contain a getter method to get the instance's id. But, when writing Neo4j code, server extensions, and/or GraphAware-based modules, I often find myself writing code that operates on both flavors. I also tend to code against the PropertyContainer interface, which both Node and Relationship implement. This means, sooner or later, I find myself having to do things such as this:

```
long id = -1;
if (propertyContainer instanceof Node) {
    id = ((Node) node).getId();
} else {
    id = ((Relationship) node).getId();
}
```

In fact, I've seen open source code -- as well as code within GraphAware's PropertyContainerUtils -- that performs the same or similar steps as above.

This trivial pull request promotes the getId() off of Node and Relationship and onto the PropertyContainer. By merely relocating the getter to the parent PropertyConatainer interface, the above code is simplified to:

`long id = propertyContainer.getId();`

While small and trivial in nature, to me this is an improvement to the Neo4j codebase that is worth making.
