### PR TITLE
Fixed parsing of config values with trailing spaces

### DIFF
--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MapUtil.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MapUtil.java
@@ -170,11 +170,19 @@ public abstract class MapUtil
      * @return the read data as a {@link Map}.
      * @throws IOException if the {@code stream} throws {@link IOException}.
      */
-    public static Map<String, String> load( InputStream stream ) throws IOException
+    public static Map<String,String> load( InputStream stream ) throws IOException
     {
         Properties props = new Properties();
         props.load( stream );
-        return new HashMap<>( (Map) props );
+
+        HashMap<String,String> result = new HashMap<>();
+        for ( Map.Entry<Object,Object> entry : props.entrySet() )
+        {
+            // Properties does not trim whitespace from the right side of values
+            result.put( (String) entry.getKey(), ( (String) entry.getValue() ).trim() );
+        }
+
+        return result;
     }
 
     /**

--- a/community/collections/src/test/java/org/neo4j/helpers/collection/MapUtilTest.java
+++ b/community/collections/src/test/java/org/neo4j/helpers/collection/MapUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapUtilTest
+{
+    @Test
+    public void loadSpacedValue() throws Exception
+    {
+        // expecting
+        Map<String,String> expected = new HashMap<>();
+        expected.put( "key", "value" );
+
+        // given
+        InputStream inputStream = new ByteArrayInputStream( "   key   =   value   ".getBytes() );
+
+        // when
+        Map<String,String> result = MapUtil.load( inputStream );
+
+        // then
+        assertEquals( expected, result );
+    }
+
+    @Test
+    public void loadNothing() throws Exception
+    {
+        // expecting
+        Map<String,String> expected = new HashMap<>();
+        expected.put( "key", "" );
+
+        // given
+        InputStream inputStream = new ByteArrayInputStream( "   key   =      ".getBytes() );
+
+        // when
+        Map<String,String> result = MapUtil.load( inputStream );
+
+        // then
+        assertEquals( expected, result );
+    }
+}


### PR DESCRIPTION
fixes #8149

changelog: Fixed parsing of config values with trailing spaces [#8149](https://github.com/neo4j/neo4j/issues/8149)
