### PR TITLE
Nicer error message when using null keys in maps

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
+import java.util.HashMap;
 
 import org.neo4j.bolt.v1.transport.socket.client.Connection;
 import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
@@ -319,6 +320,32 @@ public class TransportSessionIT
                 msgSuccess( map( "fields", singletonList( "n.binary") ) ),
                 msgRecord(eqRecord( nullValue() )),
                 msgFailure( Status.Request.Invalid, "Byte array is not yet supported in Bolt")) );
+    }
+
+    @Test
+    public void shouldFailNicelyOnNullKeysInMap() throws Throwable
+    {
+        //Given
+        GraphDatabaseService db = server.graphDatabaseService();
+        HashMap<String,Object> params = new HashMap<>();
+        HashMap<String,Object> inner = new HashMap<>();
+        inner.put(null, 42L);
+        inner.put("foo", 1337L);
+        params.put( "p", inner );
+
+        // When
+        client.connect( address )
+                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
+                .send( TransportTestUtil.chunk(
+                        init( "TestClient/1.1", emptyMap() ),
+                        run( "RETURN {p}", params ),
+                        pullAll() ) );
+
+        // Then
+        assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
+        assertThat( client, eventuallyRecieves(
+                msgSuccess(),
+                msgFailure( Status.Request.Invalid, "Value `null` is not supported as key in maps, must be a non-nullable string.")) );
     }
 
     @Before


### PR DESCRIPTION
Bolt is not supporting `null` as keys in maps, however we should not fail
with a `NullPointerException` but with a proper error message and a proper `BoltIOException`.
