### PR TITLE
Fix bug in core catchup

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -56,7 +56,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.neo4j.com.Protocol.addLengthFieldPipes;
 import static org.neo4j.com.Protocol.assertChunkSizeIsWithinFrameSize;
 import static org.neo4j.com.ResourcePool.DEFAULT_CHECK_INTERVAL;
-import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_TX_HANDLER;
+import static org.neo4j.com.storecopy.ResponseUnpacker.TxHandler.NO_OP_TX_HANDLER;
 import static org.neo4j.helpers.NamedThreadFactory.daemon;
 
 /**

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponseUnpacker.java
@@ -28,32 +28,12 @@ public interface ResponseUnpacker
      */
     void unpackResponse( Response<?> response, TxHandler txHandler ) throws Exception;
 
-    public static final ResponseUnpacker NO_OP_RESPONSE_UNPACKER = new ResponseUnpacker()
-    {
-        @Override
-        public void unpackResponse( Response<?> response, TxHandler txHandler )
-        {
-            txHandler.done();
-        }
-    };
+    ResponseUnpacker NO_OP_RESPONSE_UNPACKER = ( response, txHandler ) -> { /* Do nothing */ };
 
-    public interface TxHandler
+    interface TxHandler
     {
+        TxHandler NO_OP_TX_HANDLER = transactionId -> { /* Do nothing */ };
+
         void accept( long transactionId );
-
-        void done();
     }
-
-    public static final TxHandler NO_OP_TX_HANDLER = new TxHandler()
-    {
-        @Override
-        public void accept( long transactionId )
-        { // Do nothing
-        }
-
-        @Override
-        public void done()
-        { // Do nothing
-        }
-    };
 }

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -50,9 +50,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.neo4j.com.MadeUpServer.FRAME_LENGTH;
-import static org.neo4j.com.TxChecksumVerifier.ALWAYS_MATCH;
-import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_TX_HANDLER;
 import static org.neo4j.com.StoreIdTestFactory.newStoreIdForCurrentVersion;
