### PR TITLE
Expose HTTP addresses in dbms.cluster.overview

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConfigIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConfigIT.java
@@ -45,8 +45,10 @@ public class BoltConfigIT
     @Rule
     public Neo4jWithSocket server = new Neo4jWithSocket( getClass(),
             settings -> {
+                settings.put( boltConnector("0").type.name(), "BOLT" );
                 settings.put( boltConnector("0").enabled.name(), "true" );
                 settings.put( boltConnector("0").address.name(), "localhost:7888" );
+                settings.put( boltConnector("1").type.name(), "BOLT" );
                 settings.put( boltConnector("1").enabled.name(), "true" );
                 settings.put( boltConnector("1").address.name(), "localhost:7687" );
                 settings.put( boltConnector("1").encryption_level.name(), REQUIRED.name() );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -135,6 +135,7 @@ public class Neo4jWithSocket extends ExternalResource
     private Map<String,String> configure( Consumer<Map<String,String>> overrideSettingsFunction ) throws IOException
     {
         Map<String,String> settings = new HashMap<>();
+        settings.put( boltConnector( "0" ).type.name(), "BOLT" );
         settings.put( boltConnector( "0" ).enabled.name(), "true" );
         settings.put( boltConnector( "0" ).encryption_level.name(), OPTIONAL.name() );
         settings.put( BoltKernelExtension.Settings.tls_key_file.name(), tempPath( "key.key" ) );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RejectTransportEncryptionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/RejectTransportEncryptionIT.java
@@ -45,7 +45,10 @@ public class RejectTransportEncryptionIT
 {
     @Rule
     public Neo4jWithSocket server = new Neo4jWithSocket( getClass(),
-            settings -> settings.put( boltConnector( "0" ).encryption_level.name(), DISABLED.name() ) );
+            settings -> {
+                settings.put( boltConnector( "0" ).type.name(), "BOLT" );
+                settings.put( boltConnector( "0" ).encryption_level.name(), DISABLED.name() );
+            } );
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/community/dbms/src/main/java/org/neo4j/server/configuration/ClientConnectorSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/server/configuration/ClientConnectorSettings.java
@@ -1,0 +1,105 @@
+package org.neo4j.server.configuration;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.Description;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.ListenSocketAddress;
+import org.neo4j.kernel.configuration.Config;
+
+import static java.util.Collections.singletonList;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.HTTP;
+import static org.neo4j.kernel.configuration.GroupSettingSupport.enumerate;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.advertisedAddress;
+import static org.neo4j.kernel.configuration.Settings.legacyFallback;
+import static org.neo4j.kernel.configuration.Settings.listenAddress;
+import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.setting;
+
+public class ClientConnectorSettings
+{
+    public static HttpConnector httpConnector( String key )
+    {
+        return new HttpConnector( key, HttpConnector.Encryption.NONE );
+    }
+
+    public static Optional<HttpConnector> httpConnector( Config config, HttpConnector.Encryption encryption )
+    {
+        List<HttpConnector> httpConnectors = config
+                .view( enumerate( GraphDatabaseSettings.Connector.class ) )
+                .map( ( key ) -> new HttpConnector( key, encryption ) )
+                .filter( ( connConfig ) -> connConfig.group.groupKey.equals( encryption.uriScheme ) ||
+                        (config.get( connConfig.type ) == HTTP && config.get( connConfig.encryption ) == encryption) )
+                .collect( Collectors.toList() );
+        if ( httpConnectors.isEmpty() )
+        {
+            httpConnectors = singletonList( new HttpConnector( encryption ) );
+        }
+
+        return httpConnectors.stream()
+                .filter( ( connConfig ) -> config.get( connConfig.enabled ) )
+                .findFirst();
+    }
+
+    @Description("Configuration options for HTTP connectors. " +
+            "\"(http-connector-key)\" is a placeholder for a unique name for the connector, for instance " +
+            "\"http-public\" or some other name that describes what the connector is for.")
+    public static class HttpConnector extends GraphDatabaseSettings.Connector
+    {
+        @Description("Enable TLS for this connector")
+        public final Setting<Encryption> encryption;
+
+        @Description( "Address the connector should bind to. " +
+                "This setting is deprecated and will be replaced by `+listen_address+`" )
+        public final Setting<ListenSocketAddress> address;
+
+        @Description( "Address the connector should bind to" )
+        public final Setting<ListenSocketAddress> listen_address;
+
+        @Description( "Advertised address for this connector" )
+        public final Setting<AdvertisedSocketAddress> advertised_address;
+
+        public HttpConnector()
+        {
+            this( Encryption.NONE );
+        }
+
+        public HttpConnector( Encryption encryptionLevel )
+        {
+            this( "(http-connector-key)", encryptionLevel );
+        }
+
+        public HttpConnector( String key, Encryption encryptionLevel )
+        {
+            super( key, null );
+            encryption = group.scope( setting( "encryption", options( HttpConnector.Encryption.class ), NO_DEFAULT ) );
+            Setting<ListenSocketAddress> legacyAddressSetting = listenAddress( "address", encryptionLevel.defaultPort );
+            Setting<ListenSocketAddress> listenAddressSetting = legacyFallback( legacyAddressSetting,
+                    listenAddress( "listen_address", encryptionLevel.defaultPort ) );
+
+            this.address = group.scope( legacyAddressSetting );
+            this.listen_address = group.scope( listenAddressSetting );
+            this.advertised_address = group.scope( advertisedAddress( "advertised_address", listenAddressSetting ) );
+        }
+
+        public enum Encryption
+        {
+            NONE( "http", 7474 ), TLS( "https", 7473 );
+
+            final String uriScheme;
+            final int defaultPort;
+
+            Encryption( String uriScheme, int defaultPort )
+            {
+                this.uriScheme = uriScheme;
+                this.defaultPort = defaultPort;
+            }
+        }
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/server/configuration/ClientConnectorSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/server/configuration/ClientConnectorSettings.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.server.configuration;
 
 import java.util.List;

--- a/community/dbms/src/test/java/org/neo4j/server/configuration/ClientConnectorSettingsTest.java
+++ b/community/dbms/src/test/java/org/neo4j/server/configuration/ClientConnectorSettingsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.configuration;
+
+import org.junit.Test;
+
+import org.neo4j.helpers.ListenSocketAddress;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encryption;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class ClientConnectorSettingsTest
+{
+    @Test
+    public void shouldHaveHttpAndHttpsEnabledByDefault() throws Exception
+    {
+        // given
+        Config config = Config.defaults();
+
+        // when
+        ClientConnectorSettings.HttpConnector httpConnector = httpConnector( config, Encryption.NONE ).get();
+        ClientConnectorSettings.HttpConnector httpsConnector = httpConnector( config, Encryption.TLS ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "localhost", 7474 ), config.get( httpConnector.listen_address ) );
+        assertEquals( new ListenSocketAddress( "localhost", 7473 ), config.get( httpsConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldBeAbleToDisableHttpConnectorWithJustOneParameter() throws Exception
+    {
+        // given
+        Config disableHttpConfig = Config.defaults();
+        disableHttpConfig.augment( stringMap( "dbms.connector.http.enabled", "false" ) );
+
+        // then
+        assertFalse( httpConnector( disableHttpConfig, Encryption.NONE ).isPresent() );
+    }
+
+    @Test
+    public void shouldBeAbleToDisableHttpsConnectorWithJustOneParameter() throws Exception
+    {
+        // given
+        Config disableHttpsConfig = Config.defaults();
+        disableHttpsConfig.augment( stringMap( "dbms.connector.https.enabled", "false" ) );
+
+        // then
+        assertFalse( httpConnector( disableHttpsConfig, Encryption.TLS ).isPresent() );
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideHttpListenAddressWithJustOneParameter() throws Exception
+    {
+        // given
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connector.http.listen_address", ":8000" ) );
+
+        ClientConnectorSettings.HttpConnector httpConnector = httpConnector( config, Encryption.NONE ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "localhost", 8000 ), config.get( httpConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideHttpsListenAddressWithJustOneParameter() throws Exception
+    {
+        // given
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connector.https.listen_address", ":9000" ) );
+
+        ClientConnectorSettings.HttpConnector httpsConnector = httpConnector( config, Encryption.TLS ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "localhost", 9000 ), config.get( httpsConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldDeriveListenAddressFromDefaultListenAddress() throws Exception
+    {
+        // given
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connectors.default_listen_address", "0.0.0.0" ) );
+
+        // when
+        ClientConnectorSettings.HttpConnector httpConnector = httpConnector( config, Encryption.NONE ).get();
+        ClientConnectorSettings.HttpConnector httpsConnector = httpConnector( config, Encryption.TLS ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "0.0.0.0", 7474 ), config.get( httpConnector.listen_address ) );
+        assertEquals( new ListenSocketAddress( "0.0.0.0", 7473 ), config.get( httpsConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldDeriveListenAddressFromDefaultListenAddressAndSpecifiedPorts() throws Exception
+    {
+        // given
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connectors.default_listen_address", "0.0.0.0" ) );
+        config.augment( stringMap( "dbms.connector.http.listen_address", ":8000" ) );
+        config.augment( stringMap( "dbms.connector.https.listen_address", ":9000" ) );
+
+        // when
+        ClientConnectorSettings.HttpConnector httpConnector = httpConnector( config, Encryption.NONE ).get();
+        ClientConnectorSettings.HttpConnector httpsConnector = httpConnector( config, Encryption.TLS ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "0.0.0.0", 8000 ), config.get( httpConnector.listen_address ) );
+        assertEquals( new ListenSocketAddress( "0.0.0.0", 9000 ), config.get( httpsConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldStillSupportCustomNameForHttpConnector() throws Exception
+    {
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.type", "HTTP" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.encryption", "NONE" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.enabled", "true" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.listen_address", ":8000" ) );
+
+        // when
+        ClientConnectorSettings.HttpConnector httpConnector = httpConnector( config, Encryption.NONE ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "localhost", 8000 ), config.get( httpConnector.listen_address ) );
+    }
+
+    @Test
+    public void shouldStillSupportCustomNameForHttpsConnector() throws Exception
+    {
+        Config config = Config.defaults();
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.type", "HTTP" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.encryption", "TLS" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.enabled", "true" ) );
+        config.augment( stringMap( "dbms.connector.random_name_that_will_be_unsupported.listen_address", ":9000" ) );
+
+        // when
+        ClientConnectorSettings.HttpConnector httpsConnector = httpConnector( config, Encryption.TLS ).get();
+
+        // then
+        assertEquals( new ListenSocketAddress( "localhost", 9000 ), config.get( httpsConnector.listen_address ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GroupSettingSupport.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GroupSettingSupport.java
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.config.Setting;
 public class GroupSettingSupport
 {
     private final String groupName;
+    public final String groupKey;
 
     /**
      * List all keys for a given group type, this is a way to enumerate all instances of a group
@@ -61,7 +62,7 @@ public class GroupSettingSupport
         return groupClass.getAnnotation( Group.class ).value();
     }
 
-    public GroupSettingSupport( Class<?> groupClass, Object groupKey )
+    public GroupSettingSupport( Class<?> groupClass, String groupKey )
     {
         this( groupPrefix( groupClass ), groupKey );
     }
@@ -71,8 +72,9 @@ public class GroupSettingSupport
      * @param groupKey the unique key for this particular group instance, eg. '0' or 'group1',
      *                 this gets combined with the groupPrefix to eg. `dbms.mygroup.0`
      */
-    private GroupSettingSupport( String groupPrefix, Object groupKey )
+    private GroupSettingSupport( String groupPrefix, String groupKey )
     {
+        this.groupKey = groupKey;
         this.groupName = String.format( "%s.%s", groupPrefix, groupKey );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -46,6 +46,9 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
+
 /**
  * Test factory for graph databases
  */
@@ -88,6 +91,8 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
         // Reduce the default page cache memory size to 8 mega-bytes for test databases.
         builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         builder.setConfig( GraphDatabaseSettings.logs_directory, new File( storeDir, "logs" ).getAbsolutePath() );
+        builder.setConfig( boltConnector("bolt").type, BOLT.name() );
+        builder.setConfig( boltConnector("bolt").enabled, "false" );
     }
 
     @Override

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.server.AbstractNeoServer;
+import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encryption;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.configuration.ThirdPartyJaxRsPackage;
 
@@ -56,7 +57,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.Iterables.append;
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 import static org.neo4j.test.Digests.md5Hex;
 
 public abstract class AbstractInProcessServerBuilder implements TestServerBuilder
@@ -84,8 +85,12 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
         withConfig( auth_enabled, "false" );
         withConfig( pagecache_memory, "8m" );
         withConfig( httpConnector( "1" ).type, "HTTP" );
+        withConfig( httpConnector( "1" ).encryption, Encryption.NONE.name() );
         withConfig( httpConnector( "1" ).enabled, "true" );
         withConfig( httpConnector( "1" ).address, "localhost:" + Integer.toString( freePort( 1001, 5000 ) ) );
+        withConfig( httpConnector( "2" ).type, "HTTP" );
+        withConfig( httpConnector( "2" ).encryption, Encryption.TLS.name() );
+        withConfig( httpConnector( "2" ).enabled, "false" );
         withConfig( boltConnector( "0" ).type, "BOLT" );
         withConfig( boltConnector( "0" ).enabled, "true" );
         withConfig( boltConnector( "0" ).address, "localhost:" + Integer.toString( freePort( 5001, 9000 ) ) );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.harness;
 
-import org.apache.commons.io.FileUtils;
-import org.codehaus.jackson.JsonNode;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -41,6 +36,11 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.commons.io.FileUtils;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -52,6 +52,7 @@ import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -66,9 +67,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.harness.TestServerBuilders.newInProcessBuilder;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
 
 public class InProcessBuilderTest
 {
@@ -110,12 +111,13 @@ public class InProcessBuilderTest
 
         // When
         try ( ServerControls server = getTestServerBuilder( testDir.directory() )
-                .withConfig( httpConnector( "0" ).type, "HTTP" )
-                .withConfig( httpConnector( "0" ).enabled, "true" )
-                .withConfig( httpConnector( "1" ).type, "HTTP" )
-                .withConfig( httpConnector( "1" ).enabled, "true" )
-                .withConfig( httpConnector( "1" ).encryption, "TLS" )
-                .withConfig( httpConnector( "1" ).address, "localhost:7473" )
+                .withConfig( ClientConnectorSettings.httpConnector( "0" ).type, "HTTP" )
+                .withConfig( ClientConnectorSettings.httpConnector( "0" ).enabled, "true" )
+                .withConfig( ClientConnectorSettings.httpConnector( "0" ).encryption, "NONE" )
+                .withConfig( ClientConnectorSettings.httpConnector( "1" ).type, "HTTP" )
+                .withConfig( ClientConnectorSettings.httpConnector( "1" ).enabled, "true" )
+                .withConfig( ClientConnectorSettings.httpConnector( "1" ).encryption, "TLS" )
+                .withConfig( ClientConnectorSettings.httpConnector( "1" ).address, "localhost:7473" )
                 .withConfig( ServerSettings.certificates_directory.name(), testDir.directory( "certificates" ).getAbsolutePath() )
                 .withConfig( GraphDatabaseSettings.dense_node_threshold, "20" )
                 .newServer() )

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -55,8 +55,9 @@ import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ServerSettings;
-import org.neo4j.server.configuration.ServerSettings.HttpConnector;
+import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector;
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.CypherExecutorProvider;
 import org.neo4j.server.database.Database;
@@ -89,7 +90,7 @@ import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.serverTransactionTimeout;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 import static org.neo4j.server.configuration.ServerSettings.http_logging_enabled;
 import static org.neo4j.server.configuration.ServerSettings.http_logging_rotation_keep_number;
 import static org.neo4j.server.configuration.ServerSettings.http_logging_rotation_size;
@@ -149,14 +150,14 @@ public abstract class AbstractNeoServer implements NeoServer
         this.logProvider = logProvider;
         this.log = logProvider.getLog( getClass() );
 
-        HttpConnector httpConnector = httpConnector( config, HttpConnector.Encryption.NONE )
+        HttpConnector httpConnector = ClientConnectorSettings.httpConnector( config, ClientConnectorSettings.HttpConnector.Encryption.NONE )
                 .orElseThrow( () ->
                         new IllegalArgumentException( "An HTTP connector must be configured to run the server" ) );
         httpListenAddress = config.get( httpConnector.listen_address );
         httpAdvertisedAddress = config.get( httpConnector.advertised_address );
 
         Optional<HttpConnector> httpsConnector =
-                httpConnector( config, HttpConnector.Encryption.TLS );
+                ClientConnectorSettings.httpConnector( config, ClientConnectorSettings.HttpConnector.Encryption.TLS );
         httpsListenAddress = httpsConnector.map( (connector) -> config.get( connector.listen_address ) );
         httpsAdvertisedAddress = httpsConnector.map( (connector) -> config.get( connector.advertised_address ) );
     }

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -35,13 +35,13 @@ import org.neo4j.kernel.info.JvmMetadataRepository;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ConfigLoader;
-import org.neo4j.server.configuration.ServerSettings.HttpConnector;
 import org.neo4j.server.logging.JULBridge;
 import org.neo4j.server.logging.JettyLogBridge;
 
 import static java.lang.String.format;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 
 public abstract class ServerBootstrapper implements Bootstrapper
 {
@@ -81,7 +81,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
             log = userLogProvider.getLog( getClass() );
             config.setLogger( log );
 
-            serverAddress = httpConnector( config, HttpConnector.Encryption.NONE )
+            serverAddress = ClientConnectorSettings.httpConnector( config, ClientConnectorSettings.HttpConnector.Encryption.NONE )
                     .map( ( connector ) -> config.get( connector.address ).toString() )
                     .orElse( serverAddress );
 

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -23,22 +23,15 @@ import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 
 import org.neo4j.bolt.BoltKernelExtension;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.helpers.ListenSocketAddress;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Internal;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.server.web.JettyThreadCalculator;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.HTTP;
-import static org.neo4j.kernel.configuration.GroupSettingSupport.enumerate;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.DURATION;
@@ -50,12 +43,8 @@ import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
-import static org.neo4j.kernel.configuration.Settings.advertisedAddress;
-import static org.neo4j.kernel.configuration.Settings.legacyFallback;
-import static org.neo4j.kernel.configuration.Settings.listenAddress;
 import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
-import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.range;
 import static org.neo4j.kernel.configuration.Settings.setting;
@@ -75,65 +64,6 @@ public interface ServerSettings
 
     @Description("Comma-seperated list of custom security rules for Neo4j to use.")
     Setting<List<String>> security_rules = setting( "dbms.security.http_authorization_classes", STRING_LIST, EMPTY );
-
-    @Description("Configuration options for HTTP connectors. " +
-            "\"(http-connector-key)\" is a placeholder for a unique name for the connector, for instance " +
-            "\"http-public\" or some other name that describes what the connector is for.")
-    public class HttpConnector extends GraphDatabaseSettings.Connector
-    {
-        @Description("Enable TLS for this connector")
-        public final Setting<HttpConnector.Encryption> encryption;
-
-        @Description( "Address the connector should bind to. " +
-                "This setting is deprecated and will be replaced by `+listen_address+`" )
-        public final Setting<ListenSocketAddress> address;
-
-        @Description( "Address the connector should bind to" )
-        public final Setting<ListenSocketAddress> listen_address;
-
-        @Description( "Advertised address for this connector" )
-        public final Setting<AdvertisedSocketAddress> advertised_address;
-
-        public HttpConnector()
-        {
-            this( "(http-connector-key)" );
-        }
-
-        public HttpConnector( String key )
-        {
-            super( key, ConnectorType.HTTP.name() );
-            encryption = group.scope( setting( "encryption", options( HttpConnector.Encryption.class ), HttpConnector.Encryption.NONE.name() ) );
-            Setting<ListenSocketAddress> legacyAddressSetting = listenAddress( "address", 7474 );
-            Setting<ListenSocketAddress> listenAddressSetting = legacyFallback( legacyAddressSetting,
-                    listenAddress( "listen_address", 7474 ) );
-
-            this.address = group.scope( legacyAddressSetting );
-            this.listen_address = group.scope( listenAddressSetting );
-            this.advertised_address = group.scope( advertisedAddress( "advertised_address", listenAddressSetting ) );
-        }
-
-        public enum Encryption
-        {
-            NONE, TLS
-        }
-    }
-
-    public static HttpConnector httpConnector( String key )
-    {
-        return new HttpConnector( key );
-    }
-
-    public static Optional<HttpConnector> httpConnector( Config config, HttpConnector.Encryption encryption )
-    {
-        return config
-                .view( enumerate( GraphDatabaseSettings.Connector.class ) )
-                .map( HttpConnector::new )
-                .filter( ( connConfig ) ->
-                        config.get( connConfig.type ) == HTTP &&
-                                config.get( connConfig.enabled ) &&
-                                config.get( connConfig.encryption ) == encryption )
-                .findFirst();
-    }
 
     @Description( "Number of Neo4j worker threads, your OS might enforce a lower limit than the maximum value " +
             "specified here." )

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -42,6 +42,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.CommunityBootstrapper;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.ServerTestUtils;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ConfigLoader;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.Database;
@@ -55,7 +56,6 @@ import org.neo4j.time.Clocks;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.ServerTestUtils.asOneLine;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
 import static org.neo4j.server.database.LifecycleManagingDatabase.lifecycleManagingDatabase;
 
 public class CommunityServerBuilder
@@ -175,17 +175,15 @@ public class CommunityServerBuilder
             properties.put( ServerSettings.security_rules.name(), propertyKeys );
         }
 
-        properties.put( httpConnector("http").type.name(), "HTTP" );
-        properties.put( httpConnector("http").enabled.name(), "true" );
-        properties.put( httpConnector("http").address.name(), address.toString() );
+        properties.put( ClientConnectorSettings.httpConnector("http").type.name(), "HTTP" );
+        properties.put( ClientConnectorSettings.httpConnector("http").enabled.name(), "true" );
+        properties.put( ClientConnectorSettings.httpConnector("http").address.name(), address.toString() );
+        properties.put( ClientConnectorSettings.httpConnector("http").encryption.name(), "NONE" );
 
-        if ( httpsEnabled )
-        {
-            properties.put( httpConnector("https").type.name(), "HTTP" );
-            properties.put( httpConnector("https").enabled.name(), "true" );
-            properties.put( httpConnector("https").address.name(), httpsAddress.toString() );
-            properties.put( httpConnector("https").encryption.name(), "TLS" );
-        }
+        properties.put( ClientConnectorSettings.httpConnector("https").type.name(), "HTTP" );
+        properties.put( ClientConnectorSettings.httpConnector("https").enabled.name(), String.valueOf( httpsEnabled ) );
+        properties.put( ClientConnectorSettings.httpConnector("https").address.name(), httpsAddress.toString() );
+        properties.put( ClientConnectorSettings.httpConnector("https").encryption.name(), "TLS" );
 
         properties.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
         properties.put( ServerSettings.certificates_directory.name(), new File(temporaryFolder, "certificates").getAbsolutePath() );

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -40,13 +40,14 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.server.CommunityBootstrapper;
 import org.neo4j.server.ServerTestUtils;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 
 public class StartupLoggingIT extends ExclusiveServerTestBase
 {
@@ -91,8 +92,8 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
             pairs.add( Pair.of( entry.getKey(), entry.getValue() ) );
         }
         pairs.add( Pair.of( GraphDatabaseSettings.allow_store_upgrade.name(), Settings.TRUE) );
-        pairs.add( Pair.of( httpConnector("1").type.name(), "HTTP" ) );
-        pairs.add( Pair.of( httpConnector("1").enabled.name(), "true" ) );
+        pairs.add( Pair.of( ClientConnectorSettings.httpConnector("1").type.name(), "HTTP" ) );
+        pairs.add( Pair.of( ClientConnectorSettings.httpConnector("1").enabled.name(), "true" ) );
         return pairs.toArray( new Pair[pairs.size()] );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/ManageNodeDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/ManageNodeDocIT.java
@@ -54,6 +54,7 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.NeoServer;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
@@ -93,7 +94,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 import static org.neo4j.test.rule.SuppressOutput.suppressAll;
 
 public class ManageNodeDocIT extends AbstractRestFunctionalDocTestBase
@@ -636,8 +637,8 @@ public class ManageNodeDocIT extends AbstractRestFunctionalDocTestBase
             when( uriInfo.getBaseUri() ).thenReturn( uri );
 
             RootService svc = new RootService( new CommunityNeoServer( new Config( stringMap(
-                    httpConnector( "1" ).type.name(), "HTTP",
-                    httpConnector( "1" ).enabled.name(), "true"
+                    ClientConnectorSettings.httpConnector( "1" ).type.name(), "HTTP",
+                    ClientConnectorSettings.httpConnector( "1" ).enabled.name(), "true"
             ) ),
                     GraphDatabaseDependencies.newDependencies().userLogProvider( NullLogProvider.getInstance() )
                             .monitors( new Monitors() ),

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
@@ -26,14 +26,10 @@ import org.junit.Test;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
-import org.neo4j.server.CommunityNeoServer;
-import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.server.ExclusiveServerTestBase;
-import org.neo4j.test.server.HTTP;
 
-import static org.junit.Assert.assertEquals;
 import static org.neo4j.test.rule.SuppressOutput.suppressAll;
 
 public class TestJetty9WebServer extends ExclusiveServerTestBase
@@ -44,7 +40,6 @@ public class TestJetty9WebServer extends ExclusiveServerTestBase
     public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
 
     private Jetty9WebServer webServer;
-    private CommunityNeoServer server;
 
     @Test
     public void shouldBeAbleToUsePortZero() throws Exception
@@ -81,41 +76,12 @@ public class TestJetty9WebServer extends ExclusiveServerTestBase
         new Jetty9WebServer( NullLogProvider.getInstance(), null ).stop();
     }
 
-    /*
-     * The default jetty behaviour serves an index page for static resources. The 'directories' exposed through this
-     * behaviour are not file system directories, but only a list of resources present on the classpath, so there is no
-     * security vulnerability. However, it might seem like a vulnerability to somebody without the context of how the
-     * whole stack works, so to avoid confusion we disable the jetty behaviour.
-     */
-    @Test
-    public void shouldDisallowDirectoryListings() throws Exception
-    {
-        // Given
-        server = CommunityServerBuilder.server().build();
-        server.start();
-
-        // When
-        HTTP.Response okResource = HTTP.GET( server.baseUri().resolve( "/browser/index.html" ).toString() );
-        HTTP.Response illegalResource = HTTP.GET( server.baseUri().resolve( "/browser/styles/" ).toString() );
-
-        // Then
-        // Depends on specific resources exposed by the browser module; if this test starts to fail,
-        // check whether the structure of the browser module has changed and adjust accordingly.
-        assertEquals( 200, okResource.status() );
-        assertEquals( 403, illegalResource.status() );
-    }
-
     @After
     public void cleanup()
     {
         if ( webServer != null )
         {
             webServer.stop();
-        }
-
-        if ( server != null )
-        {
-            server.stop();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.web;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.helpers.CommunityServerBuilder;
+import org.neo4j.test.server.ExclusiveServerTestBase;
+import org.neo4j.test.server.HTTP;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebServerDirectoryListingTest extends ExclusiveServerTestBase
+{
+    private CommunityNeoServer server;
+
+    /*
+     * The default jetty behaviour serves an index page for static resources. The 'directories' exposed through this
+     * behaviour are not file system directories, but only a list of resources present on the classpath, so there is no
+     * security vulnerability. However, it might seem like a vulnerability to somebody without the context of how the
+     * whole stack works, so to avoid confusion we disable the jetty behaviour.
+     */
+    @Test
+    public void shouldDisallowDirectoryListings() throws Exception
+    {
+        // Given
+        server = CommunityServerBuilder.server().build();
+        server.start();
+
+        // When
+        HTTP.Response okResource = HTTP.GET( server.baseUri().resolve( "/browser/index.html" ).toString() );
+        HTTP.Response illegalResource = HTTP.GET( server.baseUri().resolve( "/browser/styles/" ).toString() );
+
+        // Then
+        // Depends on specific resources exposed by the browser module; if this test starts to fail,
+        // check whether the structure of the browser module has changed and adjust accordingly.
+        assertEquals( 200, okResource.status() );
+        assertEquals( 403, illegalResource.status() );
+    }
+
+    @After
+    public void cleanup()
+    {
+        if ( server != null )
+        {
+            server.stop();
+        }
+    }
+
+}

--- a/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.shell;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -41,44 +41,35 @@ import static org.junit.Assert.assertThat;
 public class ErrorsAndWarningsTest
 {
     @Rule
-    public ImpermanentDatabaseRule db = null;
-
-    public void startDatabase( final Boolean presentError )
+    public ImpermanentDatabaseRule db = new ImpermanentDatabaseRule()
     {
-        db = new ImpermanentDatabaseRule()
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
         {
-            @Override
-            protected void configure( GraphDatabaseBuilder builder )
-            {
-                builder.setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE );
-                builder.setConfig( GraphDatabaseSettings.cypher_hints_error, presentError.toString() );
-            }
+            builder.setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE );
+            builder.setConfig( GraphDatabaseSettings.cypher_hints_error, "false" );
+        }
 
-            @Override
-            public GraphDatabaseAPI getGraphDatabaseAPI()
+        @Override
+        public GraphDatabaseAPI getGraphDatabaseAPI()
+        {
+            try
             {
-                try
-                {
-                    before();
-                }
-                catch ( Throwable throwable )
-                {
-                    throwable.printStackTrace();
-                }
-                return super.getGraphDatabaseAPI();
+                before();
             }
-        };
-
-        db.getGraphDatabaseAPI();
-    }
+            catch ( Throwable throwable )
+            {
+                throwable.printStackTrace();
+            }
+            return super.getGraphDatabaseAPI();
+        }
+    };
 
     @Test
     public void unsupportedQueryShouldBeSilent() throws IOException
     {
         // Given
         // an empty database
-
-        startDatabase( false );
 
         // When
         InputStream realStdin = System.in;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/TxPullRequestHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/TxPullRequestHandler.java
@@ -119,11 +119,4 @@ public class TxPullRequestHandler extends SimpleChannelInboundHandler<TxPullRequ
         monitor.increment();
         protocol.expect( State.MESSAGE_TYPE );
     }
-
-    @Override
-    public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause )
-    {
-        cause.printStackTrace();
-        ctx.close();
-    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/ClientConnectorAddresses.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/ClientConnectorAddresses.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encryption;
+
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.bolt;
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.http;
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.https;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnectors;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
+
+public class ClientConnectorAddresses
+{
+    private final List<ConnectorUri> connectorUris;
+
+    public ClientConnectorAddresses( List<ConnectorUri> connectorUris )
+    {
+        this.connectorUris = connectorUris;
+    }
+
+    static ClientConnectorAddresses extractFromConfig( Config config )
+    {
+        List<ConnectorUri> connectorUris = new ArrayList<>();
+
+        connectorUris.add( new ConnectorUri( bolt, boltConnectors( config ).stream().findFirst()
+                .map( boltConnector -> config.get( boltConnector.advertised_address ) ).orElseThrow( () ->
+                        new IllegalArgumentException( "A Bolt connector must be configured to run a cluster" ) ) ) );
+
+        connectorUris.add( new ConnectorUri( http, config.get( httpConnector( config, Encryption.NONE ).orElseThrow(
+                () -> new IllegalArgumentException( "An HTTP connector must be configured to run the server" ) )
+                .advertised_address ) ) );
+
+        httpConnector( config, Encryption.TLS )
+                .map( ( connector ) -> config.get( connector.advertised_address ) )
+                .ifPresent( httpsAddress -> connectorUris.add( new ConnectorUri( https, httpsAddress ) ) );
+
+        return new ClientConnectorAddresses( connectorUris );
+    }
+
+    public AdvertisedSocketAddress getBoltAddress()
+    {
+        return connectorUris.stream().filter( connectorUri -> connectorUri.scheme == bolt ).findFirst().orElseThrow(
+                () -> new IllegalArgumentException( "A Bolt connector must be configured to run a cluster" ) )
+                .socketAddress;
+    }
+
+    public List<URI> uriList()
+    {
+        return connectorUris.stream().map( ConnectorUri::toUri ).collect( Collectors.toList() );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ClientConnectorAddresses that = (ClientConnectorAddresses) o;
+        return Objects.equals( connectorUris, that.connectorUris );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( connectorUris );
+    }
+
+    @Override
+    public String toString()
+    {
+        return connectorUris.stream().map( ConnectorUri::toString ).collect( Collectors.joining( "," ) );
+    }
+
+    static ClientConnectorAddresses fromString( String value )
+    {
+        return new ClientConnectorAddresses( Stream.of( value.split( "," ) )
+                .map( ConnectorUri::fromString ).collect( Collectors.toList() ) );
+    }
+
+    public enum Scheme
+    {
+        bolt, http, https
+    }
+
+    public static class ConnectorUri
+    {
+        private final Scheme scheme;
+        private final AdvertisedSocketAddress socketAddress;
+
+        public ConnectorUri( Scheme scheme, AdvertisedSocketAddress socketAddress )
+        {
+            this.scheme = scheme;
+            this.socketAddress = socketAddress;
+        }
+
+        private URI toUri()
+        {
+            try
+            {
+                return new URI( scheme.name().toLowerCase(), null, socketAddress.getHostname(), socketAddress.getPort(),
+                        null, null, null );
+            }
+            catch ( URISyntaxException e )
+            {
+                throw new IllegalArgumentException( e );
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return toUri().toString();
+        }
+
+        private static ConnectorUri fromString( String string )
+        {
+            URI uri = URI.create( string );
+            return new ConnectorUri( Scheme.valueOf( uri.getScheme() ),
+                    new AdvertisedSocketAddress( uri.getHost(), uri.getPort() ) );
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            ConnectorUri that = (ConnectorUri) o;
+            return scheme == that.scheme &&
+                    Objects.equals( socketAddress, that.socketAddress );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( scheme, socketAddress );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreAddresses.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreAddresses.java
@@ -25,14 +25,14 @@ public class CoreAddresses
 {
     private final AdvertisedSocketAddress raftServer;
     private final AdvertisedSocketAddress catchupServer;
-    private final AdvertisedSocketAddress boltServer;
+    private final ClientConnectorAddresses clientConnectorAddresses;
 
     public CoreAddresses( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
-            AdvertisedSocketAddress boltServer )
+                          ClientConnectorAddresses clientConnectorAddresses )
     {
         this.raftServer = raftServer;
         this.catchupServer = catchupServer;
-        this.boltServer = boltServer;
+        this.clientConnectorAddresses = clientConnectorAddresses;
     }
 
     public AdvertisedSocketAddress getRaftServer()
@@ -45,8 +45,8 @@ public class CoreAddresses
         return catchupServer;
     }
 
-    public AdvertisedSocketAddress getBoltServer()
+    public ClientConnectorAddresses getClientConnectorAddresses()
     {
-        return boltServer;
+        return clientConnectorAddresses;
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
@@ -21,7 +21,6 @@ package org.neo4j.coreedge.discovery;
 
 import org.neo4j.coreedge.core.consensus.schedule.DelayedRenewableTimeoutService;
 import org.neo4j.coreedge.identity.MemberId;
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
@@ -31,6 +30,6 @@ public interface DiscoveryServiceFactory
     CoreTopologyService coreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
             LogProvider logProvider, LogProvider userLogProvider );
 
-    TopologyService edgeDiscoveryService( Config config, AdvertisedSocketAddress boltAddress, LogProvider logProvider,
+    TopologyService edgeDiscoveryService( Config config, LogProvider logProvider,
             DelayedRenewableTimeoutService timeoutService, long edgeTimeToLiveTimeout, long edgeRefreshRate );
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeAddresses.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeAddresses.java
@@ -19,25 +19,23 @@
  */
 package org.neo4j.coreedge.discovery;
 
-import org.neo4j.helpers.AdvertisedSocketAddress;
-
 public class EdgeAddresses
 {
-    private final AdvertisedSocketAddress boltAddress;
+    private final ClientConnectorAddresses clientConnectorAddresses;
 
-    public EdgeAddresses( AdvertisedSocketAddress boltAddress )
+    public EdgeAddresses( ClientConnectorAddresses clientConnectorAddresses )
     {
-        this.boltAddress = boltAddress;
+        this.clientConnectorAddresses = clientConnectorAddresses;
     }
 
-    public AdvertisedSocketAddress getBoltAddress()
+    public ClientConnectorAddresses getClientConnectorAddresses()
     {
-        return boltAddress;
+        return clientConnectorAddresses;
     }
 
     @Override
     public String toString()
     {
-        return String.format( "EdgeAddresses{boltAddress=%s}", boltAddress );
+        return String.format( "EdgeAddresses{clientConnectorAddresses=%s}", clientConnectorAddresses );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
@@ -25,20 +25,19 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicReference;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+
 import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
-import org.neo4j.coreedge.edge.EnterpriseEdgeEditionModule;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
-
-import com.hazelcast.config.MemberAttributeConfig;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IAtomicReference;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.Member;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -54,7 +53,7 @@ class HazelcastClusterTopology
     static final String TRANSACTION_SERVER = "transaction_server";
     static final String DISCOVERY_SERVER = "discovery_server";
     static final String RAFT_SERVER = "raft_server";
-    static final String BOLT_SERVER = "bolt_server";
+    static final String CLIENT_CONNECTOR_ADDRESSES = "client_connector_addresses";
 
     static EdgeTopology getEdgeTopology( HazelcastInstance hazelcastInstance, Log log )
     {
@@ -117,8 +116,7 @@ class HazelcastClusterTopology
 
         return edgeServerMap
                 .entrySet().stream()
-                .map( entry -> new EdgeAddresses(
-                        socketAddress( entry.getValue() /*boltAddress*/, AdvertisedSocketAddress::new ) ) )
+                .map( entry -> new EdgeAddresses( ClientConnectorAddresses.fromString( entry.getValue() ) ) )
                 .collect( toSet() );
     }
 
@@ -164,8 +162,8 @@ class HazelcastClusterTopology
         AdvertisedSocketAddress raftAddress = config.get( CoreEdgeClusterSettings.raft_advertised_address );
         memberAttributeConfig.setStringAttribute( RAFT_SERVER, raftAddress.toString() );
 
-        AdvertisedSocketAddress boltAddress = EnterpriseEdgeEditionModule.extractBoltAddress( config );
-        memberAttributeConfig.setStringAttribute( BOLT_SERVER, boltAddress.toString() );
+        ClientConnectorAddresses clientConnectorAddresses = ClientConnectorAddresses.extractFromConfig( config );
+        memberAttributeConfig.setStringAttribute( CLIENT_CONNECTOR_ADDRESSES, clientConnectorAddresses.toString() );
         return memberAttributeConfig;
     }
 
@@ -176,7 +174,7 @@ class HazelcastClusterTopology
         return Pair.of( memberId, new CoreAddresses(
                 socketAddress( member.getStringAttribute( RAFT_SERVER ), AdvertisedSocketAddress::new ),
                 socketAddress( member.getStringAttribute( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
-                socketAddress( member.getStringAttribute( BOLT_SERVER ), AdvertisedSocketAddress::new ) )
-        );
+                ClientConnectorAddresses.fromString( member.getStringAttribute( CLIENT_CONNECTOR_ADDRESSES ) )
+        ) );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
@@ -30,7 +30,6 @@ import org.neo4j.coreedge.edge.EnterpriseEdgeEditionModule;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.helpers.SocketAddressFormat;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
@@ -44,6 +43,8 @@ import com.hazelcast.core.Member;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
+
+import static org.neo4j.helpers.SocketAddressFormat.socketAddress;
 
 class HazelcastClusterTopology
 {
@@ -116,7 +117,8 @@ class HazelcastClusterTopology
 
         return edgeServerMap
                 .entrySet().stream()
-                .map( entry -> new EdgeAddresses( SocketAddressFormat.socketAddress( entry.getValue() /*boltAddress*/, AdvertisedSocketAddress::new ) ) )
+                .map( entry -> new EdgeAddresses(
+                        socketAddress( entry.getValue() /*boltAddress*/, AdvertisedSocketAddress::new ) ) )
                 .collect( toSet() );
     }
 
@@ -172,9 +174,9 @@ class HazelcastClusterTopology
         MemberId memberId = new MemberId( UUID.fromString( member.getStringAttribute( MEMBER_UUID ) ) );
 
         return Pair.of( memberId, new CoreAddresses(
-                SocketAddressFormat.socketAddress( member.getStringAttribute( RAFT_SERVER ), AdvertisedSocketAddress::new ),
-                SocketAddressFormat.socketAddress( member.getStringAttribute( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
-                SocketAddressFormat.socketAddress( member.getStringAttribute( BOLT_SERVER ), AdvertisedSocketAddress::new )
-        ) );
+                socketAddress( member.getStringAttribute( RAFT_SERVER ), AdvertisedSocketAddress::new ),
+                socketAddress( member.getStringAttribute( TRANSACTION_SERVER ), AdvertisedSocketAddress::new ),
+                socketAddress( member.getStringAttribute( BOLT_SERVER ), AdvertisedSocketAddress::new ) )
+        );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
@@ -22,7 +22,6 @@ package org.neo4j.coreedge.discovery;
 import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
 import org.neo4j.coreedge.core.consensus.schedule.DelayedRenewableTimeoutService;
 import org.neo4j.coreedge.identity.MemberId;
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
@@ -38,12 +37,13 @@ public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory
     }
 
     @Override
-    public TopologyService edgeDiscoveryService( Config config, AdvertisedSocketAddress boltAddress,
+    public TopologyService edgeDiscoveryService( Config config,
                                                  LogProvider logProvider, DelayedRenewableTimeoutService timeoutService,
                                                  long edgeTimeToLiveTimeout, long edgeRefreshRate )
     {
         configureHazelcast( config );
-        return new HazelcastClient( new HazelcastClientConnector( config ), logProvider, boltAddress, timeoutService,
+
+        return new HazelcastClient( new HazelcastClientConnector( config ), logProvider, config, timeoutService,
                 edgeTimeToLiveTimeout, edgeRefreshRate );
     }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -192,8 +192,7 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         long edgeRefreshRate = config.get( CoreEdgeClusterSettings.edge_refresh_rate );
 
         TopologyService discoveryService = discoveryServiceFactory.edgeDiscoveryService( config,
-                extractBoltAddress( config ), logProvider, refreshEdgeTimeoutService, edgeTimeToLiveTimeout,
-                edgeRefreshRate );
+                logProvider, refreshEdgeTimeoutService, edgeTimeToLiveTimeout, edgeRefreshRate );
         life.add( dependencies.satisfyDependency( discoveryService ) );
 
         Clock clock = Clocks.systemClock();
@@ -249,13 +248,6 @@ public class EnterpriseEdgeEditionModule extends EditionModule
                 new ExponentialBackoffStrategy( 1, TimeUnit.SECONDS ), logProvider, copiedStoreRecovery ) );
 
         dependencies.satisfyDependency( createSessionTracker() );
-    }
-
-    public static AdvertisedSocketAddress extractBoltAddress( Config config )
-    {
-        return boltConnectors( config ).stream().findFirst()
-                .map( boltConnector -> config.get( boltConnector.advertised_address ) ).orElseThrow( () ->
-                        new IllegalArgumentException( "A Bolt connector must be configured to run a cluster" ) );
     }
 
     private void registerRecovery( final DatabaseInfo databaseInfo, LifeSupport life,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/ClientConnectorAddressesTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/ClientConnectorAddressesTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.ClientConnectorAddresses.ConnectorUri;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.bolt;
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.http;
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.https;
+
+public class ClientConnectorAddressesTest
+{
+    @Test
+    public void shouldSerializeToString() throws Exception
+    {
+        // given
+        ClientConnectorAddresses connectorAddresses = new ClientConnectorAddresses( asList(
+                new ConnectorUri( bolt, new AdvertisedSocketAddress( "host", 1 ) ),
+                new ConnectorUri( http, new AdvertisedSocketAddress( "host", 2 ) ),
+                new ConnectorUri( https, new AdvertisedSocketAddress( "host", 3 ) ) )
+        );
+
+        // when
+        ClientConnectorAddresses out = ClientConnectorAddresses.fromString( connectorAddresses.toString() );
+
+        // then
+        assertEquals( connectorAddresses, out );
+    }
+
+    @Test
+    public void shouldSerializeWithNoHttpsAddress() throws Exception
+    {
+        // given
+        ClientConnectorAddresses connectorAddresses = new ClientConnectorAddresses( asList(
+                new ConnectorUri( bolt, new AdvertisedSocketAddress( "host", 1 ) ),
+                new ConnectorUri( http, new AdvertisedSocketAddress( "host", 2 ) )
+        ) );
+
+        // when
+        ClientConnectorAddresses out = ClientConnectorAddresses.fromString( connectorAddresses.toString() );
+
+        // then
+        assertEquals( connectorAddresses, out );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/ClusterMember.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/ClusterMember.java
@@ -28,4 +28,6 @@ public interface ClusterMember<T extends GraphDatabaseAPI>
     void shutdown();
 
     T database();
+
+    ClientConnectorAddresses clientConnectorAddresses();
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
@@ -31,16 +31,18 @@ import org.neo4j.coreedge.core.consensus.RaftMachine;
 import org.neo4j.coreedge.core.consensus.log.segmented.FileNames;
 import org.neo4j.coreedge.core.state.CoreState;
 import org.neo4j.coreedge.identity.MemberId;
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Level;
 import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encryption;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
+
 import static org.neo4j.coreedge.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.coreedge.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -83,7 +85,6 @@ public class CoreClusterMember implements ClusterMember
         config.put( GraphDatabaseSettings.record_format.name(), recordFormat );
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).type.name(), "BOLT" );
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).enabled.name(), "true" );
-        config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).address.name(), "0.0.0.0:" + boltPort );
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).listen_address.name(), "127.0.0.1:" + boltPort );
         boltAdvertisedAddress = "127.0.0.1:" + boltPort;
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).advertised_address.name(), boltAdvertisedAddress );
@@ -182,5 +183,11 @@ public class CoreClusterMember implements ClusterMember
     public int serverId()
     {
         return serverId;
+    }
+
+    @Override
+    public ClientConnectorAddresses clientConnectorAddresses()
+    {
+        return ClientConnectorAddresses.extractFromConfig( new Config( this.config ) );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/CoreClusterMember.java
@@ -36,6 +36,8 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.logging.Level;
+import org.neo4j.server.configuration.ClientConnectorSettings;
+import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encryption;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -66,6 +68,7 @@ public class CoreClusterMember implements ClusterMember
         int txPort = 6000 + serverId;
         int raftPort = 7000 + serverId;
         int boltPort = 8000 + serverId;
+        int httpPort = 10000 + serverId;
 
         String initialMembers = addresses.stream().map( AdvertisedSocketAddress::toString ).collect( joining( "," ) );
 
@@ -84,6 +87,10 @@ public class CoreClusterMember implements ClusterMember
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).listen_address.name(), "127.0.0.1:" + boltPort );
         boltAdvertisedAddress = "127.0.0.1:" + boltPort;
         config.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).advertised_address.name(), boltAdvertisedAddress );
+        config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).type.name(), "HTTP" );
+        config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).enabled.name(), "true" );
+        config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).listen_address.name(), "127.0.0.1:" + httpPort );
+        config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).advertised_address.name(), "127.0.0.1:" + httpPort );
         config.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
         config.put( GraphDatabaseSettings.auth_store.name(), new File( parentDir, "auth" ).getAbsolutePath() );
         config.putAll( extraParams );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
@@ -62,6 +62,9 @@ public class HazelcastClusterTopologyTest
         settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).type.name(), "BOLT" );
         settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).enabled.name(), "true" );
         settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).advertised_address.name(), "bolt:3001" );
