### PR TITLE
Better error messages for udf and procedures

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/CypherCompiler.scala
@@ -236,7 +236,7 @@ case class CypherCompiler(parser: CypherParser,
 
   private def procedureDeprecationNotifications(statement: Statement): Set[InternalNotification] =
     statement.treeFold(Set.empty[InternalNotification]) {
-      case f@ResolvedCall(ProcedureSignature(name, _, _, Some(deprecatedBy), _), _, _, _, _) =>
+      case f@ResolvedCall(ProcedureSignature(name, _, _, Some(deprecatedBy), _, _), _, _, _, _) =>
         (seq) => (seq + DeprecatedProcedureNotification(f.position, name.toString, deprecatedBy), None)
     }
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
@@ -101,7 +101,7 @@ case class ResolvedCall(signature: ProcedureSignature,
         }.foldLeft(success)(_ chain _)
       } else {
         val msg = (if (signature.inputSignature.isEmpty) "arguments"
-        else if (signature.inputSignature.size == 1) s"argument with type ${signature.inputSignature.head.typ.toNeoTypeString}"
+        else if (signature.inputSignature.size == 1) s"argument of type ${signature.inputSignature.head.typ.toNeoTypeString}"
         else s"arguments of type ${signature.inputSignature.map(_.typ.toNeoTypeString).mkString(", ")}") +
           signature.description.map(d => s"${System.lineSeparator()}Description: $d").getOrElse("")
         error(_: SemanticState, SemanticError(

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
@@ -100,7 +100,15 @@ case class ResolvedCall(signature: ProcedureSignature,
             arg.semanticCheck(SemanticContext.Results) chain arg.expectType(field.typ.covariant)
         }.foldLeft(success)(_ chain _)
       } else {
-        error(_: SemanticState, SemanticError(s"Procedure call does not provide the required number of arguments ($expectedNumArgs)", position))
+        val msg = (if (signature.inputSignature.isEmpty) "arguments"
+        else if (signature.inputSignature.size == 1) s"argument with type ${signature.inputSignature.head.typ.toNeoTypeString}"
+        else s"arguments of type ${signature.inputSignature.map(_.typ.toNeoTypeString).mkString(", ")}") +
+          signature.description.map(d => s"${System.lineSeparator()}Description: $d").getOrElse("")
+        error(_: SemanticState, SemanticError(
+          s"""Procedure call does not provide the required number of arguments: got $actualNumArgs expected $expectedNumArgs.
+             |
+             |Procedure ${signature.name} has signature: $signature
+             |meaning that it expects $expectedNumArgs $msg""".stripMargin, position))
       }
     } else {
       error(_: SemanticState, SemanticError(s"Procedure call inside a query does not support passing arguments implicitly (pass explicitly after procedure name instead)", position))

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
@@ -80,7 +80,14 @@ case class ResolvedFunctionInvocation(qualifiedName: QualifiedName,
               arg.semanticCheck(SemanticContext.Results) chain arg.expectType(field.typ.covariant)
           }.foldLeft(success)(_ chain _)
         } else {
-          error(_: SemanticState, SemanticError(s"Function call does not provide the required number of arguments ($expectedNumArgs)", position))
+          val msg = (if (signature.inputSignature.isEmpty) "arguments"
+          else if (signature.inputSignature.size == 1) s"argument with type ${signature.inputSignature.head.typ.toNeoTypeString}"
+          else s"arguments of type ${signature.inputSignature.map(_.typ.toNeoTypeString).mkString(", ")}") +
+            signature.description.map(d => s"${System.lineSeparator()}Description: $d").getOrElse("")
+          error(_: SemanticState, SemanticError( s"""Function call does not provide the required number of arguments: expected $expectedNumArgs got $actualNumArgs.
+             |
+             |Function ${signature.name} has signature: $signature
+             |meaning that it expects $expectedNumArgs $msg""".stripMargin, position))
         }
   }
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
@@ -81,7 +81,7 @@ case class ResolvedFunctionInvocation(qualifiedName: QualifiedName,
           }.foldLeft(success)(_ chain _)
         } else {
           val msg = (if (signature.inputSignature.isEmpty) "arguments"
-          else if (signature.inputSignature.size == 1) s"argument with type ${signature.inputSignature.head.typ.toNeoTypeString}"
+          else if (signature.inputSignature.size == 1) s"argument of type ${signature.inputSignature.head.typ.toNeoTypeString}"
           else s"arguments of type ${signature.inputSignature.map(_.typ.toNeoTypeString).mkString(", ")}") +
             signature.description.map(d => s"${System.lineSeparator()}Description: $d").getOrElse("")
           error(_: SemanticState, SemanticError( s"""Function call does not provide the required number of arguments: expected $expectedNumArgs got $actualNumArgs.

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
@@ -26,11 +26,17 @@ case class ProcedureSignature(name: QualifiedName,
                               inputSignature: IndexedSeq[FieldSignature],
                               outputSignature: Option[IndexedSeq[FieldSignature]],
                               deprecationInfo: Option[String],
-                              accessMode: ProcedureAccessMode) {
+                              accessMode: ProcedureAccessMode,
+                              description: Option[String] = None) {
 
   def outputFields = outputSignature.getOrElse(Seq.empty)
 
   def isVoid = outputSignature.isEmpty
+
+  override def toString = {
+    val sig = inputSignature.mkString(", ")
+    outputSignature.map(out => s"$name($sig) :: ${out.mkString(", ")}").getOrElse(s"$name($sig) :: VOID")
+  }
 }
 
 case class UserFunctionSignature(name: QualifiedName,
@@ -51,7 +57,12 @@ case class QualifiedName(namespace: Seq[String], name: String) {
 }
 
 case class CypherValue(value: AnyRef, cypherType: CypherType)
-case class FieldSignature(name: String, typ: CypherType, default: Option[CypherValue] = None)
+case class FieldSignature(name: String, typ: CypherType, default: Option[CypherValue] = None) {
+  override def toString = {
+    val nameValue = default.map( d => s"$name  =  ${d.value}").getOrElse(name)
+    s"$nameValue :: ${typ.toNeoTypeString}"
+  }
+}
 
 sealed trait  ProcedureAccessMode
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
@@ -43,7 +43,10 @@ case class UserFunctionSignature(name: QualifiedName,
                                  inputSignature: IndexedSeq[FieldSignature],
                                  outputType: CypherType,
                                  deprecationInfo: Option[String],
-                                 allowed: Array[String])
+                                 allowed: Array[String],
+                                 description: Option[String]) {
+  override def toString = s"$name(${inputSignature.mkString(", ")}) :: ${outputType.toNeoTypeString}"
+}
 
 object QualifiedName {
   def apply(unresolved: UnresolvedCall): QualifiedName =

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
@@ -234,7 +234,7 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
       """Procedure call does not provide the required number of arguments: got 0 expected 1.
         |
         |Procedure my.proc.foo has signature: my.proc.foo(a :: INTEGER?) :: x :: INTEGER?, y :: LIST? OF NODE?
-        |meaning that it expects 1 argument with type INTEGER? (line 1, column 0 (offset: 0))""".stripMargin
+        |meaning that it expects 1 argument of type INTEGER? (line 1, column 0 (offset: 0))""".stripMargin
     ))
   }
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
@@ -229,8 +229,12 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
     val unresolved = UnresolvedCall(ns, name, Some(callArguments), Some(callResults))(pos)
     val resolved = ResolvedCall(_ => signature)(unresolved)
 
