### PR TITLE
core-edge: fix concurrency issues for exposed raft state

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/membership/MembershipWaiterLifecycle.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/membership/MembershipWaiterLifecycle.java
@@ -50,7 +50,7 @@ public class MembershipWaiterLifecycle extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        CompletableFuture<Boolean> caughtUp = membershipWaiter.waitUntilCaughtUpMember( raft.state() );
+        CompletableFuture<Boolean> caughtUp = membershipWaiter.waitUntilCaughtUpMember( raft );
 
         try
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/membership/RaftMembershipManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/membership/RaftMembershipManager.java
@@ -22,6 +22,7 @@ package org.neo4j.coreedge.core.consensus.membership;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.LongSupplier;
@@ -65,8 +66,8 @@ public class RaftMembershipManager extends LifecycleAdapter implements RaftMembe
 
     private final int expectedClusterSize;
 
-    private volatile Set<MemberId> votingMembers = new HashSet<>();
-    private volatile Set<MemberId> replicationMembers = new HashSet<>(); // votingMembers + additionalReplicationMembers
+    private volatile Set<MemberId> votingMembers = Collections.unmodifiableSet( new HashSet<>() );
+    private volatile Set<MemberId> replicationMembers = Collections.unmodifiableSet( new HashSet<>() ); // votingMembers + additionalReplicationMembers
 
     private Set<Listener> listeners = new HashSet<>();
     private Set<MemberId> additionalReplicationMembers = new HashSet<>();
@@ -137,12 +138,12 @@ public class RaftMembershipManager extends LifecycleAdapter implements RaftMembe
      */
     private void updateMemberSets()
     {
-        votingMembers = state.getLatest();
+        votingMembers = Collections.unmodifiableSet( state.getLatest() );
 
         HashSet<MemberId> newReplicationMembers = new HashSet<>( votingMembers );
         newReplicationMembers.addAll( additionalReplicationMembers );
 
-        replicationMembers = newReplicationMembers;
+        replicationMembers = Collections.unmodifiableSet( newReplicationMembers );
         listeners.forEach( Listener::onMembershipChanged );
     }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/state/ExposedRaftState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/state/ExposedRaftState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.core.consensus.state;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.identity.MemberId;
+
+public interface ExposedRaftState
+{
+    long leaderCommit();
+
+    long commitIndex();
+
+    long appendIndex();
+
+    long term();
+
+    Set<MemberId> votingMembers();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/state/RaftState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/consensus/state/RaftState.java
@@ -207,4 +207,47 @@ public class RaftState implements ReadableRaftState
             log.info( "Leader changed from %s to %s", this.leader, leader );
         }
     }
+
+    public ExposedRaftState copy()
+    {
+        return new ExposedRaftState()
+        {
+            final long leaderCommit = RaftState.this.leaderCommit();
+            final long commitIndex = RaftState.this.commitIndex();
+            final long appendIndex = RaftState.this.entryLog().appendIndex();
+            final long term = RaftState.this.term();
+
+            final Set<MemberId> votingMembers = RaftState.this.votingMembers(); // returned set is never mutated
+
+            @Override
+            public long leaderCommit()
+            {
+                return this.leaderCommit;
+            }
+
+            @Override
+            public long commitIndex()
+            {
+                return this.commitIndex;
+            }
+
+            @Override
+            public long appendIndex()
+            {
+                return this.appendIndex;
+            }
+
+            @Override
+            public long term()
+            {
+                return this.term;
+            }
+
+            @Override
+            public Set<MemberId> votingMembers()
+            {
+                return this.votingMembers;
+            }
+        };
+    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/CoreState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/CoreState.java
@@ -176,7 +176,7 @@ public class CoreState implements MessageHandler<RaftMessages.ClusterIdAwareMess
 
     private boolean haveState()
     {
-        return raftMachine.state().entryLog().appendIndex() > -1;
+        return raftMachine.state().appendIndex() > -1;
     }
 
     @Override


### PR DESCRIPTION
MembershipWaiter::Evaluator now calls synchronized state() on the
RaftMachine every round to fetch a fresh view.
