### PR TITLE
Reload commit process on edges after a database copy

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/edge/EnterpriseEdgeEditionModule.java
@@ -183,8 +183,8 @@ public class EnterpriseEdgeEditionModule extends EditionModule
 
         LifeSupport txPulling = new LifeSupport();
         int maxBatchSize = config.get( CoreEdgeClusterSettings.edge_transaction_applier_batch_size );
-        BatchingTxApplier batchingTxApplier = new BatchingTxApplier( maxBatchSize, dependencies.provideDependency(
-                TransactionIdStore.class ),
+        BatchingTxApplier batchingTxApplier = new BatchingTxApplier( maxBatchSize,
+                dependencies.provideDependency( TransactionIdStore.class ),
                 writableCommitProcess, databaseHealthSupplier, platformModule.monitors, logProvider );
         ContinuousJob txApplyJob = new ContinuousJob( platformModule.jobScheduler, new JobScheduler.Group(
                 "tx-applier", NEW_THREAD ), batchingTxApplier, logProvider );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPollingClientTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPollingClientTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
-import java.util.concurrent.TimeUnit;
 
 import org.neo4j.coreedge.catchup.CatchUpClient;
 import org.neo4j.coreedge.catchup.CatchUpResponseCallback;
@@ -43,7 +42,6 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -157,7 +155,7 @@ public class TxPollingClientTest
         verify( localDatabase ).stop();
         verify( storeFetcher ).copyStore( any( MemberId.class ), eq( storeId ), any( File.class ) );
         verify( localDatabase ).start();
-        verify( txApplier ).refreshLastAppliedTx();
+        verify( txApplier ).refreshFromNewStore();
         verify( timeoutService.getTimeout( TX_PULLER_TIMEOUT ),
                 times( 2 ) /* at the beginning and after store copy */ ).renew();
     }


### PR DESCRIPTION
After a store copy the tx batch applier has to refresh its commit
process unless it is not able to apply transaction against the new
store.