-    errorTexts(resolved.semanticCheck(SemanticState.clean)).toList should equal(List(
-      "Procedure call does not provide the required number of arguments (1) (line 1, column 0 (offset: 0))"
+    val toList: List[String] = errorTexts(resolved.semanticCheck(SemanticState.clean)).toList
+    toList should equal(List(
+      """Procedure call does not provide the required number of arguments: got 0 expected 1.
+        |
+        |Procedure my.proc.foo has signature: my.proc.foo(a :: INTEGER?) :: x :: INTEGER?, y :: LIST? OF NODE?
+        |meaning that it expects 1 argument with type INTEGER? (line 1, column 0 (offset: 0))""".stripMargin
     ))
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -139,8 +139,9 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapperv3_1, logger: I
     val output = if (ks.isVoid) None else Some(ks.outputSignature().asScala.map(s => FieldSignature(s.name(), asCypherType(s.neo4jType()))).toIndexedSeq)
     val deprecationInfo = asOption(ks.deprecated())
     val mode = asCypherProcMode(ks.mode(), ks.allowed())
+    val description = asOption(ks.description())
 
-    ProcedureSignature(name, input, output, deprecationInfo, mode)
+    ProcedureSignature(name, input, output, deprecationInfo, mode, description)
   }
 
   override def functionSignature(name: QualifiedName): Option[UserFunctionSignature] = {
@@ -151,8 +152,9 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapperv3_1, logger: I
       val input = ks.inputSignature().asScala.map(s => FieldSignature(s.name(), asCypherType(s.neo4jType()), asOption(s.defaultValue()).map(asCypherValue))).toIndexedSeq
       val output = asCypherType(ks.outputType())
       val deprecationInfo = asOption(ks.deprecated())
+      val description = asOption(ks.description())
 
-      Some(UserFunctionSignature(name, input, output, deprecationInfo, ks.allowed()))
+      Some(UserFunctionSignature(name, input, output, deprecationInfo, ks.allowed(), description))
     }
     else None
   }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/AnyType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/AnyType.scala
