### PR TITLE
Fix: make dbms.security.showCurrentUser fallback to show LDAP user, and fix flaky log in init tests

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
@@ -41,6 +41,11 @@ public interface AuthSubject extends AccessMode
     void setPassword( String password, boolean requirePasswordChange ) throws IOException, InvalidArgumentsException;
 
     /**
+     * Changes authentication status to SUCCESS if in PASSWORD_CHANGE_REQUIRED
+     */
+    void passwordChangeNoLongerRequired();
+
+    /**
      * Determines whether this subject is allowed to execute a procedure with the parameter string in its procedure annotation.
      * @param roleNames
      * @return
@@ -90,6 +95,11 @@ public interface AuthSubject extends AccessMode
                 throws IOException, InvalidArgumentsException
         {
             throw new AuthorizationViolationException( "Anonymous cannot change password" );
+        }
+
+        @Override
+        public void passwordChangeNoLongerRequired()
+        {
         }
 
         @Override
@@ -208,6 +218,11 @@ public interface AuthSubject extends AccessMode
         @Override
         public void setPassword( String password, boolean requirePasswordChange )
                 throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public void passwordChangeNoLongerRequired()
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityModule.java
@@ -20,9 +20,14 @@
 package org.neo4j.kernel.api.security;
 
 import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.util.DependencySatisfier;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifeSupport;
 
 public abstract class SecurityModule extends Service
 {
@@ -31,5 +36,22 @@ public abstract class SecurityModule extends Service
         super( key, altKeys );
     }
 
-    public abstract void setup( PlatformModule platformModule, Procedures procedures ) throws KernelException;
+    public abstract void setup( Dependencies dependencies ) throws KernelException;
+
+    public interface Dependencies
+    {
+        LogService logService();
+
+        Config config();
+
+        Procedures procedures();
+
+        JobScheduler scheduler();
+
+        FileSystemAbstraction fileSystem();
+
+        LifeSupport lifeSupport();
+
+        DependencySatisfier dependencySatisfier();
+    }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.procedure.Context;
@@ -78,6 +79,10 @@ public class AuthProcedures
     @Procedure( name = "dbms.security.changePassword", mode = DBMS )
     public void changePassword( @Name( "password" ) String password ) throws InvalidArgumentsException, IOException
     {
+        if ( authSubject == AuthSubject.ANONYMOUS )
+        {
+            throw new AuthorizationViolationException( "Anonymous cannot change password" );
+        }
         userManager.setUserPassword( authSubject.username(), password, false );
     }
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -78,7 +78,7 @@ public class AuthProcedures
     @Procedure( name = "dbms.security.changePassword", mode = DBMS )
     public void changePassword( @Name( "password" ) String password ) throws InvalidArgumentsException, IOException
     {
-        authSubject.setPassword( password, false );
+        userManager.setUserPassword( authSubject.username(), password, false );
     }
 
     @Description( "Show the current user." )

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -84,6 +84,7 @@ public class AuthProcedures
             throw new AuthorizationViolationException( "Anonymous cannot change password" );
         }
         userManager.setUserPassword( authSubject.username(), password, false );
+        authSubject.passwordChangeNoLongerRequired();
     }
 
     @Description( "Show the current user." )

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -174,6 +174,12 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
         return user;
     }
 
+    @Override
+    public User silentlyGetUser( String username )
+    {
+        return  userRepository.getUserByName( username );
+    }
+
     public void setPassword( AuthSubject authSubject, String username, String password, boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException
     {

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
@@ -94,6 +94,12 @@ public class BasicAuthSubject implements AuthSubject
         authManager.setPassword( this, user.name(), password, requirePasswordChange );
 
         // Make user authenticated if successful
+        passwordChangeNoLongerRequired();
+    }
+
+    @Override
+    public void passwordChangeNoLongerRequired()
+    {
         if ( authenticationResult == PASSWORD_CHANGE_REQUIRED )
         {
             authenticationResult = SUCCESS;

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -43,11 +43,12 @@ public class CommunitySecurityModule extends SecurityModule
     }
 
     @Override
-    public void setup( PlatformModule platformModule, Procedures procedures ) throws KernelException
+    public void setup( Dependencies dependencies ) throws KernelException
     {
-        Config config = platformModule.config;
-        LogProvider logProvider = platformModule.logging.getUserLogProvider();
-        FileSystemAbstraction fileSystem = platformModule.fileSystem;
+        Config config = dependencies.config();
+        Procedures procedures = dependencies.procedures();
+        LogProvider logProvider = dependencies.logService().getUserLogProvider();
+        FileSystemAbstraction fileSystem = dependencies.fileSystem();
         final UserRepository userRepository = getUserRepository( config, logProvider, fileSystem );
         final UserRepository initialUserRepository = getInitialUserRepository( config, logProvider, fileSystem );
 
@@ -56,7 +57,7 @@ public class CommunitySecurityModule extends SecurityModule
         BasicAuthManager authManager =
                 new BasicAuthManager( userRepository, passwordPolicy, Clocks.systemClock(), initialUserRepository );
 
-        platformModule.life.add( platformModule.dependencies.satisfyDependency( authManager ) );
+        dependencies.lifeSupport().add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 
         procedures.registerComponent( UserManager.class, ctx -> authManager );
         procedures.registerProcedure( AuthProcedures.class );

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.SecurityModule;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
@@ -59,7 +58,7 @@ public class CommunitySecurityModule extends SecurityModule
 
         platformModule.life.add( platformModule.dependencies.satisfyDependency( authManager ) );
 
-        procedures.registerComponent( UserManager.class, ctx -> authManager.getUserManager() );
+        procedures.registerComponent( UserManager.class, ctx -> authManager );
         procedures.registerProcedure( AuthProcedures.class );
     }
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
@@ -33,6 +33,8 @@ public interface UserManager
 
     User getUser( String username ) throws InvalidArgumentsException;
 
+    User silentlyGetUser( String username );
+
     void setUserPassword( String username, String password, boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException;
 

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -23,42 +23,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AccessMode;
-import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 import org.neo4j.test.TestGraphDatabaseBuilder;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
 
 public class AuthProceduresTest extends KernelIntegrationTest
 {
     @Rule
     public ExpectedException exception = ExpectedException.none();
-
-    @Test
-    public void callDeprecatedChangePasswordWithAccessModeInDbmsMode() throws Throwable
-    {
-        // Given
-        Object[] inputArray = new Object[1];
-        inputArray[0] = "newPassword";
-        AuthSubject authSubject = mock( AuthSubject.class );
-
-        // When
-        RawIterator<Object[], ProcedureException> stream = dbmsOperations().procedureCallDbms(
-                procedureName( "dbms", "changePassword" ), inputArray, authSubject );
-
-        // Then
-        verify( authSubject ).setPassword( (String) inputArray[0], false );
-        assertThat( asList( stream ), emptyIterable() );
-    }
 
     @Test
     public void shouldFailWhenDeprecatedChangePasswordWithStaticAccessModeInDbmsMode() throws Throwable
@@ -74,23 +50,6 @@ public class AuthProceduresTest extends KernelIntegrationTest
         // When
         dbmsOperations()
                 .procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray, AccessMode.Static.NONE );
-    }
-
-    @Test
-    public void callChangePasswordWithAccessModeInDbmsMode() throws Throwable
-    {
-        // Given
-        Object[] inputArray = new Object[1];
-        inputArray[0] = "newPassword";
-        AuthSubject authSubject = mock( AuthSubject.class );
-
-        // When
-        RawIterator<Object[],ProcedureException> stream = dbmsOperations().procedureCallDbms(
-                procedureName( "dbms", "security", "changePassword" ), inputArray, authSubject );
-
-        // Then
-        verify( authSubject ).setPassword( (String) inputArray[0], false );
-        assertThat( asList( stream ), emptyIterable() );
     }
 
     @Test

--- a/community/server/src/main/java/org/neo4j/server/database/InjectableProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/database/InjectableProvider.java
@@ -25,19 +25,38 @@ import com.sun.jersey.core.spi.component.ComponentScope;
 import com.sun.jersey.server.impl.inject.AbstractHttpContextInjectable;
 import com.sun.jersey.spi.inject.Injectable;
 
+import java.util.function.Supplier;
 import javax.ws.rs.core.Context;
 
-public abstract class InjectableProvider<E> extends AbstractHttpContextInjectable<E> implements
-        com.sun.jersey.spi.inject.InjectableProvider<Context, Class<E>>
+public abstract class InjectableProvider<E> extends AbstractHttpContextInjectable<E>
+        implements com.sun.jersey.spi.inject.InjectableProvider<Context,Class<E>>
 {
     public final Class<E> t;
 
-    public static <E> InjectableProvider<? extends E> providerForSingleton(final E component, final Class<E> componentClass)
-    {
-        return new InjectableProvider<E>(componentClass) {
+    public static <E> InjectableProvider<? extends E> providerForSingleton(
+            final E component,
+            final Class<E> componentClass
+    ) {
+        return new InjectableProvider<E>( componentClass )
+        {
             @Override
-            public E getValue(HttpContext httpContext) {
+            public E getValue( HttpContext httpContext )
+            {
                 return component;
+            }
+        };
+    }
+
+    public static <E> InjectableProvider<? extends E> providerFromSupplier(
+            final Supplier<E> supplier,
+            final Class<E> componentClass
+    ) {
+        return new InjectableProvider<E>( componentClass )
+        {
+            @Override
+            public E getValue( HttpContext httpContext )
+            {
+                return supplier.get();
             }
         };
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
@@ -30,10 +30,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
-import org.neo4j.kernel.api.security.AccessMode;
-import org.neo4j.kernel.api.security.AuthManager;
-import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.server.rest.repr.AuthorizationRepresentation;
 import org.neo4j.server.rest.repr.BadInputException;
@@ -53,17 +52,14 @@ public class UserService
 {
     public static final String PASSWORD = "password";
 
-    private final UserManager userManager;
+    private final UserManagerSupplier userManagerSupplier;
     private final InputFormat input;
     private final OutputFormat output;
 
-    public UserService( @Context AuthManager authManager, @Context InputFormat input, @Context OutputFormat output )
+    public UserService( @Context UserManagerSupplier userManagerSupplier, @Context InputFormat input, @Context OutputFormat
+            output )
     {
-        if ( !(authManager instanceof UserManagerSupplier) )
-        {
-            throw new IllegalArgumentException( "The provided auth manager is not capable of user management" );
-        }
-        this.userManager = ((UserManagerSupplier) authManager).getUserManager();
+        this.userManagerSupplier = userManagerSupplier;
         this.input = input;
         this.output = output;
     }
@@ -77,6 +73,9 @@ public class UserService
         {
             return output.notFound();
         }
+
+        AuthSubject authSubject = getSubjectFromPrincipal( principal );
+        UserManager userManager = userManagerSupplier.getUserManager( authSubject );
 
         try
         {
@@ -131,7 +130,8 @@ public class UserService
             }
             else
             {
-                subject.setPassword( newPassword, false );
+                UserManager userManager = userManagerSupplier.getUserManager( subject );
+                userManager.setUserPassword( username, newPassword, false );
             }
         }
         catch ( IOException e )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthSubject.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthSubject.java
@@ -114,6 +114,11 @@ public interface EnterpriseAuthSubject extends AuthSubject
         }
 
         @Override
+        public void passwordChangeNoLongerRequired()
+        {
+        }
+
+        @Override
         public boolean allowsProcedureWith( String[] roleNames ) throws InvalidArgumentsException
         {
             return AuthSubject.AUTH_DISABLED.allowsProcedureWith( roleNames );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
@@ -35,8 +35,10 @@ import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
+import org.neo4j.server.security.auth.User;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
 
+import static java.util.Collections.emptyList;
 import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.kernel.impl.api.security.OverriddenAccessMode.getUsernameFromAccessMode;
 
@@ -51,7 +53,25 @@ public class AuthProceduresBase
     @Context
     public SecurityLog securityLog;
 
+    @Context
+    public EnterpriseUserManager userManager;
+
     // ----------------- helpers ---------------------
+
+    protected void kickoutUser( String username, String reason )
+    {
+        try
+        {
+            terminateTransactionsForValidUser( username );
+            terminateConnectionsForValidUser( username );
+        }
+        catch ( Exception e )
+        {
+            securityLog.error( authSubject, "failed to terminate running transaction and bolt connections for " +
+                    "user `%s` following %s: %s", username, reason, e.getMessage() );
+            throw e;
+        }
+    }
 
     protected void terminateTransactionsForValidUser( String username )
     {
@@ -119,6 +139,14 @@ public class AuthProceduresBase
         }
     }
 
+    protected UserResult userResultForName( String username )
+    {
+        User user = userManager.silentlyGetUser( username );
+        Iterable<String> flags = user == null ? emptyList() : user.getFlags();
+        Set<String> roles = userManager.silentlyGetRoleNamesForUser( username );
+        return new UserResult( username, roles, flags );
+    }
+
     public static class UserResult
     {
         public final String username;
@@ -133,6 +161,11 @@ public class AuthProceduresBase
             this.flags = new ArrayList<>();
             for ( String f : flags ) {this.flags.add( f );}
         }
+    }
+
+    protected RoleResult roleResultForName( String roleName )
+    {
+        return new RoleResult( roleName, userManager.silentlyGetUsernamesForRole( roleName ) );
     }
 
     public static class RoleResult

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
@@ -122,7 +122,7 @@ public class AuthProceduresBase
 
         if ( subject.isAdmin() || subject.hasUsername( username ) )
         {
-            subject.getUserManager().getUser( username );
+            userManager.getUser( username );
             return subject;
         }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -33,11 +33,11 @@ import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.SecurityModule;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
-import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -51,6 +51,8 @@ import org.neo4j.server.security.enterprise.auth.plugin.PluginRealm;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthPlugin;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthenticationPlugin;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthorizationPlugin;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.time.Clocks;
 
 import static org.neo4j.kernel.api.proc.Context.AUTH_SUBJECT;
@@ -95,6 +97,16 @@ public class EnterpriseSecurityModule extends SecurityModule
                     ctx -> authManager.getUserManager( ctx.get( AUTH_SUBJECT ) ) );
             procedures.registerProcedure( UserManagementProcedures.class, true );
         }
+    }
+
+    private EnterpriseAuthSubject asEnterprise( AuthSubject authSubject )
+    {
+        if ( authSubject instanceof EnterpriseAuthSubject )
+        {
+            return ((EnterpriseAuthSubject) authSubject);
+        }
+        // TODO: better handling of this possible cast failure
+        throw new RuntimeException( "Expected EnterpriseAuthSubject, got " + authSubject.getClass().getName() );
     }
 
     public EnterpriseAuthAndUserManager newAuthManager( Config config, LogProvider logProvider, SecurityLog securityLog,

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -89,18 +89,21 @@ public class EnterpriseSecurityModule extends SecurityModule
 
         // Register procedures
         procedures.registerComponent( SecurityLog.class, ( ctx ) -> securityLog );
-        procedures.registerProcedure( SecurityProcedures.class, true );
+        procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager );
 
         if ( config.get( SecuritySettings.native_authentication_enabled )
              || config.get( SecuritySettings.native_authorization_enabled ) )
         {
-            procedures.registerComponent( UserManager.class,
-                    ctx -> authManager.getUserManager( ctx.get( AUTH_SUBJECT ) ) );
             procedures.registerComponent( EnterpriseUserManager.class,
                     ctx -> authManager.getUserManager( asEnterprise( ctx.get( AUTH_SUBJECT ) ) ) );
-            procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager );
             procedures.registerProcedure( UserManagementProcedures.class, true );
         }
+        else
+        {
+            procedures.registerComponent( EnterpriseUserManager.class, ctx -> EnterpriseUserManager.NOOP );
+        }
+
+        procedures.registerProcedure( SecurityProcedures.class, true );
     }
 
     private EnterpriseAuthSubject asEnterprise( AuthSubject authSubject )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.SecurityModule;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -95,6 +96,9 @@ public class EnterpriseSecurityModule extends SecurityModule
         {
             procedures.registerComponent( UserManager.class,
                     ctx -> authManager.getUserManager( ctx.get( AUTH_SUBJECT ) ) );
+            procedures.registerComponent( EnterpriseUserManager.class,
+                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( AUTH_SUBJECT ) ) ) );
+            procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager );
             procedures.registerProcedure( UserManagementProcedures.class, true );
         }
     }
@@ -126,8 +130,8 @@ public class EnterpriseSecurityModule extends SecurityModule
             realms.add( internalRealm );
         }
 
-        if ( (config.get( SecuritySettings.ldap_authentication_enabled ) ||
-                config.get( SecuritySettings.ldap_authorization_enabled ))
+        if ( ( config.get( SecuritySettings.ldap_authentication_enabled ) ||
+                config.get( SecuritySettings.ldap_authorization_enabled ) )
                 && configuredRealms.contains( SecuritySettings.LDAP_REALM_NAME ) )
         {
             realms.add( new LdapRealm( config, securityLog ) );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
@@ -23,7 +23,10 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.server.security.auth.User;
 import org.neo4j.server.security.auth.UserManager;
+
+import static java.util.Collections.emptySet;
 
 public interface EnterpriseUserManager extends UserManager
 {
@@ -68,4 +71,119 @@ public interface EnterpriseUserManager extends UserManager
     Set<String> getUsernamesForRole( String roleName ) throws InvalidArgumentsException;
 
     Set<String> silentlyGetUsernamesForRole( String roleName );
+
+    EnterpriseUserManager NOOP = new EnterpriseUserManager()
+    {
+        @Override
+        public void suspendUser( String username ) throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public void activateUser( String username, boolean requirePasswordChange )
+                throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public RoleRecord newRole( String roleName, String... usernames ) throws IOException, InvalidArgumentsException
+        {
+            return null;
+        }
+
+        @Override
+        public boolean deleteRole( String roleName ) throws IOException, InvalidArgumentsException
+        {
+            return false;
+        }
+
+        @Override
+        public RoleRecord getRole( String roleName ) throws InvalidArgumentsException
+        {
+            return null;
+        }
+
+        @Override
+        public RoleRecord silentlyGetRole( String roleName )
+        {
+            return null;
+        }
+
+        @Override
+        public void addRoleToUser( String roleName, String username ) throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public void removeRoleFromUser( String roleName, String username ) throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public Set<String> getAllRoleNames()
+        {
+            return emptySet();
+        }
+
+        @Override
+        public Set<String> getRoleNamesForUser( String username ) throws InvalidArgumentsException
+        {
+            return emptySet();
+        }
+
+        @Override
+        public Set<String> silentlyGetRoleNamesForUser( String username )
+        {
+            return emptySet();
+        }
+
+        @Override
+        public Set<String> getUsernamesForRole( String roleName ) throws InvalidArgumentsException
+        {
+            return emptySet();
+        }
+
+        @Override
+        public Set<String> silentlyGetUsernamesForRole( String roleName )
+        {
+            return emptySet();
+        }
+
+        @Override
+        public User newUser( String username, String initialPassword, boolean requirePasswordChange )
+                throws IOException, InvalidArgumentsException
+        {
+            return null;
+        }
+
+        @Override
+        public boolean deleteUser( String username ) throws IOException, InvalidArgumentsException
+        {
+            return false;
+        }
+
+        @Override
+        public User getUser( String username ) throws InvalidArgumentsException
+        {
+            return null;
+        }
+
+        @Override
+        public User silentlyGetUser( String username )
+        {
+            return null;
+        }
+
+        @Override
+        public void setUserPassword( String username, String password, boolean requirePasswordChange )
+                throws IOException, InvalidArgumentsException
+        {
+        }
+
+        @Override
+        public Set<String> getAllUsernames()
+        {
+            return emptySet();
+        }
+    };
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
@@ -37,6 +37,8 @@ public interface EnterpriseUserManager extends UserManager
 
     RoleRecord getRole( String roleName ) throws InvalidArgumentsException;
 
+    RoleRecord silentlyGetRole( String roleName );
+
     /**
      * Assign a role to a user. The role and the user have to exist.
      *
@@ -61,5 +63,9 @@ public interface EnterpriseUserManager extends UserManager
 
     Set<String> getRoleNamesForUser( String username ) throws InvalidArgumentsException;
 
+    Set<String> silentlyGetRoleNamesForUser( String username );
+
     Set<String> getUsernamesForRole( String roleName ) throws InvalidArgumentsException;
+
+    Set<String> silentlyGetUsernamesForRole( String roleName );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -551,6 +551,12 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     }
 
     @Override
+    public User silentlyGetUser( String username )
+    {
+        return userRepository.getUserByName( username );
+    }
+
+    @Override
     public void setUserPassword( String username, String password, boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException
     {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -61,6 +61,7 @@ import org.neo4j.server.security.enterprise.auth.plugin.spi.RealmLifecycle;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptySet;
 
 /**
  * Shiro realm wrapping FileUserRepository and FileRoleRepository
@@ -71,7 +72,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
      * This flag is used in the same way as User.PASSWORD_CHANGE_REQUIRED, but it's
      * placed here because of user suspension not being a part of community edition
      */
