### PR TITLE
Increased the default ha.heartbeat_timeout value to 40s

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
@@ -104,8 +104,13 @@ public class ClusterSettings
     public static final Setting<Long> heartbeat_interval = setting( "ha.heartbeat_interval", DURATION,
             default_timeout );
 
-    @Description( "Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval." )
-    public static final Setting<Long> heartbeat_timeout = setting( "ha.heartbeat_timeout", DURATION, "11s" );
+    @Description( "How long to wait for heartbeats from other instances before marking them as suspects for failure. " +
+            "This value reflects considerations of network latency, expected duration of garbage collection pauses " +
+            "and other factors that can delay message sending and processing. Larger values will result in more " +
+            "stable masters but also will result in longer waits before a failover in case of master failure. This " +
+            "value should not be set to less than twice the ha.heartbeat_interval value otherwise there is a high " +
+            "risk of frequent master switches and possibly branched data occurrence." )
+    public static final Setting<Long> heartbeat_timeout = setting( "ha.heartbeat_timeout", DURATION, "40s" );
 
     /*
      * ha.join_timeout

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -171,8 +171,13 @@ ha.pull_interval=10
 # How often heartbeat messages should be sent. Defaults to ha.default_timeout.
 #ha.heartbeat_interval=5s
 
-# Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval.
-#ha.heartbeat_timeout=11s
+# How long to wait for heartbeats from other instances before marking them as suspects for failure.
+# This value reflects considerations of network latency, expected duration of garbage collection pauses
+# and other factors that can delay message sending and processing. Larger values will result in more
+# stable masters but also will result in longer waits before a failover in case of master failure.
+# This value should not be set to less than twice the ha.heartbeat_interval value otherwise there is a high
+# risk of frequent master switches and possibly branched data occurrence.
+#ha.heartbeat_timeout=40s
 
 # If you are using a load-balancer that doesn't support HTTP Auth, you may need to turn off authentication for the
 # HA HTTP status endpoint by uncommenting the following line.


### PR DESCRIPTION
Experiments have shown that 40s is a good default for typical deployments
 striking a balance between master stability and failover responsiveness.
