### PR TITLE
Add AuthorizationExpired exception to plugin API

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -403,7 +403,7 @@ public interface Status
         }
     }
 
-    enum Security implements Status  // TODO: rework by the Security Team before these are updated
+    enum Security implements Status
     {
         // client
         CredentialsExpired( ClientError, "The credentials have expired and need to be updated." ),

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpired.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpired.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth.plugin.api;
+
+/**
+ * An exception that can be thrown if authorization has expired and the user needs to re-authenticate
+ * in order to renew authorization.
+ * Throwing this exception will cause the server to disconnect the client.
+ *
+ * <p>This is typically used from the
+ * {@link org.neo4j.server.security.enterprise.auth.plugin.spi.AuthorizationPlugin#authorize}
+ * method of a combined authentication and authorization plugin (that implements
+ * the two separate interfaces <tt>AuthenticationPlugin</tt> and <tt>AuthorizationPlugin</tt>),
+ * that manages its own caching of auth info.
+ *
+ * @see org.neo4j.server.security.enterprise.auth.plugin.spi.AuthorizationPlugin
+ */
+public class AuthorizationExpired extends RuntimeException
+{
+    public AuthorizationExpired( String message )
+    {
+        super( message );
+    }
+}

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
@@ -21,8 +21,6 @@ package org.neo4j.server.security.enterprise.auth.plugin.spi;
 
 import java.util.Collection;
 
-import org.neo4j.server.security.enterprise.auth.plugin.api.RealmOperations;
-
 /**
  * An authorization plugin realm for the Neo4j enterprise security module.
  *
@@ -34,6 +32,7 @@ import org.neo4j.server.security.enterprise.auth.plugin.api.RealmOperations;
  *
  * @see AuthenticationPlugin
  * @see AuthPlugin
+ * @see org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpired
  */
 public interface AuthorizationPlugin extends RealmLifecycle
 {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.neo4j.server.security.enterprise.auth.plugin.api.AuthToken;
+import org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpired;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthenticationInfo;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthenticationPlugin;
@@ -48,6 +49,10 @@ public class TestCombinedAuthPlugin extends AuthenticationPlugin.Adapter impleme
         {
             return AuthenticationInfo.of( "neo4j" );
         }
+        else if ( principal.equals( "authorization_expired_user" ) && Arrays.equals( credentials, "neo4j".toCharArray() ) )
+        {
+            return (AuthenticationInfo) () -> "authorization_expired_user";
+        }
         return null;
     }
 
@@ -57,6 +62,10 @@ public class TestCombinedAuthPlugin extends AuthenticationPlugin.Adapter impleme
         if ( principals.stream().anyMatch( p -> "neo4j".equals( p.principal() ) ) )
         {
             return (AuthorizationInfo) () -> Collections.singleton( PredefinedRoles.READER );
+        }
+        else if ( principals.stream().anyMatch( p -> "authorization_expired_user".equals( p.principal() ) ) )
+        {
+            throw new AuthorizationExpired( "authorization_expired_user needs to re-authenticate." );
         }
         return null;
     }


### PR DESCRIPTION
Plugins that manages their own caching of authorization info that requires
a user to re-authenticate need the possibility to signal this back to the
client.
To the client this will surface in the same way as if authorization
expired in the internal cache of the ldap and plugin auth providers.

changelog: Add `AuthorizationExpired` exception to plugin API so that clients can differentiate between cache expiry requiring a simple reauthentication and more serious failures