-    private int MAX_READ_ATTEMPTS = 10;
+    private static int MAX_READ_ATTEMPTS = 10;
 
     static final String IS_SUSPENDED = "is_suspended";
 
@@ -468,6 +469,12 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     }
 
     @Override
+    public RoleRecord silentlyGetRole( String roleName )
+    {
+        return roleRepository.getRoleByName( roleName );
+    }
+
+    @Override
     public void addRoleToUser( String roleName, String username ) throws IOException, InvalidArgumentsException
     {
         roleRepository.assertValidRoleName( roleName );
@@ -651,10 +658,23 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     }
 
     @Override
+    public Set<String> silentlyGetRoleNamesForUser( String username )
+    {
+        return roleRepository.getRoleNamesByUsername( username );
+    }
+
+    @Override
     public Set<String> getUsernamesForRole( String roleName ) throws InvalidArgumentsException
     {
         RoleRecord role = getRole( roleName );
         return role.users();
+    }
+
+    @Override
+    public Set<String> silentlyGetUsernamesForRole( String roleName )
+    {
+        RoleRecord role = silentlyGetRole( roleName );
+        return role == null ? emptySet() : role.users();
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -96,7 +96,7 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         try
         {
             subject = new StandardEnterpriseAuthSubject(
-                    this, (ShiroSubject) securityManager.login( null, token ), securityLog );
+                    this, (ShiroSubject) securityManager.login( null, token ) );
             if ( logSuccessfulLogin )
             {
                 securityLog.info( subject, "logged in" );
@@ -111,14 +111,14 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         {
             // NOTE: We only get this with single (internal) realm authentication
             subject = new StandardEnterpriseAuthSubject( this,
-                    new ShiroSubject( securityManager, AuthenticationResult.TOO_MANY_ATTEMPTS ), securityLog );
+                    new ShiroSubject( securityManager, AuthenticationResult.TOO_MANY_ATTEMPTS ) );
             securityLog.error( "[%s]: failed to log in: too many failed attempts",
                     escape( token.getPrincipal().toString() ) );
         }
         catch ( AuthenticationException e )
         {
             subject = new StandardEnterpriseAuthSubject( this,
-                    new ShiroSubject( securityManager, AuthenticationResult.FAILURE ), securityLog );
+                    new ShiroSubject( securityManager, AuthenticationResult.FAILURE ) );
             securityLog.error( "[%s]: failed to log in: invalid principal or credentials",
                     escape( token.getPrincipal().toString() ) );
         }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -189,7 +189,7 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
     @Override
     public EnterpriseUserManager getUserManager( AuthSubject authSubject )
     {
-        return userManager;
+        return new PersonalUserManager( userManager, authSubject, securityLog );
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
+import org.neo4j.kernel.impl.enterprise.SecurityLog;
+import org.neo4j.server.security.auth.User;
+
+import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
+
+public class PersonalUserManager implements EnterpriseUserManager
+{
+    private EnterpriseUserManager userManager;
+    private AuthSubject authSubject;
+    private SecurityLog securityLog;
+
+    public PersonalUserManager( EnterpriseUserManager userManager, AuthSubject authSubject, SecurityLog securityLog )
+    {
+        this.userManager = userManager;
+        this.authSubject = authSubject;
+        this.securityLog = securityLog;
+    }
+
+    @Override
+    public User newUser( String username, String initialPassword, boolean requirePasswordChange )
+            throws IOException, InvalidArgumentsException
+    {
+        try
+        {
+            assertAdmin();
+            User user = userManager.newUser( username, initialPassword, requirePasswordChange );
+            securityLog.info( authSubject, "created user `%s`%s", username,
+                    requirePasswordChange ? ", with password change required" : "" );
+            return user;
+        }
+        catch ( Exception e )
+        {
+            securityLog.error( authSubject, "tried to create user `%s`: %s", username, e.getMessage() );
+            throw e;
+        }
+    }
+
+    private void assertAdmin() throws InvalidArgumentsException
+    {
+        if ( authSubject instanceof EnterpriseAuthSubject )
+        {
+            if ( ((EnterpriseAuthSubject) authSubject).isAdmin() )
+            {
+                return;
+            }
+        }
+        throw new AuthorizationViolationException( PERMISSION_DENIED );
+    }
+
+    @Override
+    public void suspendUser( String username ) throws IOException, InvalidArgumentsException
+    {
+        userManager.suspendUser( username );
+    }
+
+    @Override
+    public boolean deleteUser( String username ) throws IOException, InvalidArgumentsException
+    {
+        return userManager.deleteUser( username );
+    }
+
+    @Override
+    public void activateUser( String username, boolean requirePasswordChange )
+            throws IOException, InvalidArgumentsException
+    {
+        userManager.activateUser( username, requirePasswordChange );
+    }
+
+    @Override
+    public User getUser( String username ) throws InvalidArgumentsException
+    {
+        return userManager.getUser( username );
+    }
+
+    @Override
+    public User silentlyGetUser( String username )
+    {
+        return userManager.silentlyGetUser( username );
+    }
+
+    @Override
+    public RoleRecord newRole( String roleName, String... usernames ) throws IOException, InvalidArgumentsException
+    {
+        return userManager.newRole( roleName, usernames );
+    }
+
+    @Override
+    public void setUserPassword( String username, String password, boolean requirePasswordChange )
+            throws IOException, InvalidArgumentsException
+    {
+        if ( authSubject.hasUsername( username ) )
+        {
+            try
+            {
+                userManager.setUserPassword( username, password, requirePasswordChange );
+                securityLog.info( authSubject, "changed password%s",
+                        requirePasswordChange ? ", with password change required" : "" );
+            }
+            catch ( Exception e )
+            {
+                securityLog.error( authSubject, "tried to change password: %s", e.getMessage() );
+                throw e;
+            }
+        }
+        else
+        {
+            try
+            {
+                assertAdmin();
+                userManager.setUserPassword( username, password, requirePasswordChange );
+                securityLog.info( authSubject, "changed password for user `%s`%s", username,
+                        requirePasswordChange ? ", with password change required" : "" );
+            }
+            catch ( Exception e )
+            {
+                securityLog.error( authSubject, "tried to change password for user `%s`: %s", username,
+                        e.getMessage() );
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public boolean deleteRole( String roleName ) throws IOException, InvalidArgumentsException
+    {
+        return userManager.deleteRole( roleName );
+    }
+
+    @Override
+    public Set<String> getAllUsernames()
+    {
+        return userManager.getAllUsernames();
+    }
+
+    @Override
+    public RoleRecord getRole( String roleName ) throws InvalidArgumentsException
+    {
+        return userManager.getRole( roleName );
+    }
+
+    @Override
+    public void addRoleToUser( String roleName, String username ) throws IOException, InvalidArgumentsException
+    {
+        userManager.addRoleToUser( roleName, username );
+    }
+
+    @Override
+    public void removeRoleFromUser( String roleName, String username ) throws IOException, InvalidArgumentsException
+    {
+        userManager.removeRoleFromUser( roleName, username );
+    }
+
+    @Override
+    public Set<String> getAllRoleNames()
+    {
+        return userManager.getAllRoleNames();
+    }
+
+    @Override
+    public Set<String> getRoleNamesForUser( String username ) throws InvalidArgumentsException
+    {
+        return userManager.getRoleNamesForUser( username );
+    }
+
+    @Override
+    public Set<String> getUsernamesForRole( String roleName ) throws InvalidArgumentsException
+    {
+        return userManager.getUsernamesForRole( roleName );
+    }
+}

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
@@ -23,14 +23,19 @@ import java.io.IOException;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Procedure;
 
 import static org.neo4j.procedure.Mode.DBMS;
 
-@SuppressWarnings( "unused" )
+@SuppressWarnings( {"unused", "WeakerAccess"} )
 public class SecurityProcedures extends AuthProceduresBase
 {
+    @Context
+    public EnterpriseAuthManager authManager;
+
     @Description( "Show the current user." )
     @Procedure( name = "dbms.security.showCurrentUser", mode = DBMS )
     public Stream<UserManagementProcedures.UserResult> showCurrentUser() throws InvalidArgumentsException, IOException
@@ -42,6 +47,7 @@ public class SecurityProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.clearAuthCache", mode = DBMS )
     public void clearAuthenticationCache()
     {
-        ensureAdminAuthSubject().clearAuthCache();
+        ensureAdminAuthSubject();
+        authManager.clearAuthCache();
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
@@ -33,14 +33,9 @@ public class SecurityProcedures extends AuthProceduresBase
 {
     @Description( "Show the current user." )
     @Procedure( name = "dbms.security.showCurrentUser", mode = DBMS )
-    public Stream<UserResult> showCurrentUser() throws InvalidArgumentsException, IOException
+    public Stream<UserManagementProcedures.UserResult> showCurrentUser() throws InvalidArgumentsException, IOException
     {
-        // TODO: Support LDAP or plugin realms with native realm disabled
-        StandardEnterpriseAuthSubject enterpriseSubject = StandardEnterpriseAuthSubject.castOrFail( authSubject );
-        EnterpriseUserManager userManager = enterpriseSubject.getUserManager();
-        return Stream.of( new UserResult( enterpriseSubject.username(),
-                userManager.getRoleNamesForUser( enterpriseSubject.username() ),
-                userManager.getUser( enterpriseSubject.username() ).getFlags() ) );
+        return Stream.of( userResultForName( authSubject.username() ) );
     }
 
     @Description( "Clears authentication and authorization cache." )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -75,18 +75,7 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
     public void setPassword( String password, boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException
     {
-        try
-        {
-            getUserManager().setUserPassword( (String) shiroSubject.getPrincipal(), password, requirePasswordChange );
-            securityLog.info( this, "changed password%s",
-                    requirePasswordChange ? ", with password change required" : "" );
-        }
-        catch ( Exception e )
-        {
-            securityLog.error( this, "tried to change password: %s", e.getMessage() );
-            throw e;
-        }
-
+        getUserManager().setUserPassword( (String) shiroSubject.getPrincipal(), password, requirePasswordChange );
         // Make user authenticated if successful
         if ( getAuthenticationResult() == AuthenticationResult.PASSWORD_CHANGE_REQUIRED )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -73,6 +73,12 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
     {
         getUserManager().setUserPassword( (String) shiroSubject.getPrincipal(), password, requirePasswordChange );
         // Make user authenticated if successful
+        passwordChangeNoLongerRequired();
+    }
+
+    @Override
+    public void passwordChangeNoLongerRequired()
+    {
         if ( getAuthenticationResult() == AuthenticationResult.PASSWORD_CHANGE_REQUIRED )
         {
             shiroSubject.setAuthenticationResult( AuthenticationResult.SUCCESS );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -99,7 +99,7 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
 
     public EnterpriseUserManager getUserManager()
     {
-        return authManager.getUserManager();
+        return authManager.getUserManager( this );
     }
 
     public void clearAuthCache()

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseAuthSubject.java
@@ -23,12 +23,11 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthenticationResult;
-import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthSubject;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
 
 public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
 {
@@ -38,19 +37,16 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
 
     private final EnterpriseAuthAndUserManager authManager;
     private final ShiroSubject shiroSubject;
-    private final SecurityLog securityLog;
 
     public static StandardEnterpriseAuthSubject castOrFail( AuthSubject authSubject )
     {
         return EnterpriseAuthSubject.castOrFail( StandardEnterpriseAuthSubject.class, authSubject );
     }
 
-    public StandardEnterpriseAuthSubject( EnterpriseAuthAndUserManager authManager, ShiroSubject shiroSubject,
-            SecurityLog securityLog )
+    public StandardEnterpriseAuthSubject( EnterpriseAuthAndUserManager authManager, ShiroSubject shiroSubject )
     {
         this.authManager = authManager;
         this.shiroSubject = shiroSubject;
-        this.securityLog = securityLog;
     }
 
     @Override
@@ -100,11 +96,6 @@ public class StandardEnterpriseAuthSubject implements EnterpriseAuthSubject
     public EnterpriseUserManager getUserManager()
     {
         return authManager.getUserManager( this );
-    }
-
-    public void clearAuthCache()
-    {
-        authManager.clearAuthCache();
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -35,7 +35,6 @@ import static org.neo4j.procedure.Mode.DBMS;
 @SuppressWarnings( {"unused", "WeakerAccess"} )
 public class UserManagementProcedures extends AuthProceduresBase
 {
-
     @Context
     public EnterpriseAuthManager authManager;
 
@@ -54,7 +53,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     public void changePasswordDeprecated( @Name( "password" ) String password )
             throws InvalidArgumentsException, IOException
     {
-        authSubject.setPassword( password, false );
+        changePassword( password, false );
     }
 
     @Description( "Change the current user's password." )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -20,31 +20,29 @@
 package org.neo4j.server.security.enterprise.auth;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
-import static org.neo4j.kernel.impl.api.security.OverriddenAccessMode.getUsernameFromAccessMode;
 import static org.neo4j.procedure.Mode.DBMS;
 
 @SuppressWarnings( {"unused", "WeakerAccess"} )
 public class UserManagementProcedures extends AuthProceduresBase
 {
 
+    @Context
+    public EnterpriseAuthManager authManager;
+
     @Description( "Create a new user." )
     @Procedure( name = "dbms.security.createUser", mode = DBMS )
-    public void createUser(
-            @Name( "username" ) String username,
-            @Name( "password" ) String password,
-            @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange
-    )
+    public void createUser( @Name( "username" ) String username, @Name( "password" ) String password,
+            @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
         userManager.newUser( username, password, requirePasswordChange );
@@ -53,17 +51,16 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Deprecated
     @Description( "Change the current user's password. Deprecated by dbms.security.changePassword." )
     @Procedure( name = "dbms.changePassword", mode = DBMS, deprecatedBy = "dbms.security.changePassword" )
-    public void changePasswordDeprecated( @Name( "password" ) String password ) throws InvalidArgumentsException, IOException
+    public void changePasswordDeprecated( @Name( "password" ) String password )
+            throws InvalidArgumentsException, IOException
     {
         authSubject.setPassword( password, false );
     }
 
     @Description( "Change the current user's password." )
     @Procedure( name = "dbms.security.changePassword", mode = DBMS )
-    public void changePassword(
-            @Name( "password" ) String password,
-            @Name( value = "requirePasswordChange", defaultValue = "false"  ) boolean requirePasswordChange
-    )
+    public void changePassword( @Name( "password" ) String password,
+            @Name( value = "requirePasswordChange", defaultValue = "false" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
         userManager.setUserPassword( authSubject.username(), password, requirePasswordChange );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -62,7 +62,7 @@ public class UserManagementProcedures extends AuthProceduresBase
             @Name( value = "requirePasswordChange", defaultValue = "false" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
-        userManager.setUserPassword( authSubject.username(), password, requirePasswordChange );
+        changeUserPassword( authSubject.username(), password, requirePasswordChange );
     }
 
     @Description( "Change the given user's password." )
@@ -72,6 +72,10 @@ public class UserManagementProcedures extends AuthProceduresBase
             throws InvalidArgumentsException, IOException
     {
         userManager.setUserPassword( username, newPassword, requirePasswordChange );
+        if ( authSubject.hasUsername( username ) )
+        {
+            authSubject.passwordChangeNoLongerRequired();
+        }
     }
 
     @Description( "Assign a role to the user." )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionTest.java
@@ -98,7 +98,6 @@ public class EmbeddedBuiltInProceduresInteractionTest extends BuiltInProceduresI
     {
         return new EnterpriseAuthSubject()
         {
-
             @Override
             public boolean allowsReads()
             {
@@ -159,6 +158,11 @@ public class EmbeddedBuiltInProceduresInteractionTest extends BuiltInProceduresI
             {
                 ANONYMOUS.setPassword( password, requirePasswordChange );
 
+            }
+
+            @Override
+            public void passwordChangeNoLongerRequired()
+            {
             }
 
             @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -25,45 +25,49 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.neo4j.kernel.api.security.AuthSubject;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.FormattedLog;
 import org.neo4j.logging.Log;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
 import org.neo4j.server.security.auth.UserRepository;
+import org.neo4j.server.security.enterprise.log.SecurityLog;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class MultiRealmAuthManagerRule implements TestRule
 {
     private UserRepository users;
     private AuthenticationStrategy authStrategy;
     private MultiRealmAuthManager manager;
-    private EnterpriseUserManager userManager;
-    private AssertableLogProvider logProvider;
     private SecurityLog securityLog;
+    private StringWriter securityLogWriter;
 
     public MultiRealmAuthManagerRule(
             UserRepository users,
             AuthenticationStrategy authStrategy
-    )
-    {
+    ) {
         this.users = users;
         this.authStrategy = authStrategy;
-
-        logProvider = new AssertableLogProvider();
     }
 
     private void setupAuthManager( AuthenticationStrategy authStrategy ) throws Throwable
     {
-        Log log = logProvider.getLog( this.getClass() );
+        FormattedLog.Builder builder = FormattedLog.withUTCTimeZone();
+        securityLogWriter = new StringWriter();
+        Log log = builder.toWriter( securityLogWriter );
+
         securityLog = new SecurityLog( log );
         InternalFlatFileRealm internalFlatFileRealm =
                 new InternalFlatFileRealm(
@@ -78,8 +82,6 @@ public class MultiRealmAuthManagerRule implements TestRule
         manager = new MultiRealmAuthManager( internalFlatFileRealm, Collections.singleton( internalFlatFileRealm ),
                 new MemoryConstrainedCacheManager(), securityLog, true );
         manager.init();
-
-        userManager = manager.getUserManager();
     }
 
     public EnterpriseAuthAndUserManager getManager()
@@ -129,33 +131,23 @@ public class MultiRealmAuthManagerRule implements TestRule
         manager.shutdown();
     }
 
-    public void assertExactlyInfoInLog( String message )
+    public FullSecurityLog getFullSecurityLog()
     {
-        logProvider.assertExactly( inLog( this.getClass() ).info( message ) );
+        return new FullSecurityLog( securityLogWriter.getBuffer().toString().split( "\n" ) );
     }
 
-    public void assertExactlyInfoInLog( String message, Object... values )
+    public static class FullSecurityLog
     {
-        logProvider.assertExactly( inLog( this.getClass() ).info( message, values ) );
-    }
+        List<String> lines;
 
-    public void assertExactlyWarnInLog( String message )
-    {
-        logProvider.assertExactly( inLog( this.getClass() ).warn( message ) );
-    }
+        private FullSecurityLog( String[] logLines )
+        {
+            lines = Arrays.asList( logLines );
+        }
 
-    public void assertExactlyWarnInLog( String message, Object... values )
-    {
-        logProvider.assertExactly( inLog( this.getClass() ).warn( message, values ) );
-    }
-
-    public void assertExactlyErrorInLog( String message )
-    {
-        logProvider.assertExactly( inLog( this.getClass() ).error( message ) );
-    }
-
-    public void assertExactlyErrorInLog( String message, Object... values )
-    {
-        logProvider.assertExactly( inLog( this.getClass() ).error( message, values ) );
+        public void assertHasLine( String subject, String msg )
+        {
+            assertThat( lines, hasItem( containsString( "[" + subject + "]: " + msg ) ) );
+        }
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -89,7 +89,7 @@ public class MultiRealmAuthManagerRule implements TestRule
 
     public AuthSubject makeSubject( ShiroSubject shiroSubject )
     {
-        return new StandardEnterpriseAuthSubject( manager, shiroSubject, securityLog );
+        return new StandardEnterpriseAuthSubject( manager, shiroSubject );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
@@ -643,7 +643,7 @@ public class UserManagementProceduresLoggingTest
 
         TestAuthSubject( String name, boolean isAdmin, EnterpriseUserManager userManager, SecurityLog securityLog )
         {
-            super( null, new TestShiroSubject( name ), securityLog );
+            super( null, new TestShiroSubject( name ) );
             this.name = name;
             this.isAdmin = isAdmin;
             this.userManager = userManager;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
@@ -55,12 +55,14 @@ public class UserManagementProceduresLoggingTest
     public void setUp() throws Throwable
     {
         log = new AssertableLogProvider();
+        SecurityLog securityLog = new SecurityLog( log.getLog( getClass() ) );
+
         authProcedures = new TestUserManagementProcedures();
-        authProcedures.securityLog = new SecurityLog( log.getLog( getClass() ) );
+        authProcedures.securityLog = securityLog;
 
         EnterpriseUserManager userManager = getUserManager();
-        AuthSubject adminSubject = new TestAuthSubject( "admin", true, userManager, authProcedures.securityLog );
-        matsSubject = new TestAuthSubject( "mats", false, userManager, authProcedures.securityLog );
+        AuthSubject adminSubject = new TestAuthSubject( "admin", true, userManager, securityLog );
+        matsSubject = new TestAuthSubject( "mats", false, userManager, securityLog );
 
         authProcedures.authSubject = adminSubject;
         authProcedures.graph = mock( GraphDatabaseAPI.class );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.server.security.enterprise.auth.integration.bolt;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.util.Map;
+
+import org.neo4j.bolt.security.auth.AuthenticationException;
+import org.neo4j.bolt.security.auth.BasicAuthentication;
+import org.neo4j.server.security.auth.InMemoryUserRepository;
+import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
+import org.neo4j.server.security.enterprise.auth.MultiRealmAuthManagerRule;
+import org.neo4j.server.security.enterprise.auth.MultiRealmAuthManagerRule.FullSecurityLog;
+
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.test.assertion.Assert.assertException;
+
+public class BoltInitChangePasswordTest
+{
+    @Rule
+    public MultiRealmAuthManagerRule authManagerRule = new MultiRealmAuthManagerRule( new InMemoryUserRepository(),
+            new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ) );
+    private BasicAuthentication authentication;
+
+    @Before
+    public void setup() throws Throwable
+    {
+        authentication = new BasicAuthentication( authManagerRule.getManager() );
+        authManagerRule.getManager().getUserManager().newUser( "neo4j", "123", true );
+    }
+
+    @Test
+    public void shouldLogInitPasswordChange() throws Throwable
+    {
+        authentication.authenticate( authToken( "neo4j", "123", "secret" ) );
+
+        FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
+        fullLog.assertHasLine( "neo4j", "logged in" );
+        fullLog.assertHasLine( "neo4j", "changed password" );
+    }
+
+    @Test
+    public void shouldLogFailedInitPasswordChange() throws Throwable
+    {
+        assertException( () -> authentication.authenticate( authToken( "neo4j", "123", "123" ) ),
+                AuthenticationException.class, "Old password and new password cannot be the same." );
+
+        FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
+        fullLog.assertHasLine( "neo4j", "logged in" );
+        fullLog.assertHasLine( "neo4j", "tried to change password: Old password and new password cannot be the same." );
+    }
+
+    private Map<String,Object> authToken( String username, String password, String newPassword )
+    {
+        return map( "principal", username, "credentials", password,
+                "new_credentials", newPassword, "scheme", "basic" );
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
@@ -19,39 +19,19 @@
  */
 package org.neo4j.server.security.enterprise.auth.integration.bolt;
 
-import org.apache.commons.compress.utils.Charsets;
-import org.junit.Test;
-
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.neo4j.bolt.v1.messaging.message.InitMessage;
 import org.neo4j.bolt.v1.transport.integration.AuthenticationIT;
-import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgFailure;
-import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgSuccess;
-import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyReceives;
-import static org.neo4j.helpers.collection.MapUtil.map;
-
 public class EnterpriseAuthenticationIT extends AuthenticationIT
 {
-    private File securityLog;
-
     @Override
     protected TestGraphDatabaseFactory getTestGraphDatabaseFactory()
     {
@@ -70,7 +50,6 @@ public class EnterpriseAuthenticationIT extends AuthenticationIT
         {
             throw new RuntimeException( "Test setup failed to create temporary directory", e );
         }
-        securityLog = new File( homeDir.toFile(), "security.log" );
 
         return settings -> {
             settings.put( GraphDatabaseSettings.auth_enabled.name(), "true" );
@@ -82,70 +61,5 @@ public class EnterpriseAuthenticationIT extends AuthenticationIT
     public void shouldFailIfMalformedAuthTokenUnknownScheme() throws Throwable
     {
         // Ignore this test in enterprise since custom schemes may be allowed
-    }
-
-    @SuppressWarnings( "unchecked" )
-    @Test
-    public void shouldLogInitPasswordChange() throws Throwable
-    {
-        // When
-        client.connect( address )
-                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
-                .send( TransportTestUtil.chunk(
-                        InitMessage.init( "TestClient/1.1", map( "principal", "neo4j",
-                                "credentials", "neo4j", "new_credentials", "secret", "scheme", "basic" ) ) ) );
-
-        // Then
-        assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgSuccess() ) );
-
-        server.graphDatabaseService().shutdown(); // to force writing of async logs
-
-        FullLog log = new FullLog();
-        log.assertHasLine( "neo4j", "changed password" );
-    }
-
-    @SuppressWarnings( "unchecked" )
-    @Test
-    public void shouldLogFailedInitPasswordChange() throws Throwable
-    {
-        // When
-        client.connect( address )
-                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
-                .send( TransportTestUtil.chunk(
-                        InitMessage.init( "TestClient/1.1", map( "principal", "neo4j",
-                                "credentials", "neo4j", "new_credentials", "neo4j", "scheme", "basic" ) ) ) );
-
-        // Then
-        assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgFailure( Status.General.InvalidArguments,
-                "Old password and new password cannot be the same.") ) );
-
-        server.graphDatabaseService().shutdown(); // to force writing of async logs
-
-        FullLog log = new FullLog();
-        log.assertHasLine( "neo4j", "tried to change password: Old password and new password cannot be the same." );
-    }
-
-    private class FullLog
-    {
-        List<String> lines;
-
-        FullLog() throws IOException
-        {
-            lines = new ArrayList<>();
-            BufferedReader bufferedReader = new BufferedReader(
-                    fsRule.get().openAsReader(
-                            new File( securityLog.getAbsolutePath() ),
-                            Charsets.UTF_8
-                    ) );
-            lines.add( bufferedReader.readLine() );
-            bufferedReader.lines().forEach( lines::add );
-        }
-
-        void assertHasLine( String subject, String msg )
-        {
-            assertThat( lines, hasItem( containsString( "[" + subject + "]: " + msg ) ) );
-        }
     }
 }

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
@@ -41,8 +41,7 @@ public class EnterpriseUserServiceTest extends UserServiceTest
     @Override
     protected void setupAuthManagerAndSubject()
     {
-        authManager = authManagerRule.getManager();
-        userManager = authManagerRule.getManager().getUserManager();
+        userManagerSupplier = authManagerRule.getManager();
 
         ShiroSubject shiroSubject = mock( ShiroSubject.class );
         when( shiroSubject.getPrincipal() ).thenReturn( "neo4j" );

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
@@ -53,7 +53,8 @@ public class EnterpriseUserServiceTest extends UserServiceTest
     {
         shouldChangePasswordAndReturnSuccess();
 
-        authManagerRule.assertExactlyInfoInLog( "[neo4j]: changed password%s", "" );
+        MultiRealmAuthManagerRule.FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
+        fullLog.assertHasLine( "neo4j", "changed password" );
     }
 
     @Test
@@ -61,7 +62,7 @@ public class EnterpriseUserServiceTest extends UserServiceTest
     {
         shouldReturn422IfPasswordIdentical();
 
-        authManagerRule.assertExactlyErrorInLog( "[neo4j]: tried to change password: %s",
-                "Old password and new password cannot be the same." );
+        MultiRealmAuthManagerRule.FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
+        fullLog.assertHasLine( "neo4j", "tried to change password: Old password and new password cannot be the same." );
     }
 }


### PR DESCRIPTION
Made dbms.security.showCurrentUser procedure show authenticated user even if native security realm is not used

Internal changes:
- Refactored usermanagment to work through a delegating usermanager that now had all responsibility to log user management operations to the security log. This `PersonalUserManager` has the active AuthSubject and also checks admin status where needed.
- Fixed flaky tests for bolt init and REST UserService change password logging

changelog: Made dbms.security.showCurrentUser procedure show authenticated user even if native security realm is not used
