### PR TITLE
Improved `neo4j-admin help` output.

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -66,10 +66,7 @@ public interface AdminCommand
         /**
          * @return A single-line summary for the command. Should be 70 characters or less.
          */
-        public String summary()
-        {
-            return description();
-        }
+        public abstract String summary();
 
         /**
          * @return A description for the command's help text.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -64,6 +64,14 @@ public interface AdminCommand
         public abstract Optional<String> arguments();
 
         /**
+         * @return A single-line summary for the command. Should be 70 characters or less.
+         */
+        public String summary()
+        {
+            return description();
+        }
+
+        /**
          * @return A description for the command's help text.
          */
         public abstract String description();

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -106,7 +106,7 @@ public class AdminTool
     {
         final Usage.CommandUsage commandUsage = new Usage.CommandUsage( command, scriptName );
         outsideWorld.stdErrLine( e.getMessage() );
-        commandUsage.print( outsideWorld::stdErrLine );
+        commandUsage.printSummary( outsideWorld::stdErrLine );
         failure();
     }
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -104,9 +104,8 @@ public class AdminTool
 
     private void badUsage( AdminCommand.Provider command, IncorrectUsage e )
     {
-        final Usage.CommandUsage commandUsage = new Usage.CommandUsage( command, scriptName );
         outsideWorld.stdErrLine( e.getMessage() );
-        commandUsage.printSummary( outsideWorld::stdErrLine );
+        usage.printUsageForCommand( command, outsideWorld::stdErrLine );
         failure();
     }
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -104,15 +104,17 @@ public class AdminTool
 
     private void badUsage( AdminCommand.Provider command, IncorrectUsage e )
     {
-        failure( e.getMessage() );
         final Usage.CommandUsage commandUsage = new Usage.CommandUsage( command, scriptName );
+        outsideWorld.stdErrLine( e.getMessage() );
         commandUsage.print( outsideWorld::stdErrLine );
+        failure();
     }
 
     private void badUsage( String message )
     {
         usage.print( outsideWorld::stdErrLine );
-        failure( message );
+        outsideWorld.stdErrLine( message );
+        failure();
     }
 
     private void unexpected( RuntimeException e )
@@ -123,6 +125,11 @@ public class AdminTool
     private void commandFailed( CommandFailed e )
     {
         failure( "command failed", e );
+    }
+
+    private void failure()
+    {
+        outsideWorld.exit( 1 );
     }
 
     private void failure( String message, Exception e )

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -112,8 +112,8 @@ public class AdminTool
 
     private void badUsage( String message )
     {
-        usage.print( outsideWorld::stdErrLine );
         outsideWorld.stdErrLine( message );
+        usage.print( outsideWorld::stdErrLine );
         failure();
     }
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -104,9 +104,9 @@ public class AdminTool
 
     private void badUsage( AdminCommand.Provider command, IncorrectUsage e )
     {
+        failure( e.getMessage() );
         final Usage.CommandUsage commandUsage = new Usage.CommandUsage( command, scriptName );
         commandUsage.print( outsideWorld::stdErrLine );
-        failure( e.getMessage() );
     }
 
     private void badUsage( String message )

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -41,13 +41,13 @@ public class HelpCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.empty();
+            return Optional.of( "[<command>] ");
         }
 
         @Override
         public String description()
         {
-            return "Display this help text.";
+            return "This help text, or help for the command specified in <command>.";
         }
 
         @Override

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -82,10 +82,7 @@ public class HelpCommand implements AdminCommand
             try
             {
                 AdminCommand.Provider commandProvider = this.locator.findProvider( args[0] );
-                Usage.CommandUsage commandUsage = new Usage.CommandUsage( commandProvider, "neo4j-admin" );
-                commandUsage.print( this.output );
-                this.output.accept( commandProvider.description() );
-                this.output.accept( "" );
+                usage.printUsageForCommand( commandProvider, output );
             }
             catch ( NoSuchElementException e )
             {
@@ -94,7 +91,7 @@ public class HelpCommand implements AdminCommand
                         .forEach( commandProvider -> validCommands.append( commandProvider.name() ).append( " " ) );
 
                 throw new IncorrectUsage(
-                        format( "Unknown command: %s. Available commands are %s\n", args[0], validCommands ) );
+                        format( "Unknown command: %s. Available commands are: %s\n", args[0], validCommands ) );
             }
         }
         else

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -24,7 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import org.neo4j.helpers.Args;
+import static java.lang.String.format;
 
 public class HelpCommand implements AdminCommand
 {
@@ -41,7 +41,7 @@ public class HelpCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "[<command>] ");
+            return Optional.of( "[<command>]" );
         }
 
         @Override
