### PR TITLE
Treat deleted relationship in the middle of a chain as inconsistency

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
@@ -453,7 +453,7 @@ public class RelationshipRecordCheck extends
         };
         protected final NodeField NODE;
 
-        private RelationshipField( NodeField node )
+        RelationshipField( NodeField node )
         {
             this.NODE = node;
         }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
@@ -604,7 +604,7 @@ public class RelationshipRecordCheck extends
                 }
                 else
                 {
-                    if ( !referred.inUse() )
+                    if ( !referenceShouldBeSkipped( record, referred.getId(), records ) && !referred.inUse() )
                     {
                         engine.report().notUsedRelationshipReferencedInChain( referred );
                     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/RelationshipRecordCheck.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
 import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.NEXT;
 import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.PREV;
+import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.SLOT_IN_USE;
 import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.SLOT_REFERENCE;
 import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.SLOT_RELATIONSHIP_ID;
 import static org.neo4j.consistency.checking.cache.CacheSlots.RelationshipLink.SLOT_SOURCE_OR_TARGET;
@@ -168,6 +169,7 @@ public class RelationshipRecordCheck extends
                 {
                     rel.setSecondNextRel( cacheAccess.getFromCache( nodeId, SLOT_REFERENCE ) );
                 }
+                rel.setInUse( cacheAccess.getBooleanFromCache( nodeId, SLOT_IN_USE ) );
                 return rel;
             }
 
@@ -222,6 +224,7 @@ public class RelationshipRecordCheck extends
                 {
                     rel.setSecondPrevRel( cacheAccess.getFromCache( nodeId, SLOT_REFERENCE ) );
                 }
+                rel.setInUse( cacheAccess.getBooleanFromCache( nodeId, SLOT_IN_USE ) );
                 return rel;
             }
 
@@ -276,6 +279,7 @@ public class RelationshipRecordCheck extends
                 {
                     rel.setSecondNextRel( cacheAccess.getFromCache( nodeId, SLOT_REFERENCE ) );
                 }
+                rel.setInUse( cacheAccess.getBooleanFromCache( nodeId, SLOT_IN_USE ) );
                 return rel;
             }
 
@@ -330,6 +334,7 @@ public class RelationshipRecordCheck extends
                 {
                     rel.setSecondPrevRel( cacheAccess.getFromCache( nodeId, SLOT_REFERENCE ) );
                 }
+                rel.setInUse( cacheAccess.getBooleanFromCache( nodeId, SLOT_IN_USE ) );
                 return rel;
             }
 
@@ -406,13 +411,13 @@ public class RelationshipRecordCheck extends
                     if ( cacheAccess.withinBounds( relationship.getFirstNode() ) )
                     {
                         cacheAccess.putToCache( relationship.getFirstNode(), SOURCE, PREV,
-                                relationship.getId(), relationship.getFirstPrevRel() );
+                                relationship.getId(), relationship.getFirstPrevRel(), 1 );
                         updateCacheCounts( cache1Free, cacheAccess );
                     }
                     if ( cacheAccess.withinBounds( relationship.getSecondNode() ) )
                     {
                         cacheAccess.putToCache( relationship.getSecondNode(), TARGET, PREV,
-                                relationship.getId(), relationship.getSecondPrevRel() );
+                                relationship.getId(), relationship.getSecondPrevRel(), 1 );
                         updateCacheCounts( cache2Free, cacheAccess );
                     }
                 }
@@ -421,13 +426,13 @@ public class RelationshipRecordCheck extends
                     if ( cacheAccess.withinBounds( relationship.getFirstNode() ) )
                     {
                         cacheAccess.putToCache( relationship.getFirstNode(), SOURCE, NEXT,
-                                relationship.getId(), relationship.getFirstNextRel() );
+                                relationship.getId(), relationship.getFirstNextRel() , 1 );
                         updateCacheCounts( cache1Free, cacheAccess );
                     }
                     if ( cacheAccess.withinBounds( relationship.getSecondNode() ) )
                     {
                         cacheAccess.putToCache( relationship.getSecondNode(), TARGET, NEXT,
-                                relationship.getId(), relationship.getSecondNextRel() );
+                                relationship.getId(), relationship.getSecondNextRel() , 1 );
                         updateCacheCounts( cache2Free, cacheAccess );
                     }
                 }
