### PR TITLE
Sets the default core_edge.join_catch_up_timeout to 7s

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/CoreEdgeClusterSettings.java
@@ -48,9 +48,9 @@ public class CoreEdgeClusterSettings
     public static final Setting<Long> join_catch_up_timeout =
             setting( "core_edge.join_catch_up_timeout", DURATION, "10m" );
 
-    @Description("The time limit which a new leader election will occur if no messages are received.")
+    @Description("The time limit within which a new leader election will occur if no messages are received.")
     public static final Setting<Long> leader_election_timeout =
-            setting( "core_edge.leader_election_timeout", DURATION, "500ms" );
+            setting( "core_edge.leader_election_timeout", DURATION, "7s" );
 
     @Description("The maximum batch size when catching up (in unit of entries)")
     public static final Setting<Integer> catchup_batch_size =

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -144,31 +144,31 @@ dbms.directories.import=import
 # To operate this Neo4j instance in Core-Edge mode as a core member, uncomment this line:
 #dbms.mode=CORE
 
-#Expected number of Core machines in the cluster.
+# Expected number of Core machines in the cluster.
 #core_edge.expected_core_cluster_size=3
 
-#A comma-separated list of the address and port for which to reach all other members of the cluster. It must be in the
+# A comma-separated list of the address and port for which to reach all other members of the cluster. It must be in the
 # host:port format. For each machine in the cluster, the address will usually be the public ip address of that machine.
 # The port will be the value used in the setting "core_edge.discovery_listen_address".
 #core_edge.initial_discovery_members=localhost:5000,localhost:5001,localhost:5002
 
-#Host and port to bind the cluster member discovery management communication.
-#This is the setting to add to the collection of address in core_edge.initial_core_cluster_members.
-#Use 0.0.0.0 to bind to any network interface on the machine. If you want to only use a specific interface
-#(such as a private ip address on AWS, for example) then use that ip address instead.
+# Host and port to bind the cluster member discovery management communication.
+# This is the setting to add to the collection of address in core_edge.initial_core_cluster_members.
+# Use 0.0.0.0 to bind to any network interface on the machine. If you want to only use a specific interface
+# (such as a private ip address on AWS, for example) then use that ip address instead.
 # If you don't know what value to use here, use this machines ip address.
 #core_edge.discovery_listen_address=:5000
 
-#Network interface and port for the transaction shipping server to listen on. If you want to allow for
+# Network interface and port for the transaction shipping server to listen on. If you want to allow for
 # messages to be read from
-#any network on this machine, us 0.0.0.0. If you want to constrain communication to a specific network address
-#(such as a private ip on AWS, for example) then use that ip address instead.
+# any network on this machine, us 0.0.0.0. If you want to constrain communication to a specific network address
+# (such as a private ip on AWS, for example) then use that ip address instead.
 # If you don't know what value to use here, use this machines ip address.
 #core_edge.transaction_listen_address=:6000
 
-#Network interface and port for the RAFT server to listen on. If you want to allow for messages to be read from
-#any network on this machine, us 0.0.0.0. If you want to constrain communication to a specific network address
-#(such as a private ip on AWS, for example) then use that ip address instead.
+# Network interface and port for the RAFT server to listen on. If you want to allow for messages to be read from
+# any network on this machine, us 0.0.0.0. If you want to constrain communication to a specific network address
+# (such as a private ip on AWS, for example) then use that ip address instead.
 # If you don't know what value to use here, use this machines ip address.
 #core_edge.raft_listen_address=:7000
 
@@ -178,43 +178,45 @@ dbms.directories.import=import
 # The following settings are used less frequently.
 # If you don't know what these are, you don't need to change these from their default values.
 
-#Address and port that this machine advertises that it's RAFT server is listening at. Should be a
-#specific network address. If you are unsure about what value to use here, use this machine's ip address.
+# Address and port that this machine advertises that it's RAFT server is listening at. Should be a
+# specific network address. If you are unsure about what value to use here, use this machine's ip address.
 #core_edge.raft_advertised_address=:7000
 
-#Address and port that this machine advertises that it's transaction shipping server is listening at. Should be a
-#specific network address. If you are unsure about what value to use here, use this machine's ip address.
+# Address and port that this machine advertises that it's transaction shipping server is listening at. Should be a
+# specific network address. If you are unsure about what value to use here, use this machine's ip address.
 #core_edge.transaction_advertised_address=:6000
 
-#The time limit which a new leader election will occur if no messages from the current leader are received within.
-#core_edge.leader_election_timeout=500ms
+# The time limit within which a new leader election will occur if no messages from the current leader are received.
+# Larger values allow for more stable leaders at the expense of longer unavailability times in case of leader
+# failures.
+#core_edge.leader_election_timeout=7s
 
-#The time limit allowed for a new member to attempt to update its data to match the rest of the cluster.
+# The time limit allowed for a new member to attempt to update its data to match the rest of the cluster.
 #core_edge.join_catch_up_timeout=10m
 
-#The size of the batch for streaming entries to other machines while trying to catch up another machine.
+# The size of the batch for streaming entries to other machines while trying to catch up another machine.
 #core_edge.catchup_batch_size=64
 
-#When to pause sending entries to other machines and allow them to catch up.
+# When to pause sending entries to other machines and allow them to catch up.
 #core_edge.log_shipping_max_lag=256
 
-#A timeout for the replication of token.
+# A timeout for the replication of token.
 #core_edge.token_creation_timeout=1s
 
-#The timeout to wait on the leader to acqire a local token.
+# The timeout to wait on the leader to acqire a local token.
 #core_edge.leader_lock_token_timeout=1s
 
-#Raft log pruning frequncy.
+# Raft log pruning frequncy.
 #core_edge.raft_log_pruning_frequency=10m
 
-#The size to allow the raft log to grow before rotating.
+# The size to allow the raft log to grow before rotating.
 #core_edge.raft_log_rotation_size=250M
 
 ### The following setting is relevant for Edge servers only.
-#The interval of pulling updates from Core servers.
+# The interval of pulling updates from Core servers.
 #core_edge.pull_interval=1s
 
-#For how long should drivers cache the discovery data from
+# For how long should drivers cache the discovery data from
 # the dbms.cluster.routing.getServers() procedure. Defaults to 5s.
 #core_edge.cluster_routing_ttl=5m
 


### PR DESCRIPTION
This is the smallest value that allows for stable leaders in clusters
 without network problems under high load.
Adds a bit of documentation about the option in the neo4j.conf file as well.
