### PR TITLE
Heap size no longer hard codes unit to Mb

### DIFF
--- a/community/server/src/docs/ops/server-performance.asciidoc
+++ b/community/server/src/docs/ops/server-performance.asciidoc
@@ -22,8 +22,8 @@ Edit the following properties:
 [options="header", cols="<m,<"]
 |====================
 | Property Name                 | Meaning
-| dbms.memory.heap.initial_size | initial heap size (in MB)
-| dbms.memory.heap.max_size     | maximum heap size (in MB)
+| dbms.memory.heap.initial_size | initial heap size
+| dbms.memory.heap.max_size     | maximum heap size
 | dbms.jvm.additional           | additional literal JVM parameter
 |====================
 

--- a/manual/kernel/src/docs/ops/performance-guide.asciidoc
+++ b/manual/kernel/src/docs/ops/performance-guide.asciidoc
@@ -51,9 +51,9 @@ For this reason, the heap should ideally be sized and tuned such that transactio
 When using Neo4j Server, JVM configuration goes into the _conf/neo4j.conf_ file.
 --
 
-In server deployments, the heap size is configured with the `dbms.memory.heap.max_size` (in MBs) setting in the _neo4j.conf_ file.
-For embedded, the heap size is specified by giving the `-Xmx???m` command line flag to the `java` process, where the `???` is the maximum heap size in MBs.
-The initial size of the heap is specified by the `dbms.memory.heap.initial_size` setting, or with the `-Xms???m` flag, or chosen heuristically by the JVM itself if left unspecified.
+In server deployments, the heap size is configured with the `dbms.memory.heap.max_size` setting in the _neo4j.conf_ file.
+For embedded, the heap size is specified by giving the `-Xmx???` command line flag to the `java` process, where the `???` is the maximum heap sizes.
+The initial size of the heap is specified by the `dbms.memory.heap.initial_size` setting, or with the `-Xms???` flag, or chosen heuristically by the JVM itself if left unspecified.
 The JVM will automatically grow the heap as needed, up to the maximum size.
 The growing of the heap requires a full GC cycle.
 If you know that you will need all the heap memory, you can set the initial heap size and the maximum heap size to the same value.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -165,12 +165,21 @@ Function Get-Java
                     ,'-Dorg.neo4j.cluster.logdirectory=data/log' `
       )
 
-      # Parse Java config settings - Heap
+      # Parse Java config settings - Heap initial size
       $option = (Get-Neo4jSetting -Name 'dbms.memory.heap.initial_size' -Neo4jServer $Neo4jServer)
-      if ($option -ne $null) { $ShellArgs += "-Xms$($option.Value)m" }
+      if ($option -ne $null) {
+        $mem="$($option.Value)"
+        if ($mem -notmatch '[\d]+[gGmMkK]') { $mem += "m" }
+        $ShellArgs += "-Xms$mem"
+      }
 
+      # Parse Java config settings - Heap max size
       $option = (Get-Neo4jSetting -Name 'dbms.memory.heap.max_size' -Neo4jServer $Neo4jServer)
-      if ($option -ne $null) { $ShellArgs += "-Xmx$($option.Value)m" }
+      if ($option -ne $null) {
+        $mem="$($option.Value)"
+        if ($mem -notmatch '[\d]+[gGmMkK]') { $mem += "m" }
+        $ShellArgs += "-Xmx$mem"
+      }
 
       # Parse Java config settings - Explicit
       $option = (Get-Neo4jSetting -Name 'dbms.jvm.additional' -Neo4jServer $Neo4jServer)

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -55,7 +55,7 @@ Function Get-Java
     [Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='UtilityInvoke')]
     [Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInvoke')]
     [PSCustomObject]$Neo4jServer
-        
+
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInvoke')]
     [switch]$ForServer
 
@@ -63,21 +63,21 @@ Function Get-Java
     [switch]$ForUtility
 
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='UtilityInvoke')]
-    [string]$StartingClass    
+    [string]$StartingClass
   )
-  
+
   Begin
   {
   }
-  
+
   Process
   {
     $javaPath = ''
     $javaCMD = ''
-    
+
     $EnvJavaHome = Get-Neo4jEnv 'JAVA_HOME'
     $EnvClassPrefix = Get-Neo4jEnv 'CLASSPATH_PREFIX'
-    
+
     # Is JAVA specified in an environment variable
     if (($javaPath -eq '') -and ($EnvJavaHome -ne $null))
     {
@@ -87,7 +87,7 @@ Function Get-Java
     }
 
     # Attempt to find Java in registry
-    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'    
+    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'
     if (($javaPath -eq '') -and (Test-Path -Path $regKey))
     {
       $regJavaVersion = ''
@@ -107,7 +107,7 @@ Function Get-Java
     }
 
     # Attempt to find Java in registry (32bit Java on 64bit OS)
-    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'    
+    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'
     if (($javaPath -eq '') -and (Test-Path -Path $regKey))
     {
       $regJavaVersion = ''
@@ -125,7 +125,7 @@ Function Get-Java
         $javaPath = ''
       }
     }
-    
+
     # Attempt to find Java in the search path
     if ($javaPath -eq '')
     {
@@ -210,7 +210,7 @@ Function Get-Java
       }
       $ShellArgs += @("-Dfile.encoding=UTF-8",$serverMainClass,"--config-dir=$($Neo4jServer.ConfDir)","--home-dir=$($Neo4jServer.Home)")
     }
-    
+
     # Shell arguments for the utility classes e.g. Import, Shell
     if ($PsCmdlet.ParameterSetName -eq 'UtilityInvoke')
     {
@@ -230,14 +230,14 @@ Function Get-Java
       $ShellArgs += @("-classpath $($EnvClassPrefix);$ClassPath",
                       "-Dbasedir=`"$($Neo4jServer.Home)`"", `
                       '-Dfile.encoding=UTF-8')
