### PR TITLE
[WIP] - Allow creation of unique constraint across multiple labels

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
@@ -47,27 +47,27 @@ case class DelegatingProcedureExecutablePlanBuilder(delegate: ExecutablePlanBuil
         ProcedureCallExecutionPlan(signature, args, resolved.callResultTypes, resolved.callResultIndices,
           planContext.notificationLogger().notifications, publicTypeConverter)
 
-      // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case CreateUniquePropertyConstraint(node, label, prop) =>
-        PureSideEffectExecutionPlan("CreateUniqueConstraint", SCHEMA_WRITE, (ctx) => {
+      // CREATE CONSTRAINT ON (node:Label_0:...:Label_n) ASSERT node.prop IS UNIQUE
+      case CreateUniquePropertyConstraint(node, labels, prop) =>
+        for (label <- labels) PureSideEffectExecutionPlan("CreateUniqueConstraint", SCHEMA_WRITE, (ctx) => {
           (ctx.createUniqueConstraint _).tupled(labelProp(ctx)(label, prop.propertyKey))
         })
 
-      // DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case DropUniquePropertyConstraint(_, label, prop) =>
-        PureSideEffectExecutionPlan("DropUniqueConstraint", SCHEMA_WRITE, (ctx) => {
+      // DROP CONSTRAINT ON (node:Label_0:...:Label_n) ASSERT node.prop IS UNIQUE
+      case DropUniquePropertyConstraint(_, labels, prop) =>
+        for (label <- labels) PureSideEffectExecutionPlan("DropUniqueConstraint", SCHEMA_WRITE, (ctx) => {
           (ctx.dropUniqueConstraint _).tupled(labelProp(ctx)(label, prop.propertyKey))
         })
 
-      // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS
-      case CreateNodePropertyExistenceConstraint(_, label, prop) =>
-        PureSideEffectExecutionPlan("CreateNodePropertyExistenceConstraint", SCHEMA_WRITE, (ctx) => {
+      // CREATE CONSTRAINT ON (node:Label_0:...:Label_n) ASSERT node.prop EXISTS
+      case CreateNodePropertyExistenceConstraint(_, labels, prop) =>
+        for (label <- labels) PureSideEffectExecutionPlan("CreateNodePropertyExistenceConstraint", SCHEMA_WRITE, (ctx) => {
           (ctx.createNodePropertyExistenceConstraint _).tupled(labelProp(ctx)(label, prop.propertyKey))
         })
 
-      // DROP CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS
-      case DropNodePropertyExistenceConstraint(_, label, prop) =>
-        PureSideEffectExecutionPlan("CreateNodePropertyExistenceConstraint", SCHEMA_WRITE, (ctx) => {
+      // DROP CONSTRAINT ON (node:Label_0:...:Label_n) ASSERT node.prop EXISTS
+      case DropNodePropertyExistenceConstraint(_, labels, prop) =>
+        for (label <- labels) PureSideEffectExecutionPlan("CreateNodePropertyExistenceConstraint", SCHEMA_WRITE, (ctx) => {
           (ctx.dropNodePropertyExistenceConstraint _).tupled(labelProp(ctx)(label, prop.propertyKey))
         })
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Command.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Command.scala
@@ -53,7 +53,7 @@ trait NodePropertyConstraintCommand extends PropertyConstraintCommand {
 
   val entityType = symbols.CTNode
 
-  def label: LabelName
+  def labels: Seq[LabelName]
 }
 
 trait RelationshipPropertyConstraintCommand extends PropertyConstraintCommand {
@@ -63,13 +63,13 @@ trait RelationshipPropertyConstraintCommand extends PropertyConstraintCommand {
   def relType: RelTypeName
 }
 
-case class CreateUniquePropertyConstraint(variable: Variable, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class CreateUniquePropertyConstraint(variable: Variable, labels: Seq[LabelName], property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class DropUniquePropertyConstraint(variable: Variable, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class DropUniquePropertyConstraint(variable: Variable, labels: Seq[LabelName], property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class CreateNodePropertyExistenceConstraint(variable: Variable, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class CreateNodePropertyExistenceConstraint(variable: Variable, labels: Seq[LabelName], property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class DropNodePropertyExistenceConstraint(variable: Variable, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class DropNodePropertyExistenceConstraint(variable: Variable, labels: Seq[LabelName], property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
 case class CreateRelationshipPropertyExistenceConstraint(variable: Variable, relType: RelTypeName, property: Property)(val position: InputPosition) extends RelationshipPropertyConstraintCommand
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/Command.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/Command.scala
@@ -80,10 +80,10 @@ trait Command extends Parser
     ) ~~> (_.toIndexedSeq))
   }
 
-  private def UniqueConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+  private def UniqueConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabels ~~ ")" ~~
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
-  private def NodePropertyExistenceConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+  private def NodePropertyExistenceConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabels ~~ ")" ~~
     keyword("ASSERT EXISTS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipPropertyExistenceConstraintSyntax = keyword("CONSTRAINT ON") ~~ RelationshipPatternSyntax ~~


### PR DESCRIPTION
Addressing issue #7814 -  this is a WIP and will later include appropriate testing. My strategy is to handle this at the parsing/AST-generation level. Basically, match a `NodeLabels` pattern and create the consequent nodes in the AST and process the rest to the graph query engine as usual.

Note: I will be a bit busy for the next three weeks so if anyone feels like they can do the job in a shorter timeframe, feel free to push. Otherwise, I will get back to it once my course load gets back to normal.

---

CLA signed.
