### PR TITLE
Give client error message on all failures

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
@@ -34,19 +34,8 @@ public class MessageProcessingCallback<T> extends Session.Callback.Adapter<T,Voi
     public static void publishError( MessageHandler<IOException> out, Neo4jError error )
             throws IOException
     {
-        if ( !error.status().code().classification().shouldRespondToClient() )
-        {
-            // If not intended for client, we only return an error reference. This must
-            // be cross-referenced with the log files for full error detail.
-            out.handleFailureMessage( error.status(), String.format(
-                    "An unexpected failure occurred, see details in the database " +
-                    "logs, reference number %s.", error.reference() ) );
-        }
-        else
-        {
-            // If intended for client, we forward the message as-is.
-            out.handleFailureMessage( error.status(), error.message() );
-        }
+
+        out.handleFailureMessage( error.status(), error.message() );
     }
 
     protected final Log log;

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -605,14 +605,12 @@ public interface Status
 
         private final boolean rollbackTransaction;
         private final boolean shouldLog;
-        private final boolean respondToClient;
         private final String description;
 
         Classification( TransactionEffect transactionEffect, PublishingPolicy publishingPolicy, String description )
         {
             this.description = description;
             this.shouldLog = publishingPolicy.shouldLog();
-            this.respondToClient = publishingPolicy != PublishingPolicy.REFERS_TO_LOG;
             this.rollbackTransaction = transactionEffect == TransactionEffect.ROLLBACK;
         }
 
@@ -624,11 +622,6 @@ public interface Status
         public boolean shouldLog()
         {
             return shouldLog;
-        }
-
-        public boolean shouldRespondToClient()
-        {
-            return respondToClient;
         }
 
         public String description()


### PR DESCRIPTION
Until now we have been obfuscating error messages for
_unexpected database errors_ with the intention that these are
errors more aimed at an administrator than aimed directly at the client.
However since the classification isn't perfect we get too many false negatives,
i.e. in too many case we end up returning obfuscated messages where the client
would have benefited from a detailed message.
