### PR TITLE
Fix lifecycle bug when stopping NeoDataSource

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -84,7 +84,6 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreId;
-import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.format.RecordFormatPropertyConfigurator;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
@@ -143,6 +142,7 @@ import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.internal.TransactionEventHandlers;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.lifecycle.Lifecycles;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
@@ -851,8 +851,6 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             return;
         }
 
-        CheckPointer checkPointer = transactionLogModule.checkPointing();
-
         // First kindly await all committing transactions to close. Do this without interfering with the
         // log file monitor. Keep in mind that at this point the availability guard is raised and some time spent
         // awaiting active transaction to close, on a more coarse-grained level, so no new transactions
@@ -876,19 +874,21 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             awaitAllTransactionsClosed();
 
             // Write new checkpoint in the log only if the kernel is healthy.
-            // We cannot throw here since we need to shutdown without exceptions.
-            if ( databaseHealth.isHealthy() )
+            // We cannot throw here since we need to shutdown without exceptions,
+            // so let's make the checkpointing part of the life, so LifeSupport can handle exceptions properly
+            life.add( new LifecycleAdapter()
             {
-                try
+                @Override
+                public void shutdown() throws Throwable
                 {
-                    // Flushing of neo stores happens as part of the checkpoint
-                    checkPointer.forceCheckPoint( new SimpleTriggerInfo( "database shutdown" ) );
+                    if ( databaseHealth.isHealthy() )
+                    {
+                        // Flushing of neo stores happens as part of the checkpoint
+                        transactionLogModule.checkPointing()
+                                .forceCheckPoint( new SimpleTriggerInfo( "database shutdown" ) );
+                    }
                 }
-                catch ( IOException e )
-                {
-                    throw new UnderlyingStorageException( e );
-                }
-            }
+            } );
 
             // Shut down all services in here, effectively making the database unusable for anyone who tries.
             life.shutdown();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -851,18 +851,6 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     @Override
     public void close()
     {
-        if ( idGenerator == null || !storeOk )
-        {
-            try
-            {
-                closeStoreFile();
-            }
-            catch ( IOException e )
-            {
-                throw new UnderlyingStorageException( "Failed to close store file: " + getStorageFileName(), e );
-            }
-            return;
-        }
         try
         {
             closeStoreFile();

--- a/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.NeoStoreDataSource.Diagnostics;
@@ -39,6 +40,7 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.internal.DatabaseHealth;
+import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Logger;
 import org.neo4j.logging.NullLogProvider;
@@ -47,6 +49,7 @@ import org.neo4j.test.NeoStoreDataSourceRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -240,6 +243,34 @@ public class NeoStoreDataSourceTest
         logProvider.assertAtLeastOnce( inLog( NeoStoreDataSource.class ).warn(
                 equalTo( "Exception occurred while setting up store modules. Attempting to close things down." ),
                 equalTo( openStoresError ) ) );
+    }
+
+    @Test
+    public void shouldAlwaysShutdownLifeEvenWhenCheckPointingFails() throws Exception
+    {
+        // Given
+        File storeDir = dir.graphDbDir();
+        FileSystemAbstraction fs = this.fs.get();
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        DatabaseHealth databaseHealth = mock( DatabaseHealth.class );
+        when( databaseHealth.isHealthy() ).thenReturn( true );
+        IOException ex = new IOException( "boom!" );
+        doThrow( ex ).when( databaseHealth )
+                .assertHealthy( IOException.class ); // <- this is a trick to simulate a failure during checkpointing
+        NeoStoreDataSource dataSource = dsRule.getDataSource( storeDir, fs, pageCache, emptyMap(), databaseHealth );
+        dataSource.start();
+
+        try
+        {
+            // When
+            dataSource.stop();
+            fail( "it should have thrown" );
+        }
+        catch ( LifecycleException e )
+        {
+            // Then
+            assertEquals( ex, e.getCause() );
+        }
     }
 
     private NeoStoreDataSource neoStoreDataSourceWithLogFilesContainingLowestTxId( PhysicalLogFiles files )

--- a/community/neo4j/src/test/java/db/DatabaseShutdownTest.java
+++ b/community/neo4j/src/test/java/db/DatabaseShutdownTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package db;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.DelegatingPageCache;
+import org.neo4j.io.pagecache.IOLimiter;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
+import org.neo4j.kernel.impl.factory.DataSourceModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.kernel.lifecycle.LifecycleStatus;
+import org.neo4j.kernel.monitoring.tracing.Tracers;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DatabaseShutdownTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory =
+            TargetDirectory.testDirForTestWithEphemeralFS( fs.get(), getClass() );
+
+    @Test
+    public void shouldShutdownCorrectlyWhenCheckPointingOnShutdownFails() throws Exception
+    {
+        TestGraphDatabaseFactoryWithFailingPageCacheFlush factory =
+                new TestGraphDatabaseFactoryWithFailingPageCacheFlush();
+
+        try
+        {
+            factory.newEmbeddedDatabase( testDirectory.graphDbDir() ).shutdown();
+            fail( "Should have thrown" );
+        }
+        catch ( LifecycleException ex )
+        {
+            assertEquals( LifecycleStatus.SHUTDOWN, factory.getNeoStoreDataSourceStatus() );
+        }
+    }
+
+    private static class TestGraphDatabaseFactoryWithFailingPageCacheFlush extends TestGraphDatabaseFactory
+    {
+        private NeoStoreDataSource neoStoreDataSource;
+
+        @Override
+        protected GraphDatabaseService newDatabase( File storeDir, Map<String,String> config,
+                GraphDatabaseFacadeFactory.Dependencies dependencies )
+        {
+            return new CommunityFacadeFactory()
+            {
+                @Override
+                protected DataSourceModule createDataSource( Dependencies dependencies,
+                        PlatformModule platformModule, EditionModule editionModule )
+                {
+                    DataSourceModule dataSource = new DataSourceModule( dependencies, platformModule, editionModule );
+                    neoStoreDataSource = dataSource.neoStoreDataSource;
+                    return dataSource;
+                }
+
+                @Override
+                protected PlatformModule createPlatform( File storeDir, Map<String,String> params,
+                        Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
+                {
+                    return new PlatformModule( storeDir, params, databaseInfo(), dependencies, graphDatabaseFacade )
+                    {
+                        @Override
+                        protected PageCache createPageCache( FileSystemAbstraction fileSystem, Config config,
+                                LogService logging, Tracers tracers )
+                        {
+                            PageCache pageCache = super.createPageCache( fileSystem, config, logging, tracers );
+                            return new DelegatingPageCache( pageCache )
+                            {
+                                @Override
+                                public void flushAndForce( IOLimiter ioLimiter ) throws IOException
+                                {
+                                    // this is simulating a failing check pointing on shutdown
+                                    throw new IOException( "Boom!" );
+                                }
+                            };
+                        }
+                    };
+                }
+            }.newFacade( storeDir, config, dependencies );
+        }
+
+        LifecycleStatus getNeoStoreDataSourceStatus() throws NoSuchFieldException, IllegalAccessException
+        {
+            Field f = neoStoreDataSource.getClass().getDeclaredField( "life" );
+            f.setAccessible( true );
+            LifeSupport life = (LifeSupport) f.get( neoStoreDataSource );
+            return life.getStatus();
+        }
+    }
+}


### PR DESCRIPTION
If the checkpointing step fails in NeoDataSource.stop(), we never call
life.shutdown(). Hence we'll never unmap the store files from the page
cache. So later when we try to close the page cache it will fail due
to still mapped files.  This change we'll make sure that we always
shutdown all the lifecycled instances in the internal life in
NeoDataSource