@@ -75,9 +75,9 @@ public class HelpCommand implements AdminCommand
     }
 
     @Override
-    public void execute( String... args )
+    public void execute( String... args ) throws IncorrectUsage
     {
-        if (args.length > 0)
+        if ( args.length > 0 )
         {
             try
             {
@@ -86,12 +86,15 @@ public class HelpCommand implements AdminCommand
                 commandUsage.print( this.output );
                 this.output.accept( commandProvider.description() );
                 this.output.accept( "" );
-                return;
             }
-            catch (NoSuchElementException e)
+            catch ( NoSuchElementException e )
             {
-                this.output.accept( "Unknown command: " + args[0] );
-                this.output.accept( "" );
+                StringBuilder validCommands = new StringBuilder( "" );
+                locator.getAllProviders()
+                        .forEach( commandProvider -> validCommands.append( commandProvider.name() ).append( " " ) );
+
+                throw new IncorrectUsage(
+                        format( "Unknown command: %s. Available commands are %s\n", args[0], validCommands ) );
             }
         }
         else

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -48,6 +48,12 @@ public class HelpCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return description();
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new HelpCommand( usage, outsideWorld::stdOutLine );

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -63,10 +63,7 @@ public class Usage
             String arguments = command.arguments().map( ( s ) -> " " + s ).orElse( "" );
             output.accept( format( "%s %s%s", scriptName, command.name(), arguments ) );
             output.accept( "" );
-            for ( String line : splitLongLine( command.summary(), 80 ) )
-            {
-                output.accept( "    " + line );
-            }
+            output.accept( "    " + command.summary() );
             output.accept( "" );
         }
     }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -37,14 +37,24 @@ public class Usage
 
     public void print( Consumer<String> output )
     {
-        output.accept( "Usage:" );
+        output.accept( format( "Usage: %s <command>", scriptName ) );
         output.accept( "" );
+        output.accept( "Available commands:" );
 
         for ( AdminCommand.Provider command : commands.getAllProviders() )
         {
             final CommandUsage commandUsage = new CommandUsage( command, scriptName );
-            commandUsage.print( output );
+            commandUsage.printIndentedSummary( output );
         }
+
+        output.accept( "" );
+        output.accept( format( "Use %s help <command> for more details.", scriptName ) );
+    }
+
+    public void printUsageForCommand( AdminCommand.Provider command, Consumer<String> output )
+    {
+        final CommandUsage commandUsage = new CommandUsage( command, scriptName );
+        commandUsage.printDetailed( output );
     }
 
     public static class CommandUsage
@@ -58,13 +68,22 @@ public class Usage
             this.scriptName = scriptName;
         }
 
-        public void print( Consumer<String> output )
+        public void printSummary( Consumer<String> output )
         {
-            String arguments = command.arguments().map( ( s ) -> " " + s ).orElse( "" );
-            output.accept( format( "%s %s%s", scriptName, command.name(), arguments ) );
-            output.accept( "" );
+            output.accept( format( "%s", command.name() ) );
             output.accept( "    " + command.summary() );
+        }
+
+        public void printIndentedSummary( Consumer<String> output )
+        {
+            printSummary( s -> output.accept( "    " + s ) );
+        }
+
+        public void printDetailed( Consumer<String> output )
+        {
+            output.accept( format( "%s %s %s", scriptName, command.name(), command.arguments().orElse( "" ) ) );
             output.accept( "" );
+            output.accept( command.description() );
         }
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -63,7 +63,7 @@ public class Usage
             String arguments = command.arguments().map( ( s ) -> " " + s ).orElse( "" );
             output.accept( format( "%s %s%s", scriptName, command.name(), arguments ) );
             output.accept( "" );
