### PR TITLE
StoreUtil use page cache to move and rename files

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
@@ -335,6 +335,62 @@ public class FileUtils
         return root;
     }
 
+    /**
+     * Useful when you want to move a file from one directory to another by renaming the file
+     * and keep eventual sub directories. Example:
+     * <p>
+     * You want to move file /a/b1/c/d/file from /a/b1 to /a/b2 and keep the sub path /c/d/file.
+     * <pre>
+     * <code>fileToMove = new File( "/a/b1/c/d/file" );
+     * fromDir = new File( "/a/b1" );
+     * toDir = new File( "/a/b2" );
+     * fileToMove.rename( pathToFileAfterMove( fromDir, toDir, fileToMove ) );
+     * // fileToMove.getAbsolutePath() -> /a/b2/c/d/file</code>
+     * </pre>
+     * Calls {@link #pathToFileAfterMove(Path, Path, Path)} after
+     * transforming given files to paths by calling {@link File#toPath()}.
+     * <p>
+     * NOTE: This that this does not perform the move, it only calculates the new file name.
+     * <p>
+     * Throws {@link IllegalArgumentException} is fileToMove is not a sub path to fromDir.
+     *
+     * @param fromDir Current parent directory for fileToMove
+     * @param toDir Directory denoting new parent directory for fileToMove after move
+     * @param fileToMove File denoting current location for fileToMove
+     * @return {@link File} denoting new abstract path for file after move.
+     */
+    public static File pathToFileAfterMove( File fromDir, File toDir, File fileToMove )
+    {
+        final Path fromDirPath = fromDir.toPath();
+        final Path toDirPath = toDir.toPath();
+        final Path fileToMovePath = fileToMove.toPath();
+        return pathToFileAfterMove( fromDirPath, toDirPath, fileToMovePath ).toFile();
+    }
+
+    /**
+     * Resolve toDir against fileToMove relativized against fromDir, resulting in a path denoting the location of
+     * fileToMove after being moved fromDir toDir.
+     * <p>
+     * NOTE: This that this does not perform the move, it only calculates the new file name.
+     * <p>
+     * Throws {@link IllegalArgumentException} is fileToMove is not a sub path to fromDir.
+     *
+     * @param fromDir Path denoting current parent directory for fileToMove
+     * @param toDir Path denoting location for fileToMove after move
+     * @param fileToMove Path denoting current location for fileToMove
+     * @return {@link Path} denoting new abstract path for file after move.
+     */
+    public static Path pathToFileAfterMove( Path fromDir, Path toDir, Path fileToMove )
+    {
+        // File to move must be true sub path to from dir
+        if ( !fileToMove.startsWith( fromDir ) || fileToMove.equals( fromDir ) )
+        {
+            throw new IllegalArgumentException( "File " + fileToMove + " is not a sub path to dir " + fromDir );
+        }
+
+        return toDir.resolve( fromDir.relativize( fileToMove ) );
+    }
+
     public interface FileOperation
     {
         void perform() throws IOException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.util;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,14 +31,20 @@ import java.io.IOException;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.rule.TestDirectory;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.io.fs.FileUtils.pathToFileAfterMove;
 
 public class FileUtilsTest
 {
-    @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
+    public ExpectedException expected = ExpectedException.none();
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule( testDirectory ).around( expected );
 
     private File path;
 
@@ -82,6 +90,133 @@ public class FileUtilsTest
 
         assertTrue( FileUtils.isEmptyDirectory( emptyDir ) );
         assertFalse( FileUtils.isEmptyDirectory( nonEmptyDir ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustThrowIfFileNotSubPathToFromShorter() throws Exception
+    {
+        File file = new File( "/a" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/c" );
+
+        expected.expect( IllegalArgumentException.class );
+        pathToFileAfterMove( from, to, file );
+    }
+
+    // INVALID
+    @Test
+    public void pathToFileAfterMoveMustThrowIfFileNotSubPathToFromSameLength() throws Exception
+    {
+        File file = new File( "/a/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/c" );
+
+        expected.expect( IllegalArgumentException.class );
+        pathToFileAfterMove( from, to, file );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustThrowIfFileNotSubPathToFromLonger() throws Exception
+    {
+        File file = new File( "/a/c/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/c" );
+
+        expected.expect( IllegalArgumentException.class );
+        pathToFileAfterMove( from, to, file );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustThrowIfFromDirIsCompletePathToFile() throws Exception
+    {
+        File file = new File( "/a/b/f" );
+        File from = new File( "/a/b/f" );
+        File to   = new File( "/a/c" );
+
+        expected.expect( IllegalArgumentException.class );
+        pathToFileAfterMove( from, to, file );
+    }
+
+    // SIBLING
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingToSibling() throws Exception
+    {
+        File file = new File( "/a/b/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/c/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingToSiblingAndFileHasSubDir() throws Exception
+    {
+        File file = new File( "/a/b/d/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/c/d/f" ) );
+    }
+
+    // DEEPER
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingToSubDir() throws Exception
+    {
+        File file = new File( "/a/b/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/b/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/b/c/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingToSubDirAndFileHasSubDir() throws Exception
+    {
+        File file = new File( "/a/b/d/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/b/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/b/c/d/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingOutOfDir() throws Exception
+    {
+        File file = new File( "/a/b/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/c/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfMovingOutOfDirAndFileHasSubDir() throws Exception
+    {
+        File file = new File( "/a/b/d/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/c" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/c/d/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfNotMovingAtAll() throws Exception
+    {
+        File file = new File( "/a/b/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/b" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/b/f" ) );
+    }
+
+    @Test
+    public void pathToFileAfterMoveMustWorkIfNotMovingAtAllAndFileHasSubDir() throws Exception
+    {
+        File file = new File( "/a/b/d/f" );
+        File from = new File( "/a/b" );
+        File to   = new File( "/a/b" );
+
+        assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( "/a/b/d/f" ) );
     }
 
     private File directory( String name ) throws IOException

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.io.pagecache.FileHandle;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.ha.store.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -71,12 +70,7 @@ public class BranchedDataMigrator extends LifecycleAdapter
             try
             {
                 FileUtils.moveFile( oldBranchedDir, targetDir );
-                Iterable<FileHandle> handles = pageCache.streamFilesRecursive( oldBranchedDir )::iterator;
-                for ( FileHandle handle : handles )
-                {
-                    final File fileToMove = handle.getFile();
-                    handle.rename( FileUtils.pathToFileAfterMove( oldBranchedDir, targetDir, fileToMove ) );
-                }
+                StoreUtil.moveAwayDbWithPageCache( oldBranchedDir, targetDir, pageCache, f -> true );
             }
             catch ( IOException e )
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.FileHandle;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.util.StoreUtil;
+import org.neo4j.kernel.ha.store.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 public class BranchedDataMigrator extends LifecycleAdapter
@@ -75,7 +75,7 @@ public class BranchedDataMigrator extends LifecycleAdapter
                 for ( FileHandle handle : handles )
                 {
                     final File fileToMove = handle.getFile();
-                    handle.renameFile( FileUtils.pathToFileAfterMove( oldBranchedDir, targetDir, fileToMove ) );
+                    handle.rename( FileUtils.pathToFileAfterMove( oldBranchedDir, targetDir, fileToMove ) );
                 }
             }
             catch ( IOException e )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
@@ -24,12 +24,12 @@ import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCache;
 
-import static org.neo4j.kernel.impl.util.StoreUtil.cleanStoreDir;
-import static org.neo4j.kernel.impl.util.StoreUtil.deleteRecursive;
-import static org.neo4j.kernel.impl.util.StoreUtil.getBranchedDataRootDirectory;
-import static org.neo4j.kernel.impl.util.StoreUtil.isBranchedDataDirectory;
-import static org.neo4j.kernel.impl.util.StoreUtil.moveAwayDb;
-import static org.neo4j.kernel.impl.util.StoreUtil.newBranchedDataDir;
+import static org.neo4j.kernel.ha.store.StoreUtil.cleanStoreDir;
+import static org.neo4j.kernel.ha.store.StoreUtil.deleteRecursive;
+import static org.neo4j.kernel.ha.store.StoreUtil.getBranchedDataRootDirectory;
+import static org.neo4j.kernel.ha.store.StoreUtil.isBranchedDataDirectory;
+import static org.neo4j.kernel.ha.store.StoreUtil.moveAwayDb;
+import static org.neo4j.kernel.ha.store.StoreUtil.newBranchedDataDir;
 
 public enum BranchedDataPolicy
 {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataPolicy.java
@@ -22,9 +22,10 @@ package org.neo4j.kernel.ha;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.io.fs.FileUtils;
+import org.neo4j.io.pagecache.PageCache;
 
 import static org.neo4j.kernel.impl.util.StoreUtil.cleanStoreDir;
+import static org.neo4j.kernel.impl.util.StoreUtil.deleteRecursive;
 import static org.neo4j.kernel.impl.util.StoreUtil.getBranchedDataRootDirectory;
 import static org.neo4j.kernel.impl.util.StoreUtil.isBranchedDataDirectory;
 import static org.neo4j.kernel.impl.util.StoreUtil.moveAwayDb;
@@ -35,23 +36,23 @@ public enum BranchedDataPolicy
     keep_all
             {
                 @Override
-                public void handle( File storeDir ) throws IOException
+                public void handle( File storeDir, PageCache pageCache ) throws IOException
                 {
-                    moveAwayDb( storeDir, newBranchedDataDir( storeDir ) );
+                    moveAwayDb( storeDir, newBranchedDataDir( storeDir ), pageCache );
                 }
             },
     keep_last
             {
                 @Override
-                public void handle( File storeDir ) throws IOException
+                public void handle( File storeDir, PageCache pageCache ) throws IOException
                 {
                     File branchedDataDir = newBranchedDataDir( storeDir );
-                    moveAwayDb( storeDir, branchedDataDir );
+                    moveAwayDb( storeDir, branchedDataDir, pageCache );
                     for ( File file : getBranchedDataRootDirectory( storeDir ).listFiles() )
                     {
                         if ( isBranchedDataDirectory( file ) && !file.equals( branchedDataDir ) )
                         {
-                            FileUtils.deleteRecursively( file );
+                            deleteRecursive( file, pageCache );
                         }
                     }
                 }
@@ -59,11 +60,11 @@ public enum BranchedDataPolicy
     keep_none
             {
                 @Override
-                public void handle( File storeDir ) throws IOException
+                public void handle( File storeDir, PageCache pageCache ) throws IOException
                 {
-                    cleanStoreDir( storeDir );
+                    cleanStoreDir( storeDir, pageCache );
                 }
             };
 
-    public abstract void handle( File storeDir ) throws IOException;
+    public abstract void handle( File storeDir, PageCache pageCache ) throws IOException;
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -553,7 +553,7 @@ public class SwitchToSlave
     void cleanStoreDir() throws IOException
     {
         // Tests verify that this method is called
-        StoreUtil.cleanStoreDir( storeDir );
+        StoreUtil.cleanStoreDir( storeDir, pageCache );
     }
 
     private MasterClient newMasterClient( URI masterUri, URI me, StoreId storeId, LifeSupport life )
@@ -580,7 +580,7 @@ public class SwitchToSlave
             resolver.resolveDependency( serviceClass ).stop();
         }
 
-        branchPolicy.handle( storeDir );
+        branchPolicy.handle( storeDir, pageCache );
     }
 
     private void checkDataConsistencyWithMaster( URI availableMasterId, Master master,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -77,7 +77,7 @@ import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
-import org.neo4j.kernel.impl.util.StoreUtil;
+import org.neo4j.kernel.ha.store.StoreUtil;
 import org.neo4j.kernel.internal.StoreLockerLifecycleAdapter;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -227,7 +227,7 @@ public class HighlyAvailableEditionModule
         // Set Netty logger
         InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( logging.getInternalLogProvider() ) );
 
-        life.add( new BranchedDataMigrator( platformModule.storeDir ) );
+        life.add( new BranchedDataMigrator( platformModule.storeDir, platformModule.pageCache ) );
         DelegateInvocationHandler<Master> masterDelegateInvocationHandler =
                 new DelegateInvocationHandler<>( Master.class );
         Master master = (Master) newProxyInstance( Master.class.getClassLoader(), new Class[]{Master.class},

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.management.BranchedStore;
 import org.neo4j.management.BranchedStoreInfo;
 
-import static org.neo4j.kernel.impl.util.StoreUtil.getBranchedDataRootDirectory;
+import static org.neo4j.kernel.ha.store.StoreUtil.getBranchedDataRootDirectory;
 
 
 @Service.Implementation(ManagementBeanProvider.class)

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/StoreUtil.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/store/StoreUtil.java
@@ -5,19 +5,19 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.util;
+package org.neo4j.kernel.ha.store;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -47,7 +47,7 @@ import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
 import org.neo4j.kernel.impl.logging.StoreLogService;
 import org.neo4j.kernel.impl.util.Listener;
-import org.neo4j.kernel.impl.util.StoreUtil;
+import org.neo4j.kernel.ha.store.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.test.TestGraphDatabaseFactory;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.ClusterSettings;
@@ -266,6 +267,7 @@ public class SwitchToSlaveTest
         PagedFile pagedFileMock = mock( PagedFile.class );
         when( pagedFileMock.getLastPageId() ).thenReturn( 1L );
         when( pageCacheMock.map( any( File.class ), anyInt() ) ).thenReturn( pagedFileMock );
+        when( pageCacheMock.streamFilesRecursive( any( File.class ) ) ).thenReturn( Stream.empty() );
 
         return newSwitchToSlaveSpy( pageCacheMock, mock( StoreCopyClient.class) );
     }


### PR DESCRIPTION
**What?**
Use page cache as well as file system to move and delete files when copy store in HA.

**Why?**
When using a different storage device (blockdevice) for record files, only the page cache knows how to move and delete those files.

Changes:
`StoreUtil` use page cache to move and delete files.
`BranchedDataMigrator` use page cache to move files.
Added `pathToFileAfterMove` method to `FileUtils`.

Only last commit in PR is new, rebased on top of #8031 