+        settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).type.name(), "HTTP" );
+        settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).enabled.name(), "true" );
+        settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).advertised_address.name(), "http:3001" );
         config.augment( settings );
 
         // when
@@ -74,7 +77,7 @@ public class HazelcastClusterTopologyTest
         CoreAddresses addresses = extracted.other();
         assertEquals( new AdvertisedSocketAddress( "tx", 1001 ), addresses.getCatchupServer() );
         assertEquals( new AdvertisedSocketAddress( "raft", 2001 ), addresses.getRaftServer() );
-        assertEquals( new AdvertisedSocketAddress( "bolt", 3001 ), addresses.getBoltServer() );
+        assertEquals( new AdvertisedSocketAddress( "bolt", 3001 ), addresses.getClientConnectorAddresses().getBoltAddress() );
     }
 
     @Test
@@ -94,6 +97,10 @@ public class HazelcastClusterTopologyTest
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).type.name(), "BOLT" );
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).enabled.name(), "true" );
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).advertised_address.name(), "bolt:" + (i + 1) );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).type.name(), "HTTP" );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).enabled.name(), "true" );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).advertised_address.name(), "http:" + (i + 1) );
+
             config.augment( settings );
             Map<String, Object> attributes = buildMemberAttributes( memberId, config ).getAttributes();
             hazelcastMembers.add( new MemberImpl( new Address( "localhost", i ), null, attributes, false ) );