@@ -27,6 +27,8 @@ object AnyType {
     override def isAssignableFrom(other: CypherType): Boolean = true
 
     override val toString = "Any"
+    override val toNeoTypeString = "ANY?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/BooleanType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/BooleanType.scala
@@ -23,6 +23,8 @@ object BooleanType {
   val instance = new BooleanType() {
     val parentType = CTAny
     override val toString = "Boolean"
+    override val toNeoTypeString = "BOOLEAN?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/CypherType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/CypherType.scala
@@ -63,4 +63,6 @@ abstract class CypherType {
   lazy val contravariant: TypeSpec = TypeSpec.all leastUpperBounds this
 
   def rewrite(f: CypherType => CypherType) = f(this)
+
+  def toNeoTypeString: String
 }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/FloatType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/FloatType.scala
@@ -23,6 +23,8 @@ object FloatType {
   val instance = new FloatType() {
     val parentType = CTNumber
     override val toString = "Float"
+    override val toNeoTypeString = "FLOAT?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/GeometryType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/GeometryType.scala
@@ -23,6 +23,8 @@ object GeometryType {
   val instance = new GeometryType() {
     val parentType = CTAny
     override val toString = "Geometry"
+
+    override def toNeoTypeString = "GEOMETRY?"
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/IntegerType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/IntegerType.scala
@@ -24,6 +24,8 @@ object IntegerType {
     val parentType = CTNumber
     override lazy val coercibleTo: Set[CypherType] = Set(CTFloat)
     override val toString = "Integer"
+    override val toNeoTypeString = "INTEGER?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/ListType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/ListType.scala
@@ -33,6 +33,8 @@ object ListType {
     override def parents = innerType.parents.map(copy) ++ super.parents
 
     override val toString = s"List<$innerType>"
+    override val toNeoTypeString = s"LIST? OF ${innerType.toNeoTypeString}"
+
 
     override def isAssignableFrom(other: CypherType): Boolean = other match {
       case otherCollection: ListType =>

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/MapType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/MapType.scala
@@ -23,6 +23,8 @@ object MapType {
   val instance = new MapType() {
     val parentType = CTAny
     override val toString = "Map"
+    override val toNeoTypeString = "MAP?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/NodeType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/NodeType.scala
@@ -23,6 +23,8 @@ object NodeType {
   val instance = new NodeType() {
     val parentType = CTMap
     override val toString = "Node"
+    override val toNeoTypeString = "NODE?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/NumberType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/NumberType.scala
@@ -24,6 +24,7 @@ object NumberType {
     val parentType = CTAny
     override val isAbstract = true
     override val toString = "Number"
+    override val toNeoTypeString = "NUMBER?"
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/PathType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/PathType.scala
@@ -23,6 +23,8 @@ object PathType {
   val instance = new PathType() {
     val parentType = CTAny
     override val toString = "Path"
+    override val toNeoTypeString = "PATH?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/PointType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/PointType.scala
@@ -23,6 +23,7 @@ object PointType {
   val instance = new PointType() {
     val parentType = CTAny
     override val toString = "Point"
+    override val toNeoTypeString = "POINT?"
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/RelationshipType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/RelationshipType.scala
@@ -23,6 +23,8 @@ object RelationshipType {
   val instance = new RelationshipType() {
     val parentType = CTMap
     override val toString = "Relationship"
+    override val toNeoTypeString = "RELATIONSHIP?"
+
   }
 }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/StringType.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/symbols/StringType.scala
@@ -23,6 +23,7 @@ object StringType {
   val instance = new StringType() {
     val parentType = CTAny
     override val toString = "String"
+    override val toNeoTypeString = "STRING?"
   }
 }
 

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
@@ -175,7 +175,7 @@ case class SpecSuiteErrorHandler(typ: String, phase: String, detail: String) ext
       detail should equal(NO_VARIABLES_IN_SCOPE)
     else if (msg.matches(semanticError("RETURN \\* is not allowed when there are no identifiers in scope")))
       detail should equal(NO_VARIABLES_IN_SCOPE)
-    else if (msg.matches(semanticError("Procedure call does not provide the required number of arguments (.+)")))
+    else if (msg.matches(semanticError("Procedure call does not provide the required number of arguments.+")))
       detail should equal("InvalidNumberOfArguments")
     else if (msg.matches("Expected a parameter named .+"))
       detail should equal("MissingParameter")

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -206,7 +206,7 @@ public class ProcedureIT
         exception.expectMessage(
                 String.format("Procedure call does not provide the required number of arguments: got 0 expected 1.%n%n" +
                               "Procedure org.neo4j.procedure.simpleArgument has signature: org.neo4j.procedure.simpleArgument(name :: INTEGER?) :: someVal :: INTEGER?%n" +
-                              "meaning that it expects 1 argument with type INTEGER?" ));
+                              "meaning that it expects 1 argument of type INTEGER?" ));
         // When
         try ( Transaction ignore = db.beginTx() )
         {
@@ -239,7 +239,7 @@ public class ProcedureIT
         exception.expectMessage(
                 String.format("Procedure call does not provide the required number of arguments: got 0 expected 1.%n%n" +
                               "Procedure org.neo4j.procedure.nodeWithDescription has signature: org.neo4j.procedure.nodeWithDescription(node :: NODE?) :: node :: NODE?%n" +
-                              "meaning that it expects 1 argument with type NODE?%n" +
+                              "meaning that it expects 1 argument of type NODE?%n" +
                               "Description: This is a description (line 1, column 1 (offset: 0))" ));
         // When
         try ( Transaction ignore = db.beginTx() )

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -204,11 +204,47 @@ public class ProcedureIT
         //Expect
         exception.expect( QueryExecutionException.class );
         exception.expectMessage(
-                "Procedure call does not provide the required number of arguments (1) (line 1, column 1 (offset: 0))" );
+                String.format("Procedure call does not provide the required number of arguments: got 0 expected 1.%n%n" +
+                              "Procedure org.neo4j.procedure.simpleArgument has signature: org.neo4j.procedure.simpleArgument(name :: INTEGER?) :: someVal :: INTEGER?%n" +
+                              "meaning that it expects 1 argument with type INTEGER?" ));
         // When
         try ( Transaction ignore = db.beginTx() )
         {
             db.execute( "CALL org.neo4j.procedure.simpleArgument()" );
+        }
+    }
+
+    @Test
+    public void shouldGiveNiceErrorWhenMissingArgumentsToVoidFunction() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage(
+                String.format("Procedure call does not provide the required number of arguments: got 1 expected 3.%n%n" +
+                              "Procedure org.neo4j.procedure.sideEffectWithDefault has signature: org.neo4j.procedure" +
+                              ".sideEffectWithDefault(label :: STRING?, propertyKey :: STRING?, value  =  Zhang Wei :: STRING?) :: VOID%n" +
+                              "meaning that it expects 3 arguments of type STRING?, STRING?, STRING? (line 1, column 1 (offset: 0))" ));
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            db.execute( "CALL org.neo4j.procedure.sideEffectWithDefault()" );
+        }
+    }
+
+    @Test
+    public void shouldShowDescriptionWhenMissingArguments() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage(
+                String.format("Procedure call does not provide the required number of arguments: got 0 expected 1.%n%n" +
+                              "Procedure org.neo4j.procedure.nodeWithDescription has signature: org.neo4j.procedure.nodeWithDescription(node :: NODE?) :: node :: NODE?%n" +
+                              "meaning that it expects 1 argument with type NODE?%n" +
+                              "Description: This is a description (line 1, column 1 (offset: 0))" ));
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            db.execute( "CALL org.neo4j.procedure.nodeWithDescription()" );
         }
     }
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -109,12 +109,29 @@ public class UserFunctionIT
     {
         //Expect
         exception.expect( QueryExecutionException.class );
-        exception.expectMessage(
-                "Function call does not provide the required number of arguments (1) (line 1, column 8 (offset: 7)" );
+        exception.expectMessage( String.format("Function call does not provide the required number of arguments: expected 1 got 0.%n%n" +
+                                 "Function org.neo4j.procedure.simpleArgument has signature: org.neo4j.procedure.simpleArgument(someValue :: INTEGER?) :: INTEGER?%n" +
+                                 "meaning that it expects 1 argument with type INTEGER? (line 1, column 8 (offset: 7))" ));
         // When
         try ( Transaction ignore = db.beginTx() )
         {
             db.execute( "RETURN org.neo4j.procedure.simpleArgument()" );
+        }
+    }
+
+    @Test
+    public void shouldShowDescriptionWhenMissingArguments() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( String.format("Function call does not provide the required number of arguments: expected 1 got 0.%n%n" +
+                                               "Function org.neo4j.procedure.nodeWithDescription has signature: org.neo4j.procedure.nodeWithDescription(someValue :: NODE?) :: NODE?%n" +
+                                               "meaning that it expects 1 argument with type NODE?%n" +
+                                               "Description: This is a description (line 1, column 8 (offset: 7))" ));
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            db.execute( "RETURN org.neo4j.procedure.nodeWithDescription()" );
         }
     }
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -111,7 +111,7 @@ public class UserFunctionIT
         exception.expect( QueryExecutionException.class );
         exception.expectMessage( String.format("Function call does not provide the required number of arguments: expected 1 got 0.%n%n" +
                                  "Function org.neo4j.procedure.simpleArgument has signature: org.neo4j.procedure.simpleArgument(someValue :: INTEGER?) :: INTEGER?%n" +
-                                 "meaning that it expects 1 argument with type INTEGER? (line 1, column 8 (offset: 7))" ));
+                                 "meaning that it expects 1 argument of type INTEGER? (line 1, column 8 (offset: 7))" ));
         // When
         try ( Transaction ignore = db.beginTx() )
         {
@@ -126,7 +126,7 @@ public class UserFunctionIT
         exception.expect( QueryExecutionException.class );
         exception.expectMessage( String.format("Function call does not provide the required number of arguments: expected 1 got 0.%n%n" +
                                                "Function org.neo4j.procedure.nodeWithDescription has signature: org.neo4j.procedure.nodeWithDescription(someValue :: NODE?) :: NODE?%n" +
-                                               "meaning that it expects 1 argument with type NODE?%n" +
+                                               "meaning that it expects 1 argument of type NODE?%n" +
                                                "Description: This is a description (line 1, column 8 (offset: 7))" ));
         // When
         try ( Transaction ignore = db.beginTx() )


### PR DESCRIPTION
When providing the wrong number of arguments to a procedure or user-defined function we should print the whole signature making it easier for use it correctly.

changelog: User-defined functions and procedures will now print a more helpful error message, including its signature, when used erroneously.
