### PR TITLE
Add security section to enterprise neo4j.conf

### DIFF
--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -130,6 +130,8 @@ dbms.directories.import=import
 # Maximum number of history files for the query log.
 #dbms.logs.query.rotation.keep_number=7
 
+# NOTE: There is also a security log. Its settings are listed separately under the "Security Configuration" section.
+
 #*****************************************************************
 # Core-Edge Configuration
 #*****************************************************************
@@ -293,6 +295,159 @@ dbms.directories.import=import
 # Whether this instance should only participate as slave in cluster. If set to
 # true, it will never be elected as master.
 #ha.slave_only=false
+
+#********************************************************************
+# Security Configuration
+#********************************************************************
+
+# The authentication and authorization provider that contains both users and roles.
+# This can be one of the built-in `native` or `ldap` auth providers,
+# or it can be an externally provided plugin, with a custom name prefixed by `plugin`,
+# i.e. `plugin-<AUTH_PROVIDER_NAME>`.
+#dbms.security.auth_provider=native
+
+#================================================
+# LDAP Auth Provider Configuration
+#================================================
+
+# URL of LDAP server (with protocol, hostname and port) to use for authentication and authorization.
+# If no protocol is specified the default will be `ldap://`.
+# To use LDAPS, set the protocol and port, e.g. `ldaps://ldap.example.com:636`
+# NOTE: You may want to consider using STARTTLS (`dbms.security.ldap.use_starttls`) over LDAPS
+# for secure connections, in which case the default port will be sufficient.
+#dbms.security.ldap.host=0.0.0.0:389
+
+# Use secure communication with the LDAP server using opportunistic TLS.
+# First an initial insecure connection will be made with the LDAP server, and then a STARTTLS command
+# will be issued to negotiate an upgrade of the connection to TLS before initiating authentication.
+#dbms.security.ldap.use_starttls=false
+
+# LDAP authentication mechanism. This is one of `simple` or a SASL mechanism supported by JNDI,
+# e.g. `DIGEST-MD5`. `simple` is basic username
+# and password authentication and SASL is used for more advanced mechanisms. See RFC 2251 LDAPv3
+# documentation for more details.
+#dbms.security.ldap.auth_mechanism=simple
+
+# The LDAP referral behavior when creating a connection. This is one of `follow`, `ignore` or `throw`.
+# `follow` automatically follows any referrals
+# `ignore` ignores any referrals
+# `throw` throws an exception, which will lead to authentication failure
+#dbms.security.ldap.referral=follow
+
+#----------------------------------
+# LDAP Authentication Configuration
+#----------------------------------
+
+# LDAP user DN template. An LDAP object is referenced by its distinguished name (DN), and a user DN is
+# an LDAP fully-qualified unique user identifier. This setting is used to generate an LDAP DN that
+# conforms with the LDAP directory's schema from the user principal that is submitted with the
+# authentication token when logging in.
+# The special token {0} is a placeholder where the user principal will be substituted into the DN string.
+#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com"
+
+# Determines if the result of authentication via the LDAP server should be cached or not.
+# Caching is used to limit the number of LDAP requests that have to be made over the network
+# for users that have already been authenticated successfully. A user can be authenticated against
+# an existing cache entry (instead of via an LDAP server) as long as it is alive
+# (see `dbms.security.auth_cache_ttl`).
+# An important consequence of setting this to `true` than needs to be well understood, is that
+# Neo4j then needs to cache a hashed version of the credentials in order to perform credentials
+# matching. This hashing is done using a cryptographic hash function together with a random salt.
+# Preferably a conscious decision should be made if this method is considered acceptable by
+# the security standards of the organization in which this Neo4j instance is deployed.
+#dbms.security.ldap.authentication_cache_enabled=true
+
+#----------------------------------
+# LDAP Authorization Configuration
+#----------------------------------
+# Authorization is performed by searching the directory for the groups that
+# the user is a member of, and then map those groups to Neo4j roles.
+
+# Perform LDAP search for authorization info using a system account or the user's own account.
+#
+# If this is set to `false` (default), the search for group membership will be performed
+# directly after authentication using the ldap context bound with the user's own account.
+# The mapped roles will be cached for the duration of `dbms.security.auth_cache_ttl`,
+# and then expire, requiring re-authentication. To avoid frequently having to re-authenticate
+# sessions you may want to set a relatively long auth cache expiration time together with this option.
+# NOTE: This option will only work if the users are permitted to search for the
+# group membership attributes on themselves in the directory.
+#
+# If this is set to `true`, the search will be performed using a special system account user
+# with read access to all the users in the directory.
+# You need to specify the username and password with the next two settings below with his option.
+# Note that this account only needs read-only access to the relevant parts of the LDAP directory
+# and does not need to have access rights to Neo4j or any other systems.
+#dbms.security.ldap.authorization.use_system_account=false
+
+# An LDAP system account username to use for authorization searches when
+# `dbms.security.ldap.authorization.use_system_account` is `true`.
+# Note that the `dbms.security.ldap.user_dn_template` will not be applied to this username,
+# so you may have to specify a full DN.
+#dbms.security.ldap.system_username=
+
+# An LDAP system account password to use for authorization searches when
+# `dbms.security.ldap.authorization.use_system_account` is `true`.
+#dbms.security.ldap.system_password=
+
+# The name of the base object or named context to search for user objects when LDAP authorization is enabled.
+# A common case is that this matches the last part of `dbms.security.ldap.user_dn_template`,
+# e.g. `ou=users,dc=example,dc=com`.
+#dbms.security.ldap.authorization.user_search_base=
+
+# The LDAP search filter to search for a user principal when LDAP authorization is
+# enabled. The filter should contain the placeholder token {0} which will be substituted for the
+# user principal.
+#dbms.security.ldap.authorization.user_search_filter=(&(objectClass=*)(uid={0}))
+
+# A list of attribute names on a user object that contains groups to be used for mapping to roles
+# when LDAP authorization is enabled.
+#dbms.security.ldap.authorization.group_membership_attributes=memberOf
+
+# An authorization mapping from LDAP group names to Neo4j role names.
+# The map should be formatted as a semicolon separated list of key-value pairs, where the
+# key is the LDAP group name and the value is a comma separated list of corresponding role names.
+# E.g. group1=role1;group2=role2;group3=role3,role4,role5
+#dbms.security.ldap.authorization.group_to_role_mapping=
+
+# You could also use whitespaces and quotes around group names to make this mapping more readable,
+# e.g: dbms.security.ldap.authorization.group_to_role_mapping=\
+#          "cn=Neo4j Read Only,cn=users,dc=example,dc=com"      = reader;    \
+#          "cn=Neo4j Read-Write,cn=users,dc=example,dc=com"     = publisher; \
+#          "cn=Neo4j Schema Manager,cn=users,dc=example,dc=com" = architect; \
+#          "cn=Neo4j Administrator,cn=users,dc=example,dc=com"  = admin
+
+#================================================
+# Auth Cache Configuration
+#================================================
+
+# The time to live (TTL) for cached authentication and authorization info when using
+# external auth providers (ldap or plugin). Setting the TTL to 0 will
+# disable auth caching.
+#dbms.security.auth_cache_ttl=10m
+
+# The maximum capacity for authentication and authorization caches (respectively).
+#dbms.security.auth_cache_max_capacity=10000
+
+#================================================
+# Security Log Configuration
+#================================================
+# The security log is always enabled and resides in `logs/security.log`.
+
+# Set to log successful authentication events.
+# If this is set to `false` only failed authentication events will be logged, which
+# could be useful if you find that the successful events spam the logs too much,
+# and you do not require full auditing capability.
+#dbms.security.log_successful_authentication=true
+
+# Threshold for rotation of the security log.
+#dbms.logs.security.rotation.size=20m
+
+# Minimum time interval after last rotation of the security log before it may be rotated again.
+#dbms.logs.security.rotation.delay=300s
+
+# Maximum number of history files for the security log.
+#dbms.logs.security.rotation.keep_number=7
 
 #*****************************************************************
 # Miscellaneous configuration


### PR DESCRIPTION
This adds a section "Security Configuration" with explanations of all the
new enterprise security settings, and their default values commented out.
The security log settings are grouped under this new section, with just a
reference from the "Logging configuration" section.
