### PR TITLE
Fix problem with terminating inner transactions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PlaceboTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/PlaceboTransaction.java
@@ -32,25 +32,25 @@ public class PlaceboTransaction implements InternalTransaction
 {
     private final static PropertyContainerLocker locker = new PropertyContainerLocker();
     private final Supplier<Statement> stmt;
-    private final Supplier<KernelTransaction> currentTransaction;
+    private final KernelTransaction currentTransaction;
     private boolean success;
 
     public PlaceboTransaction( Supplier<KernelTransaction> currentTransaction, Supplier<Statement> stmt )
     {
         this.stmt = stmt;
-        this.currentTransaction = currentTransaction;
+        this.currentTransaction = currentTransaction.get();
     }
 
     @Override
     public void terminate()
     {
-        currentTransaction.get().markForTermination( Status.Transaction.Terminated );
+        currentTransaction.markForTermination( Status.Transaction.Terminated );
     }
 
     @Override
     public void failure()
     {
-    	currentTransaction.get().failure();
+    	currentTransaction.failure();
     }
 
     @Override
@@ -64,7 +64,7 @@ public class PlaceboTransaction implements InternalTransaction
     {
         if ( !success )
         {
-            currentTransaction.get().failure();
+            currentTransaction.failure();
         }
     }
 
@@ -83,18 +83,18 @@ public class PlaceboTransaction implements InternalTransaction
     @Override
     public KernelTransaction.Type transactionType()
     {
-        return currentTransaction.get().transactionType();
+        return currentTransaction.transactionType();
     }
 
     @Override
     public AccessMode mode()
     {
-        return currentTransaction.get().mode();
+        return currentTransaction.mode();
     }
 
     @Override
     public KernelTransaction.Revertable restrict( AccessMode mode )
     {
-        return currentTransaction.get().restrict( mode );
+        return currentTransaction.restrict( mode );
     }
 }


### PR DESCRIPTION
PlaceboTransaction was not getting a KernelTransaction, it was getting a
Supplier<KernelTransaction>, which would return the currently thread bound transaction.

This works well in most cases, since transactions are thread bound and should not be used
from other threads. When using terminate() though, the caller is almost always from a different
thread, and in these situations we can't use a supplier.

changelog: Fix problem where terminating transaction from a different thread could end up terminating wrong transaction when using nested transactions. This could occur when one user attempts to terminate another user's transaction, but incorrectly ends up having their own transaction terminated.
