### PR TITLE
Use `neo4j-admin backup` in tests

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -31,8 +31,8 @@ public class AdminTool
 {
     public static void main( String[] args )
     {
-        Path homeDir = Paths.get( System.getenv( "NEO4J_HOME" ) );
-        Path configDir = Paths.get( System.getenv( "NEO4J_CONF" ) );
+        Path homeDir = Paths.get( System.getenv().getOrDefault( "NEO4J_HOME", "" ) );
+        Path configDir = Paths.get( System.getenv().getOrDefault( "NEO4J_CONF", "" ) );
         boolean debug = System.getenv( "NEO4J_DEBUG" ) != null;
 
         new AdminTool( CommandLocator.fromServiceLocator(), new RealOutsideWorld(), debug )

--- a/community/dbms/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
+++ b/community/dbms/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
@@ -61,10 +61,10 @@ public class ConfigLoader
                 settingsClassesSupplier );
     }
 
-    public Config loadOfflineConfig( Optional<File> homeDir, Optional<File> configFile,
-            Pair<String,String>... configOverrides )
+    public Config loadOfflineConfig( Optional<File> homeDir, Optional<File> configFile )
     {
-        return overrideBoltSettings( loadConfig( homeDir, configFile, configOverrides ) );
+        return overrideBoltSettings( loadConfig( homeDir, configFile,
+                Pair.of( GraphDatabaseSettings.auth_enabled.name(), Settings.FALSE ) ) );
     }
 
     private Map<String, String> calculateSettings( Optional<File> homeDir,

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.backup;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
@@ -31,11 +36,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
@@ -105,15 +106,14 @@ public class BackupEmbeddedIT
         startDb( null );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "-from",
-                        BackupTool.DEFAULT_SCHEME + "://" + ip, "-to",
-                        backupPath.getPath() ) );
+                runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
+                        "--to", backupPath.getPath() ) );
         assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
         createSomeData( db );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "-from", BackupTool.DEFAULT_SCHEME + "://"+ ip,
-                        "-to", backupPath.getPath() ) );
+                runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
+                        "--to", backupPath.getPath() ) );
         assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
     }
 
@@ -125,20 +125,19 @@ public class BackupEmbeddedIT
         startDb( "" + port );
         assertEquals(
                 1,
-                runBackupToolFromOtherJvmToGetExitCode( "-from",
-                        BackupTool.DEFAULT_SCHEME + "://" + ip, "-to",
-                        backupPath.getPath() ) );
+                runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
+                        "--to", backupPath.getPath() ) );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "-from",
-                        BackupTool.DEFAULT_SCHEME + "://" + ip + ":" + port,
-                        "-to", backupPath.getPath() ) );
+                runBackupToolFromOtherJvmToGetExitCode( "--from",
+                        ip + ":" + port,
+                        "--to", backupPath.getPath() ) );
         assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
         createSomeData( db );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "-from", BackupTool.DEFAULT_SCHEME + "://"+ ip +":"
-                                 + port, "-to",
+                runBackupToolFromOtherJvmToGetExitCode( "--from", ip +":"
+                                 + port, "--to",
                         backupPath.getPath() ) );
         assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
     }
@@ -159,7 +158,9 @@ public class BackupEmbeddedIT
             throws Exception
     {
         List<String> allArgs = new ArrayList<>( Arrays.asList(
-                ProcessUtil.getJavaExecutable().toString(), "-cp", ProcessUtil.getClassPath(), BackupTool.class.getName() ) );
+                ProcessUtil.getJavaExecutable().toString(), "-cp", ProcessUtil.getClassPath(),
+                AdminTool.class.getName() ) );
+        allArgs.add("backup");
         allArgs.addAll( Arrays.asList( args ) );
 
         Process process = Runtime.getRuntime().exec( allArgs.toArray( new String[allArgs.size()] ));


### PR DESCRIPTION
This removes a bunch of deprecation warnings from the test logs (and of
course stops using deprecated code).

Had to make sure `neo4j-admin` (and as a side-effect other tools too)
could be started by the tests where System.env won't have the variables
set by the wrapper script.

Adding the disabled `auth` setting for embedded offline configs was also
necessary, so the tests did not try to load classes which were not
available to the class loader.
