### PR TITLE
Restructure security settings in neo4j.conf

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -117,7 +117,7 @@ public class SecuritySettings
                   "If no protocol is specified the default will be `ldap://`. To use LDAPS, " +
                   "set the protocol and port, e.g. `ldaps://ldap.example.com:636`" )
     public static final Setting<String> ldap_server =
-            setting( "dbms.security.ldap.host", STRING, "0.0.0.0:389" );
+            setting( "dbms.security.ldap.host", STRING, "localhost:389" );
 
     @Description( "Use secure communication with the LDAP server using opportunistic TLS. " +
             "First an initial insecure connection will be made with the LDAP server and a STARTTLS command will be " +

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -183,7 +183,7 @@ public class SecuritySettings
     @Description( "The name of the base object or named context to search for user objects when LDAP authorization is " +
                   "enabled." )
     public static Setting<String> ldap_authorization_user_search_base =
-            setting( "dbms.security.ldap.authorization.user_search_base", STRING, NO_DEFAULT );
+            setting( "dbms.security.ldap.authorization.user_search_base", STRING, "ou=users,dc=example,dc=com" );
 
     @Description( "The LDAP search filter to search for a user principal when LDAP authorization is " +
                   "enabled. The filter should contain the placeholder token {0} which will be substituted for the " +

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -130,7 +130,16 @@ dbms.directories.import=import
 # Maximum number of history files for the query log.
 #dbms.logs.query.rotation.keep_number=7
 
-# NOTE: There is also a security log. Its settings are listed separately under the "Security Configuration" section.
+# The security log is always enabled when `dbms.security.auth_enabled=true`, and resides in `logs/security.log`.
+
+# Threshold for rotation of the security log.
+#dbms.logs.security.rotation.size=20m
+
+# Minimum time interval after last rotation of the security log before it may be rotated again.
+#dbms.logs.security.rotation.delay=300s
+
+# Maximum number of history files for the security log.
+#dbms.logs.security.rotation.keep_number=7
 
 #*****************************************************************
 # Core-Edge Configuration
@@ -306,6 +315,20 @@ dbms.directories.import=import
 # i.e. `plugin-<AUTH_PROVIDER_NAME>`.
 #dbms.security.auth_provider=native
 
+# The time to live (TTL) for cached authentication and authorization info when using
+# external auth providers (ldap or plugin). Setting the TTL to 0 will
+# disable auth caching.
+#dbms.security.auth_cache_ttl=10m
+
+# The maximum capacity for authentication and authorization caches (respectively).
+#dbms.security.auth_cache_max_capacity=10000
+
+# Set to log successful authentication events to the security log.
+# If this is set to `false` only failed authentication events will be logged, which
+# could be useful if you find that the successful events spam the logs too much,
+# and you do not require full auditing capability.
+#dbms.security.log_successful_authentication=true
+
 #================================================
 # LDAP Auth Provider Configuration
 #================================================
@@ -416,38 +439,6 @@ dbms.directories.import=import
 #          "cn=Neo4j Read-Write,cn=users,dc=example,dc=com"     = publisher; \
 #          "cn=Neo4j Schema Manager,cn=users,dc=example,dc=com" = architect; \
 #          "cn=Neo4j Administrator,cn=users,dc=example,dc=com"  = admin
-
-#================================================
-# Auth Cache Configuration
-#================================================
-
-# The time to live (TTL) for cached authentication and authorization info when using
-# external auth providers (ldap or plugin). Setting the TTL to 0 will
-# disable auth caching.
-#dbms.security.auth_cache_ttl=10m
-
-# The maximum capacity for authentication and authorization caches (respectively).
-#dbms.security.auth_cache_max_capacity=10000
-
-#================================================
-# Security Log Configuration
-#================================================
-# The security log is always enabled and resides in `logs/security.log`.
-
-# Set to log successful authentication events.
-# If this is set to `false` only failed authentication events will be logged, which
-# could be useful if you find that the successful events spam the logs too much,
-# and you do not require full auditing capability.
-#dbms.security.log_successful_authentication=true
-
-# Threshold for rotation of the security log.
-#dbms.logs.security.rotation.size=20m
-
-# Minimum time interval after last rotation of the security log before it may be rotated again.
-#dbms.logs.security.rotation.delay=300s
-
-# Maximum number of history files for the security log.
-#dbms.logs.security.rotation.keep_number=7
 
 #*****************************************************************
 # Miscellaneous configuration

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -338,7 +338,7 @@ dbms.directories.import=import
 # To use LDAPS, set the protocol and port, e.g. `ldaps://ldap.example.com:636`
 # NOTE: You may want to consider using STARTTLS (`dbms.security.ldap.use_starttls`) over LDAPS
 # for secure connections, in which case the default port will be sufficient.
-#dbms.security.ldap.host=0.0.0.0:389
+#dbms.security.ldap.host=localhost:389
 
 # Use secure communication with the LDAP server using opportunistic TLS.
 # First an initial insecure connection will be made with the LDAP server, and then a STARTTLS command

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -414,9 +414,8 @@ dbms.directories.import=import
 #dbms.security.ldap.system_password=
 
 # The name of the base object or named context to search for user objects when LDAP authorization is enabled.
-# A common case is that this matches the last part of `dbms.security.ldap.user_dn_template`,
-# e.g. `ou=users,dc=example,dc=com`.
-#dbms.security.ldap.authorization.user_search_base=
+# A common case is that this matches the last part of `dbms.security.ldap.user_dn_template`.
+#dbms.security.ldap.authorization.user_search_base=ou=users,dc=example,dc=com
 
 # The LDAP search filter to search for a user principal when LDAP authorization is
 # enabled. The filter should contain the placeholder token {0} which will be substituted for the


### PR DESCRIPTION
- Move the security log settings to the Logging section, but keep the
  `dbms.security.log_successful_authentication` in the top section of the
  Security section.
- Remove the auth cache sub-section and move to the top section.
- Change the default value of ldap host setting to `localhost`
- Set the default value of ldap user search base setting to an example value.
