### PR TITLE
Unbind an instance from the cluster.

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
@@ -17,24 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.commandline.admin;
+package org.neo4j.commandline.dbms;
 
-import org.neo4j.kernel.StoreLockException;
-
-public class CommandFailed extends Exception
+public class CannotWriteException extends Exception
 {
-    public CommandFailed( String message, Exception cause )
+    public CannotWriteException( String message )
     {
-        super( message, cause );
-    }
-
-    public CommandFailed( StoreLockException exception )
-    {
-        super( exception );
-    }
-
-    public CommandFailed( String message )
-    {
-        super( message );
+        super(message);
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CannotWriteException.java
@@ -19,10 +19,14 @@
  */
 package org.neo4j.commandline.dbms;
 
-public class CannotWriteException extends Exception
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+
+class CannotWriteException extends Exception
 {
-    public CannotWriteException( String message )
+    CannotWriteException( Path file )
     {
-        super(message);
+        super( format("Could not write to: %s", file.toAbsolutePath().toString() ));
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.Closeable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.internal.StoreLocker;
+
+public class StoreLockChecker
+{
+    public Closeable withLock( Path databaseDirectory ) throws CommandFailed, CannotWriteException
+    {
+        Path lockFile = databaseDirectory.resolve( StoreLocker.STORE_LOCK_FILENAME );
+        if ( Files.exists( lockFile ) )
+        {
+            if ( Files.isWritable( lockFile ) )
+            {
+                StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
+
+                storeLocker.checkLock( databaseDirectory.toFile() );
+
+                return storeLocker::release;
+            }
+            else
+            {
+                throw new CannotWriteException( "Store is not writable. Check permissions and try again." );
+            }
+        }
+        return () ->
+        {
+        };
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
@@ -27,9 +27,9 @@ import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.internal.StoreLocker;
 
-public class StoreLockChecker
+class StoreLockChecker
 {
-    public Closeable withLock( Path databaseDirectory ) throws CommandFailed, CannotWriteException
+    Closeable withLock( Path databaseDirectory ) throws CommandFailed, CannotWriteException
     {
         Path lockFile = databaseDirectory.resolve( StoreLocker.STORE_LOCK_FILENAME );
         if ( Files.exists( lockFile ) )
@@ -44,7 +44,7 @@ public class StoreLockChecker
             }
             else
             {
-                throw new CannotWriteException( "Store is not writable. Check permissions and try again." );
+                throw new CannotWriteException( lockFile );
             }
         }
         return () ->

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -22,6 +22,7 @@ package org.neo4j.commandline.dbms;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -117,7 +118,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldRespectTheStoreLock() throws IOException, IncorrectUsage
+    public void shouldRespectTheStoreLock() throws IOException, IncorrectUsage, CommandFailed
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
         Files.createDirectories( databaseDirectory );
@@ -318,7 +319,7 @@ public class DumpCommandTest
         }
     }
 
-    private void execute( final String database ) throws IncorrectUsage, CommandFailed
+    private void execute( final String database ) throws IncorrectUsage, CommandFailed, AccessDeniedException
     {
         new DumpCommand( homeDir, configDir, dumper )
                 .execute( new String[]{"--database=" + database, "--to=" + archive} );

--- a/enterprise/core-edge/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.helpers.Args;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.StoreLockException;
+import org.neo4j.kernel.internal.StoreLocker;
+
+import static java.lang.String.format;
+import static java.nio.file.Files.exists;
+import static org.neo4j.coreedge.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
+
+public class UnbindFromClusterCommand implements AdminCommand
+{
+    public static class Provider extends AdminCommand.Provider
+    {
+        public Provider()
+        {
+            super( "unbind" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "[--database=<name>] " );
+        }
+
+        @Override
+        public String description()
+        {
+            return "Removes cluster state data from the specified database making it suitable for use non-Core-Edge " +
+                    "databases";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new UnbindFromClusterCommand( homeDir, new DefaultFileSystemAbstraction() );
+        }
+    }
+
+    private Path homeDir;
+    private FileSystemAbstraction fsa;
+
+    UnbindFromClusterCommand( Path homeDir, FileSystemAbstraction fsa )
+    {
+        this.homeDir = homeDir;
+        this.fsa = fsa;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        Args parsedArgs = Args.parse( args );
+
+        try
+        {
+            Path pathToSpecificDatabase =
+                    homeDir.resolve( "data" ).resolve( "databases" ).resolve( databaseNameFrom( parsedArgs ) );
+            confirmTargetDatabaseDirectoryExists( pathToSpecificDatabase );
+            confirmClusterStateDirectoryExists( Paths.get( pathToSpecificDatabase.toString(), "cluster-state" ) );
+            confirmTargetDirectoryIsWritable( pathToSpecificDatabase );
+            deleteClusterStateIn( clusterStateFrom( pathToSpecificDatabase ) );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+        catch ( UnbindFailureException e )
+        {
+            throw new CommandFailed( "Unbind failed: " + e.getMessage(), e );
+        }
+    }
+
+    private Path clusterStateFrom( Path target )
+    {
+        return Paths.get( target.toString(), CLUSTER_STATE_DIRECTORY_NAME );
+    }
+
+    private void confirmTargetDirectoryIsWritable( Path dbDir ) throws CommandFailed
+    {
+        Path lockFile = dbDir.resolve( StoreLocker.STORE_LOCK_FILENAME );
+        if ( exists( lockFile ) )
+        {
+            if ( Files.isWritable( lockFile ) )
+            {
+                StoreLocker storeLocker = new StoreLocker( fsa );
+                try
+                {
+                    storeLocker.checkLock( dbDir.toFile() );
+                }
+                catch ( StoreLockException e )
+                {
+                    throw new CommandFailed( "Database is currently locked. Is a Neo4j instance still using it?" );
+                }
+            }
+        }
+    }
+
+    private void confirmTargetDatabaseDirectoryExists( Path target )
+    {
+        if ( !exists( target ) )
+        {
+            throw new IllegalArgumentException( format( "Database %s does not exist", target ) );
+        }
+    }
+
+    private void confirmClusterStateDirectoryExists( Path clusterStateDirectory ) throws UnbindFailureException
+    {
+        if ( !exists( clusterStateDirectory ) )
+        {
+            throw new UnbindFailureException( "Database %s is not bound to any cluster", clusterStateDirectory );
+        }
+    }
+
+    private void deleteClusterStateIn( Path target ) throws UnbindFailureException
+    {
+        try
+        {
+            FileUtils.deleteRecursively( target.toFile() );
+        }
+        catch ( IOException e )
+        {
+            throw new UnbindFailureException( e );
+        }
+    }
+
+    private String databaseNameFrom( Args parsedArgs )
+    {
+        String databaseName = parsedArgs.get( "database" );
+        if ( databaseName == null )
+        {
+            throw new IllegalArgumentException(
+                    "No database name specified. Usage: neo4j-admin " + "unbind --database-<name>" );
+        }
+        else
+        {
+            return databaseName;
+        }
+    }
+
+    private class UnbindFailureException extends Exception
+    {
+        UnbindFailureException( Exception e )
+        {
+            super( e );
+        }
+
+        UnbindFailureException( String message, Object... args )
+        {
+            super( format( message, args ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -105,7 +105,7 @@ public class UnbindFromClusterCommand implements AdminCommand
             }
             else
             {
-                outsideWorld.stdOutLine(
+                outsideWorld.stdErrLine(
                         format( "No cluster state found in %s. No work perfomed.", pathToSpecificDatabase ) );
             }
         }

--- a/enterprise/core-edge/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/enterprise/core-edge/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,0 +1,1 @@
+org.neo4j.commandline.dbms.UnbindFromClusterCommand$Provider

--- a/enterprise/core-edge/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.kernel.internal.StoreLocker.STORE_LOCK_FILENAME;
+
+public class UnbindFromClusterCommandTest
+{
+    @Rule
+    public TestDirectory testDir = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldFailIfDatabaseNotSpecified() throws Exception
+    {
+        // given
+        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
+        fsa.mkdir( testDir.directory() );
+
+        UnbindFromClusterCommand command =
+                new UnbindFromClusterCommand( testDir.directory().toPath(), fsa );
+
+        try
+        {
+            // when
+            command.execute( noArgs() );
+            fail();
+        }
+        catch ( IncorrectUsage e )
+        {
+            // then
+            assertThat( e.getMessage(), containsString( "No database name specified" ) );
+        }
+    }
+
+    @Test
+    public void shouldFailIfSpecifiedDatabaseDoesNotExist() throws Exception
+    {
+        // given
+        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
+        fsa.mkdir( testDir.directory() );
+
+        UnbindFromClusterCommand command =
+                new UnbindFromClusterCommand( testDir.directory().toPath(), fsa );
+
+        try
+        {
+            // when
+            command.execute( nonExistentDatabaseArg() );
+            fail();
+        }
+        catch ( IncorrectUsage e )
+        {
+            // then
+            assertThat( e.getMessage(), containsString( "does not exist" ) );
+        }
+    }
+
+    @Test
+    public void shouldFailToUnbindLiveDatabase() throws Exception
+    {
+        // given
+        FileSystemAbstraction fsa = new DefaultFileSystemAbstraction(); // because locking
+        fsa.mkdir( testDir.directory() );
+
+        UnbindFromClusterCommand command =
+                new UnbindFromClusterCommand( testDir.directory().toPath(), fsa );
+
+        Path fakeDbDir = createLockedFakeDbDir( testDir.directory().toPath() );
+
+        try
+        {
+            // when
+            command.execute( databaseName( "graph.db" ) );
+            fail();
+        }
+        catch ( CommandFailed e )
+        {
+            // then
+            assertThat( e.getMessage(),
+                    containsString( "Database is currently locked. Is a Neo4j instance still using it?" ) );
+        }
+    }
+
+    @Test
+    public void shouldRemoveClusterStateDirectoryForGivenDatabase() throws Exception
+    {
+        // given
+        final int numberOfFilesAndDirsInANormalNeo4jStoreDir = 35;
+
+        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
+        fsa.mkdir( testDir.directory() );
+
+        Path fakeDbDir = createUnlockedFakeDbDir( testDir.directory().toPath() );
+        UnbindFromClusterCommand command =
+                new UnbindFromClusterCommand( testDir.directory().toPath(), fsa );
+
+        // when
+        command.execute( databaseName( "graph.db" ) );
+
+        // then
+        assertEquals( numberOfFilesAndDirsInANormalNeo4jStoreDir, Files.list( fakeDbDir ).toArray().length );
+    }
+
+    @Test
+    public void shouldReportWhenClusterStateDirectoryIsNotPresent() throws Exception
+    {
+        // given
+        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
+        fsa.mkdir( testDir.directory() );
+
+        Path fakeDbDir = createUnlockedFakeDbDir( testDir.directory().toPath() );
+        Files.delete( Paths.get( fakeDbDir.toString(), "cluster-state" ) );
+
+        UnbindFromClusterCommand command =
+                new UnbindFromClusterCommand( testDir.directory().toPath(), fsa );
+
+        // when
+        try
+        {
+            command.execute( databaseName( "graph.db" ) );
+            fail();
+        }
+        // then
+        catch ( CommandFailed expected )
+        {
+            assertThat( expected.getMessage(), containsString( "is not bound to any cluster" ) );
+        }
+    }
+
+    private String[] databaseName( String databaseName )
+    {
+        return new String[]{"--database=" + databaseName};
+    }
+
+    private Path createUnlockedFakeDbDir( Path parent ) throws IOException
+    {
+        return createFakeDbDir( parent, false );
+    }
+
+    private Path createLockedFakeDbDir( Path parent ) throws IOException
+    {
+        return createFakeDbDir( parent, true );
+    }
+
+    private Path createFakeDbDir( Path parent, boolean locked ) throws IOException
+    {
+        Path data = createDirectory( parent, "data" );
+        Path database = createDirectory( data, "databases" );
+        Path graph_db = createDirectory( database, "graph.db" );
+        createDirectory( graph_db, "cluster-state" );
+        createDirectory( graph_db, "schema" );
+        createDirectory( graph_db, "index" );
+        createFile( graph_db, "neostore" );
+        createFile( graph_db, "neostore.counts.db.a" );
+        createFile( graph_db, "neostore.id" );
+        createFile( graph_db, "neostore.labeltokenstore.db" );
+        createFile( graph_db, "neostore.labeltokenstore.db.id" );
+        createFile( graph_db, "neostore.labeltokenstore.db.names" );
+        createFile( graph_db, "neostore.labeltokenstore.db.names.id" );
+        createFile( graph_db, "neostore.nodestore.db" );
+        createFile( graph_db, "neostore.nodestore.db.id" );
+        createFile( graph_db, "neostore.nodestore.db.labels" );
+        createFile( graph_db, "neostore.nodestore.db.labels.id" );
+        createFile( graph_db, "neostore.propertystore.db" );
+        createFile( graph_db, "neostore.propertystore.db.arrays" );
+        createFile( graph_db, "neostore.propertystore.db.arrays.id" );
+        createFile( graph_db, "neostore.propertystore.db.id" );
+        createFile( graph_db, "neostore.propertystore.db.index" );
+        createFile( graph_db, "neostore.propertystore.db.index.id" );
+        createFile( graph_db, "neostore.propertystore.db.index.keys" );
+        createFile( graph_db, "neostore.propertystore.db.index.keys.id" );
+        createFile( graph_db, "neostore.propertystore.db.strings" );
+        createFile( graph_db, "neostore.propertystore.db.strings.id" );
+        createFile( graph_db, "neostore.relationshipgroupstore.db" );
+        createFile( graph_db, "neostore.relationshipgroupstore.db.id" );
+        createFile( graph_db, "neostore.relationshipstore.db" );
+        createFile( graph_db, "neostore.relationshipstore.db.id" );
+        createFile( graph_db, "neostore.relationshiptypestore.db" );
+        createFile( graph_db, "neostore.relationshiptypestore.db.id" );
+        createFile( graph_db, "neostore.relationshiptypestore.db.names" );
+        createFile( graph_db, "neostore.relationshiptypestore.db.names.id" );
+        createFile( graph_db, "neostore.schemastore.db" );
+        createFile( graph_db, "neostore.schemastore.db.id" );
+        createFile( graph_db, "neostore.transaction.db.0" );
+        if ( locked )
+        {
+            createLockedStoreLockFileIn( graph_db );
+        }
+        else
+        {
+            createFile( graph_db, "store_lock" );
+        }
+
+        return graph_db;
+    }
+
+    private Path createFile( Path parent, String file ) throws IOException
+    {
+        return Files.createFile( Paths.get( parent.toString(), file ) );
+    }
+
+    private Path createDirectory( Path parent, String subDir ) throws IOException
+    {
+        return Files.createDirectory( Paths.get( parent.toString(), subDir ) );
+    }
+
+    private FileLock createLockedStoreLockFileIn( Path parent ) throws IOException
+    {
+        Path storeLockFile = Files.createFile( Paths.get( parent.toString(), STORE_LOCK_FILENAME ) );
+        FileChannel channel = FileChannel.open( storeLockFile, READ, WRITE );
+        return channel.lock( 0, Long.MAX_VALUE, true );
+    }
+
+    private String[] nonExistentDatabaseArg()
+    {
+        return new String[]{"--database=" + UUID.randomUUID().toString()};
+    }
+
+    private String[] noArgs()
+    {
+        return new String[]{};
+    }
+}


### PR DESCRIPTION
Current implementation merely checks that the database exists,
and that it isn't locked by an active Neo4j instance.

If all is good then it deletes the cluster-state directory reverting the
store to a Neo4j standalone/ha format (which can be used to
seed another core-edge cluster).
