### PR TITLE
Use secure hasher in ldap realm

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -138,7 +138,7 @@ public class EnterpriseSecurityModule extends SecurityModule
                 config.get( SecuritySettings.ldap_authorization_enabled ) )
                 && configuredRealms.contains( SecuritySettings.LDAP_REALM_NAME ) )
         {
-            realms.add( new LdapRealm( config, securityLog ) );
+            realms.add( new LdapRealm( config, securityLog, secureHasher ) );
         }
 
         // Load plugin realms if we have any

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -374,7 +374,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
         // so all authentication request will go through this method.
         // Hence the credentials matcher is set to AllowAllCredentialsMatcher,
         // and we do not need to store hashed credentials in the AuthenticationInfo.
-        return new ShiroAuthenticationInfo( user.name(), null, getName(), result );
+        return new ShiroAuthenticationInfo( user.name(), getName(), result );
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -21,11 +21,12 @@ package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
+import org.apache.shiro.authc.credential.AllowAllCredentialsMatcher;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.cache.Cache;
+import org.apache.shiro.crypto.hash.SimpleHash;
 import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
 import org.apache.shiro.realm.ldap.JndiLdapRealm;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
@@ -89,23 +90,29 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
     private Boolean useSystemAccountForAuthorization;
     private Map<String,Collection<String>> groupToRoleMapping;
     private final SecurityLog securityLog;
+    private final SecureHasher secureHasher;
 
     // Parser regex for group-to-role-mapping
     private static final String KEY_GROUP = "\\s*('(.+)'|\"(.+)\"|(\\S)|(\\S.*\\S))\\s*";
     private static final String VALUE_GROUP = "\\s*(.*)";
     private Pattern keyValuePattern = Pattern.compile( KEY_GROUP + KEY_VALUE_DELIMITER + VALUE_GROUP );
 
-    public LdapRealm( Config config, SecurityLog securityLog )
+    public LdapRealm( Config config, SecurityLog securityLog, SecureHasher secureHasher )
     {
         super();
-        setName( SecuritySettings.LDAP_REALM_NAME );
         this.securityLog = securityLog;
+        this.secureHasher = secureHasher;
+        setName( SecuritySettings.LDAP_REALM_NAME );
         setRolePermissionResolver( PredefinedRolesBuilder.rolePermissionResolver );
         configureRealm( config );
-        setCredentialsMatcher( new HashedCredentialsMatcher( Credential.DIGEST_ALGO ) );
-        setAuthorizationCachingEnabled( true );
-        boolean authenticationCachingEnabled = config.get( SecuritySettings.ldap_authentication_cache_enabled );
-        setAuthenticationCachingEnabled( authenticationCachingEnabled );
+        if ( isAuthenticationCachingEnabled() )
+        {
+            setCredentialsMatcher( secureHasher.getHashedCredentialsMatcher() );
+        }
+        else
+        {
+            setCredentialsMatcher( new AllowAllCredentialsMatcher() );
+        }
     }
 
     private String withRealm( String template, Object... args )
@@ -282,8 +289,16 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
             cacheAuthorizationInfo( username, roleNames );
         }
 
-        return new ShiroAuthenticationInfo( token.getPrincipal(), (String) token.getCredentials(), getName(),
-                AuthenticationResult.SUCCESS );
+        if ( isAuthenticationCachingEnabled() )
+        {
+            SimpleHash hashedCredentials = secureHasher.hash( ((String) token.getCredentials()).getBytes() );
+            return new ShiroAuthenticationInfo( token.getPrincipal(), hashedCredentials.getBytes(),
+                    hashedCredentials.getSalt(), getName(), AuthenticationResult.SUCCESS );
+        }
+        else
+        {
+            return new ShiroAuthenticationInfo( token.getPrincipal(), null, getName(), AuthenticationResult.SUCCESS );
+        }
     }
 
     @Override
@@ -362,6 +377,9 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
         useSystemAccountForAuthorization = config.get( SecuritySettings.ldap_authorization_use_system_account );
         groupToRoleMapping =
                 parseGroupToRoleMapping( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) );
