### PR TITLE
Support username and metadata in TransactionData events

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
@@ -167,16 +167,16 @@ public interface TransactionData
     /**
      * Get the username under which authorization state this transaction is running.
      *
-     * @return name of subject
+     * @return the username of the user who initiated the transaction.
      */
-    String getUsername();
+    String username();
 
     /**
      * Applications that start transactions may attach additional application specific meta-data to each transaction.
      *
-     * @return The application specific meta-data map associated with this transaction
+     * @return The application specific meta-data map associated with this transaction.
      */
-    Map<String,Object> getMetaData();
+    Map<String,Object> metaData();
 
     /**
      * Return transaction id that assigned during transaction commit process.

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionData.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.graphdb.event;
 
+import java.util.Map;
+import java.util.Optional;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
@@ -160,6 +163,20 @@ public interface TransactionData
      * @return all properties that have been removed from relationships.
      */
     Iterable<PropertyEntry<Relationship>> removedRelationshipProperties();
+
+    /**
+     * Get the username under which authorization state this transaction is running.
+     *
+     * @return name of subject
+     */
+    String getUsername();
+
+    /**
+     * Applications that start transactions may attach additional application specific meta-data to each transaction.
+     *
+     * @return The application specific meta-data map associated with this transaction
+     */
+    Map<String,Object> getMetaData();
 
     /**
      * Return transaction id that assigned during transaction commit process.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -158,13 +158,13 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     }
 
     @Override
-    public String getUsername()
+    public String username()
     {
         return transaction.mode().username();
     }
 
     @Override
-    public Map<String,Object> getMetaData()
+    public Map<String,Object> metaData()
     {
         if ( transaction instanceof KernelTransactionImplementation )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -21,7 +21,10 @@ package org.neo4j.kernel.impl.coreapi;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
@@ -38,6 +41,9 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.core.NodeProxy;
 import org.neo4j.kernel.impl.core.RelationshipProxy;
 import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
@@ -149,6 +155,25 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     public Iterable<PropertyEntry<Relationship>> removedRelationshipProperties()
     {
         return removedRelationshipProperties;
+    }
+
+    @Override
+    public String getUsername()
+    {
+        return transaction.mode().username();
+    }
+
+    @Override
+    public Map<String,Object> getMetaData()
+    {
+        if ( transaction instanceof KernelTransactionImplementation )
+        {
+            return ((KernelTransactionImplementation) transaction).getMetaData();
+        }
+        else
+        {
+            return Collections.emptyMap();
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -20,8 +20,11 @@
 package org.neo4j.kernel.internal;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.neo4j.graphdb.Node;
@@ -280,6 +283,18 @@ public class TransactionEventHandlers
         public boolean isDeleted( Relationship relationship )
         {
             return false;
+        }
+
+        @Override
+        public String getUsername()
+        {
+            return "";
+        }
+
+        @Override
+        public Map<String,Object> getMetaData()
+        {
+            return Collections.EMPTY_MAP;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -286,15 +286,15 @@ public class TransactionEventHandlers
         }
 
         @Override
-        public String getUsername()
+        public String username()
         {
             return "";
         }
 
         @Override
-        public Map<String,Object> getMetaData()
+        public Map<String,Object> metaData()
         {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -310,7 +310,7 @@ public class TxStateTransactionDataViewTest
         when( transaction.mode() ).thenReturn( accessMode );
 
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
-        assertEquals( "", transactionDataSnapshot.getUsername() );
+        assertEquals( "", transactionDataSnapshot.username() );
     }
 
     @Test
@@ -321,14 +321,14 @@ public class TxStateTransactionDataViewTest
         when( transaction.mode() ).thenReturn( authSubject );
 
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
-        assertEquals( "Christof", transactionDataSnapshot.getUsername() );
+        assertEquals( "Christof", transactionDataSnapshot.username() );
     }
 
     @Test
     public void shouldAccessEmptyMetaData()
     {
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
-        assertEquals( 0, transactionDataSnapshot.getMetaData().size() );
+        assertEquals( 0, transactionDataSnapshot.metaData().size() );
     }
 
     @Test
@@ -340,8 +340,8 @@ public class TxStateTransactionDataViewTest
         when( transaction.getMetaData() ).thenReturn( genericMap( "username", "Igor" ) );
         TxStateTransactionDataSnapshot transactionDataSnapshot =
                 new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops, storeStatement, transaction );
-        assertEquals( 1, transactionDataSnapshot.getMetaData().size() );
-        assertThat( "Expected metadata map to contain defined username", transactionDataSnapshot.getMetaData(),
+        assertEquals( 1, transactionDataSnapshot.metaData().size() );
+        assertThat( "Expected metadata map to contain defined username", transactionDataSnapshot.metaData(),
                 equalTo( genericMap( "username", "Igor" ) ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
@@ -34,7 +35,10 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.state.StubCursors;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
@@ -50,6 +54,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterables.single;
+import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asLabelCursor;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asNodeCursor;
@@ -296,6 +301,48 @@ public class TxStateTransactionDataViewTest
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
         assertEquals( committedTransactionId, transactionDataSnapshot.getTransactionId() );
         assertEquals( commitTime, transactionDataSnapshot.getCommitTime() );
+    }
+
+    @Test
+    public void shouldNotAccessUsernameFromStaticAccessMode()
+    {
+        AccessMode accessMode = AccessMode.Static.READ;
+        when( transaction.mode() ).thenReturn( accessMode );
+
+        TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
+        assertEquals( "", transactionDataSnapshot.getUsername() );
+    }
+
+    @Test
+    public void shouldAccessUsernameFromAuthSubject()
+    {
+        AuthSubject authSubject = mock( AuthSubject.class );
+        when( authSubject.username() ).thenReturn( "Christof" );
+        when( transaction.mode() ).thenReturn( authSubject );
+
+        TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
+        assertEquals( "Christof", transactionDataSnapshot.getUsername() );
+    }
+
+    @Test
+    public void shouldAccessEmptyMetaData()
+    {
+        TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
+        assertEquals( 0, transactionDataSnapshot.getMetaData().size() );
+    }
+
+    @Test
+    public void shouldAccessExampleMetaData()
+    {
+        NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
+        final RelationshipProxy.RelationshipActions relActions = mock( RelationshipProxy.RelationshipActions.class );
+        final KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
+        when( transaction.getMetaData() ).thenReturn( genericMap( "username", "Igor" ) );
+        TxStateTransactionDataSnapshot transactionDataSnapshot =
+                new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops, storeStatement, transaction );
+        assertEquals( 1, transactionDataSnapshot.getMetaData().size() );
+        assertThat( "Expected metadata map to contain defined username", transactionDataSnapshot.getMetaData(),
+                equalTo( genericMap( "username", "Igor" ) ) );
     }
 
     private List<Long> idList( Iterable<? extends PropertyContainer> entities )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -159,8 +159,8 @@ public class TransactionEventsIT
     public void shouldGetEmptyUsernameOnAuthDisabled()
     {
         db.registerTransactionEventHandler( getBeforeCommitHandler( txData -> {
-            assertThat( "Should have no username", txData.getUsername(), equalTo( "" ) );
-            assertThat( "Should have no metadata", txData.getMetaData(), equalTo( Collections.emptyMap() ) );
+            assertThat( "Should have no username", txData.username(), equalTo( "" ) );
+            assertThat( "Should have no metadata", txData.metaData(), equalTo( Collections.emptyMap() ) );
         }) );
         runTransaction();
     }
@@ -171,8 +171,8 @@ public class TransactionEventsIT
         final AtomicReference<String> usernameRef = new AtomicReference<>();
         final AtomicReference<Map<String,Object>> metaDataRef = new AtomicReference<>();
         db.registerTransactionEventHandler( getBeforeCommitHandler( txData -> {
-            usernameRef.set( txData.getUsername() );
-            metaDataRef.set( txData.getMetaData() );
+            usernameRef.set( txData.username() );
+            metaDataRef.set( txData.metaData() );
         } ) );
         AuthSubject subject = mock( AuthSubject.class );
         when( subject.allowsWrites() ).thenReturn( true );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -28,7 +28,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -40,11 +44,20 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 import org.neo4j.test.rule.RandomRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.genericMap;
 
 /**
  * Test for randomly creating data and verifying transaction data seen in transaction event handlers.
@@ -142,6 +155,36 @@ public class TransactionEventsIT
         runTransaction();
     }
 
+    @Test
+    public void shouldGetEmptyUsernameOnAuthDisabled()
+    {
+        db.registerTransactionEventHandler( getBeforeCommitHandler( txData -> {
+            assertThat( "Should have no username", txData.getUsername(), equalTo( "" ) );
+            assertThat( "Should have no metadata", txData.getMetaData(), equalTo( Collections.emptyMap() ) );
+        }) );
+        runTransaction();
+    }
+
+    @Test
+    public void shouldGetSpecifiedUsernameAndMetaDataInTXData()
+    {
+        final AtomicReference<String> usernameRef = new AtomicReference<>();
+        final AtomicReference<Map<String,Object>> metaDataRef = new AtomicReference<>();
+        db.registerTransactionEventHandler( getBeforeCommitHandler( txData -> {
+            usernameRef.set( txData.getUsername() );
+            metaDataRef.set( txData.getMetaData() );
+        } ) );
+        AuthSubject subject = mock( AuthSubject.class );
+        when( subject.allowsWrites() ).thenReturn( true );
+        when( subject.username() ).thenReturn( "Christof" );
+        when( subject.getSnapshot() ).thenReturn( subject );
+        Map<String,Object> metadata = genericMap( "username", "joe" );
+        runTransaction( subject, metadata );
+
+        assertThat( "Should have specified username", usernameRef.get(), equalTo( "Christof" ) );
+        assertThat( "Should have metadata with specified username", metaDataRef.get(), equalTo( metadata ) );
+    }
+
     private TransactionEventHandler.Adapter<Object> getBeforeCommitHandler(Consumer<TransactionData> dataConsumer)
     {
         return new TransactionEventHandler.Adapter<Object>(){
@@ -156,9 +199,16 @@ public class TransactionEventsIT
 
     private void runTransaction()
     {
-        try (Transaction transaction = db.beginTx())
+        runTransaction( AccessMode.Static.WRITE, Collections.emptyMap() );
+    }
+
+    private void runTransaction(AccessMode accessMode, Map<String,Object> metaData)
+    {
+        try ( Transaction transaction = db.beginTransaction( KernelTransaction.Type.explicit, accessMode ) )
         {
-            Node node = db.createNode();
+            db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get()
+                    .queryRegistration().setMetaData( metaData );
+            db.createNode();
             transaction.success();
         }
     }


### PR DESCRIPTION
Users that write transaction events handlers are interested in having access to the information about the user running the transaction. This information can be either the username of the logged in user running the transaction, or the metadata map attached using the setTXMetaData procedure, which is used sometimes to associated 'ultimate user' or 'application user' to transactions run using a system account.

changelog [security] Support username and metadata in TransactionData events