### PR TITLE
Fixes a race condition creating input groups in importer

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IdGroup.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IdGroup.java
@@ -61,6 +61,6 @@ class IdGroup
     @Override
     public String toString()
     {
-        return group.toString();
+        return "[" + group.toString() + ",lowDataIndex:" + lowDataIndex + ",highDataIndex:" + highDataIndex + "]";
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
@@ -38,7 +38,7 @@ public class Groups
      * This method also prevents mixing global and non-global groups, i.e. if first call is {@code null},
      * then consecutive calls have to specify {@code null} name as well. The same holds true for non-null values.
      */
-    public Group getOrCreate( String name )
+    public synchronized Group getOrCreate( String name )
     {
         boolean global = name == null;
         if ( globalMode == null )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
@@ -106,8 +106,8 @@ public class InputRelationship extends InputEntity
     protected void toStringFields( Collection<Pair<String, ?>> fields )
     {
         super.toStringFields( fields );
-        fields.add( Pair.of( "startNode", startNode ) );
-        fields.add( Pair.of( "endNode", endNode ) );
+        fields.add( Pair.of( "startNode", startNode + " (" + startNodeGroup.name() + ")" ) );
+        fields.add( Pair.of( "endNode", endNode + " (" + endNodeGroup.name() + ")" ) );
         if ( hasTypeId() )
         {
             fields.add( Pair.of( "typeId", typeId ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -34,6 +34,9 @@ import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
 
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DeserializerFactories.defaultNodeDeserializer;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DeserializerFactories.defaultRelationshipDeserializer;
+
 /**
  * Provides {@link Input} from data contained in tabular/csv form. Expects factories for instantiating
  * the {@link CharSeeker} objects seeking values in the csv data and header factories for how to
@@ -108,13 +111,7 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputNode> iterator()
             {
-                DeserializerFactory<InputNode> factory = (dataHeader, dataStream, decorator, validator) ->
-                {
-                        InputNodeDeserialization deserialization =
-                                new InputNodeDeserialization( dataHeader, dataStream, groups, idType.idsAreExternal() );
-                        return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
-                                deserialization, decorator, validator, badCollector );
-                };
+                DeserializerFactory<InputNode> factory = defaultNodeDeserializer( groups, config, idType, badCollector );
                 return new InputGroupsDeserializer<>( nodeDataFactory.iterator(), nodeHeaderFactory, config,
                         idType, maxProcessors, 1, factory, Validators.<InputNode>emptyValidator(), InputNode.class );
             }
@@ -135,13 +132,8 @@ public class CsvInput implements Input
             @Override
             public InputIterator<InputRelationship> iterator()
             {
-                DeserializerFactory<InputRelationship> factory = (dataHeader, dataStream, decorator, validator) ->
-                {
-                        InputRelationshipDeserialization deserialization =
-                                new InputRelationshipDeserialization( dataHeader, dataStream, groups );
-                        return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
-                                deserialization, decorator, validator, badCollector );
-                };
+                DeserializerFactory<InputRelationship> factory =
+                        defaultRelationshipDeserializer( groups, config, idType, badCollector );
                 return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(), relationshipHeaderFactory,
                         config, idType, maxProcessors, 1, factory, new InputRelationshipValidator(),
                         InputRelationship.class );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -116,7 +116,7 @@ public class CsvInput implements Input
                                 deserialization, decorator, validator, badCollector );
                 };
                 return new InputGroupsDeserializer<>( nodeDataFactory.iterator(), nodeHeaderFactory, config,
-                        idType, maxProcessors, factory, Validators.<InputNode>emptyValidator(), InputNode.class );
+                        idType, maxProcessors, 1, factory, Validators.<InputNode>emptyValidator(), InputNode.class );
             }
 
             @Override
@@ -143,7 +143,7 @@ public class CsvInput implements Input
                                 deserialization, decorator, validator, badCollector );
                 };
                 return new InputGroupsDeserializer<>( relationshipDataFactory.iterator(), relationshipHeaderFactory,
-                        config, idType, maxProcessors, factory, new InputRelationshipValidator(),
+                        config, idType, maxProcessors, 1, factory, new InputRelationshipValidator(),
                         InputRelationship.class );
             }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DeserializerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DeserializerFactories.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input.csv;
+
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.DeserializerFactory;
+
+/**
+ * Common {@link DeserializerFactory} implementations.
+ */
+public class DeserializerFactories
+{
+    public static DeserializerFactory<InputNode> defaultNodeDeserializer(
+            Groups groups, Configuration config, IdType idType, Collector badCollector )
+    {
+        return (header,stream,decorator,validator) ->
+        {
+            InputNodeDeserialization deserialization =
+                    new InputNodeDeserialization( header, stream, groups, idType.idsAreExternal() );
+            return new InputEntityDeserializer<>( header, stream, config.delimiter(),
+                    deserialization, decorator, validator, badCollector );
+        };
+    }
+
+    public static DeserializerFactory<InputRelationship> defaultRelationshipDeserializer(
+            Groups groups, Configuration config, IdType idType, Collector badCollector )
+    {
+        return (header,stream,decorator,validator) ->
+        {
+                InputRelationshipDeserialization deserialization =
+                        new InputRelationshipDeserialization( header, stream, groups );
+                return new InputEntityDeserializer<>( header, stream, config.delimiter(),
+                        deserialization, decorator, validator, badCollector );
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -60,7 +60,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
     }
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
-            Configuration config, IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory,
+            Configuration config, IdType idType, int maxProcessors, int processors, DeserializerFactory<ENTITY> factory,
             Validator<ENTITY> validator, Class<ENTITY> entityClass )
     {
         super( dataFactory );
@@ -68,6 +68,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
         this.config = config;
         this.idType = idType;
         this.maxProcessors = maxProcessors;
+        this.previousInputProcessors = processors;
         this.factory = factory;
         this.validator = validator;
         this.entityClass = entityClass;
@@ -111,8 +112,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
             // complete rows of data and can be parsed individually by multiple threads.
 
             currentInput = new ParallelInputEntityDeserializer<>( data, headerFactory, config, idType,
-                    maxProcessors, factory, validator, entityClass );
-            currentInput.processors( previousInputProcessors );
+                    maxProcessors, previousInputProcessors, factory, validator, entityClass );
             currentInputOpen = true;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializer.java
@@ -45,7 +45,7 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
     private final IdType idType;
     private InputIterator<ENTITY> currentInput = new InputIterator.Empty<>();
     private long previousInputsCollectivePositions;
-    private int previousInputProcessors = 1;
+    private int previousInputProcessors;
     private boolean currentInputOpen;
     private final int maxProcessors;
     private final DeserializerFactory<ENTITY> factory;
@@ -60,15 +60,15 @@ class InputGroupsDeserializer<ENTITY extends InputEntity>
     }
 
     InputGroupsDeserializer( Iterator<DataFactory<ENTITY>> dataFactory, Header.Factory headerFactory,
-            Configuration config, IdType idType, int maxProcessors, int processors, DeserializerFactory<ENTITY> factory,
-            Validator<ENTITY> validator, Class<ENTITY> entityClass )
+            Configuration config, IdType idType, int maxProcessors, int initialProcessors,
+            DeserializerFactory<ENTITY> factory, Validator<ENTITY> validator, Class<ENTITY> entityClass )
     {
         super( dataFactory );
         this.headerFactory = headerFactory;
         this.config = config;
         this.idType = idType;
         this.maxProcessors = maxProcessors;
-        this.previousInputProcessors = processors;
+        this.previousInputProcessors = initialProcessors;
         this.factory = factory;
         this.validator = validator;
         this.entityClass = entityClass;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -68,7 +68,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
 
     @SuppressWarnings( "unchecked" )
     public ParallelInputEntityDeserializer( Data<ENTITY> data, Header.Factory headerFactory, Configuration config,
-            IdType idType, int maxProcessors, int processors, DeserializerFactory<ENTITY> factory,
+            IdType idType, int maxProcessors, int initialProcessors, DeserializerFactory<ENTITY> factory,
             Validator<ENTITY> validator, Class<ENTITY> entityClass )
     {
         // Reader of chunks, characters aligning to nearest newline
@@ -110,7 +110,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
                 return entities.toArray( (ENTITY[]) Array.newInstance( entityClass, entities.size() ) );
             },
             () -> dataHeader.clone() /*We need to clone the stateful header to each processing thread*/ );
-            processing.processors( processors - processing.processors( 0 ) );
+            processing.processors( initialProcessors - processing.processors( 0 ) );
 
             // Utility cursor which takes care of moving over processed results from chunk to chunk
             Supplier<ENTITY[]> batchSupplier = rebaseBatches( processing );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -68,7 +68,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
 
     @SuppressWarnings( "unchecked" )
     public ParallelInputEntityDeserializer( Data<ENTITY> data, Header.Factory headerFactory, Configuration config,
-            IdType idType, int maxProcessors, DeserializerFactory<ENTITY> factory,
+            IdType idType, int maxProcessors, int processors, DeserializerFactory<ENTITY> factory,
             Validator<ENTITY> validator, Class<ENTITY> entityClass )
     {
         // Reader of chunks, characters aligning to nearest newline
@@ -110,6 +110,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
                 return entities.toArray( (ENTITY[]) Array.newInstance( entityClass, entities.size() ) );
             },
             () -> dataHeader.clone() /*We need to clone the stateful header to each processing thread*/ );
+            processing.processors( processors - processing.processors( 0 ) );
 
             // Utility cursor which takes care of moving over processed results from chunk to chunk
             Supplier<ENTITY[]> batchSupplier = rebaseBatches( processing );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import org.junit.Test;
+
+import org.neo4j.test.Race;
+
+import static org.junit.Assert.assertEquals;
+
+public class GroupsTest
+{
+    @Test
+    public void shouldHandleConcurrentGetOrCreate() throws Throwable
+    {
+        // GIVEN
+        Groups groups = new Groups();
+        Race race = new Race();
+        String name = "MyGroup";
+        for ( int i = 0; i < Runtime.getRuntime().availableProcessors(); i++ )
+        {
+            race.addContestant( () ->
+            {
+                Group group = groups.getOrCreate( name );
+                assertEquals( 0, group.id() );
+            } );
+        }
+
+        // WHEN
+        race.go();
+
+        // THEN
+        Group otherGroup = groups.getOrCreate( "MyOtherGroup" );
+        assertEquals( 1, otherGroup.id() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputGroupsDeserializerTest.java
@@ -22,15 +22,19 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 import org.junit.Test;
 
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.neo4j.function.Suppliers;
 import org.neo4j.kernel.impl.util.Validators;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
-
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,8 +55,8 @@ public class InputGroupsDeserializerTest
         final AtomicInteger flips = new AtomicInteger();
         final AtomicReference<InputGroupsDeserializer<InputNode>> deserializerTestHack = new AtomicReference<>( null );
         InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<>(
-                data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS ), INTEGER,
-                Runtime.getRuntime().availableProcessors(), (header,stream,decorator,validator) ->
+                data.iterator(), defaultFormatNodeFileHeader(), lowBufferSize( COMMAS, true ), INTEGER,
+                Runtime.getRuntime().availableProcessors(), 1, (header,stream,decorator,validator) ->
                 {
                     // This is the point where the currentInput field in InputGroupsDeserializer was null
                     // so ensure that's no longer the case, just by poking those source methods right here and now.
@@ -80,7 +84,52 @@ public class InputGroupsDeserializerTest
         assertEquals( 2, flips.get() );
     }
 
-    private Configuration lowBufferSize( Configuration conf )
+    @Test
+    public void shouldCoordinateGroupCreationForParallelProcessing() throws Exception
+    {
+        // GIVEN
+        List<DataFactory<InputNode>> data = new ArrayList<>();
+        int processors = Runtime.getRuntime().availableProcessors();
+        for ( int i = 0; i < processors; i++ )
+        {
+            StringBuilder builder = new StringBuilder( ":ID(Group" + i + ")" );
+            for ( int j = 0; j < 100; j++ )
+            {
+                builder.append( "\n" + j );
+            }
+            data.add( data( builder.toString() ) );
+        }
+        Groups groups = new Groups();
+        IdType idType = IdType.INTEGER;
+        Collector badCollector = mock( Collector.class );
+        Configuration config = lowBufferSize( COMMAS, false );
+        try ( InputGroupsDeserializer<InputNode> deserializer = new InputGroupsDeserializer<>(
+                data.iterator(), defaultFormatNodeFileHeader(), config, idType,
+                processors, processors, (header,stream,decorator,validator) ->
+                {
+                    InputNodeDeserialization deserialization =
+                            new InputNodeDeserialization( header, stream, groups, idType.idsAreExternal() );
+                    return new InputEntityDeserializer<>( header, stream, config.delimiter(),
+                            deserialization, decorator, validator, badCollector );
+                }, Validators.<InputNode>emptyValidator(), InputNode.class ) )
+        {
+            // WHEN
+            count( deserializer );
+        }
+
+        // THEN
+        assertEquals( processors, groups.getOrCreate( "LastOne" ).id() );
+        boolean[] seen = new boolean[processors];
+        for ( int i = 0; i < processors; i++ )
+        {
+            String groupName = "Group" + i;
+            groups.getOrCreate( groupName );
+            assertFalse( seen[i] );
+            seen[i] = true;
+        }
+    }
+
+    private Configuration lowBufferSize( Configuration conf, boolean multilineFields )
     {
         return new Configuration.Overridden( conf )
         {
@@ -93,7 +142,7 @@ public class InputGroupsDeserializerTest
             @Override
             public boolean multilineFields()
             {
-                return true;
+                return multilineFields;
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.unsafe.impl.batchimport.input.csv.IdType.ACTUAL;
 public class ParallelInputEntityDeserializerTest
 {
     @Rule
-    public final RandomRule random = new RandomRule().withSeed( 1468928804595L );
+    public final RandomRule random = new RandomRule();
 
     @Test
     public void shouldParseDataInParallel() throws Exception
@@ -78,11 +78,9 @@ public class ParallelInputEntityDeserializerTest
                     validator, badCollector );
         };
         try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,
-                defaultFormatNodeFileHeader(), config, idType, threads, deserializerFactory,
+                defaultFormatNodeFileHeader(), config, idType, threads, threads, deserializerFactory,
                 Validators.<InputNode>emptyValidator(), InputNode.class ) )
         {
-            deserializer.processors( threads );
-
             // WHEN/THEN
             long previousLineNumber = -1;
             long previousPosition = -1;


### PR DESCRIPTION
Now that input may be processed in parallel, different groups of inputs
which have different groups may request to create new groups concurrently.
Groups class wasn't thread safe since there was previously no requirement
for it.

This commit makes Groups#getOrCreate call synchronized to handle concurrent
invocation. It's typically invoked quite rarely so the locking nature of it
is fine.

cl [tools] Fixed a race condition in `neoj4-import` with ID groups which would have some correct relationships considered invalid and logged into bad.log instead
