### PR TITLE
Traces calls to free() in EFSA

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -75,7 +75,7 @@ import static java.util.Arrays.asList;
 
 public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 {
-    private Clock clock;
+    private final Clock clock;
 
     interface Positionable
     {
@@ -551,7 +551,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         for ( File name : names )
         {
             EphemeralFileData file = files.get( name );
-            ByteBuffer buf = file.fileAsBuffer.buf;
+            ByteBuffer buf = file.fileAsBuffer.buf();
             buf.position( 0 );
             while ( buf.position() < buf.limit() )
             {
@@ -902,7 +902,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         private int size;
         private int forcedSize;
         private int locked;
-        private Clock clock;
+        private final Clock clock;
         private long lastModified;
 
         public EphemeralFileData( Clock clock )
@@ -1108,10 +1108,17 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         private static final int[] SIZES;
         private static final byte[] zeroBuffer = new byte[1024];
         private ByteBuffer buf;
+        private Exception freeCall;
 
         public DynamicByteBuffer()
         {
             buf = allocate( 0 );
+        }
+
+        public ByteBuffer buf()
+        {
+            assertNotFreed();
+            return buf;
         }
 
         /** This is a copying constructor, the input buffer is just read from, never stored in 'this'. */
@@ -1199,6 +1206,8 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
         void free()
         {
+            assertNotFreed();
+
             try
             {
                 clear();
@@ -1206,11 +1215,13 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             finally
             {
                 buf = null;
+                freeCall = new Exception();
             }
         }
 
         synchronized void put( int pos, byte[] bytes, int offset, int length )
         {
+            assertNotFreed();
             verifySize( pos + length );
             try
             {
@@ -1225,12 +1236,14 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
         synchronized void get( int pos, byte[] scratchPad, int i, int howMuchToReadThisTime )
         {
+            assertNotFreed();
             buf.position( pos );
             buf.get( scratchPad, i, howMuchToReadThisTime );
         }
 
         synchronized void fillWithZeros( int pos, int bytes )
         {
+            assertNotFreed();
             buf.position( pos );
             while ( bytes > 0 )
             {
@@ -1246,6 +1259,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
          */
         private void verifySize( int totalAmount )
         {
+            assertNotFreed();
             if ( buf.capacity() >= totalAmount )
             {
                 return;
@@ -1269,11 +1283,24 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
         public void clear()
         {
+            assertNotFreed();
             this.buf.clear();
+        }
+
+        private void assertNotFreed()
+        {
+            if ( this.buf == null )
+            {
+                String message = "This buffer have been freed";
+                throw this.freeCall != null
+                        ? new IllegalStateException( message, freeCall )
+                        : new IllegalStateException( message );
+            }
         }
 
         void dump( OutputStream target, byte[] scratchPad, int size ) throws IOException
         {
+            assertNotFreed();
             buf.position( 0 );
             while ( size > 0 )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/FreeIdKeeperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/FreeIdKeeperTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
@@ -26,9 +27,8 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -43,6 +43,9 @@ import static org.neo4j.kernel.impl.store.id.FreeIdKeeper.NO_RESULT;
 
 public class FreeIdKeeperTest
 {
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
     @Test
     public void newlyConstructedInstanceShouldReportProperDefaultValues() throws Exception
     {
@@ -100,7 +103,6 @@ public class FreeIdKeeperTest
     public void shouldOnlyOverflowWhenThresholdIsReached() throws Exception
     {
         // Given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = spy( fs.open( new File( "id.file" ), "rw" ) );
 
         int threshold = 10;
@@ -128,7 +130,6 @@ public class FreeIdKeeperTest
     public void shouldReadBackPersistedIdsWhenAggressiveReuseIsSet() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -153,7 +154,6 @@ public class FreeIdKeeperTest
     public void shouldReadBackManyPersistedIdBatchesWhenAggressiveReuseIsSet() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -182,7 +182,6 @@ public class FreeIdKeeperTest
     {
         // this is testing the stack property, but from the viewpoint of avoiding unnecessary disk reads
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -219,7 +218,6 @@ public class FreeIdKeeperTest
     public void persistedIdsShouldStillBeCounted() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -247,7 +245,6 @@ public class FreeIdKeeperTest
     public void shouldStoreAndRestoreIds() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -291,7 +288,6 @@ public class FreeIdKeeperTest
     public void shouldNotReturnNewlyReleasedIdsIfAggressiveIsFalse() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File( "id.file" ), "rw" );
 
         int threshold = 10;
@@ -309,7 +305,6 @@ public class FreeIdKeeperTest
     public void shouldNotReturnIdsPersistedDuringThisRunIfAggressiveIsFalse() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = spy( fs.open( new File( "id.file" ), "rw" ) );
 
         int threshold = 10;
@@ -333,7 +328,6 @@ public class FreeIdKeeperTest
     public void shouldReturnIdsRestoredAndIgnoreNewlyReleasedIfAggressiveReuseIsFalse() throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File("id.file" ), "rw" );
 
         int threshold = 10;
@@ -374,7 +368,6 @@ public class FreeIdKeeperTest
             throws Exception
     {
         // given
-        FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
         StoreChannel channel = fs.open( new File("id.file" ), "rw" );
 
         int threshold = 10;

--- a/community/kernel/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/fs/EphemeralFileSystemRule.java
@@ -21,13 +21,25 @@ package org.neo4j.test.rule.fs;
 
 import org.junit.rules.ExternalResource;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.CopyOption;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
 
-public class EphemeralFileSystemRule extends ExternalResource implements Supplier<FileSystemAbstraction>
+public class EphemeralFileSystemRule extends ExternalResource implements Supplier<FileSystemAbstraction>,
+        FileSystemAbstraction
 {
     private EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
 
@@ -67,5 +79,197 @@ public class EphemeralFileSystemRule extends ExternalResource implements Supplie
     public static Runnable shutdownDbAction( final GraphDatabaseService db )
     {
         return () -> db.shutdown();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return fs.hashCode();
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        return fs.equals( obj );
+    }
+
+    public void crash()
+    {
+        fs.crash();
+    }
+
+    public void shutdown()
+    {
+        fs.shutdown();
+    }
+
+    public void assertNoOpenFiles() throws Exception
+    {
+        fs.assertNoOpenFiles();
+    }
+
+    public void dumpZip( OutputStream output ) throws IOException
+    {
+        fs.dumpZip( output );
+    }
+
+    @Override
+    public StoreChannel open( File fileName, String mode ) throws IOException
+    {
+        return fs.open( fileName, mode );
+    }
+
+    @Override
+    public OutputStream openAsOutputStream( File fileName, boolean append ) throws IOException
+    {
+        return fs.openAsOutputStream( fileName, append );
+    }
+
+    @Override
+    public InputStream openAsInputStream( File fileName ) throws IOException
+    {
+        return fs.openAsInputStream( fileName );
+    }
+
+    @Override
+    public Reader openAsReader( File fileName, Charset charset ) throws IOException
+    {
+        return fs.openAsReader( fileName, charset );
+    }
+
+    @Override
+    public String toString()
+    {
+        return fs.toString();
+    }
+
+    @Override
+    public Writer openAsWriter( File fileName, Charset charset, boolean append ) throws IOException
+    {
+        return fs.openAsWriter( fileName, charset, append );
+    }
+
+    @Override
+    public StoreChannel create( File fileName ) throws IOException
+    {
+        return fs.create( fileName );
+    }
+
+    @Override
+    public long getFileSize( File fileName )
+    {
+        return fs.getFileSize( fileName );
+    }
+
+    @Override
+    public boolean fileExists( File file )
+    {
+        return fs.fileExists( file );
+    }
+
+    @Override
+    public boolean isDirectory( File file )
+    {
+        return fs.isDirectory( file );
+    }
+
+    @Override
+    public boolean mkdir( File directory )
+    {
+        return fs.mkdir( directory );
+    }
+
+    @Override
+    public void mkdirs( File directory )
+    {
+        fs.mkdirs( directory );
+    }
+
+    @Override
+    public boolean deleteFile( File fileName )
+    {
+        return fs.deleteFile( fileName );
+    }
+
+    @Override
+    public void deleteRecursively( File directory ) throws IOException
+    {
+        fs.deleteRecursively( directory );
+    }
+
+    @Override
+    public void renameFile( File from, File to, CopyOption... copyOptions ) throws IOException
+    {
+        fs.renameFile( from, to, copyOptions );
+    }
+
+    @Override
+    public File[] listFiles( File directory )
+    {
+        return fs.listFiles( directory );
+    }
+
+    @Override
+    public File[] listFiles( File directory, FilenameFilter filter )
+    {
+        return fs.listFiles( directory, filter );
+    }
+
+    @Override
+    public void moveToDirectory( File file, File toDirectory ) throws IOException
+    {
+        fs.moveToDirectory( file, toDirectory );
+    }
+
+    @Override
+    public void copyFile( File from, File to ) throws IOException
+    {
+        fs.copyFile( from, to );
+    }
+
+    @Override
+    public void copyRecursively( File fromDirectory, File toDirectory ) throws IOException
+    {
+        fs.copyRecursively( fromDirectory, toDirectory );
+    }
+
+    public EphemeralFileSystemAbstraction snapshot()
+    {
+        return fs.snapshot();
+    }
+
+    public void copyRecursivelyFromOtherFs( File from, FileSystemAbstraction fromFs, File to ) throws IOException
+    {
+        fs.copyRecursivelyFromOtherFs( from, fromFs, to );
+    }
+
+    public long checksum()
+    {
+        return fs.checksum();
+    }
+
+    @Override
+    public <K extends ThirdPartyFileSystem> K getOrCreateThirdPartyFileSystem( Class<K> clazz,
+            Function<Class<K>,K> creator )
+    {
+        return fs.getOrCreateThirdPartyFileSystem( clazz, creator );
+    }
+
+    @Override
+    public void truncate( File file, long size ) throws IOException
+    {
+        fs.truncate( file, size );
+    }
+
+    @Override
+    public long lastModifiedTime( File file ) throws IOException
+    {
+        return fs.lastModifiedTime( file );
+    }
+
+    @Override
+    public void deleteFileOrThrow( File file ) throws IOException
+    {
+        fs.deleteFileOrThrow( file );
     }
 }


### PR DESCRIPTION
and includes that stack trace as cause in exception thrown when accessing
freed buffer later on. This to more easily track down bugs in tests.
