### PR TITLE
Improved `http.log` output in case of nulls

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
+++ b/community/server/src/main/java/org/neo4j/server/web/AsyncRequestLog.java
@@ -43,6 +43,8 @@ import org.neo4j.logging.RotatingFileOutputStreamSupplier;
 import org.neo4j.logging.async.AsyncLogEvent;
 import org.neo4j.logging.async.AsyncLogProvider;
 
+import static org.apache.commons.lang.StringUtils.defaultString;
+
 public class AsyncRequestLog
         extends AbstractLifeCycle
         implements RequestLog, Consumer<AsyncLogEvent>, AsyncEvents.Monitor
@@ -83,7 +85,15 @@ public class AsyncRequestLog
         long serviceTime = requestTimeStamp < 0 ? -1 : now - requestTimeStamp;
 
         log.info( "%s - %s [%tc] \"%s\" %s %s \"%s\" \"%s\" %s",
-                remoteHost, user, now, requestURL, statusCode, length, referer, userAgent, serviceTime );
+                defaultString( remoteHost ),
+                defaultString( user ),
+                now,
+                defaultString( requestURL ),
+                statusCode,
+                length,
+                defaultString( referer ),
+                defaultString( userAgent ),
+                serviceTime );
     }
 
     private <T> T swallowExceptions( HttpServletRequest outerRequest, Function<HttpServletRequest, T> function )


### PR DESCRIPTION
Tries to replicate prior art and prints empty string instead "null" in
case of uninitialized values.
