### PR TITLE
Don't create static arrays lazily

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessage.java
@@ -36,7 +36,13 @@ public enum BoltRequestMessage
     DISCARD_ALL( 0x2F ),
     PULL_ALL( 0x3F );
 
-    private static BoltRequestMessage[] valuesBySignature = null;
+    private static BoltRequestMessage[] valuesBySignature = new BoltRequestMessage[0x40];
+    static {
+        for ( BoltRequestMessage value : values() )
+        {
+            valuesBySignature[value.signature()] = value;
+        }
+    }
 
     /**
      * Obtain a request message by signature.
@@ -47,14 +53,6 @@ public enum BoltRequestMessage
      */
     public static BoltRequestMessage withSignature( int signature )
     {
-        if ( valuesBySignature == null )
-        {
-            valuesBySignature = new BoltRequestMessage[0x40];
-            for ( BoltRequestMessage value : values() )
-            {
-                valuesBySignature[value.signature()] = value;
-            }
-        }
         BoltRequestMessage message = valuesBySignature[signature];
         if ( message == null )
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltResponseMessage.java
@@ -34,7 +34,13 @@ public enum BoltResponseMessage
     IGNORED( 0x7E ),
     FAILURE( 0x7F );
 
-    private static BoltResponseMessage[] valuesBySignature = null;
+    private static BoltResponseMessage[] valuesBySignature =  new BoltResponseMessage[0x80];
+    static {
+        for ( BoltResponseMessage value : values() )
+        {
+            valuesBySignature[value.signature()] = value;
+        }
+    }
 
     /**
      * Obtain a response message by signature.
@@ -45,14 +51,6 @@ public enum BoltResponseMessage
      */
     public static BoltResponseMessage withSignature( int signature )
     {
-        if ( valuesBySignature == null )
-        {
-            valuesBySignature = new BoltResponseMessage[0x80];
-            for ( BoltResponseMessage value : values() )
-            {
-                valuesBySignature[value.signature()] = value;
-            }
-        }
         BoltResponseMessage message = valuesBySignature[signature];
         if ( message == null )
         {


### PR DESCRIPTION
Static arrays `valuesBySignature` in `BoltRequestMessage` and `BoltResponseMessage`
were being initialized lazily on calling `withSignature`. However this creates a race
when multiple threads are calling `withSignature` before the arrays have been properly
initialized.