@@ -110,7 +117,7 @@ public class HazelcastClusterTopologyTest
             CoreAddresses coreAddresses = coreMemberMap.get( coreMembers.get( i ) );
             assertEquals( new AdvertisedSocketAddress( "tx", (i + 1) ), coreAddresses.getCatchupServer() );
             assertEquals( new AdvertisedSocketAddress( "raft", (i + 1) ), coreAddresses.getRaftServer() );
-            assertEquals( new AdvertisedSocketAddress( "bolt", (i + 1) ), coreAddresses.getBoltServer() );
+            assertEquals( new AdvertisedSocketAddress( "bolt", (i + 1) ), coreAddresses.getClientConnectorAddresses().getBoltAddress() );
         }
     }
 
@@ -129,6 +136,10 @@ public class HazelcastClusterTopologyTest
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).type.name(), "BOLT" );
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).enabled.name(), "true" );
             settings.put( new GraphDatabaseSettings.BoltConnector( "bolt" ).advertised_address.name(), "bolt:" + (i + 1) );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).type.name(), "HTTP" );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).enabled.name(), "true" );
+            settings.put( new GraphDatabaseSettings.BoltConnector( "http" ).advertised_address.name(), "http:" + (i + 1) );
+
             config.augment( settings );
             Map<String, Object> attributes = buildMemberAttributes( memberId, config ).getAttributes();
             if ( i == 2 )

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryCoreClient.java
@@ -26,7 +26,6 @@ import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
 import org.neo4j.coreedge.identity.MemberId;