-            for ( String line : splitLongLine( command.description(), 80 ) )
+            for ( String line : splitLongLine( command.summary(), 80 ) )
             {
                 output.accept( "    " + line );
             }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.commandline.admin;
 
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -29,6 +30,7 @@ import org.neo4j.helpers.collection.Iterables;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 
 public class AdminToolTest
 {
@@ -162,8 +164,9 @@ public class AdminToolTest
         };
         new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
                 .execute( null, null, "exception" );
-        verify( outsideWorld ).stdErrLine( "neo4j-admin exception" );
-        verify( outsideWorld ).stdErrLine( "the-usage-message" );
+        InOrder inOrder = inOrder(outsideWorld);
+        inOrder.verify( outsideWorld ).stdErrLine( "the-usage-message" );
+        inOrder.verify( outsideWorld ).stdErrLine( "neo4j-admin exception" );
         verify( outsideWorld ).exit( 1 );
     }
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -57,7 +57,7 @@ public class AdminToolTest
     {
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new NullCommandLocator(), outsideWorld, false ).execute( null, null, "help" );
-        verify( outsideWorld ).stdOutLine( "neo4j-admin help [<command>]" );
+        verify( outsideWorld ).stdOutLine( "    help" );
     }
 
     @Test
@@ -66,7 +66,7 @@ public class AdminToolTest
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new NullCommandLocator(), outsideWorld, false ).execute( null, null );
         verify( outsideWorld ).stdErrLine( "you must provide a command" );
-        verify( outsideWorld ).stdErrLine( "Usage:" );
+        verify( outsideWorld ).stdErrLine( "Usage: neo4j-admin <command>" );
         verify( outsideWorld ).exit( 1 );
     }
 
@@ -159,7 +159,6 @@ public class AdminToolTest
         new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
         InOrder inOrder = inOrder( outsideWorld );
         inOrder.verify( outsideWorld ).stdErrLine( "the-usage-message" );
-        inOrder.verify( outsideWorld ).stdErrLine( "neo4j-admin exception" );
         verify( outsideWorld ).exit( 1 );
     }
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -57,7 +57,7 @@ public class AdminToolTest
     {
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new NullCommandLocator(), outsideWorld, false ).execute( null, null, "help" );
-        verify( outsideWorld ).stdOutLine( "neo4j-admin help [<command>] " );
+        verify( outsideWorld ).stdOutLine( "neo4j-admin help [<command>]" );
     }
 
     @Test

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -184,6 +184,12 @@ public class AdminToolTest
             }
 
             @Override
+            public String summary()
+            {
+                return "";
+            }
+
+            @Override
             public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
             {
                 return command;
@@ -221,6 +227,12 @@ public class AdminToolTest
 
         @Override
         public String description()
+        {
+            return "";
+        }
+
+        @Override
+        public String summary()
         {
             return "";
         }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -27,10 +27,10 @@ import java.util.Optional;
 
 import org.neo4j.helpers.collection.Iterables;
 
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.inOrder;
 
 public class AdminToolTest
 {
@@ -57,7 +57,7 @@ public class AdminToolTest
     {
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new NullCommandLocator(), outsideWorld, false ).execute( null, null, "help" );
-        verify( outsideWorld ).stdOutLine( "neo4j-admin help" );
+        verify( outsideWorld ).stdOutLine( "neo4j-admin help [<command>] " );
     }
 
     @Test
@@ -78,8 +78,7 @@ public class AdminToolTest
         {
             throw new RuntimeException( "the-exception-message" );
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
         verify( outsideWorld ).stdErrLine( "unexpected error: the-exception-message" );
         verify( outsideWorld ).exit( 1 );
     }
@@ -93,8 +92,7 @@ public class AdminToolTest
         {
             throw exception;
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, true )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, true ).execute( null, null, "exception" );
         verify( outsideWorld ).printStacktrace( exception );
     }
 
