### PR TITLE
Convert parameters to known cypher types

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -453,4 +453,15 @@ order by a.age""").toList)
 
     result.toList should equal(List(Map("count" -> 1)))
   }
+
+  test("parameters should be transformed to cypher types") {
+    def echo(any: Any) = {
+      executeScalarWithAllPlannersAndCompatibilityMode[AnyRef]("RETURN {p} AS p", "p" -> any)
+    }
+
+    echo(41.asInstanceOf[Byte]) shouldBe a[java.lang.Long]
+    echo(41.asInstanceOf[Short]) shouldBe a[java.lang.Long]
+    echo(41) shouldBe a[java.lang.Long]
+    echo(41.0f) shouldBe a[java.lang.Double]
+  }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -68,11 +68,14 @@ object typeConversionsFor3_0 extends RuntimeTypeConverter {
   }
 
   override def asPrivateType = {
-    case map: Map[String, Any] => asPrivateMap(map)
+    case map: Map[_, _] => asPrivateMap(map.asInstanceOf[Map[String, Any]])
     case seq: Seq[Any] => seq.map(asPrivateType)
     case arr: Array[Any] => arr.map(asPrivateType)
     case point: spatial.Point => asPrivatePoint(point)
     case geometry: spatial.Geometry => asPrivateGeometry(geometry)
+    case float: Float => float.toDouble
+    case double: Double => double
+    case number: Number => number.longValue()
     case value => value
   }
 


### PR DESCRIPTION
Cypher should only know about longs, and doubles, hence when parameters are past in to cypher
we should convert them to these known entities. Currently this causes issues when using parameters to procedures in languages where there is no concept of 64 bit integers and floating point numbers.

fixes #7115
