### PR TITLE
Reverts previous move of bad.log during import

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -345,7 +345,7 @@ public class ImportTool
             logsDir = config.get( GraphDatabaseSettings.logs_directory );
             fs.mkdirs( logsDir );
 
-            badFile = new File( logsDir, BAD_FILE_NAME );
+            badFile = new File( storeDir, BAD_FILE_NAME );
             badOutput = new BufferedOutputStream( fs.openAsOutputStream( badFile, false ) );
             nodesFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.NODE_DATA.key() );
             relationshipsFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.RELATIONSHIP_DATA.key() );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -52,7 +52,6 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
@@ -1941,10 +1940,7 @@ public class ImportToolTest
 
     private File badFile()
     {
-        Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.neo4j_home.name(), dbRule.getStoreDirAbsolutePath() ) );
-        File logsDir = config.get( GraphDatabaseSettings.logs_directory );
-        return new File( logsDir, BAD_FILE_NAME );
+        return new File( dbRule.getStoreDirFile(), BAD_FILE_NAME );
     }
 
     private void writeRelationshipHeader( PrintStream writer, Configuration config,

--- a/manual/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/manual/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -41,9 +41,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -52,7 +50,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.ArrayUtil.join;
 import static org.neo4j.helpers.collection.Iterators.asSet;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.fs.FileUtils.readTextFile;
 import static org.neo4j.io.fs.FileUtils.writeToFile;
 import static org.neo4j.tooling.ImportTool.MULTI_FILE_DELIMITER;
@@ -761,10 +758,6 @@ public class ImportToolDocIT
 
     private File badFile()
     {
-        Config config = Config.defaults();
-        config.augment( stringMap( GraphDatabaseSettings.neo4j_home.name(),
-                directory.absolutePath().getAbsolutePath() ) );
-        File logsDir = config.get( GraphDatabaseSettings.logs_directory );
-        return new File( logsDir, BAD_FILE_NAME );
+        return new File( directory.absolutePath(), BAD_FILE_NAME );
     }
 }


### PR DESCRIPTION
since it's a surface change. This could instead be done in a major release.