@@ -107,8 +105,7 @@ public class AdminToolTest
         {
             throw exception;
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
         verify( outsideWorld, never() ).printStacktrace( exception );
     }
 
@@ -120,8 +117,7 @@ public class AdminToolTest
         {
             throw new CommandFailed( "the-failure-message" );
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
         verify( outsideWorld ).stdErrLine( "command failed: the-failure-message" );
         verify( outsideWorld ).exit( 1 );
     }
@@ -135,8 +131,7 @@ public class AdminToolTest
         {
             throw exception;
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, true )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, true ).execute( null, null, "exception" );
         verify( outsideWorld ).printStacktrace( exception );
     }
 
@@ -149,8 +144,7 @@ public class AdminToolTest
         {
             throw exception;
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
-                .execute( null, null, "exception" );
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
         verify( outsideWorld, never() ).printStacktrace( exception );
     }
 
@@ -162,9 +156,8 @@ public class AdminToolTest
         {
             throw new IncorrectUsage( "the-usage-message" );
         };
-        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false )
-                .execute( null, null, "exception" );
-        InOrder inOrder = inOrder(outsideWorld);
+        new AdminTool( cannedCommand( "exception", command ), outsideWorld, false ).execute( null, null, "exception" );
+        InOrder inOrder = inOrder( outsideWorld );
         inOrder.verify( outsideWorld ).stdErrLine( "the-usage-message" );
         inOrder.verify( outsideWorld ).stdErrLine( "neo4j-admin exception" );
         verify( outsideWorld ).exit( 1 );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HelpCommandTest
+{
+    @Mock
+    private Consumer<String> out;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Ignore
+    public void showsGeneralHelpOutputWhenNoCommandIsProvided() {};
+
+    @Test
+    public void printsUnknownCommandWhenUnknownCommandIsProvided()
+    {
+        CommandLocator commandLocator = mock( CommandLocator.class );
+        when( commandLocator.findProvider( "foobar" ) ).thenThrow( new NoSuchElementException( "foobar" ) );
+
+        HelpCommand helpCommand = new HelpCommand( mock( Usage.class ), out, commandLocator );
+        helpCommand.execute( "foobar" );
+
+        InOrder ordered = inOrder( out );
+        ordered.verify( out ).accept( "Unknown command: foobar" );
+        ordered.verify( out ).accept( "" );
+        ordered.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void showsArgumentsAndDescriptionForSpecifiedCommand()
+    {
+        CommandLocator commandLocator = mock( CommandLocator.class );
+        AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );
+        when( commandProvider.name() ).thenReturn( "foobar" );
+        when( commandProvider.arguments() ).thenReturn( Optional.of( "--baz --qux" ) );
+        when( commandProvider.summary() ).thenReturn( "This is a summary of the foobar command." );
+        when( commandProvider.description() ).thenReturn( "This is a description of the foobar command." );
+        when( commandLocator.findProvider( "foobar" ) ).thenReturn( commandProvider );
+
+        HelpCommand helpCommand = new HelpCommand( mock( Usage.class ), out, commandLocator );
+        helpCommand.execute( "foobar" );
+
+        InOrder ordered = inOrder( out );
+        ordered.verify( out ).accept( "neo4j-admin foobar --baz --qux" );
+        ordered.verify( out ).accept( "" );
+        ordered.verify( out ).accept( "    This is a summary of the foobar command." );
+        ordered.verify( out ).accept( "" );
+        ordered.verify( out ).accept( "This is a description of the foobar command." );
+        ordered.verify( out ).accept( "" );
+        ordered.verifyNoMoreInteractions();
+    }
+}

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -88,7 +88,7 @@ public class HelpCommandTest
         }
         catch ( IncorrectUsage e )
         {
-            assertThat( e.getMessage(), containsString( "Available commands are foo bar baz" ) );
+            assertThat( e.getMessage(), containsString( "Available commands are: foo bar baz" ) );
         }
     }
 
@@ -106,20 +106,16 @@ public class HelpCommandTest
         AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );
         when( commandProvider.name() ).thenReturn( "foobar" );
         when( commandProvider.arguments() ).thenReturn( Optional.of( "--baz --qux" ) );
