### PR TITLE
Fix bug with `allowed` procedure annotation

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -617,10 +617,10 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   }
 
   override def callReadOnlyProcedure(name: QualifiedProcedureName, args: Seq[Any]) =
-    callProcedure(name, args, transactionalContext.statement.readOperations().procedureCallRead)
+    callProcedure(name, args, transactionalContext.statement.procedureCallOperations().procedureCallRead)
 
   override def callReadWriteProcedure(name: QualifiedProcedureName, args: Seq[Any]) =
-    callProcedure(name, args, transactionalContext.statement.dataWriteOperations().procedureCallWrite)
+    callProcedure(name, args, transactionalContext.statement.procedureCallOperations().procedureCallWrite)
 
   override def callDbmsProcedure(name: QualifiedProcedureName, args: Seq[Any]) =
     callProcedure(name, args, transactionalContext.dbmsOperations.procedureCallDbms(_,_,transactionalContext.accessMode))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -590,9 +590,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def callReadOnlyProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
     val call: KernelProcedureCall = transactionalContext.accessMode match {
       case a: AuthSubject if a.allowsProcedureWith(allowed) =>
-        transactionalContext.statement.readOperations().procedureCallRead(_, _, AccessMode.Static.OVERRIDE_READ)
+        transactionalContext.statement.procedureCallOperations.procedureCallRead(_, _, AccessMode.Static.OVERRIDE_READ)
       case _ =>
-        transactionalContext.statement.readOperations().procedureCallRead(_, _)
+        transactionalContext.statement.procedureCallOperations.procedureCallRead(_, _)
     }
     callProcedure(name, args, call)
   }
@@ -600,9 +600,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def callReadWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
     val call: KernelProcedureCall = transactionalContext.accessMode match {
       case a: AuthSubject if a.allowsProcedureWith(allowed) =>
-        transactionalContext.statement.dataWriteOperations().procedureCallWrite(_, _, AccessMode.Static.OVERRIDE_WRITE)
+        transactionalContext.statement.procedureCallOperations.procedureCallWrite(_, _, AccessMode.Static.OVERRIDE_WRITE)
       case _ =>
-        transactionalContext.statement.dataWriteOperations().procedureCallWrite(_, _)
+        transactionalContext.statement.procedureCallOperations.procedureCallWrite(_, _)
     }
     callProcedure(name, args, call)
   }
@@ -610,9 +610,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
     val call: KernelProcedureCall = transactionalContext.accessMode match {
       case a: AuthSubject if a.allowsProcedureWith(allowed) =>
-        transactionalContext.statement.schemaWriteOperations().procedureCallSchema(_, _, AccessMode.Static.OVERRIDE_SCHEMA)
+        transactionalContext.statement.procedureCallOperations.procedureCallSchema(_, _, AccessMode.Static.OVERRIDE_SCHEMA)
       case _ =>
-        transactionalContext.statement.schemaWriteOperations().procedureCallSchema(_, _)
+        transactionalContext.statement.procedureCallOperations.procedureCallSchema(_, _)
     }
     callProcedure(name, args, call)
   }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
@@ -149,10 +149,4 @@ public interface DataWriteOperations extends TokenWriteOperations
     void nodeLegacyIndexDrop( String indexName ) throws LegacyIndexNotFoundKernelException;
 
     void relationshipLegacyIndexDrop( String indexName ) throws LegacyIndexNotFoundKernelException;
-
-    /** Invoke a read/write procedure by name */
-    RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input ) throws ProcedureException;
-
-    RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input, AccessMode override )
-            throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelExceptio
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.security.AccessMode;
 
 public interface DataWriteOperations extends TokenWriteOperations
 {
@@ -151,4 +152,7 @@ public interface DataWriteOperations extends TokenWriteOperations
 
     /** Invoke a read/write procedure by name */
     RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input ) throws ProcedureException;