@@ -598,7 +603,12 @@ public class RelationshipRecordCheck extends
                     }
                 }
                 else
-                {   // successfully checked
+                {
+                    if ( !referred.inUse() )
+                    {
+                        engine.report().notUsedRelationshipReferencedInChain( referred );
+                    }
+                    // successfully checked
                     // clear cache only if cache is used - meaning referred was built using cache.
                     if ( referred.isCreated() )
                     {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheAccess.java
@@ -57,6 +57,17 @@ public interface CacheAccess
         long getFromCache( long id, int slot );
 
         /**
+         * Gets a cached value, put there with {@link #putToCache(long, long...)} or
+         * {@link #putToCacheSingle(long, int, long)} and interpret field value as a boolean.
+         * 0 will be treated as false all the rest as true.
+         *
+         * @param id the entity id this cached value is tied to.
+         * @param slot which cache slot for this id.
+         * @return false if slot value is 0, true otherwise.
+         */
+        boolean getBooleanFromCache(long id, int slot);
+
+        /**
          * Caches all values for an id, i.e. fills all slots.
          *
          * @param id the entity id these cached values will be tied to.
@@ -198,6 +209,12 @@ public interface CacheAccess
         public long getFromCache( long id, int slot )
         {
             return 0;
+        }
+
+        @Override
+        public boolean getBooleanFromCache( long id, int slot )
+        {
+            return false;
         }
 
         @Override

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
@@ -24,20 +24,20 @@ public interface CacheSlots
     int LABELS_SLOT_SIZE = 63;
     int ID_SLOT_SIZE = 35;
 
-    public interface NodeLabel
+    interface NodeLabel
     {
         int SLOT_IN_USE = 0;
         int SLOT_LABEL_FIELD = 1;
     }
 
-    public interface NextRelationhip
+    interface NextRelationhip
     {
         int SLOT_FIRST_IN_SOURCE = 0;
         int SLOT_FIRST_IN_TARGET = 1;
         int SLOT_RELATIONSHIP_ID = 2;
     }
 
-    public interface RelationshipLink
+    interface RelationshipLink
     {
         int SLOT_SOURCE_OR_TARGET = 0;
         int SLOT_PREV_OR_NEXT = 1;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
@@ -30,7 +30,7 @@ public interface CacheSlots
         int SLOT_LABEL_FIELD = 1;
     }
 
-    interface NextRelationhip
+    interface NextRelationship
     {
         int SLOT_FIRST_IN_SOURCE = 0;
         int SLOT_FIRST_IN_TARGET = 1;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheSlots.java
@@ -43,6 +43,7 @@ public interface CacheSlots
         int SLOT_PREV_OR_NEXT = 1;
         int SLOT_RELATIONSHIP_ID = 2;
         int SLOT_REFERENCE = 3;
+        int SLOT_IN_USE = 4;
         long SOURCE = 0;
         long TARGET = -1;
         long PREV = 0;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/CacheTask.java
@@ -81,7 +81,7 @@ public abstract class CacheTask extends ConsistencyCheckerTask
                     NodeRecord node = nodeRecords.next();
                     if ( node.inUse() )
                     {
-                        fields[CacheSlots.NextRelationhip.SLOT_RELATIONSHIP_ID] = node.getNextRel();
+                        fields[CacheSlots.NextRelationship.SLOT_RELATIONSHIP_ID] = node.getNextRel();
                         client.putToCache( node.getId(), fields );
                     }
                 }
@@ -109,7 +109,7 @@ public abstract class CacheTask extends ConsistencyCheckerTask
             CacheAccess.Client client = cacheAccess.client();
             for ( long nodeId = 0; nodeId < nodeStore.getHighId(); nodeId++ )
             {
-                if ( client.getFromCache( nodeId, CacheSlots.NextRelationhip.SLOT_FIRST_IN_TARGET ) == 0 )
+                if ( client.getFromCache( nodeId, CacheSlots.NextRelationship.SLOT_FIRST_IN_TARGET ) == 0 )
                 {
                     // TODO reuse record instances?
                     NodeRecord node = nodeStore.getRecord( nodeId, nodeStore.newRecord(), FORCE );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/DefaultCacheAccess.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/DefaultCacheAccess.java
@@ -108,6 +108,12 @@ public class DefaultCacheAccess implements CacheAccess
         }
 
         @Override
+        public boolean getBooleanFromCache( long id, int slot )
+        {
+            return cache.get( id, slot ) != 0;
+        }
+
+        @Override
         public void putToCache( long id, long... values )
         {
             cache.put( id, values );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CheckStage.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CheckStage.java
@@ -32,8 +32,8 @@ public enum CheckStage implements Stage
     Stage3_NS_NextRel( false, true, "NodeStore pass - just cache nextRel and inUse", 1, 1, ID_SLOT_SIZE ),
     Stage4_RS_NextRel( true, true, "RelationshipStore pass - check nodes inUse, FirstInFirst, FirstInSecond using cached info", 1, 1, ID_SLOT_SIZE ),
     Stage5_Check_NextRel( false, true, "NodeRelationship cache pass - check nextRel", 1, 1, ID_SLOT_SIZE ),
-    Stage6_RS_Forward( true, true, "RelationshipStore pass - forward scan of source chain using the cache", 1, 1, ID_SLOT_SIZE, ID_SLOT_SIZE ),
-    Stage7_RS_Backward( true, false, "RelationshipStore pass - reverse scan of source chain using the cache", 1, 1, ID_SLOT_SIZE, ID_SLOT_SIZE ),
+    Stage6_RS_Forward( true, true, "RelationshipStore pass - forward scan of source chain using the cache", 1, 1, ID_SLOT_SIZE, ID_SLOT_SIZE, 1 ),
+    Stage7_RS_Backward( true, false, "RelationshipStore pass - reverse scan of source chain using the cache", 1, 1, ID_SLOT_SIZE, ID_SLOT_SIZE, 1 ),
     Stage8_PS_Props( true, true, "PropertyStore and Node to Index check pass" ),
     Stage9_NS_LabelCounts( true, true, "NodeStore pass - Label counts" ),
     Stage10_NS_PropertyRelocator( true, true, "Property store relocation" );
@@ -43,7 +43,7 @@ public enum CheckStage implements Stage
     private final String purpose;
     private final int[] cacheSlotSizes;
 
-    private CheckStage( boolean parallel, boolean forward, String purpose, int... cacheFields )
+    CheckStage( boolean parallel, boolean forward, String purpose, int... cacheFields )
     {
         this.parallel = parallel;
         this.forward = forward;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/CountsBuilderDecorator.java
@@ -274,7 +274,7 @@ class CountsBuilderDecorator extends CheckDecorator.Adapter
                 {
                     CacheAccess.Client cacheAccess = records.cacheAccess().client();
                     Set<Long> firstNodeLabels = null, secondNodeLabels = null;
-                    long firstLabelsField = cacheAccess.getFromCache( record.getFirstNode(), 1 );
+                    long firstLabelsField = cacheAccess.getFromCache( record.getFirstNode(), SLOT_LABEL_FIELD );
                     if ( NodeLabelsField.fieldPointsToDynamicRecordOfLabels( firstLabelsField ) )
                     {
                         firstNodeLabels = labelsFor( nodeStore, engine, records, record.getFirstNode() );
@@ -283,7 +283,7 @@ class CountsBuilderDecorator extends CheckDecorator.Adapter
                     {
                         firstNodeLabels = NodeLabelReader.getListOfLabels( firstLabelsField );
                     }
-                    long secondLabelsField = cacheAccess.getFromCache( record.getSecondNode(), 1 );
+                    long secondLabelsField = cacheAccess.getFromCache( record.getSecondNode(), SLOT_LABEL_FIELD );
                     if ( NodeLabelsField.fieldPointsToDynamicRecordOfLabels( secondLabelsField ) )
                     {
                         secondNodeLabels = labelsFor( nodeStore, engine, records, record.getSecondNode() );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -143,14 +143,7 @@ public class FullCheck
                     multiPass, reporter, threads );
             List<ConsistencyCheckerTask> tasks =
                     taskCreator.createTasksForFullCheck( checkLabelScanStore, checkIndexes, checkGraph );
-            TaskExecutor.execute( tasks, new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    decorator.prepare();
-                }
-            } );
+            TaskExecutor.execute( tasks, decorator::prepare );
         }
         catch ( Exception e )
         {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/OwnerCheck.java
@@ -66,7 +66,7 @@ class OwnerCheck implements CheckDecorator
 
     OwnerCheck( boolean active, DynamicStore... stores )
     {
-        this.owners = active ? new ConcurrentHashMap<Long, PropertyOwner>( 16, 0.75f, 4 ) : null;
+        this.owners = active ? new ConcurrentHashMap<>( 16, 0.75f, 4 ) : null;
         this.dynamics = active ? initialize( stores ) : null;
     }
 
@@ -76,7 +76,7 @@ class OwnerCheck implements CheckDecorator
                 new EnumMap<>( RecordType.class );
         for ( DynamicStore store : stores )
         {
-            map.put( store.type, new ConcurrentHashMap<Long, DynamicOwner>( 16, 0.75f, 4 ) );
+            map.put( store.type, new ConcurrentHashMap<>( 16, 0.75f, 4 ) );
         }
         return unmodifiableMap( map );
     }
@@ -448,14 +448,5 @@ class OwnerCheck implements CheckDecorator
     }
 
     private static final ComparativeRecordChecker<PropertyRecord, PrimitiveRecord, ConsistencyReport.PropertyConsistencyReport> ORPHAN_CHECKER =
-            new ComparativeRecordChecker<PropertyRecord, PrimitiveRecord, ConsistencyReport.PropertyConsistencyReport>()
-            {
-                @Override
-                public void checkReference( PropertyRecord record, PrimitiveRecord primitiveRecord,
-                                            CheckerEngine<PropertyRecord, ConsistencyReport.PropertyConsistencyReport> engine,
-                                            RecordAccess records )
-                {
-                    engine.report().orphanPropertyChain();
-                }
-            };
+            ( record, primitiveRecord, engine, records ) -> engine.report().orphanPropertyChain();
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
@@ -35,7 +35,7 @@ public interface QueueDistribution
     /**
      * Distributes records into {@link RecordConsumer}.
      */
-    public interface QueueDistributor<RECORD>
+    interface QueueDistributor<RECORD>
     {
         void distribute( RECORD record, RecordConsumer<RECORD> consumer ) throws InterruptedException;
     }
@@ -43,7 +43,7 @@ public interface QueueDistribution
     /**
      * Distributes records round-robin style to all queues.
      */
-    public static final QueueDistribution ROUND_ROBIN = new QueueDistribution()
+    QueueDistribution ROUND_ROBIN = new QueueDistribution()
     {
         @Override
         public <RECORD> QueueDistributor<RECORD> distributor( long recordsPerCpu, int numberOfThreads )
@@ -55,7 +55,7 @@ public interface QueueDistribution
     /**
      * Distributes {@link RelationshipRecord} depending on the start/end node ids.
      */
-    public static final QueueDistribution RELATIONSHIPS = new QueueDistribution()
+    QueueDistribution RELATIONSHIPS = new QueueDistribution()
     {
         @Override
         public QueueDistributor<RelationshipRecord> distributor( long recordsPerCpu, int numberOfThreads )
@@ -64,12 +64,12 @@ public interface QueueDistribution
         }
     };
 
-    static class RoundRobinQueueDistributor<RECORD> implements QueueDistributor<RECORD>
+    class RoundRobinQueueDistributor<RECORD> implements QueueDistributor<RECORD>
     {
         private final int numberOfThreads;
         private int nextQIndex;
 
-        public RoundRobinQueueDistributor( int numberOfThreads )
+        RoundRobinQueueDistributor( int numberOfThreads )
         {
             this.numberOfThreads = numberOfThreads;
         }
@@ -88,11 +88,11 @@ public interface QueueDistribution
         }
     }
 
-    static class RelationshipNodesQueueDistributor implements QueueDistributor<RelationshipRecord>
+    class RelationshipNodesQueueDistributor implements QueueDistributor<RelationshipRecord>
     {
         private final long recordsPerCpu;
 
-        public RelationshipNodesQueueDistributor( long recordsPerCpu )
+        RelationshipNodesQueueDistributor( long recordsPerCpu )
         {
             this.recordsPerCpu = recordsPerCpu;
         }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
@@ -58,14 +58,10 @@ public class RecordDistributor
         }
 
         final int[] recsProcessed = new int[numberOfThreads];
-        RecordConsumer<RECORD> recordConsumer = new RecordConsumer<RECORD>()
+        RecordConsumer<RECORD> recordConsumer = ( record, qIndex ) ->
         {
-            @Override
-            public void accept( RECORD record, int qIndex ) throws InterruptedException
-            {
-                recordQ[qIndex].put( record );
-                recsProcessed[qIndex]++;
-            }
+            recordQ[qIndex].put( record );
+            recsProcessed[qIndex]++;
         };
 
         try

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/labelscan/LabelScanCheck.java
@@ -36,8 +36,8 @@ public class LabelScanCheck implements RecordCheck<LabelScanDocument, Consistenc
         NodeLabelRange range = record.getNodeLabelRange();
         for ( long nodeId : range.nodes() )
         {
-            engine.comparativeCheck( records.node( nodeId ), new NodeInUseWithCorrectLabelsCheck<LabelScanDocument,ConsistencyReport.LabelScanConsistencyReport>(
-                    record.getNodeLabelRange().labels( nodeId ) ) );
+            engine.comparativeCheck( records.node( nodeId ),
+                    new NodeInUseWithCorrectLabelsCheck<>( record.getNodeLabelRange().labels( nodeId ) ) );
         }
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -51,7 +51,7 @@ public interface ConsistencyReport
     {
     }
 
-    public interface Reporter
+    interface Reporter
     {
         void forSchema( DynamicRecord schema,
                         RecordCheck<DynamicRecord, SchemaConsistencyReport> checker );
@@ -490,7 +490,7 @@ public interface ConsistencyReport
         void nodeLabelNotInIndex( NodeRecord referredNodeRecord, long missingLabelId );
     }
 
-    public interface CountsConsistencyReport extends ConsistencyReport
+    interface CountsConsistencyReport extends ConsistencyReport
     {
         @Documented( "The node count does not correspond with the expected count." )
         void inconsistentNodeCount( long expectedCount );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -204,6 +204,9 @@ public interface ConsistencyReport
     interface RelationshipConsistencyReport
             extends PrimitiveConsistencyReport
     {
+        @Documented( "The relationship record is not in use, but referenced from relationships chain." )
+        void notUsedRelationshipReferencedInChain( RelationshipRecord relationshipRecord );
+
         @Documented( "The relationship type field has an illegal value." )
         void illegalRelationshipType();
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -94,12 +94,8 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
         void reported( Class<?> report, String method, String message );
     }
 
-    public static final Monitor NO_MONITOR = new Monitor()
+    public static final Monitor NO_MONITOR = ( report, method, message ) ->
     {
-        @Override
-        public void reported( Class<?> report, String method, String message )
-        {
-        }
     };
 
     public ConsistencyReporter( RecordAccess records, InconsistencyReport report )
@@ -235,7 +231,7 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
                 RecordReference<REFERRED> reference, ComparativeRecordChecker<RECORD, ? super REFERRED, REPORT> checker )
         {
             references++;
-            reference.dispatch( new PendingReferenceCheck<REFERRED>( this, checker ) );
+            reference.dispatch( new PendingReferenceCheck<>( this, checker ) );
         }
 
         @Override
@@ -370,59 +366,6 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
                                  RecordAccess records )
         {
             checker.checkReference( record, newReferenced, this, records );
-        }
-    }
-
-    private static class DiffReportHandler
-            <RECORD extends AbstractBaseRecord, REPORT extends ConsistencyReport>
-            extends ReportInvocationHandler<RECORD,REPORT>
-    {
-        private final AbstractBaseRecord oldRecord;
-        private final AbstractBaseRecord newRecord;
-
-        private DiffReportHandler( InconsistencyReport report, ProxyFactory<REPORT> factory,
-                                   RecordType type,
-                                   RecordAccess records,
-                                   AbstractBaseRecord oldRecord, AbstractBaseRecord newRecord, Monitor monitor )
-        {
-            super( report, factory, type, records, monitor );
-            this.oldRecord = oldRecord;
-            this.newRecord = newRecord;
-        }
-
-        @Override
-        long recordId()
-        {
-            return newRecord.getId();
-        }
-
-        @Override
-        protected void logError( String message, Object[] args )
-        {
-            report.error( type, oldRecord, newRecord, message, args );
-        }
-
-        @Override
-        protected void logWarning( String message, Object[] args )
-        {
-            report.warning( type, oldRecord, newRecord, message, args );
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        void checkReference( CheckerEngine engine, ComparativeRecordChecker checker, AbstractBaseRecord referenced,
-                             RecordAccess records )
-        {
-            checker.checkReference( newRecord, referenced, this, records );
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        void checkDiffReference( CheckerEngine engine, ComparativeRecordChecker checker,
-                                 AbstractBaseRecord oldReferenced, AbstractBaseRecord newReferenced,
-                                 RecordAccess records )
-        {
-            checker.checkReference( newRecord, newReferenced, this, records );
         }
     }
 

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
@@ -99,21 +99,12 @@ public abstract class RecordCheckTestBase<RECORD extends AbstractBaseRecord,
 
     public static RecordCheck<PropertyRecord, ConsistencyReport.PropertyConsistencyReport> dummyPropertyChecker()
     {
-        return new RecordCheck<PropertyRecord, ConsistencyReport.PropertyConsistencyReport>()
-        {
-            @Override
-            public void check( PropertyRecord record,
-                               CheckerEngine<PropertyRecord, ConsistencyReport.PropertyConsistencyReport> engine,
-                               RecordAccess records )
-            {
-            }
-        };
+        return ( record, engine, records ) -> {};
     }
 
     public static PrimitiveRecordCheck<NeoStoreRecord, ConsistencyReport.NeoStoreConsistencyReport> dummyNeoStoreCheck()
     {
-        return new NeoStoreCheck( new PropertyChain<NeoStoreRecord,ConsistencyReport.NeoStoreConsistencyReport>(
-                from -> null ) )
+        return new NeoStoreCheck( new PropertyChain<>( from -> null ) )
         {
             @Override
             public void check( NeoStoreRecord record,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -246,7 +246,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         return true;
     }
 
-    private static enum GroupChain
+    private enum GroupChain
     {
         OUT
                 {


### PR DESCRIPTION
Enhance consistency checker to track usage flag of relationship records in chain. 
This gives possibility to check chain for presence of deleted records and treat them as inconsistencies. 