-        when( commandProvider.summary() ).thenReturn( "This is a summary of the foobar command." );
         when( commandProvider.description() ).thenReturn( "This is a description of the foobar command." );
         when( commandLocator.findProvider( "foobar" ) ).thenReturn( commandProvider );
 
-        HelpCommand helpCommand = new HelpCommand( mock( Usage.class ), out, commandLocator );
+        HelpCommand helpCommand = new HelpCommand( new Usage( "neo4j-admin", commandLocator ), out, commandLocator );
         helpCommand.execute( "foobar" );
 
         InOrder ordered = inOrder( out );
         ordered.verify( out ).accept( "neo4j-admin foobar --baz --qux" );
         ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "    This is a summary of the foobar command." );
-        ordered.verify( out ).accept( "" );
         ordered.verify( out ).accept( "This is a description of the foobar command." );
-        ordered.verify( out ).accept( "" );
         ordered.verifyNoMoreInteractions();
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -55,17 +55,16 @@ public class UsageTest
         usage.print( out );
 
         InOrder ordered = inOrder( out );
-        ordered.verify( out ).accept( "Usage:" );
+        ordered.verify( out ).accept( "Usage: neo4j-admin <command>" );
         ordered.verify( out ).accept( "" );
+        ordered.verify( out ).accept( "Available commands:" );
         ordered.verify( out )
-                .accept( "neo4j-admin restore ---from <backup-directory> --database=<database-name> [--force]" );
+                .accept( "    restore" );
+        ordered.verify( out ).accept( "        Restores a database backed up using the neo4j-backup tool." );
+        ordered.verify( out ).accept( "    bam" );
+        ordered.verify( out ).accept( "        A summary" );
         ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "    Restores a database backed up using the neo4j-backup tool." );
-        ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "neo4j-admin bam" );
-        ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "    A summary" );
-        ordered.verify( out ).accept( "" );
+        ordered.verify( out ).accept( "Use neo4j-admin help <command> for more details." );
         ordered.verifyNoMoreInteractions();
     }
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -49,7 +49,7 @@ public class UsageTest
                         new StubProvider( "restore",
                                 Optional.of( "---from <backup-directory> --database=<database-name> [--force]" ),
                                 "Restores a database backed up using the neo4j-backup tool." ),
-                        new StubProvider( "bam", Optional.empty(), "Some description" )
+                        new StubProvider( "bam", Optional.empty(), "A summary" )
                 };
         final Usage usage = new Usage( "neo4j-admin", new CannedLocator( commands ) );
         usage.print( out );
@@ -64,7 +64,7 @@ public class UsageTest
         ordered.verify( out ).accept( "" );
         ordered.verify( out ).accept( "neo4j-admin bam" );
         ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "    Some description" );
+        ordered.verify( out ).accept( "    A summary" );
         ordered.verify( out ).accept( "" );
         ordered.verifyNoMoreInteractions();
     }
@@ -72,13 +72,13 @@ public class UsageTest
     private static class StubProvider extends AdminCommand.Provider
     {
         private final Optional<String> arguments;
-        private final String description;
+        private final String summary;
 
-        public StubProvider( String name, Optional<String> arguments, String description )
+        public StubProvider( String name, Optional<String> arguments, String summary )
         {
             super( name );
             this.arguments = arguments;
-            this.description = description;
+            this.summary = summary;
         }
 
         @Override
@@ -90,13 +90,13 @@ public class UsageTest
         @Override
         public String description()
         {
-            return description;
+            return "";
         }
 
         @Override
         public String summary()
         {
-            return description;
+            return summary;
         }
 
         @Override

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -94,6 +94,12 @@ public class UsageTest
         }
 
         @Override
