### PR TITLE
Enforce write privileges for token writes

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
@@ -21,11 +21,10 @@ package org.neo4j.cypher.internal.compiler.v3_1.executionplan.procs
 
 import org.neo4j.cypher.internal.compiler.v3_1.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_1.executionplan._
-import org.neo4j.cypher.internal.compiler.v3_1.spi.{FieldSignature, PlanContext, ProcedureSignature, QueryContext}
+import org.neo4j.cypher.internal.compiler.v3_1.spi.{PlanContext, QueryContext}
 import org.neo4j.cypher.internal.compiler.v3_1.{CompilationPhaseTracer, PreparedQuerySemantics, SyntaxExceptionCreator}
 import org.neo4j.cypher.internal.frontend.v3_1._
 import org.neo4j.cypher.internal.frontend.v3_1.ast._
-import org.neo4j.cypher.internal.frontend.v3_1.symbols.TypeSpec
 
 /**
   * This planner takes on queries that requires no planning such as procedures and schema commands
@@ -106,19 +105,6 @@ case class DelegatingProcedureExecutablePlanBuilder(delegate: ExecutablePlanBuil
   private def typeProp(ctx: QueryContext)(relType: RelTypeName, prop: PropertyKeyName) =
     (ctx.getOrCreateRelTypeId(relType.name), ctx.getOrCreatePropertyKeyId(prop.name))
 
-  private def typeCheck(semanticTable: SemanticTable)(exp: Expression, field: FieldSignature, proc: ProcedureSignature) = {
-    val actual = semanticTable.types(exp).actual
-    val expected = field.typ
-    val intersected = actual intersectOrCoerce expected.covariant
-    if (intersected == TypeSpec.none)
-      throw new CypherTypeException(
-        s"""Parameter `${field.name}` for procedure `${proc.name}`
-            |expects value of type $expected but got value of type ${actual.toShortString}.
-            |
-        |Usage: CALL ${proc.name}(${proc.inputSignature.map(s => s"<${s.name}>").mkString(", ")})
-            |${proc.inputSignature.map(s => s"    ${s.name} (type ${s.typ})").mkString("Parameters:" + System.lineSeparator(), System.lineSeparator(),"")}
-        """.stripMargin)
-  }
 }
 
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
@@ -200,6 +200,8 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
     inner.isGraphKernelResultValue(v)
 
   override def detachDeleteNode(node: Node): Int = manyDbHits(inner.detachDeleteNode(node))
+
+  override def assertSchemaWritesAllowed(): Unit = inner.assertSchemaWritesAllowed()
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
@@ -171,6 +171,9 @@ trait QueryContext extends TokenContext {
   def isGraphKernelResultValue(v: Any): Boolean
 
   def detachDeleteNode(node: Node): Int
+
+  def assertSchemaWritesAllowed(): Unit
+
 }
 
 trait Operations[T <: PropertyContainer] {

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
@@ -163,4 +163,6 @@ trait QueryContextAdaptation {
   override def getLabelId(labelName: String): Int = ???
 
   override def detachDeleteNode(node: Node): Int = ???
+
+  override def assertSchemaWritesAllowed(): Unit = ???
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
@@ -225,6 +225,8 @@ class ExceptionTranslatingQueryContextFor3_1(val inner: QueryContext) extends Qu
   override def detachDeleteNode(node: Node): Int =
     translateException(inner.detachDeleteNode(node))
 
+  override def assertSchemaWritesAllowed(): Unit = translateException(inner.assertSchemaWritesAllowed())
+
   class ExceptionTranslatingOperations[T <: PropertyContainer](inner: Operations[T])
     extends DelegatingOperations[T](inner) {
     override def delete(obj: T) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -690,6 +690,9 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
       case _: exceptions.EntityNotFoundException => 0 // node has been deleted by another transaction, oh well...
     }
   }
+
+  override def assertSchemaWritesAllowed(): Unit =
+    transactionalContext.statement.schemaWriteOperations()
 }
 
 object TransactionBoundQueryContext {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -160,7 +160,6 @@ class EagerizationAcceptanceTest
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
-            val relType = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName("KNOWS")
             val idX = input(0).asInstanceOf[Node].getId
             val idY = input(1).asInstanceOf[Node].getId
             val nodeCursor = statement.readOperations().nodeCursor(idX)
@@ -209,11 +208,9 @@ class EagerizationAcceptanceTest
           val transaction = ctx.get(proc.Context.KERNEL_TRANSACTION)
           val statement = transaction.acquireStatement()
           try {
-            val relType = statement.tokenWriteOperations().relationshipTypeGetOrCreateForName("KNOWS")
             val idX = input(0).asInstanceOf[Node].getId
             val idY = input(1).asInstanceOf[Node].getId
             val nodeCursor = statement.readOperations().nodeCursor(idX)
-            val result = Array.newBuilder[Array[AnyRef]]
             while (nodeCursor.next()) {
               val relCursor = nodeCursor.get().relationships( Direction.OUTGOING )
               while (relCursor.next()) {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -108,6 +108,12 @@ public class KernelStatement implements TxStateHolder, Statement
     public TokenWriteOperations tokenWriteOperations()
     {
         accessCapability.assertCanWrite();
+
+        if ( !transaction.mode().allowsWrites() )
+        {
+            throw transaction.mode().onViolation(
+                    String.format( "Write operations are not allowed for '%s'.", transaction.mode().name() ) );
+        }
         return facade;
     }
 


### PR DESCRIPTION
Cypher was recently changed to not perform token writes in read queries.
This commit adds a test that will fail if it would do so. It further enforces that
acquiring `TokenWriteOperations` requires the `AccessMode` to allow writes.

This PR adds a test for the change in #8100.
