### PR TITLE
Restore compatibility within BOLT protocol v1

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -368,13 +368,23 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                         catch ( AuthenticationException | AuthProviderTimeoutException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e.status(), e.getMessage() ) );
-                            throw new BoltConnectionAuthFatality( e.getMessage() );
+                            return CONNECTED;
                         }
                         catch ( Throwable t )
                         {
                             fail( machine, Neo4jError.fatalFrom( Status.General.UnknownError, t.getMessage() ) );
                             throw new BoltConnectionFatality( t.getMessage() );
                         }
+                    }
+
+                    @Override
+                    public State ackFailure( BoltStateMachine machine ) throws BoltConnectionFatality
+                    {
+                        // While ACK_FAILURE should only be sent after a failure, allowing it anytime
+                        // in the CONNECTED state simplifies the state machine by avoiding the need for
+                        // an INIT_FAILED state. This makes it easier to observe that it is impossible
+                        // to move to the READY state without successful authentication.
+                        return CONNECTED;
                     }
                 },
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
@@ -26,7 +26,6 @@ import org.neo4j.bolt.v1.runtime.BoltResponseHandler;
 import org.neo4j.bolt.testing.BoltResponseRecorder;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.Neo4jError;
-import org.neo4j.bolt.testing.NullResponseHandler;
 import org.neo4j.bolt.testing.RecordedBoltResponse;
 import org.neo4j.bolt.v1.runtime.spi.Record;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
@@ -60,17 +59,17 @@ public class BoltConnectionIT
     public SessionRule env = new SessionRule();
 
     @Test
-    public void shouldCloseConnectionAckFailureBeforeInit() throws Throwable
+    public void shouldAllowAckFailureBeforeInit() throws Throwable
     {
         // Given
         BoltStateMachine machine = env.newMachine( "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        verifyKillsConnection( () -> machine.ackFailure( recorder ) );
+        machine.ackFailure( recorder );
 
         // then
-        assertThat( recorder.nextResponse(), failedWithStatus( Status.Request.Invalid ) );
+        assertThat( recorder.nextResponse(), succeeded() );
     }
 
     @Test


### PR DESCRIPTION
This PR restores compatibility with previous releases of the BOLT protocol v1.

Specifically, it allows a FAILURE of INIT to be acknowledged by the client, thus clearing the failure state. Failure of INIT is a common error path, easily reached by a user error, and thus maintaining correct protocol behaviour is important and necessary for compatibility.
