### PR TITLE
Errors raised in unpacking should also be sent back to client

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltMessageRouter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.bolt.v1.runtime.spi.Record;
 import org.neo4j.logging.Log;
@@ -78,6 +79,12 @@ public class BoltMessageRouter implements BoltRequestMessageHandler<RuntimeExcep
     public void onRun( String statement, Map<String,Object> params )
     {
         worker.enqueue( session -> session.run( statement, params, runHandler ) );
+    }
+
+    @Override
+    public void onExternalError( Neo4jError error)
+    {
+        worker.enqueue( session -> session.externalError( error, defaultHandler ) );
     }
 
     @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageHandler.java
@@ -22,6 +22,8 @@ package org.neo4j.bolt.v1.messaging;
 
 import java.util.Map;
 
+import org.neo4j.bolt.v1.runtime.Neo4jError;
+
 /**
  * Interface defining simple handler methods for each defined
  * Bolt request message.
@@ -30,16 +32,18 @@ import java.util.Map;
  */
 public interface BoltRequestMessageHandler<E extends Exception>
 {
-    void onInit( String userAgent, Map<String, Object> authToken ) throws E;
+    void onInit( String userAgent, Map<String,Object> authToken ) throws E;
 
     void onAckFailure() throws E;
 
     void onReset() throws E;
 
-    void onRun( String statement, Map<String, Object> params ) throws E;
+    void onRun( String statement, Map<String,Object> params ) throws E;
 
     void onDiscardAll() throws E;
 
     void onPullAll() throws E;
+
+    void onExternalError( Neo4jError error ) throws E;
 
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageReader.java
@@ -20,13 +20,13 @@
 
 package org.neo4j.bolt.v1.messaging;
 
-import org.neo4j.bolt.v1.packstream.PackStream;
-import org.neo4j.bolt.v1.runtime.Neo4jError;
-import org.neo4j.kernel.api.exceptions.Status;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+
+import org.neo4j.bolt.v1.packstream.PackStream;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
+import org.neo4j.kernel.api.exceptions.Status;
 
 /**
  * Reader for Bolt request messages made available via a {@link Neo4jPack.Unpacker}.
@@ -64,7 +64,7 @@ public class BoltRequestMessageReader
                 {
                 case INIT:
                     String clientName = unpacker.unpackString();
-                    Map<String, Object> credentials = unpacker.unpackMap();
+                    Map<String,Object> credentials = unpacker.unpackMap();
                     handler.onInit( clientName, credentials );
                     break;
                 case ACK_FAILURE:
@@ -75,14 +75,15 @@ public class BoltRequestMessageReader
                     break;
                 case RUN:
                     String statement = unpacker.unpackString();
-                    Map<String, Object> params = unpacker.unpackMap();
+                    Map<String,Object> params = unpacker.unpackMap();
                     Optional<Neo4jError> error = unpacker.consumeError();
-                    if (error.isPresent())
+                    if ( error.isPresent() )
                     {
                         handler.onExternalError( error.get() );
-                    } else {
+                    }
+                    else
+                    {
                         handler.onRun( statement, params );
-
                     }
                     break;
                 case DISCARD_ALL:
@@ -105,7 +106,7 @@ public class BoltRequestMessageReader
         catch ( PackStream.PackStreamException e )
         {
             throw new BoltIOException( Status.Request.InvalidFormat, "Unable to read message type. " +
-                    "Error was: " + e.getMessage(), e );
+                                                                     "Error was: " + e.getMessage(), e );
         }
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -33,6 +33,7 @@ import org.neo4j.bolt.v1.packstream.PackInput;
 import org.neo4j.bolt.v1.packstream.PackOutput;
 import org.neo4j.bolt.v1.packstream.PackStream;
 import org.neo4j.bolt.v1.packstream.PackType;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
@@ -111,7 +112,7 @@ public class Neo4jPack
                         error = Optional.of( new Error( Status.Request.Invalid,
                                 "Value `null` is not supported as key in maps, must be a non-nullable string." ) );
                         packNull();
-                        return;
+                        pack( entry.getValue() );
                     }
                     else
                     {
@@ -262,7 +263,8 @@ public class Neo4jPack
 
     public static class Unpacker extends PackStream.Unpacker
     {
-        private PathPack.Unpacker pathUnpacker = new PathPack.Unpacker();
+
+        private Optional<Neo4jError> error = Optional.empty();
 
         public Unpacker( PackInput input )
         {
@@ -396,11 +398,16 @@ public class Neo4jPack
                             val = unpack();
                             if( map.put( key, val ) != null )
                             {
-                                throw new BoltIOException( Status.Request.Invalid, "Duplicate map key `" + key + "`." );
+                                error = Optional.of( Neo4jError.from( Status.Request.Invalid, "Duplicate map key `" + key + "`." ));
                             }
                             break;
                         case NULL:
-                            throw new BoltIOException( Status.Request.Invalid, "Value `null` is not supported as key in maps, must be a non-nullable string." );
+                            error = Optional.of( Neo4jError.from( Status.Request.Invalid,
+                                    "Value `null` is not supported as key in maps, must be a non-nullable string." ) );
+                            unpackNull();
+                            val = unpack();
+                            map.put( null, val );
+                            break;
                         default:
                             throw new PackStream.PackStreamException( "Bad key type" );
                     }
@@ -416,7 +423,11 @@ public class Neo4jPack
                     switch ( type )
                     {
                     case NULL:
-                        throw new BoltIOException( Status.Request.Invalid, "Value `null` is not supported as key in maps, must be a non-nullable string." );
+                        error = Optional.of( Neo4jError.from( Status.Request.Invalid,
+                                "Value `null` is not supported as key in maps, must be a non-nullable string." ) );
+                        unpackNull();
+                        key = null;
+                        break;
                     case STRING:
                         key = unpackString();
                         break;
@@ -427,12 +438,26 @@ public class Neo4jPack
                     Object val = unpack();
                     if( map.put( key, val ) != null )
                     {
-                        throw new BoltIOException( Status.Request.Invalid, "Duplicate map key `" + key + "`." );
+                        error = Optional.of( Neo4jError.from( Status.Request.Invalid, "Duplicate map key `" + key + "`." ));
                     }
                 }
             }
             return map;
         }
+
+        public Optional<Neo4jError> consumeError()
+        {
+            if (error.isPresent())
+            {
+                Neo4jError e = error.get();
+                error = Optional.empty();
+                return Optional.of( e );
+            } else
+            {
+                return Optional.empty();
+            }
+        }
+
     }
 
     private static class Error

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -580,14 +580,6 @@ public class PackStream
             assert markerByte == END_OF_STREAM;
         }
 
-        private void discardRawBytes( int size ) throws IOException
-        {
-            for ( int i = 0; i < size; i++ )
-            {
-                in.readByte();
-            }
-        }
-
         private byte[] unpackRawBytes( int size ) throws IOException
         {
             if ( size == 0 )

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -262,6 +262,18 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
         ctx.statementProcessor.markCurrentTransactionForTermination();
     }
 
+    public void externalError( Neo4jError error, BoltResponseHandler handler ) throws BoltConnectionFatality
+    {
+        before( handler );
+        try
+        {
+            fail( this, error );
+            this.state = State.FAILED;
+        }
+        finally { after(); }
+
+    }
+
     public boolean isClosed()
     {
         return ctx.closed;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -270,8 +270,10 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
             fail( this, error );
             this.state = State.FAILED;
         }
-        finally { after(); }
-
+        finally
+        {
+            after();
+        }
     }
 
     public boolean isClosed()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageRecorder.java
@@ -21,6 +21,7 @@
 package org.neo4j.bolt.v1.messaging;
 
 import org.neo4j.bolt.v1.messaging.message.*;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
 
 import java.util.Map;
 
@@ -69,4 +70,9 @@ public class BoltRequestMessageRecorder extends MessageRecorder<RequestMessage> 
         messages.add( pullAll() );
     }
 
+    @Override
+    public void onExternalError( Neo4jError error ) throws RuntimeException
+    {
+        //ignore
+    }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/BoltRequestMessageWriter.java
@@ -20,6 +20,7 @@
 package org.neo4j.bolt.v1.messaging;
 
 import org.neo4j.bolt.v1.messaging.message.RequestMessage;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
 
 import java.io.IOException;
 import java.util.Map;
@@ -98,4 +99,9 @@ public class BoltRequestMessageWriter implements BoltRequestMessageHandler<IOExc
         packer.flush();
     }
 
+    @Override
+    public void onExternalError( Neo4jError error ) throws IOException
+    {
+        //ignore
+    }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -421,7 +421,7 @@ public class TransportSessionIT
         return bytes;
     }
 
-    @Ignore
+    @Test
     public void shouldFailNicelyOnNullKeysInMap() throws Throwable
     {
         //Given
@@ -444,7 +444,17 @@ public class TransportSessionIT
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives(
                 msgSuccess(),
-                msgFailure( Status.Request.Invalid, "Value `null` is not supported as key in maps, must be a non-nullable string.")) );
+                msgFailure( Status.Request.Invalid, "Value `null` is not supported as key in maps, must be a non-nullable string."),
+                msgIgnored()));
+
+        client.send( TransportTestUtil.chunk( ackFailure(), run( "RETURN 1" ), pullAll() ) );
+
+        // Then
+        assertThat( client, eventuallyReceives(
+                msgSuccess(),
+                msgSuccess(),
+                msgRecord( eqRecord( equalTo( 1L ) ) ),
+                msgSuccess() ) );
     }
 
     @Before


### PR DESCRIPTION
After the state-machine refactoring we no longer send back fatal/external errors
to the client but only abruptly closes the connection. In some cases such as invalid
parameters to a run statement we should send back a proper error to the client and not
just silently fail.