+        public String summary()
+        {
+            return description;
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             throw new UnsupportedOperationException( "not implemented" );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -63,19 +63,26 @@ public class CheckConsistencyCommand implements AdminCommand
         @Override
         public Optional<String> arguments()
         {
-            return Optional.of( "--database=<database> [--additional-config=<file>] [--verbose]" );
+            return Optional.of( "--database=<database-name> [--additional-config=<config-file-path>] [--verbose]" );
         }
 
         @Override
         public String description()
         {
-            return "Check the consistency of a database.";
+            return "Check the consistency of a database.\n" +
+                    "\n" +
+                    "--database=<database>\n" +
+                    "        The name of the database to check the consistency of.\n" +
+                    "--additional-config=<config-file-path>\n" +
+                    "        Configuration file to supply additional configuration in.\n" +
+                    "--verbose\n" +
+                    "        Enable verbose output.\n";
         }
 
         @Override
         public String summary()
         {
-            return description();
+            return "Check the consistency of a database.";
         }
 
         @Override

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -73,6 +73,12 @@ public class CheckConsistencyCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return description();
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new CheckConsistencyCommand( homeDir, configDir, outsideWorld );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -76,6 +76,12 @@ public class DumpCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return "Dump a database into a single-file archive.";
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new DumpCommand( homeDir, configDir, new Dumper() );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -83,6 +83,12 @@ public class ImportCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return "Import from a collection of CSV files or a pre-3.0 database.";
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new ImportCommand( homeDir, configDir, outsideWorld );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -73,6 +73,12 @@ public class LoadCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return "Load a database from an archive created with the dump command.";
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new LoadCommand( homeDir, configDir, new Loader() );

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
@@ -65,6 +65,12 @@ public class SetInitialPasswordCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return description();
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new SetInitialPasswordCommand( homeDir, configDir, outsideWorld );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -83,6 +83,12 @@ public class OnlineBackupCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return "Perform a backup, over the network, from a running Neo4j server.";
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new OnlineBackupCommand(

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -67,6 +67,12 @@ public class RestoreDatabaseCli implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return description();
+        }
+
+        @Override
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new RestoreDatabaseCli( homeDir, configDir );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -62,6 +62,12 @@ public class UnbindFromClusterCommand implements AdminCommand
         }
 
         @Override