-            
+
       # Add the starting class
       $ShellArgs += @($StartingClass)
     }
 
     Write-Output @{'java' = $javaCMD; 'args' = $ShellArgs}
   }
-  
+
   End
   {
   }

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -87,8 +87,16 @@ check_limits() {
 setup_java_opts() {
   JAVA_OPTS=("-server")
 
-  [[ -n "${dbms_memory_heap_initial_size:-}" ]] && JAVA_MEMORY_OPTS+=("-Xms${dbms_memory_heap_initial_size}m")
-  [[ -n "${dbms_memory_heap_max_size:-}" ]] && JAVA_MEMORY_OPTS+=("-Xmx${dbms_memory_heap_max_size}m")
+  if [[ -n "${dbms_memory_heap_initial_size:-}" ]]; then
+    local mem="${dbms_memory_heap_initial_size}"
+    [[ ${mem} =~ .*[gGmMkK] ]] || mem="${mem}m"
+    JAVA_MEMORY_OPTS+=("-Xms${mem}")
+  fi
+  if [[ -n "${dbms_memory_heap_max_size:-}" ]]; then
+    local mem="${dbms_memory_heap_max_size}"
+    [[ ${mem} =~ .*[gGmMkK] ]] || mem="${mem}m"
+    JAVA_MEMORY_OPTS+=("-Xmx${mem}")
+  fi
   [[ -n "${JAVA_MEMORY_OPTS:-}" ]] && JAVA_OPTS+=("${JAVA_MEMORY_OPTS[@]}")
 
   if [[ "${dbms_logs_gc_enabled:-}" = "true" ]]; then

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -11,7 +11,7 @@ InModuleScope Neo4j-Management {
     # Setup mocking environment
     #  Mock Java environment
     $javaHome = global:New-MockJavaHome
-    Mock Get-Neo4jEnv { $javaHome } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+    Mock Get-Neo4jEnv { $javaHome } -ParameterFilter { $Name -eq 'JAVA_HOME' }
     Mock Test-Path { $false } -ParameterFilter {
       $Path -like 'Registry::*\JavaSoft\Java Runtime Environment'
     }
@@ -35,7 +35,7 @@ InModuleScope Neo4j-Management {
 
     Context "Legacy Java install in JAVA_HOME environment variable" {
       Mock Confirm-JavaVersion -Verifiable { $false }
-      
+
       It "should throw if java is not supported" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
@@ -47,24 +47,24 @@ InModuleScope Neo4j-Management {
 
     Context "Invalid Java install in JAVA_HOME environment variable" {
       Mock Test-Path { $false } -ParameterFile { $Path -like "$javaHome\bin\java.exe" }
-      
+
       It "should throw if java missing" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
     }
 
     Context "Valid Java install in Registry (32bit Java on 64bit OS)" {
-      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' }
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       $result = Get-Java
 
       It "should return java location from registry" {
@@ -77,17 +77,17 @@ InModuleScope Neo4j-Management {
     }
 
     Context "Valid Java install in Registry" {
-      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' }
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       $result = Get-Java
 
       It "should return java location from registry" {
@@ -101,17 +101,17 @@ InModuleScope Neo4j-Management {
 
     Context "Invalid Java install in Registry" {
       Mock Test-Path { $false } -ParameterFile { $Path -like "$javaHome\bin\java.exe" }
-      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' }
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       It "should throw if java missing" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
@@ -122,10 +122,10 @@ InModuleScope Neo4j-Management {
     }
 
     Context "Valid Java install in search path" {
-      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' }
 
       Mock Get-Command -Verifiable { return @{ 'Path' = "$javaHome\bin\java.exe" } }
-            
+
       $result = Get-Java
 
       It "should return java location from search path" {
@@ -138,14 +138,14 @@ InModuleScope Neo4j-Management {
     }
 
     Context "No Java install at all" {
-      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+      Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' }
       Mock Get-Command { $null }
-      
+
       It "should throw if java not detected" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
     }
-    
+
     # ForServer tests
     Context "Server Invoke - Community v3.0" {
       $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community'
@@ -253,15 +253,15 @@ InModuleScope Neo4j-Management {
       $resultArgs = ($result.args -join ' ')
 
       It "should have jars from bin" {
-        $resultArgs | Should Match ([regex]::Escape('\bin\bin1.jar"'))
+        $resultArgs | Should Match ([regex]::Escape('bin1.jar"'))
       }
       It "should have jars from lib" {
-        $resultArgs | Should Match ([regex]::Escape('\lib\lib1.jar"'))
+        $resultArgs | Should Match ([regex]::Escape('lib1.jar"'))
       }
       It "should have correct Starting Class" {
         $resultArgs | Should Match ([regex]::Escape(' someclass'))
       }
-    }    
+    }
 
   }
 }

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -180,6 +180,38 @@ InModuleScope Neo4j-Management {
       }
     }
 
+    Context "Server Invoke - Should set heap size" {
+      $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community' `
+        -NeoConfSettings 'dbms.memory.heap.initial_size=123k','dbms.memory.heap.max_size=234g'
+
+      $result = Get-Java -ForServer -Neo4jServer $serverObject
+      $resultArgs = ($result.args -join ' ')
+
+      It "should set initial heap size" {
+        $resultArgs | Should Match ([regex]::Escape(' -Xms123k '))
+      }
+
+      It "should set max heap size" {
+        $resultArgs | Should Match ([regex]::Escape(' -Xmx234g '))
+      }
+    }
+
+    Context "Server Invoke - Should default heap size unit to megabytes" {
+      $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community' `
+        -NeoConfSettings 'dbms.memory.heap.initial_size=123','dbms.memory.heap.max_size=234'
+
+      $result = Get-Java -ForServer -Neo4jServer $serverObject
+      $resultArgs = ($result.args -join ' ')
+
+      It "should set initial heap size" {
+        $resultArgs | Should Match ([regex]::Escape(' -Xms123m '))
+      }
+
+      It "should set max heap size" {
+        $resultArgs | Should Match ([regex]::Escape(' -Xmx234m '))
+      }
+    }
+
     Context "Server Invoke - Enable Default GC Logs" {
       $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community' `
         -NeoConfSettings 'dbms.logs.gc.enabled=true'

--- a/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
@@ -27,20 +27,37 @@ for run_command in run_console run_daemon; do
 
   test_expect_success "should set heap size constraints from wrapper conf" "
     clear_config &&
-    set_config 'dbms.memory.heap.initial_size' '512' neo4j-wrapper.conf &&
-    set_config 'dbms.memory.heap.max_size' '1024' neo4j-wrapper.conf &&
+    set_config 'dbms.memory.heap.initial_size' '1g' neo4j-wrapper.conf &&
+    set_config 'dbms.memory.heap.max_size' '2g' neo4j-wrapper.conf &&
     ${run_command} &&
-    test_expect_java_arg '-Xms512m' &&
-    test_expect_java_arg '-Xmx1024m'
+    test_expect_java_arg '-Xms1g' &&
+    test_expect_java_arg '-Xmx2g'
+  "
+  test_expect_success "should default heap size unit to megabytes" "
+    clear_config &&
+    set_config 'dbms.memory.heap.initial_size' '333' neo4j-wrapper.conf &&
+    set_config 'dbms.memory.heap.max_size' '666' neo4j-wrapper.conf &&
+    ${run_command} &&
+    test_expect_java_arg '-Xms333m' &&
+    test_expect_java_arg '-Xmx666m'
   "
 
   test_expect_success "should set heap size constraints" "
     clear_config &&
-    set_config 'dbms.memory.heap.initial_size' '512' neo4j.conf &&
-    set_config 'dbms.memory.heap.max_size' '1024' neo4j.conf &&
+    set_config 'dbms.memory.heap.initial_size' '123k' neo4j.conf &&
+    set_config 'dbms.memory.heap.max_size' '678g' neo4j.conf &&
     ${run_command} &&
-    test_expect_java_arg '-Xms512m' &&
-    test_expect_java_arg '-Xmx1024m'
+    test_expect_java_arg '-Xms123k' &&
+    test_expect_java_arg '-Xmx678g'
+  "
+
+  test_expect_success "should set heap size default unit" "
+    clear_config &&
+    set_config 'dbms.memory.heap.initial_size' '123' neo4j.conf &&
+    set_config 'dbms.memory.heap.max_size' '678' neo4j.conf &&
+    ${run_command} &&
+    test_expect_java_arg '-Xms123m' &&
+    test_expect_java_arg '-Xmx678m'
   "
 
   test_expect_success "should invoke main class" "
@@ -129,8 +146,8 @@ done
 
 test_expect_success "should set heap size constraints when checking version from wrapper conf" "
   clear_config &&
-  set_config 'dbms.memory.heap.initial_size' '512' neo4j-wrapper.conf &&
-  set_config 'dbms.memory.heap.max_size' '1024' neo4j-wrapper.conf &&
+  set_config 'dbms.memory.heap.initial_size' '512m' neo4j-wrapper.conf &&
+  set_config 'dbms.memory.heap.max_size' '1024m' neo4j-wrapper.conf &&
   neo4j-home/bin/neo4j status || true &&
   test_expect_java_arg '-Xms512m' &&
   test_expect_java_arg '-Xmx1024m'
@@ -138,8 +155,8 @@ test_expect_success "should set heap size constraints when checking version from
 
 test_expect_success "should set heap size constraints when checking version" "
   clear_config &&
-  set_config 'dbms.memory.heap.initial_size' '512' neo4j.conf &&
-  set_config 'dbms.memory.heap.max_size' '1024' neo4j.conf &&
+  set_config 'dbms.memory.heap.initial_size' '512m' neo4j.conf &&
+  set_config 'dbms.memory.heap.max_size' '1024m' neo4j.conf &&
   neo4j-home/bin/neo4j status || true &&
   test_expect_java_arg '-Xms512m' &&
   test_expect_java_arg '-Xmx1024m'

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -27,9 +27,9 @@ dbms.directories.import=import
 # Java Heap Size: by default the Java heap size is dynamically
 # calculated based on available system resources.
 # Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#dbms.memory.heap.initial_size=512
-#dbms.memory.heap.max_size=512
+# heap size.
+#dbms.memory.heap.initial_size=512m
+#dbms.memory.heap.max_size=512m
 
 # The amount of memory to use for mapping the store files, in bytes (or
 # kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -27,9 +27,9 @@ dbms.directories.import=import
 # Java Heap Size: by default the Java heap size is dynamically
 # calculated based on available system resources.
 # Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#dbms.memory.heap.initial_size=512
-#dbms.memory.heap.max_size=512
+# heap size.
+#dbms.memory.heap.initial_size=512m
+#dbms.memory.heap.max_size=512m
 
 # The amount of memory to use for mapping the store files, in bytes (or
 # kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').


### PR DESCRIPTION
The problem with this is that it provides a non-uniform interface
compared to the page cache settings (which allow the user to specify the
unit, and defaults to bytes). It is also at variance with what
experienced Java users will expect.

The particular motivation for fixing this is that the Docker image
configuration exposes two memory-related settings, one of which takes a
unit and the other doesn't.

To preserve backwards-compatibility, we still assume that the default
unit is megabytes.

Powershell tests can be run with this command:

``` shell
docker run --rm --name=powershell -it -v /path/to/standalone:/standalone centos/powershell /usr/bin/powershell /standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
```
## TODO
- [x] Should still treat no suffix as megabytes, for backward compatibility
- [x] Make sure both shell script and windows handle missing suffix correctly
- [x] Default value should not be `512`, it should be `512m`

changelog: Heap size config setting is no longer hardcoded to Mb

It is now possible to use the standard java suffixes as a unit `k|K|m|M|g|G`. For backwards-compatibility reasons, if no unit is specified we will still assume you mean Megabytes.