-import org.neo4j.coreedge.edge.EnterpriseEdgeEditionModule;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -118,8 +117,8 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     {
         AdvertisedSocketAddress raftAddress = config.get( CoreEdgeClusterSettings.raft_advertised_address );
         AdvertisedSocketAddress transactionSource = config.get( CoreEdgeClusterSettings.transaction_advertised_address );
-        AdvertisedSocketAddress boltAddress = EnterpriseEdgeEditionModule.extractBoltAddress( config );
+        ClientConnectorAddresses clientConnectorAddresses = ClientConnectorAddresses.extractFromConfig( config );
 
-        return new CoreAddresses( raftAddress, transactionSource, boltAddress );
+        return new CoreAddresses( raftAddress, transactionSource, clientConnectorAddresses );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryEdgeClient.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryEdgeClient.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.coreedge.discovery;
 
-import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -30,11 +30,11 @@ class SharedDiscoveryEdgeClient extends LifecycleAdapter implements TopologyServ
     private final EdgeAddresses addresses;
     private final Log log;
 
-    SharedDiscoveryEdgeClient( SharedDiscoveryService sharedDiscoveryService, AdvertisedSocketAddress boltAddress,
+    SharedDiscoveryEdgeClient( SharedDiscoveryService sharedDiscoveryService, Config config,
                                LogProvider logProvider )
     {
         this.sharedDiscoveryService = sharedDiscoveryService;
-        this.addresses = new EdgeAddresses( boltAddress );
+        this.addresses = new EdgeAddresses( ClientConnectorAddresses.extractFromConfig( config ) );
         this.log = logProvider.getLog( getClass() );
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryService.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/SharedDiscoveryService.java
@@ -33,7 +33,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.neo4j.coreedge.core.consensus.schedule.DelayedRenewableTimeoutService;
 import org.neo4j.coreedge.identity.ClusterId;
 import org.neo4j.coreedge.identity.MemberId;
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
@@ -62,11 +61,11 @@ public class SharedDiscoveryService implements DiscoveryServiceFactory
     }
 
     @Override
-    public TopologyService edgeDiscoveryService( Config config, AdvertisedSocketAddress boltAddress,
-            LogProvider logProvider, DelayedRenewableTimeoutService timeoutService, long edgeTimeToLiveTimeout,
-            long edgeRefreshRate )
+    public TopologyService edgeDiscoveryService( Config config, LogProvider logProvider,
+                                                 DelayedRenewableTimeoutService timeoutService,
+                                                 long edgeTimeToLiveTimeout, long edgeRefreshRate )
     {
-        return new SharedDiscoveryEdgeClient( this, boltAddress, logProvider );
+        return new SharedDiscoveryEdgeClient( this, config, logProvider );
     }
 
     void waitForClusterFormation() throws InterruptedException

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -48,7 +48,7 @@ import static org.neo4j.helpers.collection.Iterators.asList;
 public class ClusterOverviewProcedureTest
 {
     @Test
-    public void shouldProvideOverivewOfCoreAndEdgeServers() throws Exception
+    public void shouldProvideOverviewOfCoreAndEdgeServers() throws Exception
     {
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
@@ -78,11 +78,11 @@ public class ClusterOverviewProcedureTest
 
         // then
         assertThat( members, IsIterableContainingInOrder.contains(
-                new Object[]{theLeader.getUuid().toString(), "localhost:3000", "LEADER"},
-                new Object[]{follower1.getUuid().toString(), "localhost:3001", "FOLLOWER"},
-                new Object[]{follower2.getUuid().toString(), "localhost:3002", "FOLLOWER"},
-                new Object[]{"00000000-0000-0000-0000-000000000000", "localhost:3004", "READ_REPLICA"},
-                new Object[]{"00000000-0000-0000-0000-000000000000", "localhost:3005", "READ_REPLICA"}
+                new Object[]{theLeader.getUuid().toString(), new String[] {"bolt://localhost:3000"}, "LEADER"},
+                new Object[]{follower1.getUuid().toString(), new String[] {"bolt://localhost:3001"}, "FOLLOWER"},
+                new Object[]{follower2.getUuid().toString(), new String[] {"bolt://localhost:3002"}, "FOLLOWER"},
+                new Object[]{"00000000-0000-0000-0000-000000000000", new String[] {"bolt://localhost:3004"}, "READ_REPLICA"},
+                new Object[]{"00000000-0000-0000-0000-000000000000", new String[] {"bolt://localhost:3005"}, "READ_REPLICA"}
         ) );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/GetServersProcedureTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/procedures/GetServersProcedureTest.java
@@ -22,6 +22,7 @@ package org.neo4j.coreedge.discovery.procedures;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,8 @@ import java.util.stream.Collectors;
 import org.neo4j.coreedge.core.CoreEdgeClusterSettings;
 import org.neo4j.coreedge.core.consensus.LeaderLocator;
 import org.neo4j.coreedge.core.consensus.NoLeaderFoundException;
+import org.neo4j.coreedge.discovery.ClientConnectorAddresses;
+import org.neo4j.coreedge.discovery.ClientConnectorAddresses.ConnectorUri;
 import org.neo4j.coreedge.discovery.CoreAddresses;
 import org.neo4j.coreedge.discovery.CoreTopology;
 import org.neo4j.coreedge.discovery.CoreTopologyService;
@@ -47,6 +50,8 @@ import org.neo4j.kernel.configuration.Config;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -54,6 +59,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.discovery.ClientConnectorAddresses.Scheme.bolt;
 import static org.neo4j.coreedge.identity.RaftTestMember.member;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
@@ -261,7 +268,7 @@ public class GetServersProcedureTest
         assertThat( readServers.get( "role" ), equalTo( "READ" ) );
         assertThat( asList( readServers.get( "addresses" ) ),
                 containsInAnyOrder( coreAddresses( 0 ).getRaftServer().toString(),
-                        edgeAddresses( 1 ).getBoltAddress().toString() ) );
+                        edgeAddresses( 1 ).getClientConnectorAddresses().getBoltAddress().toString() ) );
 
         Map<String,Object[]> routingServers = servers.get( 2 );
         assertThat( routingServers.get( "role" ), equalTo( "ROUTE" ) );
@@ -403,12 +410,14 @@ public class GetServersProcedureTest
     static CoreAddresses coreAddresses( int id )
     {
         AdvertisedSocketAddress advertisedSocketAddress = new AdvertisedSocketAddress( "localhost", (3000 + id) );
-        return new CoreAddresses( advertisedSocketAddress, advertisedSocketAddress, advertisedSocketAddress );
+        return new CoreAddresses( advertisedSocketAddress, advertisedSocketAddress,
+                new ClientConnectorAddresses( singletonList( new ConnectorUri( bolt, advertisedSocketAddress ) ) ) );
     }
 
     private static EdgeAddresses edgeAddresses( int id )
     {
         AdvertisedSocketAddress advertisedSocketAddress = new AdvertisedSocketAddress( "localhost", (3000 + id) );
-        return new EdgeAddresses( advertisedSocketAddress );
+        return new EdgeAddresses(
+                new ClientConnectorAddresses( singletonList( new ConnectorUri( bolt, advertisedSocketAddress ) ) ) );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConnectionInfoIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConnectionInfoIT.java
@@ -118,7 +118,6 @@ public class ConnectionInfoIT
                 defaults().with( singletonMap( discovery_listen_address.name(), ":" + testSocket.getLocalPort() ) );
         config.augment( singletonMap( CoreEdgeClusterSettings.initial_discovery_members.name(),
                 "localhost:" + testSocket.getLocalPort() ) );
-        config.augment( singletonMap( GraphDatabaseSettings.boltConnector( "bolt" ).enabled.name(), "true" ) );
 
         Neo4jJobScheduler jobScheduler = new Neo4jJobScheduler();
         jobScheduler.init();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
@@ -56,6 +56,22 @@ public class CoreReplicationIT
     }
 
     @Test
+    public void shouldReplicateTransactionsToCoreMembers() throws Exception
+    {
+        // when
+        CoreClusterMember leader = cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        } );
+
+        // then
+        assertEquals( 1, countNodes( leader ) );
+        dataMatchesEventually( leader, cluster.coreMembers() );
+    }
+
+    @Test
     public void shouldNotAllowWritesFromAFollower() throws Exception
     {
         // given
@@ -125,27 +141,6 @@ public class CoreReplicationIT
             // expected
             assertThat( ignored.getMessage(), containsString( "No write operations are allowed" ) );
         }