+        public String summary()
+        {
+            return "Removes cluster state data from the specified database.";
+        }
+
+        @Override
         public String description()
         {
             return "Removes cluster state data from the specified database making it suitable for use in single " +


### PR DESCRIPTION
## Before
### General help

```
$ bin/neo4j-admin help
Usage:

neo4j-admin set-initial-password <password>

    Sets the initial password of the initial admin user ('neo4j').

neo4j-admin dump --database=<database> --to=<destination-path>

    Dump a database into a single-file archive. The archive can be used by the load
    command. <destination-path> can be a file or directory (in which case a file
    called <database>.dump will be created). It is not possible to dump a database
    that is mounted in a running Neo4j server.

neo4j-admin load --from=<archive-path> --database=<database> [--force]

    Load a database from an archive. <archive-path> must be an archive created with
    the dump command. <database> is the name of the database to create. Existing
    databases can be replaced by specifying --force. It is not possible to replace a
    database that is mounted in a running Neo4j server.

neo4j-admin check-consistency --database=<database> [--additional-config=<file>] [--verbose]

    Check the consistency of a database.

neo4j-admin import --database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>] [--from=<source-directory>] [--report-file=<filename>] [--nodes[:Label1:Label2]="<file1>,<file2>,..."] [--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."] [--id-type=<id-type>] [--input-encoding=<character-set>] [--page-size=<page-size>]

    Import a collection of CSV files with --mode=csv (default), or a database from
    a pre-3.0 installation with --mode=database.

    --database=<database-name>
            The name of the new database to import into. This cannot be an existing
            database.
    --additional-config=<config-file-path>
            Configuration file to supply additional configuration values to
            the import tools.

    --mode=database
            Import a database from a pre-3.0 Neo4j installation.
    --from=<source-directory>
            <source-directory> is the location of the pre-3.0 database
            (e.g. <neo4j-root>/data/graph.db).

    --mode=csv
            Import a database from a collection of CSV files.
    --report-file=<filename>
            File name in which to store the report of the import.
            Defaults to import.report in the current directory.
    --nodes[:Label1:Label2]="<file1>,<file2>,..."
            Node CSV header and data. Multiple files will be logically seen as
            one big file from the perspective of the importer. The first line
            must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."
            Relationship CSV header and data. Multiple files will be logically
            seen as one big file from the perspective of the importer. The first
            line must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --id-type=<id-type>
            Each node must provide a unique id. This is used to find the correct
            nodes when creating relationships. Must be one of:
                STRING: (default) arbitrary strings for identifying nodes.
                INTEGER: arbitrary integer values for identifying nodes.
                ACTUAL: (advanced) actual node ids. The default option is STRING.
            For more information on id handling, please see the Neo4j Manual:
            http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
    --input-encoding <character-set>
            Character set that input data is encoded in. Defaults to UTF-8.

neo4j-admin help

    Display this help text.
```
### When a command is used incorrectly

```
$ bin/neo4j-admin check-consistency
neo4j-admin check-consistency --database=<database> [--additional-config=<file>] [--verbose]

    Check the consistency of a database.

Missing argument 'database'
```
## After
### General help

```
$ bin/neo4j-admin help
Usage: neo4j-admin <command>

Available commands:
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').
    dump
        Dump a database into a single-file archive.
    load
        Load a database from an archive created with the dump command.
    check-consistency
        Check the consistency of a database.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    help
        This help text, or help for the command specified in <command>.

Use neo4j-admin help <command> for more details.
```
### When a command is used incorrectly

```
$ bin/neo4j-admin check-consistency blah
Missing argument 'database'
neo4j-admin check-consistency --database=<database-name> [--additional-config=<config-file-path>] [--verbose]

Check the consistency of a database.

--database=<database>
        The name of the database to check the consistency of.
--additional-config=<config-file-path>
        Configuration file to supply additional configuration in.

```
### Help on a specific command

Import has a _lot_ of options, so it's the best example of where improvements might be made.

```
$ bin/neo4j-admin help import
neo4j-admin import --database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>] [--from=<source-directory>] [--report-file=<filename>] [--nodes[:Label1:Label2]="<file1>,<file2>,..."] [--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."] [--id-type=<id-type>] [--input-encoding=<character-set>] [--page-size=<page-size>]

Import a collection of CSV files with --mode=csv (default), or a database from
a pre-3.0 installation with --mode=database.

--database=<database-name>
        The name of the new database to import into. This cannot be an existing
        database.
--additional-config=<config-file-path>
        Configuration file to supply additional configuration values to
        the import tools.

--mode=database
        Import a database from a pre-3.0 Neo4j installation.
--from=<source-directory>
        <source-directory> is the location of the pre-3.0 database
        (e.g. <neo4j-root>/data/graph.db).

--mode=csv
        Import a database from a collection of CSV files.
--report-file=<filename>
        File name in which to store the report of the import.
        Defaults to import.report in the current directory.
--nodes[:Label1:Label2]="<file1>,<file2>,..."
        Node CSV header and data. Multiple files will be logically seen as
        one big file from the perspective of the importer. The first line
        must contain the header. Multiple data sources like these can be
        specified in one import, where each data source has its own header.
        Note that file groups must be enclosed in quotation marks.
--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."
        Relationship CSV header and data. Multiple files will be logically
        seen as one big file from the perspective of the importer. The first
        line must contain the header. Multiple data sources like these can be
        specified in one import, where each data source has its own header.
        Note that file groups must be enclosed in quotation marks.
--id-type=<id-type>
        Each node must provide a unique id. This is used to find the correct
        nodes when creating relationships. Must be one of:
            STRING: (default) arbitrary strings for identifying nodes.
            INTEGER: arbitrary integer values for identifying nodes.
            ACTUAL: (advanced) actual node ids. The default option is STRING.
        For more information on id handling, please see the Neo4j Manual:
        http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
--input-encoding <character-set>
        Character set that input data is encoded in. Defaults to UTF-8.
```
### Help on a command that doesn't exist

```
$ bin/neo4j-admin help foobar
Unknown command: foobar. Available commands are: set-initial-password dump load check-consistency import

neo4j-admin help [<command>]

This help text, or help for the command specified in <command>.
```
