### PR TITLE
Timed out handlers should stop their work

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/TimeoutLoop.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/TimeoutLoop.java
@@ -40,11 +40,11 @@ class TimeoutLoop
             catch ( InterruptedException e )
             {
                 Thread.interrupted();
-                throw new CatchUpClientException( e );
+                throw exception( future, operation, e );
             }
             catch ( ExecutionException e )
             {
-                throw new CatchUpClientException( e );
+                throw exception( future, operation, e );
             }
             catch ( TimeoutException e )
             {
@@ -55,9 +55,15 @@ class TimeoutLoop
                 }
                 else
                 {
-                    throw new CatchUpClientException( operation, e );
+                    throw exception( future, operation, e );
                 }
             }
         }
+    }
+
+    private static CatchUpClientException exception( Future<?> future, String operation, Exception e )
+    {
+        future.cancel( true );
+        return new CatchUpClientException( operation, e );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/TrackingResponseHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/TrackingResponseHandler.java
@@ -56,50 +56,72 @@ class TrackingResponseHandler implements CatchUpResponseHandler
     @Override
     public void onFileHeader( FileHeader fileHeader )
     {
-        recordLastResponse();
-        delegate.onFileHeader( requestOutcomeSignal, fileHeader );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onFileHeader( requestOutcomeSignal, fileHeader );
+        }
     }
 
     @Override
     public boolean onFileContent( FileContent fileContent ) throws IOException
     {
-        recordLastResponse();
-        return delegate.onFileContent( requestOutcomeSignal, fileContent );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            return delegate.onFileContent( requestOutcomeSignal, fileContent );
+        }
+        return false;
     }
 
     @Override
     public void onFileStreamingComplete( StoreCopyFinishedResponse response )
     {
-        recordLastResponse();
-        delegate.onFileStreamingComplete( requestOutcomeSignal, response );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onFileStreamingComplete( requestOutcomeSignal, response );
+        }
     }
 
     @Override
     public void onTxPullResponse( TxPullResponse tx )
     {
-        recordLastResponse();
-        delegate.onTxPullResponse( requestOutcomeSignal, tx );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onTxPullResponse( requestOutcomeSignal, tx );
+        }
     }
 
     @Override
     public void onTxStreamFinishedResponse( TxStreamFinishedResponse response )
     {
-        recordLastResponse();
-        delegate.onTxStreamFinishedResponse( requestOutcomeSignal, response );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onTxStreamFinishedResponse( requestOutcomeSignal, response );
+        }
     }
 
     @Override
     public void onGetStoreIdResponse( GetStoreIdResponse response )
     {
-        recordLastResponse();
-        delegate.onGetStoreIdResponse( requestOutcomeSignal, response );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onGetStoreIdResponse( requestOutcomeSignal, response );
+        }
     }
 
     @Override
     public void onCoreSnapshot( CoreSnapshot coreSnapshot )
     {
-        recordLastResponse();
-        delegate.onCoreSnapshot( requestOutcomeSignal, coreSnapshot );
+        if ( !requestOutcomeSignal.isCancelled() )
+        {
+            recordLastResponse();
+            delegate.onCoreSnapshot( requestOutcomeSignal, coreSnapshot );
+        }
     }
 
     long lastResponseTime()

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/TimeoutLoopTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/TimeoutLoopTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TimeoutLoopTest
@@ -72,6 +73,7 @@ public class TimeoutLoopTest
         {
             // then
             // expected
+            verify( future ).cancel( true );
         }
     }
 


### PR DESCRIPTION
Currently timed out handlers could carry on their work even after have
been timed out. This cause race condition in various part of the code
base.  This change will cancel explicittly the future (and hence
dispose the channel) and force the handler to discard any other
message it might receiver after the cancellation.