+
+    RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input, AccessMode override )
+            throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.kernel.api.security.AccessMode;
+
+/**
+ * Specifies procedure call operations for the three types of procedure calls that can be made.
+ */
+public interface ProcedureCallOperations
+{
+    /**
+     * Invoke a read-only procedure by name.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] arguments )
+            throws ProcedureException;
+
+    /**
+     * Invoke a read-only procedure by name, and override the transaction's access mode with
+     * the given access mode for the duration of the procedure execution.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @param override the access mode to be used for the execution of the procedure.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] arguments, AccessMode override )
+            throws ProcedureException;
+
+    /**
+     * Invoke a read/write procedure by name.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] arguments )
+            throws ProcedureException;
+    /**
+     * Invoke a read/write procedure by name, and override the transaction's access mode with
+     * the given access mode for the duration of the procedure execution.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @param override the access mode to be used for the execution of the procedure.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] arguments, AccessMode override )
+            throws ProcedureException;
+
+    /**
+     * Invoke a schema write procedure by name.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] arguments )
+            throws ProcedureException;
+    /**
+     * Invoke a schema write procedure by name, and override the transaction's access mode with
+     * the given access mode for the duration of the procedure execution.
+     * @param name the name of the procedure.
+     * @param arguments the procedure arguments.
+     * @param override the access mode to be used for the execution of the procedure.
+     * @return an iterator containing the procedure results.
+     * @throws ProcedureException if there was an exception thrown during procedure execution.
+     */
+    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] arguments, AccessMode override )
+            throws ProcedureException;
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -48,6 +48,7 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.register.Register.DoubleLongRegister;
@@ -567,7 +568,11 @@ public interface ReadOperations
     Set<ProcedureSignature> proceduresGetAll();
 
     /** Invoke a read-only procedure by name */
-    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input ) throws ProcedureException;
+    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input )
+            throws ProcedureException;
+
+    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input, AccessMode override )
+            throws ProcedureException;
 
     /** Invoke a read-only procedure by name */
    Object functionCall( QualifiedName name, Object[] input ) throws ProcedureException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -568,12 +568,5 @@ public interface ReadOperations
     Set<ProcedureSignature> proceduresGetAll();
 
     /** Invoke a read-only procedure by name */
-    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input )
-            throws ProcedureException;
-
-    RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input, AccessMode override )
-            throws ProcedureException;
-
-    /** Invoke a read-only procedure by name */
    Object functionCall( QualifiedName name, Object[] input ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -65,11 +65,4 @@ public interface SchemaWriteOperations extends TokenWriteOperations
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
-
-    /** Invoke a schema procedure by name */
-    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input )
-            throws ProcedureException;
-
-    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input, AccessMode override )
-            throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.kernel.api.security.AccessMode;
 
 public interface SchemaWriteOperations extends TokenWriteOperations
 {
@@ -66,5 +67,9 @@ public interface SchemaWriteOperations extends TokenWriteOperations
     void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
 
     /** Invoke a schema procedure by name */
-    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input ) throws ProcedureException;
+    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input )
+            throws ProcedureException;
+
+    RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input, AccessMode override )
+            throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
@@ -63,4 +63,9 @@ public interface Statement extends Resource
      * @return interface exposing operations for associating metadata with this statement
      */
     QueryRegistryOperations queryRegistration();
+
+    /**
+     * @return interface exposing all procedure call operations.
+     */
+    ProcedureCallOperations procedureCallOperations();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.api.QueryRegistryOperations;
@@ -94,6 +95,12 @@ public class KernelStatement implements TxStateHolder, Statement
             throw transaction.mode().onViolation(
                     String.format( "Read operations are not allowed for '%s'.", transaction.mode().name() ) );
         }