+import static org.neo4j.com.TxChecksumVerifier.ALWAYS_MATCH;
+import static org.neo4j.com.storecopy.ResponseUnpacker.TxHandler.NO_OP_TX_HANDLER;
 
 public class TestCommunication
 {

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
@@ -39,7 +39,6 @@ import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
-import org.neo4j.kernel.impl.transaction.command.Commands;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
@@ -56,7 +55,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_TX_HANDLER;
+import static org.neo4j.com.storecopy.ResponseUnpacker.TxHandler.NO_OP_TX_HANDLER;
 import static org.neo4j.kernel.impl.transaction.log.LogPosition.UNSPECIFIED;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFetcher.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFetcher.java
@@ -66,7 +66,7 @@ public class StoreFetcher
     {
         ReadOnlyTransactionIdStore transactionIdStore = new ReadOnlyTransactionIdStore( pageCache, storeDir );
         long lastCommittedTxId = transactionIdStore.getLastCommittedTransactionId();
-        return pullTransactions( from, expectedStoreId, storeDir, lastCommittedTxId - 1 );
+        return pullTransactions( from, expectedStoreId, storeDir, lastCommittedTxId );
     }
 
     private CatchupResult pullTransactions( MemberId from, StoreId expectedStoreId, File storeDir, long fromTxId ) throws IOException, StoreCopyFailedException
@@ -88,7 +88,8 @@ public class StoreFetcher
         try
         {
             log.info( "Copying store from %s", from );
-            long lastFlushedTxId = storeCopyClient.copyStoreFiles( from, expectedStoreId, new StreamToDisk( destDir, fs ) );
+            long lastFlushedTxId =
+                    storeCopyClient.copyStoreFiles( from, expectedStoreId, new StreamToDisk( destDir, fs ) );
 
             // We require at least one transaction for extracting the log index of the consensus log.
             // Given there might not have been any activity on the source server we need to ask for the

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
@@ -24,25 +24,15 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.FileUtils;
 
 public class StoreFiles
 {
-    private static final FilenameFilter STORE_FILE_FILTER = new FilenameFilter()
+    private static final FilenameFilter STORE_FILE_FILTER = ( dir, name ) ->
     {
-        @Override
-        public boolean accept( File dir, String name )
-        {
-            // Skip log files and tx files from temporary database
-            return !(
-                    name.startsWith( "metrics" ) ||
-                            name.startsWith( "temp-copy" ) ||
-                            name.startsWith( "raft-messages." ) ||
-                            name.startsWith( "debug." ) ||
-                            name.startsWith( "cluster-state" ) ||
-                            name.startsWith( "store_lock" )
-            );
-        }
+        // Skip log files and tx files from temporary database
+        return !name.startsWith( "metrics" ) && !name.startsWith( "temp-copy" ) &&
+                !name.startsWith( "raft-messages." ) && !name.startsWith( "debug." ) &&
+                !name.startsWith( "cluster-state" ) && !name.startsWith( "store_lock" );
     };
     private FileSystemAbstraction fs;
 
@@ -55,16 +45,16 @@ public class StoreFiles
     {
         for ( File file : fs.listFiles( storeDir, STORE_FILE_FILTER ) )
         {
-            FileUtils.deleteRecursively( file );
+            fs.deleteRecursively( file );
         }
 
     }
 
-    public void moveTo( File source, File target ) throws IOException
+    void moveTo( File source, File target ) throws IOException
     {
         for ( File candidate : fs.listFiles( source, STORE_FILE_FILTER ) )
         {
-            FileUtils.moveFileToDirectory( candidate, target );
+            fs.moveToDirectory( candidate, target );
         }
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/core/state/snapshot/CoreStateDownloader.java
@@ -108,7 +108,8 @@ public class CoreStateDownloader
             }
             else
             {
-                CatchupResult catchupResult = storeFetcher.tryCatchingUp( source, localStoreId, localDatabase.storeDir() );
+                CatchupResult catchupResult =
+                        storeFetcher.tryCatchingUp( source, localStoreId, localDatabase.storeDir() );
 
                 if ( catchupResult == E_TRANSACTION_PRUNED )
                 {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
@@ -193,7 +193,7 @@ public class MasterClient214 extends Client<Master> implements MasterClient
     @Override
     public Response<Void> pullUpdates( RequestContext context )
     {
-        return pullUpdates( context, ResponseUnpacker.NO_OP_TX_HANDLER );
+        return pullUpdates( context, ResponseUnpacker.TxHandler.NO_OP_TX_HANDLER );
     }
 
     @Override
@@ -210,7 +210,7 @@ public class MasterClient214 extends Client<Master> implements MasterClient
         Deserializer<HandshakeResult> deserializer =
                 ( buffer, temporaryBuffer ) -> new HandshakeResult( buffer.readLong(), buffer.readLong() );
         return sendRequest( requestTypes.type( HaRequestTypes.Type.HANDSHAKE ), RequestContext.EMPTY,
-                serializer, deserializer, storeId, ResponseUnpacker.NO_OP_TX_HANDLER );
+                serializer, deserializer, storeId, ResponseUnpacker.TxHandler.NO_OP_TX_HANDLER );
     }
 
     @Override

--- a/stresstests/src/test/java/org/neo4j/coreedge/stresstests/BackupLoad.java
+++ b/stresstests/src/test/java/org/neo4j/coreedge/stresstests/BackupLoad.java
@@ -35,10 +35,10 @@ class BackupLoad extends RepeatUntilOnSelectedMemberCallable
     private final File baseDirectory;
     private final BiFunction<Boolean,Integer,SocketAddress> backupAddress;
 
-    BackupLoad( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster, File baseDirectory,
-            BiFunction<Boolean,Integer,SocketAddress> backupAddress )
+    BackupLoad( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster, int numberOfCores, int numberOfEdges,
+            File baseDirectory, BiFunction<Boolean,Integer,SocketAddress> backupAddress )
     {
-        super( keepGoing, onFailure, cluster, cluster.edgeMembers().isEmpty() );
+        super( keepGoing, onFailure, cluster, numberOfCores, numberOfEdges );
         this.baseDirectory = baseDirectory;
         this.backupAddress = backupAddress;
     }

--- a/stresstests/src/test/java/org/neo4j/coreedge/stresstests/BackupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/coreedge/stresstests/BackupStoreCopyInteractionStressTesting.java
@@ -50,6 +50,7 @@ import static org.neo4j.StressTestingHelper.prettyPrintStackTrace;
 import static org.neo4j.coreedge.stresstests.ClusterConfiguration.configureBackup;
 import static org.neo4j.coreedge.stresstests.ClusterConfiguration.configureRaftLogRotationAndPruning;
 import static org.neo4j.coreedge.stresstests.ClusterConfiguration.configureTxLogRotationAndPruning;
+import static org.neo4j.coreedge.stresstests.ClusterConfiguration.enableRaftMessageLogging;
 import static org.neo4j.function.Suppliers.untilTimeExpired;
 
 public class BackupStoreCopyInteractionStressTesting
@@ -83,8 +84,8 @@ public class BackupStoreCopyInteractionStressTesting
         BiFunction<Boolean,Integer,SocketAddress> backupAddress = ( isCore, id ) ->
                 new AdvertisedSocketAddress( "localhost", (isCore ? baseCoreBackupPort : baseEdgeBackupPort) + id );
 
-        Map<String,String> coreParams =
-                configureRaftLogRotationAndPruning( configureTxLogRotationAndPruning( new HashMap<>() ) );
+        Map<String,String> coreParams = enableRaftMessageLogging(
+                configureRaftLogRotationAndPruning( configureTxLogRotationAndPruning( new HashMap<>() ) ) );
         Map<String,String> edgeParams = configureTxLogRotationAndPruning( new HashMap<>() );
 
         Map<String,IntFunction<String>> instanceCoreParams =

--- a/stresstests/src/test/java/org/neo4j/coreedge/stresstests/ClusterConfiguration.java
+++ b/stresstests/src/test/java/org/neo4j/coreedge/stresstests/ClusterConfiguration.java
@@ -32,6 +32,12 @@ import static org.neo4j.kernel.configuration.Settings.TRUE;
 
 class ClusterConfiguration
 {
+    static Map<String,String> enableRaftMessageLogging( Map<String,String> settings )
+    {
+        settings.put( CoreEdgeClusterSettings.raft_messages_log_enable.name(), Settings.TRUE );
+        return settings;
+    }
+
     static Map<String,String> configureRaftLogRotationAndPruning( Map<String,String> settings )
     {
         settings.put( CoreEdgeClusterSettings.raft_log_rotation_size.name(), "1K" );

--- a/stresstests/src/test/java/org/neo4j/coreedge/stresstests/RepeatUntilOnSelectedMemberCallable.java
+++ b/stresstests/src/test/java/org/neo4j/coreedge/stresstests/RepeatUntilOnSelectedMemberCallable.java
@@ -30,22 +30,25 @@ abstract class RepeatUntilOnSelectedMemberCallable extends RepeatUntilCallable
 {
     private final Random random = new Random();
     final Cluster cluster;
-    private final boolean onlyCores;
+    private final int numberOfCores;
+    private final int numberOfEdges;
 
-    RepeatUntilOnSelectedMemberCallable( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster, boolean onlyCores )
+    RepeatUntilOnSelectedMemberCallable( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster,
+            int numberOfCores, int numberOfEdges )
     {
         super( keepGoing , onFailure );
         this.cluster = cluster;
-        this.onlyCores = onlyCores;
+        this.numberOfCores = numberOfCores;
+        this.numberOfEdges = numberOfEdges;
     }
 
     @Override
     protected final void doWork()
     {
-        boolean isCore = onlyCores || random.nextBoolean();
+        boolean isCore = numberOfEdges == 0 || random.nextBoolean();
         Collection<? extends ClusterMember> members = isCore ? cluster.coreMembers() : cluster.edgeMembers();
         assert !members.isEmpty();
-        int id = random.nextInt( members.size() );
+        int id = random.nextInt( isCore ? numberOfCores : numberOfEdges );
         doWorkOnMember( isCore, id );
     }
 

--- a/stresstests/src/test/java/org/neo4j/coreedge/stresstests/StartStopLoad.java
+++ b/stresstests/src/test/java/org/neo4j/coreedge/stresstests/StartStopLoad.java
@@ -27,9 +27,10 @@ import org.neo4j.coreedge.discovery.ClusterMember;
 
 class StartStopLoad extends RepeatUntilOnSelectedMemberCallable
 {
-    StartStopLoad( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster )
+    StartStopLoad( BooleanSupplier keepGoing, Runnable onFailure, Cluster cluster, int numberOfCores,
+            int numberOfEdges )
     {
-        super( keepGoing, onFailure, cluster, cluster.edgeMembers().isEmpty() );
+        super( keepGoing, onFailure, cluster, numberOfCores, numberOfEdges );
     }
 
     @Override


### PR DESCRIPTION
Off-by-one bug that was causing core to pull an extra transaction causing duplication of transaction in the transaction log.  This should fix incremental backup.
