### PR TITLE
Fixed `neo4j-admin backup` printing to stdout

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -21,6 +21,7 @@ package org.neo4j.backup;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -113,7 +114,13 @@ class BackupService
 
     BackupService()
     {
-        this( new DefaultFileSystemAbstraction(), FormattedLogProvider.toOutputStream( System.out ), new Monitors() );
+        this( System.out );
+    }
+
+    BackupService( OutputStream logDestination )
+    {
+        this( new DefaultFileSystemAbstraction(), FormattedLogProvider.toOutputStream( logDestination ),
+                new Monitors() );
     }
 
     BackupService( FileSystemAbstraction fileSystem, LogProvider logProvider, Monitors monitors )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.configuration.ConfigLoader;
 
 import static java.util.Arrays.asList;
-
 import static org.neo4j.kernel.impl.util.Converters.mandatory;
 import static org.neo4j.kernel.impl.util.Converters.optional;
 import static org.neo4j.kernel.impl.util.Converters.toFile;
@@ -87,7 +86,8 @@ public class OnlineBackupCommand implements AdminCommand
         public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
         {
             return new OnlineBackupCommand(
-                    new BackupTool( new BackupService(), outsideWorld.errorStream() ), homeDir, configDir );
+                    new BackupTool( new BackupService( outsideWorld.errorStream() ), outsideWorld.errorStream() ),
+                    homeDir, configDir );
         }
     }
 


### PR DESCRIPTION
Diagnostic output should go to stderr, with the rest.
