### PR TITLE
Simplify security realm configuration

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -96,6 +96,7 @@ class InternalFlatFileRealm extends AuthorizingRealm implements RealmLifecycle, 
     {
         super();
 
+        setName( SecuritySettings.NATIVE_REALM_NAME );
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.passwordPolicy = passwordPolicy;

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -95,6 +95,7 @@ public class LdapRealm extends JndiLdapRealm
     public LdapRealm( Config config, SecurityLog securityLog )
     {
         super();
+        setName( SecuritySettings.LDAP_REALM_NAME );
         this.securityLog = securityLog;
         setRolePermissionResolver( PredefinedRolesBuilder.rolePermissionResolver );
         configureRealm( config );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
@@ -53,10 +53,10 @@ import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthorizationPlugin;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.CustomCacheableAuthenticationInfo;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.RealmLifecycle;
 
+import static org.neo4j.server.security.enterprise.auth.SecuritySettings.PLUGIN_REALM_NAME_PREFIX;
+
 public class PluginRealm extends AuthorizingRealm implements RealmLifecycle
 {
-    private static final String PLUGIN_REALM_NAME_PREFIX = "plugin-";
-
     private AuthenticationPlugin authenticationPlugin;
     private AuthorizationPlugin authorizationPlugin;
     private final Config config;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -90,8 +90,8 @@ public class LdapCachingTest
     private Config getLdapConfig()
     {
         return new Config( stringMap(
-                SecuritySettings.internal_authentication_enabled.name(), "false",
-                SecuritySettings.internal_authorization_enabled.name(), "false",
+                SecuritySettings.native_authentication_enabled.name(), "false",
+                SecuritySettings.native_authorization_enabled.name(), "false",
                 SecuritySettings.ldap_authentication_enabled.name(), "true",
                 SecuritySettings.ldap_authorization_enabled.name(), "true",
                 SecuritySettings.ldap_authorization_user_search_base.name(), "dc=example,dc=com",

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
@@ -100,8 +100,8 @@ public class ActiveDirectoryAuthenticationIT
         return settings -> {
             settings.put( GraphDatabaseSettings.auth_enabled, "true" );
             settings.put( GraphDatabaseSettings.auth_manager, "enterprise-auth-manager" );
-            settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-            settings.put( SecuritySettings.internal_authorization_enabled, "false" );
+            settings.put( SecuritySettings.native_authentication_enabled, "false" );
+            settings.put( SecuritySettings.native_authorization_enabled, "false" );
             settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
             settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
             settings.put( SecuritySettings.ldap_server, "activedirectory.neohq.net:389" );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
@@ -121,22 +121,7 @@ public abstract class EnterpriseAuthenticationTestBase extends AbstractLdapTestU
 
     protected static Consumer<Map<Setting<?>,String>> ldapOnlyAuthSettings = settings ->
     {
-        settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-        settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-        settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
-        settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
-        settings.put( SecuritySettings.plugin_authentication_enabled, "false" );
-        settings.put( SecuritySettings.plugin_authorization_enabled, "false" );
-    };
-
-    protected static Consumer<Map<Setting<?>,String>> pluginOnlyAuthSettings = settings ->
-    {
-        settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-        settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-        settings.put( SecuritySettings.ldap_authentication_enabled, "false" );
-        settings.put( SecuritySettings.ldap_authorization_enabled, "false" );
-        settings.put( SecuritySettings.plugin_authentication_enabled, "true" );
-        settings.put( SecuritySettings.plugin_authorization_enabled, "true" );
+        settings.put( SecuritySettings.active_realm, SecuritySettings.LDAP_REALM_NAME );
     };
 
     protected void testCreateReaderUser() throws Exception

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.server.security.enterprise.auth.SecuritySettings;
+import org.neo4j.server.security.enterprise.auth.plugin.LdapGroupHasUsersAuthPlugin;
 
 @RunWith( FrameworkRunner.class )
 @CreateDS(
@@ -83,7 +85,9 @@ public class LdapExamplePluginAuthenticationIT extends EnterpriseAuthenticationT
 
     protected Consumer<Map<Setting<?>, String>> getSettingsFunction()
     {
-        return super.getSettingsFunction().andThen( pluginOnlyAuthSettings ).andThen( settings -> {
+        return super.getSettingsFunction().andThen( settings -> {
+            settings.put( SecuritySettings.active_realm,
+                    SecuritySettings.PLUGIN_REALM_NAME_PREFIX + new LdapGroupHasUsersAuthPlugin().name() );
         } );
     }
 


### PR DESCRIPTION
Introduces a new setting `dbms.security.realm` which sets a single
active realm to be used for both authentication and authorization.
Valid alternatives are either one of the built-in realms `native` or `ldap`,
or a plugin realm, e.g. `plugin-<ExamplePlugin>`.

The pre-existing realm settings are now derived from this and considered
an advanced feature and is marked @Internal.
- Added new internal setting `dbms.securtiy.realms`, derived from the single
  realm setting, that can be overridden with a list of active realms. This defines
  the order in which realms are considered in a multiple realm setup.
- The pre-existing `...authentication_enabled` and `...authorization_enabled`
  settings are derived `true` from the single realm setting, but can be overridden
  to toggle authentication and authorization on/off individually to support existing
  multiple realm scenarios.
- Renamed `dbms.security.realms.internal...` to `dbms.security.realms.native...`
  for consistency with the new name of the native realm.

changelog: Simplify security realm configuration to require only the single line dbms.security.realm=name for most configs