+        return facade;
+    }
+
+    @Override
+    public ProcedureCallOperations procedureCallOperations()
+    {
         return facade;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -33,6 +33,7 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -101,7 +102,8 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 
 public class OperationsFacade
-        implements ReadOperations, DataWriteOperations, SchemaWriteOperations, QueryRegistryOperations
+        implements ReadOperations, DataWriteOperations, SchemaWriteOperations, QueryRegistryOperations,
+        ProcedureCallOperations
 {
     private final KernelTransaction tx;
     private final KernelStatement statement;
@@ -569,18 +571,6 @@ public class OperationsFacade
     public Object functionCall( QualifiedName name, Object[] input ) throws ProcedureException
     {
         return callFunction( name, input );
-    }
-
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input ) throws ProcedureException
-    {
-        return callProcedure( name, input, AccessMode.Static.READ );
-    }
-
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
-    {
-        return callProcedure( name, input, override );
     }
 
     @Override
@@ -1095,19 +1085,6 @@ public class OperationsFacade
         return dataWrite().graphRemoveProperty( statement, propertyKeyId );
     }
 
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input ) throws ProcedureException
-    {
-        // FIXME: should this be AccessMode.Static.WRITE instead?
-        return callProcedure( name, input, AccessMode.Static.FULL );
-    }
-
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
-    {
-        return callProcedure( name, input, override );
-    }
-
     // </DataWrite>
 
     // <SchemaWrite>
@@ -1170,18 +1147,6 @@ public class OperationsFacade
     {
         statement.assertOpen();
         schemaWrite().uniqueIndexDrop( statement, descriptor );
-    }
-
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input ) throws ProcedureException
-    {
-        return callProcedure( name, input, AccessMode.Static.FULL );
-    }
-
-    @Override
-    public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
-    {
-        return callProcedure( name, input, override );
     }
 
     // </SchemaWrite>
@@ -1527,6 +1492,43 @@ public class OperationsFacade
     // query monitoring
 
     // <Procedures>
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input ) throws ProcedureException
+    {
+        return callProcedure( name, input, AccessMode.Static.READ );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input ) throws ProcedureException
+    {
+        // FIXME: should this be AccessMode.Static.WRITE instead?
+        return callProcedure( name, input, AccessMode.Static.FULL );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input ) throws ProcedureException
+    {
+        return callProcedure( name, input, AccessMode.Static.FULL );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
+    }
 
     private RawIterator<Object[],ProcedureException> callProcedure(
             QualifiedName name, Object[] input, AccessMode mode )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1518,8 +1518,7 @@ public class OperationsFacade
         {
             throw tx.mode().onViolation( format( "Write operations are not allowed for '%s'.", tx.mode().name() ) );
         }
-        // FIXME: should this be AccessMode.Static.WRITE instead?
-        return callProcedure( name, input, AccessMode.Static.FULL );
+        return callProcedure( name, input, AccessMode.Static.WRITE );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -101,6 +101,8 @@ import org.neo4j.storageengine.api.Token;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 
+import static java.lang.String.format;
+
 public class OperationsFacade
         implements ReadOperations, DataWriteOperations, SchemaWriteOperations, QueryRegistryOperations,
         ProcedureCallOperations
@@ -1496,6 +1498,10 @@ public class OperationsFacade
     @Override
     public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input ) throws ProcedureException
     {
+        if ( !tx.mode().allowsReads() )
+        {
+            throw tx.mode().onViolation( format( "Read operations are not allowed for '%s'.", tx.mode().name() ) );
+        }
         return callProcedure( name, input, AccessMode.Static.READ );
     }
 
@@ -1508,6 +1514,10 @@ public class OperationsFacade
     @Override
     public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input ) throws ProcedureException
     {
+        if ( !tx.mode().allowsWrites() )
+        {
+            throw tx.mode().onViolation( format( "Write operations are not allowed for '%s'.", tx.mode().name() ) );
+        }
         // FIXME: should this be AccessMode.Static.WRITE instead?
         return callProcedure( name, input, AccessMode.Static.FULL );
     }