-    }
-
-    @Test
-    public void shouldReplicateTransactionsToCoreMembers() throws Exception
-    {
-        // when
-        cluster.coreTx( ( db, tx ) ->
-        {
-            Node node = db.createNode( label( "boo" ) );
-            node.setProperty( "foobar", "baz_bat" );
-            tx.success();
-        } );
-        CoreClusterMember last = cluster.coreTx( ( db, tx ) ->
-        {
-            db.schema().indexFor( label( "boo" ) ).on( "foobar" ).create();
-            tx.success();
-        } );
-
-        // then
-        assertEquals( 1, countNodes( last ) );
-        dataMatchesEventually( last, cluster.coreMembers() );
     }
 
     @Test

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -98,6 +98,8 @@ import org.neo4j.storageengine.api.StorageEngine;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
 import static org.neo4j.helpers.ArrayUtil.contains;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -138,7 +140,10 @@ public class ClusterManager
 
     public static final long DEFAULT_TIMEOUT_SECONDS = 60L;
     public static final Map<String,String> CONFIG_FOR_SINGLE_JVM_CLUSTER = unmodifiableMap( stringMap(
-            GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
+            GraphDatabaseSettings.pagecache_memory.name(), "8m",
+            boltConnector( "0" ).type.name(), "BOLT",
+            boltConnector( "0" ).enabled.name(), "false"
+    ) );
 
     public interface StoreDirInitializer
     {

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
@@ -65,6 +65,7 @@ public class BoltMetricsIT
         File metricsFolder = tmpDir.newFolder( "metrics" );
         db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
+                .setConfig( boltConnector( "0" ).type, "BOLT" )
                 .setConfig( boltConnector( "0" ).enabled, "true" )
                 .setConfig( GraphDatabaseSettings.auth_enabled, "false" )
                 .setConfig( MetricsSettings.boltMessagesEnabled, "true" )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
@@ -65,6 +65,7 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseAuthSu
 
     private void init( GraphDatabaseBuilder builder, Map<String, String> config ) throws Throwable
     {
+        builder.setConfig( boltConnector( "0" ).type, "BOLT" );
         builder.setConfig( boltConnector( "0" ).enabled, "true" );
         builder.setConfig( boltConnector( "0" ).encryption_level, OPTIONAL.name() );
         builder.setConfig( BoltKernelExtension.Settings.tls_key_file, NeoInteractionLevel.tempPath( "key", ".key" ) );

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTInteraction.java
@@ -73,6 +73,7 @@ class RESTInteraction extends CommunityServerTestBase implements NeoInteractionL
     {
         CommunityServerBuilder builder = EnterpriseServerBuilder.server();
         builder = builder
+                .withProperty( boltConnector( "0" ).type.name(), "BOLT" )
                 .withProperty( boltConnector( "0" ).enabled.name(), "true" )
                 .withProperty( boltConnector( "0" ).encryption_level.name(), OPTIONAL.name() )
                 .withProperty( BoltKernelExtension.Settings.tls_key_file.name(),

--- a/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BoltQueryLoggingIT.java
@@ -54,6 +54,7 @@ public class BoltQueryLoggingIT
             .withConfig( GraphDatabaseSettings.auth_enabled, "false" )
             .withConfig( GraphDatabaseSettings.logs_directory, tmpDir )
             .withConfig( GraphDatabaseSettings.log_queries, "true")
+            .withConfig( GraphDatabaseSettings.boltConnector( "0" ).type, "BOLT" )
             .withConfig( GraphDatabaseSettings.boltConnector( "0" ).enabled, "true" )
             .withConfig( GraphDatabaseSettings.boltConnector( "0" ).address, "localhost:8776" )
             .withConfig( GraphDatabaseSettings.boltConnector( "0" ).encryption_level, "DISABLED" );

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -72,6 +72,7 @@ import org.neo4j.register.Registers;
 import org.neo4j.server.CommunityBootstrapper;
 import org.neo4j.server.ServerBootstrapper;
 import org.neo4j.server.ServerTestUtils;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.Unzip;
 import org.neo4j.test.rule.SuppressOutput;
@@ -87,7 +88,7 @@ import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 
 @RunWith( Enclosed.class )
 public class StoreUpgradeIntegrationTest
@@ -219,8 +220,8 @@ public class StoreUpgradeIntegrationTest
             props.setProperty( GraphDatabaseSettings.logs_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.allow_store_upgrade.name(), "true" );
             props.setProperty( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
-            props.setProperty( httpConnector( "1" ).type.name(), "HTTP" );
-            props.setProperty( httpConnector( "1" ).enabled.name(), "true" );
+            props.setProperty( ClientConnectorSettings.httpConnector( "1" ).type.name(), "HTTP" );
+            props.setProperty( ClientConnectorSettings.httpConnector( "1" ).enabled.name(), "true" );
             try ( FileWriter writer = new FileWriter( configFile ) )
             {
                 props.store( writer, "" );

--- a/manual/config-docs/pom.xml
+++ b/manual/config-docs/pom.xml
@@ -138,7 +138,7 @@
                 <java classname="org.neo4j.kernel.configuration.docs.GenerateConfigDocumentation"
                       classpathref="maven.compile.classpath" failonerror="true">
                   <arg line="-o ${project.build.directory}/docs/ops/configuration-http-connector-attributes.asciidoc" />
-                  <arg value="org.neo4j.server.configuration.ServerSettings$HttpConnector" />
+                  <arg value="org.neo4j.server.configuration.ClientConnectorSettings$HttpConnector" />
                 </java>
               </target>
             </configuration>

--- a/manual/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithBolt.java
+++ b/manual/embedded-examples/src/main/java/org/neo4j/examples/EmbeddedNeo4jWithBolt.java
@@ -40,6 +40,7 @@ public class EmbeddedNeo4jWithBolt
 
         GraphDatabaseService graphDb = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( DB_PATH )
+                .setConfig( bolt.type, "BOLT" )
                 .setConfig( bolt.enabled, "true" )
                 .setConfig( bolt.address, "localhost:7687" )
                 .newGraphDatabase();

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -29,9 +29,8 @@ import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLog;
 import org.neo4j.server.CommunityBootstrapper;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.server.configuration.ConfigLoader;
-import org.neo4j.server.configuration.ServerSettings;
-import org.neo4j.server.configuration.ServerSettings.HttpConnector;
 
 import static org.neo4j.helpers.collection.Pair.pair;
 
@@ -84,6 +83,6 @@ public class DesktopConfigurator
 
     public ListenSocketAddress getServerAddress()
     {
-        return ServerSettings.httpConnector( config, HttpConnector.Encryption.NONE ).get().address.from( config );
+        return ClientConnectorSettings.httpConnector( config, ClientConnectorSettings.HttpConnector.Encryption.NONE ).get().address.from( config );
     }
 }

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
@@ -27,20 +27,16 @@ dbms.security.auth_enabled=true
 # individual advertised_address.
 
 # Bolt connector
-dbms.connector.bolt.type=BOLT
-dbms.connector.bolt.enabled=true
+#dbms.connector.bolt.enabled=true
 #dbms.connector.bolt.tls_level=OPTIONAL
 #dbms.connector.bolt.listen_address=:7687
 
 # HTTP Connector
-dbms.connector.http.type=HTTP
-dbms.connector.http.enabled=true
+#dbms.connector.http.enabled=true
 #dbms.connector.http.listen_address=:#{default.http.port}
 
 # HTTPS Connector
-#dbms.connector.https.type=HTTP
 #dbms.connector.https.enabled=true
-#dbms.connector.https.encryption=TLS
 #dbms.connector.https.listen_address=:#{default.https.port}
 
 # Certificates directory

--- a/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
+++ b/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
@@ -31,12 +31,13 @@ import java.util.Properties;
 import org.neo4j.desktop.Parameters;
 import org.neo4j.desktop.config.Installation;
 import org.neo4j.desktop.model.DesktopModel;
+import org.neo4j.server.configuration.ClientConnectorSettings;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.server.configuration.ServerSettings.httpConnector;
+import static org.neo4j.server.configuration.ClientConnectorSettings.httpConnector;
 
 public class DatabaseActionsTest
 {
@@ -81,8 +82,8 @@ public class DatabaseActionsTest
 
         configFile = new File( testDirectory.directory(), "neo4j.conf" );
         Properties props = new Properties();
-        props.setProperty( httpConnector( "1" ).type.name(), "HTTP" );
-        props.setProperty( httpConnector( "1" ).enabled.name(), "true" );
+        props.setProperty( ClientConnectorSettings.httpConnector( "1" ).type.name(), "HTTP" );
+        props.setProperty( ClientConnectorSettings.httpConnector( "1" ).enabled.name(), "true" );
         try ( FileWriter writer = new FileWriter( configFile ) )
         {
             props.store( writer, "" );

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -62,21 +62,17 @@ dbms.directories.import=import
 # individual advertised_address.
 
 # Bolt connector
-dbms.connector.bolt.type=BOLT
-dbms.connector.bolt.enabled=true
+#dbms.connector.bolt.enabled=true
 #dbms.connector.bolt.tls_level=OPTIONAL
 #dbms.connector.bolt.listen_address=:7687
 
 # HTTP Connector
-dbms.connector.http.type=HTTP
-dbms.connector.http.enabled=true
+#dbms.connector.http.enabled=true
 #dbms.connector.http.listen_address=:#{default.http.port}
 
 # HTTPS Connector
-dbms.connector.https.type=HTTP
-dbms.connector.https.enabled=true
-dbms.connector.https.encryption=TLS
-dbms.connector.https.listen_address=:#{default.https.port}
+#dbms.connector.https.enabled=true
+#dbms.connector.https.listen_address=:#{default.https.port}
 
 # Number of Neo4j worker threads.
 #dbms.threads.worker_count=

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -68,21 +68,17 @@ dbms.directories.import=import
 # individual advertised_address.
 
 # Bolt connector
-dbms.connector.bolt.type=BOLT
-dbms.connector.bolt.enabled=true
+#dbms.connector.bolt.enabled=true
 #dbms.connector.bolt.tls_level=OPTIONAL
 #dbms.connector.bolt.listen_address=:7687
 
 # HTTP Connector
-dbms.connector.http.type=HTTP
-dbms.connector.http.enabled=true
+#dbms.connector.http.enabled=true
 #dbms.connector.http.listen_address=:#{default.http.port}
 
 # HTTPS Connector
-dbms.connector.https.type=HTTP
-dbms.connector.https.enabled=true
-dbms.connector.https.encryption=TLS
-dbms.connector.https.listen_address=:#{default.https.port}
+#dbms.connector.https.enabled=true
+#dbms.connector.https.listen_address=:#{default.https.port}
 
 # Number of Neo4j worker threads.
 #dbms.threads.worker_count=
@@ -210,9 +206,6 @@ dbms.connector.https.listen_address=:#{default.https.port}
 
 #Raft log pruning frequncy.
 #core_edge.raft_log_pruning_frequency=10m
-
-#RAFT log pruning strategy.
-#core_edge.raft_log_prune_strategy=1g size
 
 #The size to allow the raft log to grow before rotating.
 #core_edge.raft_log_rotation_size=250M


### PR DESCRIPTION
This PR publishes HTTP addresses in `dbms.cluster.overview`, alongside bolt addresses.

The procedure lives in the core-edge module, but there was a dependency problem preventing core-edge from reading HTTP configuration, since it lived in the neo4j-server module. Therefore, this PR also moves the HTTP configuration classes from neo4j-server into neo4j-dbms, which was chosen as lower level module that neo4j-core-edge already depended on.

While moving the configuration I found a number of problems with the way connector config was handled, so I've taken the chance to make it more straight-forward.

We now expect users to use the default names for the default set of connectors: any connector named `bolt`, `http` or `https` is assumed to refer to the respective protocol; you don't need to specify a type if you use these names. There are also sensible defaults for all the settings, so that no configuration at all is required. For example, the section of `neo4j.conf` for HTTPS used to look like this:

```
dbms.connector.https.type=HTTP
dbms.connector.https.enabled=true
dbms.connector.https.encryption=TLS     
dbms.connector.https.listen_address=:7473
```

All those parameters were required. For example, if you omitted a value for `dbms.connector.https.type` you could end up changing the port of the bolt connector!

Now the equivalent settings look like this:

```
#dbms.connector.https.enabled=true
#dbms.connector.https.listen_address=:7473
```

Note that both settings are commented out, because those are the default values; no explicit configuration is required.

The old mechanism, with arbitrary names is still supported, but we can choose to deprecate and then remove it in future.
