### PR TITLE
Fix "flaky test" StoreVersionCheckTest.shouldReportShortFileDoesNotHaveSpecifiedVersion

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -291,6 +291,10 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
                             {
                                 value = record.getValue();
                             }
+                            else
+                            {
+                                value = FIELD_NOT_PRESENT;
+                            }
                         }
                         while ( cursor.shouldRetry() );
                         if ( cursor.checkAndClearBoundsFlag() )


### PR DESCRIPTION
The problem is actually not with the test being "flaky", this is a legitimate bug exposed by the `AdversarialPageCache` (with a probability of 1/256).

The value read from the page on a faulty read would leak out of the `MetaDataStore.getRecord()` method if the subsequent correct read reported that the record was not in use.
Even though the `AdversarialPageCache` always exposes its user to faulty reads, in this particular use case the only read that mattered was the `inUse` byte (since the test expects this record to be not in use), and that byte will only take on the `IN_USE` value of `1` with a probability of 1/256. When that byte was found to be in use another `long` value (of garbled data) would be read from the page, which would then leak in the invoking method. In the subsequent read read from the page cache all data would be correct again, and the record would be found not to be in use. At this point the damage was already done, and the value had already been leaked.

The solution is to have the retry-loop reset the value to `FIELD_NOT_PRESENT` every time a record is found that is not in use.
