### PR TITLE
Avoid neo4j crash when indexing long string

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
@@ -140,7 +140,7 @@ public abstract class IndexType
         {
             // TODO We should honor ValueContext instead of doing value.toString() here.
             // if changing it, also change #get to honor ValueContext.
-            document.add( new StringField( exactKey( key ), value.toString(), Store.YES ) );
+            document.add( new TextField( exactKey( key ), value.toString(), Store.YES ) ); // modified by ZHANG Hua, 2016-9-30
             document.add( instantiateField( key, value, TextField.TYPE_STORED ) );
             document.add( instantiateSortField( key, value ) );
         }
@@ -351,6 +351,9 @@ public abstract class IndexType
             {
                 field = new SortedNumericDocValuesField( key, number.longValue() );
             }
+        }
+        else if (value.toString().length() > 10240) { // 10240 < 10922=32766/3, modified by ZHANG Hua at 2016-9-30         
+            field = new BinaryDocValuesField( key, new BytesRef( value.toString() ) );        
         }
         else
         {


### PR DESCRIPTION
When string property byte array length is bigger than 32768, lucene will throw Exception due to LUCENE-5472 improvement, which leads neo4j engine stopped to response. This modification change StringField to TextField, and BinaryDocValuesField instead of SortedSetDocValuesField when longer than 10240 (for UTF8 encoding, the String bytes length are close to 10922=32766/3). It is only a workaround solution.