@@ -1521,6 +1531,10 @@ public class OperationsFacade
     @Override
     public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input ) throws ProcedureException
     {
+        if ( !tx.mode().allowsSchemaWrites() )
+        {
+            throw tx.mode().onViolation( format( "Schema operations are not allowed for '%s'.", tx.mode().name() ) );
+        }
         return callProcedure( name, input, AccessMode.Static.FULL );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -578,6 +578,12 @@ public class OperationsFacade
     }
 
     @Override
+    public RawIterator<Object[], ProcedureException> procedureCallRead( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
+    }
+
+    @Override
     public Set<ProcedureSignature> proceduresGetAll()
     {
         statement.assertOpen();
@@ -1096,6 +1102,12 @@ public class OperationsFacade
         return callProcedure( name, input, AccessMode.Static.FULL );
     }
 
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallWrite( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
+    }
+
     // </DataWrite>
 
     // <SchemaWrite>
@@ -1164,6 +1176,12 @@ public class OperationsFacade
     public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input ) throws ProcedureException
     {
         return callProcedure( name, input, AccessMode.Static.FULL );
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> procedureCallSchema( QualifiedName name, Object[] input, AccessMode override ) throws ProcedureException
+    {
+        return callProcedure( name, input, override );
     }
 
     // </SchemaWrite>

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -58,7 +58,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
 
         // When
         RawIterator<Object[],ProcedureException> stream =
-                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+                procedureCallOpsInNewTx().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
 
         // Then
         assertThat( asList( stream ), contains( equalTo( new Object[]{new ArrayList<>(), new ArrayList<>()} ) ) );
@@ -84,7 +84,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
 
         // When
         RawIterator<Object[],ProcedureException> stream =
-                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+                procedureCallOpsInNewTx().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
 
         // Then
         while ( stream.hasNext() )
@@ -117,7 +117,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
 
         // When
         RawIterator<Object[],ProcedureException> stream =
-                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
+                procedureCallOpsInNewTx().procedureCallRead( procedureName( "db", "schema" ), new Object[0] );
 
         // Then
         while ( stream.hasNext() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -68,6 +69,12 @@ public class StubStatement implements Statement
 
     @Override
     public QueryRegistryOperations queryRegistration()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public ProcedureCallOperations procedureCallOperations()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -57,7 +57,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
 
         // When
         RawIterator<Object[], ProcedureException> stream =
-                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "labels" ), new Object[0] );
+                procedureCallOpsInNewTx().procedureCallRead( procedureName( "db", "labels" ), new Object[0] );
 
         // Then
         assertThat( asList( stream ), contains( equalTo( new Object[]{"MyLabel"} ) ) );
@@ -72,7 +72,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         commit();
 
         // When
-        RawIterator<Object[], ProcedureException> stream = readOperationsInNewTransaction()
+        RawIterator<Object[], ProcedureException> stream = procedureCallOpsInNewTx()
                 .procedureCallRead( procedureName( "db", "propertyKeys" ), new Object[0] );
 
         // Then
@@ -89,7 +89,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         commit();
 
         // When
-        RawIterator<Object[], ProcedureException> stream = readOperationsInNewTransaction()
+        RawIterator<Object[], ProcedureException> stream = procedureCallOpsInNewTx()
                 .procedureCallRead( procedureName( "db", "relationshipTypes" ), new Object[0] );
 
         // Then
