### PR TITLE
Added status code for AcquireLockTimeoutException

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -185,7 +185,9 @@ public interface Status
         LockClientStopped( TransientError,
                 "Transaction terminated, no more locks can be acquired." ),
         Terminated( TransientError,
-                "Explicitly terminated by the user." );
+                "Explicitly terminated by the user." ),
+        Interrupted( TransientError,
+                "Interrupted while waiting." );
 
         private final Code code;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/concurrent/LockWaitStrategies.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.util.concurrent;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
 
+import static org.neo4j.kernel.api.exceptions.Status.Transaction.Interrupted;
+
 public enum LockWaitStrategies implements WaitStrategy<AcquireLockTimeoutException>
 {
     SPIN
@@ -73,7 +75,7 @@ public enum LockWaitStrategies implements WaitStrategy<AcquireLockTimeoutExcepti
             catch(InterruptedException e)
             {
                 Thread.interrupted();
-                throw new AcquireLockTimeoutException( e , "Interrupted while waiting.");
+                throw new AcquireLockTimeoutException( e , "Interrupted while waiting.", Interrupted );
             }
         }
     };

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/AcquireLockTimeoutException.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/AcquireLockTimeoutException.java
@@ -19,19 +19,31 @@
  */
 package org.neo4j.storageengine.api.lock;
 
+import org.neo4j.kernel.api.exceptions.Status;
+
 /**
  * Acquiring a lock failed. This is a runtime exception now to ease the transition from the old lock interface, but
  * it should be made into a {@link org.neo4j.kernel.api.exceptions.KernelException} asap.
  */
-public class AcquireLockTimeoutException extends RuntimeException
+public class AcquireLockTimeoutException extends RuntimeException implements Status.HasStatus
 {
-    public AcquireLockTimeoutException( Throwable cause, String message, Object... parameters )
+    private final Status statusCode;
+
+    public AcquireLockTimeoutException( Throwable cause, String message, Status statusCode )
     {
-        super( String.format(message, parameters), cause );
+        super( message, cause );
+        this.statusCode = statusCode;
     }
 
-    public AcquireLockTimeoutException( String message )
+    public AcquireLockTimeoutException( String message, Status statusCode )
     {
         super( message );
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public Status status()
+    {
+        return statusCode;
     }
 }


### PR DESCRIPTION
to better help a client, i.e. a driver, to classify the error for end users.

AcquireLockTimeoutException is mainly used in CE to indicate that we cannot grab a lock on a `Leader`. There is a chance that we will get this exception if a leadership switch happened after we've checked that the server is the `Leader`, but before we really start to take a lock.
