### PR TITLE
Specific handling of upgrade transaction during update pooling

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
@@ -25,12 +25,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
+import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
@@ -25,15 +25,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
-import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -23,11 +23,14 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +39,7 @@ import java.util.List;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -56,6 +60,7 @@ import org.neo4j.kernel.impl.store.format.standard.StandardV2_1;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnableToUpgradeException;
@@ -75,9 +80,11 @@ import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
@@ -86,6 +93,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -104,10 +112,15 @@ import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.verifyFile
 @RunWith(Parameterized.class)
 public class StoreUpgraderTest
 {
+    private final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+    private final ExpectedException expectedException = ExpectedException.none();
+
     @Rule
-    public final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
-    @Rule
-    public final PageCacheRule pageCacheRule = new PageCacheRule();
+    public final RuleChain ruleChain = RuleChain.outerRule( expectedException )
+                                                .around( pageCacheRule )
+                                                .around( directory );
+
     private File dbDirectory;
     private final FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
     private StoreVersionCheck check;
@@ -141,6 +154,53 @@ public class StoreUpgraderTest
         dbDirectory = directory.directory( "db_" + version );
         File prepareDirectory = directory.directory( "prepare_" + version );
         prepareSampleLegacyDatabase( version, fileSystem, dbDirectory, prepareDirectory );
+    }
+
+    @Test
+    public void failMigrationWhenFailDuringTransactionInformationRetrieval() throws IOException
+    {
+        File storeDirectory = directory.graphDbDir();
+        File prepare = directory.directory( "prepare" );
+        FileSystemAbstraction fs = new DelegatingFileSystemAbstraction( fileSystem )
+        {
+            @Override
+            public File[] listFiles( File directory, FilenameFilter filter )
+            {
+                sneakyThrow( new IOException( "Enforced IO Exception Fail to open file" ) );
+                return super.listFiles( directory, filter );
+            }
+
+            @Override
+            public boolean fileExists( File fileName )
+            {
+                return true;
+            }
+        };
+
+        MigrationTestUtils.prepareSampleLegacyDatabase( version, fs, storeDirectory, prepare );
+        // and a state of the migration saying that it has done the actual migration
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        UpgradableDatabase upgradableDatabase = new UpgradableDatabase( fs, new StoreVersionCheck( pageCache ),
+                new LegacyStoreVersionCheck( fs ), getRecordFormats() ) {
+            @Override
+            public RecordFormats checkUpgradeable( File storeDirectory )
+            {
+                return getRecordFormats();
+            }
+        };
+        SilentMigrationProgressMonitor progressMonitor = new SilentMigrationProgressMonitor();
+
+        StoreMigrator defaultMigrator = new StoreMigrator( fs, pageCache, getTuningConfig(), NullLogService.getInstance(),
+                schemaIndexProvider );
+        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowMigrateConfig, fs,
+                NullLogProvider.getInstance() );
+        upgrader.addParticipant( defaultMigrator );
+
+        expectedException.expect( UnableToUpgradeException.class );
+        expectedException.expectCause( instanceOf( IOException.class ) );
+        expectedException.expectCause( hasMessage( containsString( "Enforced IO Exception Fail to open file" ) ) );
+
+        upgrader.migrateIfNeeded( dbDirectory );
     }
 
     @Test
@@ -437,6 +497,11 @@ public class StoreUpgraderTest
         upgrader.addParticipant( indexMigrator );
         upgrader.addParticipant( defaultMigrator );
         return upgrader;
+    }
+
+    private static <T extends Throwable> void sneakyThrow( Throwable throwable ) throws T
+    {
+        throw (T) throwable;
     }
 
     private List<File> migrationHelperDirs()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -84,9 +84,6 @@ public class DefaultMasterImplSPI implements MasterImpl.SPI
                                  NeoStoreDataSource neoStoreDataSource)
     {
         this.graphDb = graphDb;
-
-        // Hmm, fetching the dependencies here instead of handing them in the constructor directly feels bad,
-        // but it seems like there's some intricate usage and need for the db's dependency resolver.
         this.fileSystem = fileSystemAbstraction;
         this.labels = labels;
         this.propertyKeyTokenHolder = propertyKeyTokenHolder;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TransactionChecksumLookupTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TransactionChecksumLookupTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.impl.store.TransactionId;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransactionChecksumLookupTest
+{
+
+    private TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+    private LogicalTransactionStore transactionStore = mock( LogicalTransactionStore.class );
+
+    @Before
+    public void setUp() throws IOException
+    {
+        when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new TransactionId( 1, 1, 1 ) );
+        when( transactionIdStore.getUpgradeTransaction() ).thenReturn( new TransactionId( 2, 2, 2 ) );
+        when( transactionStore.getMetadataFor( 3 ) ).thenReturn(
+                new TransactionMetadataCache.TransactionMetadata( 1, 1, mock( LogPosition.class ), 3, 3 ) );
+    }
+
+    @Test
+    public void lookupChecksumUsingUpgradeTransaction() throws Exception
+    {
+        TransactionChecksumLookup checksumLookup = new TransactionChecksumLookup( transactionIdStore, transactionStore );
+        assertEquals(2, checksumLookup.applyAsLong( 2 ));
+    }
+
+    @Test
+    public void lookupChecksumUsingCommittedTransaction() throws Exception
+    {
+        TransactionChecksumLookup checksumLookup = new TransactionChecksumLookup( transactionIdStore, transactionStore );
+        assertEquals(1, checksumLookup.applyAsLong( 1 ));
+    }
+
+    @Test
+    public void lookupChecksumUsingTransactionStore() throws Exception
+    {
+        TransactionChecksumLookup checksumLookup = new TransactionChecksumLookup( transactionIdStore, transactionStore );
+        assertEquals(3, checksumLookup.applyAsLong( 3 ));
+    }
+}


### PR DESCRIPTION
During store upgrade in case if transaction logs are missing upgrade transaction checksum will be set to predefined constant value
(since we can't get find real value in the logs).
In HA setup upgraded store will be copied by slaves and update pullers will try to fetch updates starting from upgrade transaction id.
Master should be able to recognise that specific upgrade transaction id and use checksum that was assign to it during upgrade.