@@ -100,7 +100,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listProcedures() throws Throwable
     {
         // When
-        RawIterator<Object[], ProcedureException> stream = readOperationsInNewTransaction()
+        RawIterator<Object[], ProcedureException> stream = procedureCallOpsInNewTx()
                 .procedureCallRead( procedureName( "dbms", "procedures" ), new Object[0] );
 
         // Then
@@ -154,7 +154,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         // Given a running database
 
         // When
-        RawIterator<Object[], ProcedureException> stream = readOperationsInNewTransaction()
+        RawIterator<Object[], ProcedureException> stream = procedureCallOpsInNewTx()
                 .procedureCallRead( procedureName( "dbms", "components" ), new Object[0] );
 
         // Then
@@ -183,7 +183,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
 
         // When
         RawIterator<Object[],ProcedureException> stream =
-                readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "indexes" ), new Object[0] );
+                procedureCallOpsInNewTx().procedureCallRead( procedureName( "db", "indexes" ), new Object[0] );
 
         // Then
         assertThat( stream.next(), equalTo( new Object[]{"INDEX ON :Age(foo)", "ONLINE",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -27,6 +27,7 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
@@ -73,6 +74,13 @@ public abstract class KernelIntegrationTest
         transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AccessMode.Static.FULL );
         statement = transaction.acquireStatement();
         return statement.schemaWriteOperations();
+    }
+
+    protected ProcedureCallOperations procedureCallOpsInNewTx() throws TransactionFailureException
+    {
+        transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AccessMode.Static.READ );
+        statement = transaction.acquireStatement();
+        return statement.procedureCallOperations();
     }
 
     protected ReadOperations readOperationsInNewTransaction() throws TransactionFailureException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -30,7 +30,6 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Context;
-import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 
@@ -118,7 +117,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
         kernel.registerProcedure( procedure );
 
         // When
-        RawIterator<Object[], ProcedureException> found = readOperationsInNewTransaction()
+        RawIterator<Object[], ProcedureException> found = procedureCallOpsInNewTx()
                 .procedureCallRead( new QualifiedName( new String[]{"example"}, "exampleProc" ), new Object[]{ 1337 } );
 
         // Then
@@ -139,7 +138,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
         } );
 
         // When
-        RawIterator<Object[], ProcedureException> stream = readOperationsInNewTransaction().procedureCallRead( signature.name(), new Object[]{""} );
+        RawIterator<Object[], ProcedureException> stream = procedureCallOpsInNewTx().procedureCallRead( signature.name(), new Object[]{""} );
 
         // Then
         assertNotNull( asList( stream  ).get( 0 )[0] );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterDiscoveryIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterDiscoveryIT.java