+
+        setAuthenticationCachingEnabled( config.get( SecuritySettings.ldap_authentication_cache_enabled ) );
+        setAuthorizationCachingEnabled( true );
     }
 
     private String parseLdapServerUrl( String rawLdapServer )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -69,7 +69,6 @@ import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
 
 import static java.lang.String.format;
-import org.neo4j.server.security.auth.Credential;
 
 /**
  * Shiro realm for LDAP based on configuration settings
@@ -297,7 +296,7 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
         }
         else
         {
-            return new ShiroAuthenticationInfo( token.getPrincipal(), null, getName(), AuthenticationResult.SUCCESS );
+            return new ShiroAuthenticationInfo( token.getPrincipal(), getName(), AuthenticationResult.SUCCESS );
         }
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
@@ -24,7 +24,6 @@ import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.util.ByteSource;
 
 import org.neo4j.kernel.api.security.AuthenticationResult;
-import org.neo4j.server.security.auth.Credential;
 
 import static org.neo4j.kernel.api.security.AuthenticationResult.*;
 
@@ -38,17 +37,10 @@ public class ShiroAuthenticationInfo extends SimpleAuthenticationInfo
         this.authenticationResult = AuthenticationResult.FAILURE;
     }
 
-    public ShiroAuthenticationInfo( Object principal, String credentials, String realmName,
-            AuthenticationResult authenticationResult )
+    public ShiroAuthenticationInfo( Object principal, String realmName, AuthenticationResult authenticationResult )
     {
         super( principal, null, realmName );
         this.authenticationResult = authenticationResult;
-        if ( credentials != null )
-        {
-            Credential hashedCredentials = Credential.forPassword( credentials );
-            setCredentials( hashedCredentials.passwordHash() );
-            setCredentialsSalt( ByteSource.Util.bytes( hashedCredentials.salt() ) );
-        }
     }
 
     public ShiroAuthenticationInfo( Object principal, Object hashedCredentials, ByteSource credentialsSalt,

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
@@ -21,7 +21,6 @@ package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
-import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.util.ByteSource;
 
 import org.neo4j.kernel.api.security.AuthenticationResult;

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthInfo.java
@@ -41,7 +41,7 @@ public class PluginAuthInfo extends ShiroAuthenticationInfo implements Authoriza
 
     private PluginAuthInfo( Object principal, String realmName, Set<String> roles )
     {
-        super( principal, null, realmName, AuthenticationResult.SUCCESS );
+        super( principal, realmName, AuthenticationResult.SUCCESS );
         this.roles = roles;
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfo.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.server.security.enterprise.auth.plugin;
 
-import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.crypto.hash.SimpleHash;
 import org.apache.shiro.util.ByteSource;
 
@@ -37,7 +36,7 @@ public class PluginAuthenticationInfo extends ShiroAuthenticationInfo implements
     public PluginAuthenticationInfo( Object principal, String realmName,
             CustomCacheableAuthenticationInfo.CredentialsMatcher credentialsMatcher )
     {
-        super( principal, null, realmName, AuthenticationResult.SUCCESS );
+        super( principal, realmName, AuthenticationResult.SUCCESS );
         this.credentialsMatcher = credentialsMatcher;
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -75,7 +75,7 @@ public class LdapCachingTest
                 new InMemoryUserRepository()
             );
 
-        testRealm = new TestRealm( getLdapConfig(), securityLog );
+        testRealm = new TestRealm( getLdapConfig(), securityLog, new SecureHasher() );
 
         List<Realm> realms = listOf( internalFlatFileRealm, testRealm );
 
@@ -218,9 +218,9 @@ public class LdapCachingTest
             return t;
         }
 
-        TestRealm( Config config, SecurityLog securityLog )
+        TestRealm( Config config, SecurityLog securityLog, SecureHasher secureHasher )
         {
-            super( config, securityLog );
+            super( config, securityLog, secureHasher );
             setAuthenticationCachingEnabled( true );
             setAuthorizationCachingEnabled( true );
         }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfoTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfoTest.java
@@ -31,10 +31,10 @@ import static org.neo4j.kernel.api.security.AuthenticationResult.TOO_MANY_ATTEMP
 
 public class ShiroAuthenticationInfoTest
 {
-    private ShiroAuthenticationInfo successInfo = new ShiroAuthenticationInfo( "user", "password", "realm", SUCCESS );
-    private ShiroAuthenticationInfo failureInfo = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
-    private ShiroAuthenticationInfo tooManyAttemptsInfo = new ShiroAuthenticationInfo( "user", "password", "realm", TOO_MANY_ATTEMPTS );
-    private ShiroAuthenticationInfo pwChangeRequiredInfo = new ShiroAuthenticationInfo( "user", "password", "realm", PASSWORD_CHANGE_REQUIRED );
+    private ShiroAuthenticationInfo successInfo = new ShiroAuthenticationInfo( "user", "realm", SUCCESS );
+    private ShiroAuthenticationInfo failureInfo = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
+    private ShiroAuthenticationInfo tooManyAttemptsInfo = new ShiroAuthenticationInfo( "user", "realm", TOO_MANY_ATTEMPTS );
+    private ShiroAuthenticationInfo pwChangeRequiredInfo = new ShiroAuthenticationInfo( "user", "realm", PASSWORD_CHANGE_REQUIRED );
 
     // These tests are here to remind you that you need to update the ShiroAuthenticationInfo.mergeMatrix[][]
     // whenever you add/remove/move values in the AuthenticationResult enum
@@ -54,7 +54,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeTwoSuccessToSameValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", SUCCESS );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", SUCCESS );
         info.merge( successInfo );
 
         assertEquals( info.getAuthenticationResult(), SUCCESS );
@@ -63,7 +63,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeTwoFailureToSameValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
         info.merge( failureInfo );
 
         assertEquals( info.getAuthenticationResult(), FAILURE );
@@ -72,7 +72,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeTwoTooManyAttemptsToSameValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", TOO_MANY_ATTEMPTS );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", TOO_MANY_ATTEMPTS );
         info.merge( tooManyAttemptsInfo );
 
         assertEquals( info.getAuthenticationResult(), TOO_MANY_ATTEMPTS );
@@ -81,7 +81,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeTwoPasswordChangeRequiredToSameValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", PASSWORD_CHANGE_REQUIRED );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", PASSWORD_CHANGE_REQUIRED );
         info.merge( pwChangeRequiredInfo );
 
         assertEquals( info.getAuthenticationResult(), PASSWORD_CHANGE_REQUIRED );
@@ -90,7 +90,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeFailureWithSuccessToNewValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
         info.merge( successInfo );
 
         assertEquals( info.getAuthenticationResult(), SUCCESS );
@@ -99,7 +99,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeFailureWithTooManyAttemptsToNewValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
         info.merge( tooManyAttemptsInfo );
 
         assertEquals( info.getAuthenticationResult(), TOO_MANY_ATTEMPTS );
@@ -108,7 +108,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeFailureWithPasswordChangeRequiredToNewValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
         info.merge( pwChangeRequiredInfo );
 
         assertEquals( info.getAuthenticationResult(), PASSWORD_CHANGE_REQUIRED );
@@ -117,7 +117,7 @@ public class ShiroAuthenticationInfoTest
     @Test
     public void shouldMergeToNewValue()
     {
-        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "password", "realm", FAILURE );
+        ShiroAuthenticationInfo info = new ShiroAuthenticationInfo( "user", "realm", FAILURE );
         info.merge( pwChangeRequiredInfo );
 
         assertEquals( info.getAuthenticationResult(), PASSWORD_CHANGE_REQUIRED );


### PR DESCRIPTION
Plugin realm was already using a new credentials hasher (based on Apache Shiro) that also does iterations and uses a secure random number generator, while the ldap realm was using the credentials hasher from the community edition. 

This unifies the implementation on the new hasher in enterprise edition.
