### PR TITLE
Bump high limit store version

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreId.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreId.java
@@ -26,13 +26,8 @@ import java.io.ObjectOutput;
 import java.security.SecureRandom;
 import java.util.Random;
 
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
-
-import static org.neo4j.kernel.impl.store.MetaDataStore.versionStringToLong;
-
 public final class StoreId implements Externalizable
 {
-    public static final long CURRENT_STORE_VERSION = versionStringToLong( StandardV3_0.STORE_VERSION );
 
     public static final StoreId DEFAULT = new StoreId( -1, -1, -1, -1, -1 );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
@@ -31,8 +31,8 @@ public enum StoreVersion
     STANDARD_V3_0( "v0.A.7" ),
 
     HIGH_LIMIT_V3_0_0( "vE.H.0" ),
-    HIGH_LIMIT_V3_0_6( "vE.H.0b"),
-    HIGH_LIMIT_V3_1( "vE.H.1" );
+    HIGH_LIMIT_V3_0_6( "vE.H.0b" ),
+    HIGH_LIMIT_V3_1_0( "vE.H.2" );
 
     private final String versionString;
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -49,7 +49,7 @@ public class HighLimit extends BaseRecordFormats
      */
     static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
 
-    public static final String STORE_VERSION = StoreVersion.HIGH_LIMIT_V3_1.versionString();
+    public static final String STORE_VERSION = StoreVersion.HIGH_LIMIT_V3_1_0.versionString();
 
     public static final RecordFormats RECORD_FORMATS = new HighLimit();
     public static final String NAME = "high_limit";


### PR DESCRIPTION
Bump high limit store version to have clear separation between milestone and release version store format.
Format by itself does not contain any changes.

changelog: Bump high limit store version for 3.1 release. 
Stores created with milestone store versions are no longer acceptable.