@@ -107,7 +107,7 @@ public class ClusterDiscoveryIT
         try ( Statement statement = transaction.acquireStatement() )
         {
             // when
-            return asList( statement.readOperations().procedureCallRead(
+            return asList( statement.procedureCallOperations().procedureCallRead(
                     procedureName( "dbms", "cluster", "routing", GetServersProcedure.NAME ),
                     new Object[0] ) );
         }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterMembershipChangeIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterMembershipChangeIT.java
@@ -91,7 +91,7 @@ public class ClusterMembershipChangeIT
         Statement statement = transaction.acquireStatement();
 
         // when
-        return asList( statement.readOperations().procedureCallRead(
+        return asList( statement.procedureCallOperations().procedureCallRead(
                 procedureName( "dbms", "cluster", GetServersProcedure.NAME ), new Object[0] ) );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterOverviewIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterOverviewIT.java
@@ -339,7 +339,7 @@ public class ClusterOverviewIT
         try ( Statement statement = transaction.acquireStatement() )
         {
 
-            RawIterator<Object[],ProcedureException> itr = statement.readOperations().procedureCallRead(
+            RawIterator<Object[],ProcedureException> itr = statement.procedureCallOperations().procedureCallRead(
                     procedureName( "dbms", "cluster", ClusterOverviewProcedure.PROCEDURE_NAME ), null );
 
             while ( itr.hasNext() )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -705,6 +705,17 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
                 "CALL test.allowedProcedure2() YIELD value CREATE (:NEWNODE {name:value})", WRITE_OPS_NOT_ALLOWED );
     }
 
+    @Test
+    public void shouldNotAllowUnauthorizedAccessToProcedure() throws Exception
+    {
+        userManager = neo.getLocalUserManager();
+        userManager.newUser( "nopermission", "abc", false );
+        // should not be able to invoke any procedure
+        assertFail( neo.login( "nopermission", "abc" ), "CALL test.staticReadProcedure()", READ_OPS_NOT_ALLOWED );
+        assertFail( neo.login( "nopermission", "abc" ), "CALL test.staticWriteProcedure()", WRITE_OPS_NOT_ALLOWED );
+        assertFail( neo.login( "nopermission", "abc" ), "CALL test.staticSchemaProcedure()", SCHEMA_OPS_NOT_ALLOWED );
+    }
+
     /*
     This surface is hidden in 3.1, to possibly be completely removed or reworked later
     ==================================================================================

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -716,6 +716,20 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         assertFail( neo.login( "nopermission", "abc" ), "CALL test.staticSchemaProcedure()", SCHEMA_OPS_NOT_ALLOWED );
     }
 
+    @Test
+    public void shouldNotAllowNonReaderToReadAfterCallingAllowedReadProc() throws Exception
+    {
+        userManager = neo.getLocalUserManager();
+        userManager.newUser( "nopermission", "abc", false );
+        userManager.newRole( "role1" );
+        userManager.addRoleToUser( "role1", "nopermission" );
+        // should not be able to invoke any procedure
+        assertSuccess( neo.login( "nopermission", "abc" ), "CALL test.allowedProcedure1()",
+                itr -> assertEquals( itr.stream().collect( toList() ).size(), 1 ));
+        assertFail( neo.login( "nopermission", "abc" ),
+                "CALL test.allowedProcedure1() YIELD value MATCH (n:Secret) RETURN n.pass", READ_OPS_NOT_ALLOWED);
+    }
+
     /*
     This surface is hidden in 3.1, to possibly be completely removed or reworked later
     ==================================================================================

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -519,6 +519,7 @@ public abstract class ProcedureInteractionTestBase<S>
         }
     }
 
+    @SuppressWarnings( "unused" )
     public static class ClassWithProcedures
     {
         @Context

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -541,6 +541,24 @@ public abstract class ProcedureInteractionTestBase<S>
             return Stream.of( new CountResult( nNodes ) );
         }
 
+        @Procedure( name = "test.staticReadProcedure", mode = Mode.READ )
+        public Stream<AuthProceduresBase.StringResult> staticReadProcedure()
+        {
+            return Stream.of( new AuthProceduresBase.StringResult( "static" ) );
+        }
+
+        @Procedure( name = "test.staticWriteProcedure", mode = Mode.WRITE )
+        public Stream<AuthProceduresBase.StringResult> staticWriteProcedure()
+        {
+            return Stream.of( new AuthProceduresBase.StringResult( "static" ) );
+        }
+
+        @Procedure( name = "test.staticSchemaProcedure", mode = Mode.SCHEMA )
+        public Stream<AuthProceduresBase.StringResult> staticSchemaProcedure()
+        {
+            return Stream.of( new AuthProceduresBase.StringResult( "static" ) );
+        }
+
         @Procedure( name = "test.allowedProcedure1", allowed = {"role1"}, mode = Mode.READ )
         public Stream<AuthProceduresBase.StringResult> allowedProcedure1()
         {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -41,6 +41,7 @@ import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.helpers.HostnamePort;
@@ -75,13 +76,16 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.api.security.OverriddenAccessMode.getUsernameFromAccessMode;
 import static org.neo4j.procedure.Mode.READ;
 import static org.neo4j.procedure.Mode.WRITE;
-import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.*;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ADMIN;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.READER;
 
 public abstract class ProcedureInteractionTestBase<S>
 {
     protected boolean PWD_CHANGE_CHECK_FIRST = false;
     protected String CHANGE_PWD_ERR_MSG = AuthorizationViolationException.PERMISSION_DENIED;
-    private String BOLT_PWD_ERR_MSG =
+    private static final String BOLT_PWD_ERR_MSG =
             "The credentials you provided were valid, but must be changed before you can use this instance.";
     String READ_OPS_NOT_ALLOWED = "Read operations are not allowed";
     String WRITE_OPS_NOT_ALLOWED = "Write operations are not allowed";
@@ -300,7 +304,7 @@ public abstract class ProcedureInteractionTestBase<S>
         assertSuccess( subject, "CALL test.allowedProcedure1()",
                 r -> assertKeyIs( r, "value", "foo" ) );
         assertSuccess( subject, "CALL test.allowedProcedure2()",
-                r -> assertKeyIs( r, "value", "a" ) );
+                r -> assertKeyIs( r, "value", "a", "a" ) );
         assertSuccess( subject, "CALL test.allowedProcedure3()",
                 r -> assertKeyIs( r, "value", "OK" ) );
     }
@@ -420,7 +424,7 @@ public abstract class ProcedureInteractionTestBase<S>
     @SuppressWarnings( "unchecked" )
     public static void assertKeyIsMap( ResourceIterator<Map<String, Object>> r, String keyKey, String valueKey, Map<String,Object> expected )
     {
-        List<Map<String, Object>> result = r.stream().collect( Collectors.toList() );
+        List<Map<String, Object>> result = r.stream().collect( toList() );
 
         assertEquals( "Results for should have size " + expected.size() + " but was " + result.size(),
                 expected.size(), result.size() );
@@ -540,16 +544,16 @@ public abstract class ProcedureInteractionTestBase<S>
         @Procedure( name = "test.allowedProcedure1", allowed = {"role1"}, mode = Mode.READ )
         public Stream<AuthProceduresBase.StringResult> allowedProcedure1()
         {
-            db.execute( "MATCH (:Foo) RETURN 'foo' AS foo" );
-            return Stream.of( new AuthProceduresBase.StringResult( "foo" ) );
+            Result result = db.execute( "MATCH (:Foo) WITH count(*) AS c RETURN 'foo' AS foo" );
+            return result.stream().map( r -> new AuthProceduresBase.StringResult( r.get( "foo" ).toString() ) );
         }
 
         @Procedure( name = "test.allowedProcedure2", allowed = {"otherRole", "role1"}, mode = Mode.WRITE )
         public Stream<AuthProceduresBase.StringResult> allowedProcedure2()
         {
-            db.execute( "CREATE (:VeryUniqueLabel {prop: 'a'})" );
-            return db.execute( "MATCH (n:VeryUniqueLabel) RETURN n.prop AS a LIMIT 1" ).stream()
-                    .map( r -> new AuthProceduresBase.StringResult( (String) r.get( "a" ) ) );
+            db.execute( "UNWIND [1, 2] AS i CREATE (:VeryUniqueLabel {prop: 'a'})" );
+            Result result = db.execute( "MATCH (n:VeryUniqueLabel) RETURN n.prop AS a LIMIT 2" );
+            return result.stream().map( r -> new AuthProceduresBase.StringResult( r.get( "a" ).toString() ) );
         }
 
         @Procedure( name = "test.allowedProcedure3", allowed = {"role1"}, mode = Mode.SCHEMA )

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -575,7 +575,7 @@ public class ProcedureIT
     {
         // Expect
         exception.expect( QueryExecutionException.class );
-        exception.expectMessage( "Cannot perform schema updates in a transaction that has performed data updates" );
+        exception.expectMessage( "Schema operations are not allowed for 'FULL restricted to WRITE'." );
 
         // Give
         try ( Transaction ignore = db.beginTx() )


### PR DESCRIPTION
Previously, the `allowed` flag for procedures would restrict the transaction in such a way that subsequent operations in the Cypher statement were also restricted, leading to cases where write operations that were authorized were refused by the system. This commit pushes down the transaction restriction to wrap only the procedure call, and fall back to the normal access mode once the procedure has returned.

changelog: Fixed bug with `allowed` procedure annotation impacting later parts of same cypher query
