### PR TITLE
Remove token request and leader only lock replication timeouts

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/ReplicationModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/ReplicationModule.java
@@ -68,8 +68,7 @@ public class ReplicationModule
         LocalSessionPool sessionPool = new LocalSessionPool( myGlobalSession );
         progressTracker = new ProgressTrackerImpl( myGlobalSession );
 
-        replicator = new RaftReplicator( consensusModule.raftMachine(), myself,
-                outbound, sessionPool, progressTracker,
+        replicator = new RaftReplicator( consensusModule.raftMachine(), myself, outbound, sessionPool, progressTracker,
                 new ExponentialBackoffStrategy( 10, SECONDS ) );
 
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
@@ -70,10 +70,6 @@ public class CoreEdgeClusterSettings
     public static final Setting<Integer> raft_in_queue_max_batch =
             setting( "core_edge.raft_in_queue_max_batch", INTEGER, "64" );
 
-    @Description("Time out for a token to be replicated")
-    public static final Setting<Long> token_creation_timeout =
-            setting( "core_edge.token_creation_timeout", DURATION, "1s" );
-
     @Description("Time out waiting for the leader locking token")
     public static final Setting<Long> leader_lock_token_timeout =
             setting( "core_edge.leader_lock_token_timeout", DURATION, "1s" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
@@ -70,10 +70,6 @@ public class CoreEdgeClusterSettings
     public static final Setting<Integer> raft_in_queue_max_batch =
             setting( "core_edge.raft_in_queue_max_batch", INTEGER, "64" );
 
-    @Description("Time out waiting for the leader locking token")
-    public static final Setting<Long> leader_lock_token_timeout =
-            setting( "core_edge.leader_lock_token_timeout", DURATION, "1s" );
-
     @Description("Expected number of Core machines in the cluster")
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "core_edge.expected_core_cluster_size", INTEGER, "3" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/replication/RaftReplicator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/replication/RaftReplicator.java
@@ -45,9 +45,9 @@ public class RaftReplicator implements Replicator, Listener<MemberId>
 
     private MemberId leader;
 
-    public RaftReplicator( LeaderLocator leaderLocator, MemberId me, Outbound<MemberId,RaftMessages.RaftMessage> outbound,
-                           LocalSessionPool sessionPool, ProgressTracker progressTracker,
-                           RetryStrategy retryStrategy )
+    public RaftReplicator( LeaderLocator leaderLocator, MemberId me,
+            Outbound<MemberId,RaftMessages.RaftMessage> outbound, LocalSessionPool sessionPool,
+            ProgressTracker progressTracker, RetryStrategy retryStrategy )
     {
         this.me = me;
         this.outbound = outbound;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/CoreStateMachinesModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/CoreStateMachinesModule.java
@@ -70,7 +70,6 @@ import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.array_block_id_all
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.id_alloc_state_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.label_token_id_allocation_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.label_token_name_id_allocation_size;
-import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.leader_lock_token_timeout;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.neostore_block_id_allocation_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.node_id_allocation_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.node_labels_id_allocation_size;
@@ -176,8 +175,7 @@ public class CoreStateMachinesModule
 
         dependencies.satisfyDependencies( replicatedTxStateMachine );
 
-        long leaderLockTokenTimeout = config.get( leader_lock_token_timeout );
-        lockManager = createLockManager( config, logging, replicator, myself, leaderLocator, leaderLockTokenTimeout,
+        lockManager = createLockManager( config, logging, replicator, myself, leaderLocator,
                 replicatedLockTokenStateMachine );
 
         coreStateMachines = new CoreStateMachines( replicatedTxStateMachine, labelTokenStateMachine,
@@ -228,12 +226,9 @@ public class CoreStateMachinesModule
     }
 
     private Locks createLockManager( final Config config, final LogService logging, final Replicator replicator,
-                                     MemberId myself, LeaderLocator leaderLocator, long leaderLockTokenTimeout,
-                                     ReplicatedLockTokenStateMachine lockTokenStateMachine )
+            MemberId myself, LeaderLocator leaderLocator, ReplicatedLockTokenStateMachine lockTokenStateMachine )
     {
         Locks localLocks = CommunityEditionModule.createLockManager( config, logging );
-
-        return new LeaderOnlyLockManager( myself, replicator, leaderLocator, localLocks, leaderLockTokenTimeout,
-                lockTokenStateMachine );
+        return new LeaderOnlyLockManager( myself, replicator, leaderLocator, localLocks, lockTokenStateMachine );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/CoreStateMachinesModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/CoreStateMachinesModule.java
@@ -85,7 +85,6 @@ import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.replicated_lock_to
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.schema_id_allocation_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.state_machine_apply_max_batch_size;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.string_block_id_allocation_size;
-import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.token_creation_timeout;
 
 public class CoreStateMachinesModule
 {
@@ -142,22 +141,19 @@ public class CoreStateMachinesModule
 
         dependencies.satisfyDependency( new IdBasedStoreEntityCounters( this.idGeneratorFactory ) );
 
-        Long tokenCreationTimeout = config.get( token_creation_timeout );
-
         TokenRegistry<RelationshipTypeToken> relationshipTypeTokenRegistry = new TokenRegistry<>( "RelationshipType" );
         ReplicatedRelationshipTypeTokenHolder relationshipTypeTokenHolder =
                 new ReplicatedRelationshipTypeTokenHolder( relationshipTypeTokenRegistry, replicator,
-                        this.idGeneratorFactory, dependencies, tokenCreationTimeout );
+                        this.idGeneratorFactory, dependencies );
 
         TokenRegistry<Token> propertyKeyTokenRegistry = new TokenRegistry<>( "PropertyKey" );
         ReplicatedPropertyKeyTokenHolder propertyKeyTokenHolder =
                 new ReplicatedPropertyKeyTokenHolder( propertyKeyTokenRegistry, replicator, this.idGeneratorFactory,
-                        dependencies, tokenCreationTimeout );
+                        dependencies );
 
         TokenRegistry<Token> labelTokenRegistry = new TokenRegistry<>( "Label" );
         ReplicatedLabelTokenHolder labelTokenHolder =
-                new ReplicatedLabelTokenHolder( labelTokenRegistry, replicator, this.idGeneratorFactory, dependencies,
-                        tokenCreationTimeout );
+                new ReplicatedLabelTokenHolder( labelTokenRegistry, replicator, this.idGeneratorFactory, dependencies );
 
         ReplicatedLockTokenStateMachine replicatedLockTokenStateMachine =
                 new ReplicatedLockTokenStateMachine( lockTokenState );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -66,18 +66,15 @@ public class LeaderOnlyLockManager implements Locks
     private final Replicator replicator;
     private final LeaderLocator leaderLocator;
     private final Locks localLocks;
-    private final long leaderLockTokenTimeout;
     private final ReplicatedLockTokenStateMachine lockTokenStateMachine;
 
-    public LeaderOnlyLockManager(
-            MemberId myself, Replicator replicator, LeaderLocator leaderLocator,
-            Locks localLocks, long leaderLockTokenTimeout, ReplicatedLockTokenStateMachine lockTokenStateMachine )
+    public LeaderOnlyLockManager( MemberId myself, Replicator replicator, LeaderLocator leaderLocator, Locks localLocks,
+            ReplicatedLockTokenStateMachine lockTokenStateMachine )
     {
         this.myself = myself;
         this.replicator = replicator;
         this.leaderLocator = leaderLocator;
         this.localLocks = localLocks;
-        this.leaderLockTokenTimeout = leaderLockTokenTimeout;
         this.lockTokenStateMachine = lockTokenStateMachine;
     }
 
@@ -117,7 +114,7 @@ public class LeaderOnlyLockManager implements Locks
 
         try
         {
-            boolean success = (boolean) future.get( leaderLockTokenTimeout, MILLISECONDS );
+            boolean success = (boolean) future.get();
             if( success )
             {
                 return lockTokenRequest.id();
@@ -127,7 +124,7 @@ public class LeaderOnlyLockManager implements Locks
                 throw new AcquireLockTimeoutException( "Failed to acquire lock token. Was taken by another candidate." );
             }
         }
-        catch ( ExecutionException | TimeoutException e )
+        catch ( ExecutionException e )
         {
             throw new AcquireLockTimeoutException( e, "Failed to acquire lock token." );
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedLabelTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedLabelTokenHolder.java
@@ -29,13 +29,10 @@ import org.neo4j.storageengine.api.Token;
 
 public class ReplicatedLabelTokenHolder extends ReplicatedTokenHolder<Token> implements LabelTokenHolder
 {
-    public ReplicatedLabelTokenHolder(
-            TokenRegistry<Token> registry,
-            Replicator replicator,
-            IdGeneratorFactory idGeneratorFactory, Dependencies dependencies, Long timeoutMillis )
+    public ReplicatedLabelTokenHolder( TokenRegistry<Token> registry, Replicator replicator,
+            IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
     {
-        super( registry, replicator, idGeneratorFactory, IdType.LABEL_TOKEN, dependencies, TokenType.LABEL,
-                timeoutMillis );
+        super( registry, replicator, idGeneratorFactory, IdType.LABEL_TOKEN, dependencies, TokenType.LABEL );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedPropertyKeyTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedPropertyKeyTokenHolder.java
@@ -30,13 +30,10 @@ import org.neo4j.storageengine.api.Token;
 public class ReplicatedPropertyKeyTokenHolder extends ReplicatedTokenHolder<Token> implements
         PropertyKeyTokenHolder
 {
-    public ReplicatedPropertyKeyTokenHolder(
-            TokenRegistry<Token> registry,
-            RaftReplicator replicator,
-            IdGeneratorFactory idGeneratorFactory, Dependencies dependencies, Long timeoutMillis )
+    public ReplicatedPropertyKeyTokenHolder( TokenRegistry<Token> registry, RaftReplicator replicator,
+            IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
     {
-        super( registry, replicator, idGeneratorFactory, IdType.PROPERTY_KEY_TOKEN, dependencies, TokenType.PROPERTY,
-                timeoutMillis );
+        super( registry, replicator, idGeneratorFactory, IdType.PROPERTY_KEY_TOKEN, dependencies, TokenType.PROPERTY );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedRelationshipTypeTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/machines/token/ReplicatedRelationshipTypeTokenHolder.java
@@ -30,13 +30,11 @@ import org.neo4j.kernel.impl.util.Dependencies;
 public class ReplicatedRelationshipTypeTokenHolder extends
         ReplicatedTokenHolder<RelationshipTypeToken> implements RelationshipTypeTokenHolder
 {
-    public ReplicatedRelationshipTypeTokenHolder(
-            TokenRegistry<RelationshipTypeToken> registry,
-            RaftReplicator replicator,
-            IdGeneratorFactory idGeneratorFactory, Dependencies dependencies, Long timeoutMillis )
+    public ReplicatedRelationshipTypeTokenHolder( TokenRegistry<RelationshipTypeToken> registry,
+            RaftReplicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
     {
         super( registry, replicator, idGeneratorFactory, IdType.RELATIONSHIP_TYPE_TOKEN, dependencies,
-                TokenType.RELATIONSHIP, timeoutMillis );
+                TokenType.RELATIONSHIP );
     }
 
     @Override

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/machines/locks/LeaderOnlyLockManagerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/core/state/machines/locks/LeaderOnlyLockManagerTest.java
@@ -37,8 +37,6 @@ import static org.neo4j.coreedge.identity.RaftTestMember.member;
 @SuppressWarnings("unchecked")
 public class LeaderOnlyLockManagerTest
 {
-    private long LEADER_LOCK_TOKEN_TIMEOUT = 1000;
-
     @Test
     public void shouldIssueLocksOnLeader() throws Exception
     {
@@ -55,8 +53,8 @@ public class LeaderOnlyLockManagerTest
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        LeaderOnlyLockManager lockManager = new LeaderOnlyLockManager( me, replicator, leaderLocator,
-                locks, LEADER_LOCK_TOKEN_TIMEOUT, replicatedLockStateMachine );
+        LeaderOnlyLockManager lockManager =
+                new LeaderOnlyLockManager( me, replicator, leaderLocator, locks, replicatedLockStateMachine );
 
         // when
         lockManager.newClient().acquireExclusive( ResourceTypes.NODE, 0L );
@@ -80,8 +78,8 @@ public class LeaderOnlyLockManagerTest
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        LeaderOnlyLockManager lockManager = new LeaderOnlyLockManager( me, replicator, leaderLocator,
-                locks, LEADER_LOCK_TOKEN_TIMEOUT, replicatedLockStateMachine );
+        LeaderOnlyLockManager lockManager =
+                new LeaderOnlyLockManager( me, replicator, leaderLocator, locks, replicatedLockStateMachine );
 
         // when
         Locks.Client lockClient = lockManager.newClient();


### PR DESCRIPTION
This timeout is unnecessary since there is already a timeout on the
inner transaction replicator.  Moreover it is harmful since it might
prevent the inner replicator to retry if something went wrong with the
replication of the transaction.
