### PR TITLE
Log exception when transaction metadata can't be found during migration

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -53,6 +53,11 @@ public interface TransactionIdStore
     long BASE_TX_COMMIT_TIMESTAMP = 0;
 
     /**
+     * CONSTANT FOR UNKNOWN TX CHECKSUM
+     */
+    long UNKNOWN_TX_CHECKSUM = 1;
+
+    /**
      * Timestamp value used when record in the metadata store is not present and there are no transactions in logs.
      */
     long UNKNOWN_TX_COMMIT_TIMESTAMP = 1;


### PR DESCRIPTION
Log exception in case of exception during store update when transaction can't be found in legacy logs.
Use UNKNOWN_TX_CHECKSUM as checksum of transaction in that case.
