### PR TITLE
Longer timeout for awaiting leader in CoreReplicationIT

### DIFF
--- a/community/common/src/main/java/org/neo4j/function/Predicates.java
+++ b/community/common/src/main/java/org/neo4j/function/Predicates.java
@@ -140,16 +140,30 @@ public class Predicates
     public static <TYPE> TYPE await( Supplier<TYPE> supplier, Predicate<TYPE> predicate, long timeout,
             TimeUnit timeoutUnit, long pollInterval, TimeUnit pollUnit ) throws TimeoutException
     {
-        Suppliers.CapturingSupplier<TYPE> composed = Suppliers.compose( supplier, predicate );
-        await( composed, timeout, timeoutUnit, pollInterval, pollUnit );
-        return composed.lastInput();
+        return awaitEx( supplier::get, predicate::test, timeout, timeoutUnit, pollInterval, pollUnit );
     }
 
     public static <TYPE> TYPE await( Supplier<TYPE> supplier, Predicate<TYPE> predicate, long timeout,
             TimeUnit timeoutUnit ) throws TimeoutException
     {
-        Suppliers.CapturingSupplier<TYPE> composed = Suppliers.compose( supplier, predicate );
-        await( composed, timeout, timeoutUnit );
+        return awaitEx( supplier::get, predicate::test, timeout, timeoutUnit );
+    }
+
+    public static <TYPE, EXCEPTION extends Exception> TYPE awaitEx( ThrowingSupplier<TYPE,EXCEPTION> supplier,
+            ThrowingPredicate<TYPE,EXCEPTION> predicate, long timeout, TimeUnit timeoutUnit, long pollInterval,
+            TimeUnit pollUnit ) throws TimeoutException, EXCEPTION
+    {
+        Suppliers.ThrowingCapturingSupplier<TYPE,EXCEPTION> composed = Suppliers.compose( supplier, predicate );
+        awaitEx( composed, timeout, timeoutUnit, pollInterval, pollUnit );
+        return composed.lastInput();
+    }
+
+    public static <TYPE, EXCEPTION extends Exception> TYPE awaitEx( ThrowingSupplier<TYPE,EXCEPTION> supplier,
+            ThrowingPredicate<TYPE,EXCEPTION> predicate, long timeout, TimeUnit timeoutUnit )
+            throws TimeoutException, EXCEPTION
+    {
+        Suppliers.ThrowingCapturingSupplier<TYPE,EXCEPTION> composed = Suppliers.compose( supplier, predicate );
+        awaitEx( composed, timeout, timeoutUnit );
         return composed.lastInput();
     }
 

--- a/community/common/src/main/java/org/neo4j/function/Suppliers.java
+++ b/community/common/src/main/java/org/neo4j/function/Suppliers.java
@@ -118,9 +118,10 @@ public final class Suppliers
         };
     }
 
-    public static <T> CapturingSupplier<T> compose( final Supplier<T> input, final Predicate<T> predicate )
+    public static <T, E extends Exception> ThrowingCapturingSupplier<T,E> compose( final ThrowingSupplier<T,E> input,
+            final ThrowingPredicate<T,E> predicate )
     {
-        return new CapturingSupplier<T>( input, predicate );
+        return new ThrowingCapturingSupplier<>( input, predicate );
     }
 
     public static BooleanSupplier untilTimeExpired( long duration, TimeUnit unit )
@@ -129,14 +130,14 @@ public final class Suppliers
         return () -> currentTimeMillis() <= endTimeInMilliseconds;
     }
 
-    static class CapturingSupplier<T> implements Supplier<Boolean>
+    static class ThrowingCapturingSupplier<T, E extends Exception> implements ThrowingSupplier<Boolean,E>
     {
-        private final Supplier<T> input;
-        private final Predicate<T> predicate;
+        private final ThrowingSupplier<T,E> input;
+        private final ThrowingPredicate<T,E> predicate;
 
         private T current;
 
-        CapturingSupplier( Supplier<T> input, Predicate<T> predicate )
+        ThrowingCapturingSupplier( ThrowingSupplier<T,E> input, ThrowingPredicate<T,E> predicate )
         {
             this.input = input;
             this.predicate = predicate;
@@ -148,7 +149,7 @@ public final class Suppliers
         }
 
         @Override
-        public Boolean get()
+        public Boolean get() throws E
         {
             current = input.get();
             return predicate.test( current );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreReplicationIT.java
@@ -193,6 +193,7 @@ public class CoreReplicationIT
 
         // when
         cluster.removeCoreMember( cluster.awaitLeader() );
+        cluster.awaitLeader( 1, TimeUnit.MINUTES ); // <- let's give a bit more time for the leader to show up
         CoreClusterMember last = cluster.coreTx( ( db, tx ) ->
         {
             Node node = db.createNode();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreToCoreCopySnapshotIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreToCoreCopySnapshotIT.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.coreedge.scenarios;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -35,9 +38,6 @@ import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.coreedge.ClusterRule;
 import org.neo4j.time.Clocks;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.coreedge.core.CoreEdgeClusterSettings.raft_log_pruning_frequency;
@@ -50,8 +50,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class CoreToCoreCopySnapshotIT
 {
-    private static final int TIMEOUT_MS = 5000;
-
     @Rule
     public final ClusterRule clusterRule = new ClusterRule( getClass() )
             .withNumberOfCoreMembers( 3 )
@@ -69,12 +67,11 @@ public class CoreToCoreCopySnapshotIT
         } );
 
         // when
-        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( TIMEOUT_MS, Role.FOLLOWER );
+        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( Role.FOLLOWER, 5, TimeUnit.SECONDS );
 
         // shutdown the follower, remove the store, restart
         follower.shutdown();
         FileUtils.deleteRecursively( follower.storeDir() );
-        follower.storeDir().mkdir();
         follower.start();
 
         // then

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
@@ -183,7 +183,7 @@ public class EdgeServerReplicationIT
 
         executeOnLeaderWithRetry( this::createData, cluster );
 
-        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( 2000, Role.FOLLOWER );
+        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( Role.FOLLOWER, 2, TimeUnit.SECONDS );
         // Shutdown server before copying its data, because Windows can't copy open files.
         follower.shutdown();
 
@@ -493,7 +493,7 @@ public class EdgeServerReplicationIT
         {
             try
             {
-                CoreGraphDatabase coreDB = cluster.awaitLeader( 5000 ).database();
+                CoreGraphDatabase coreDB = cluster.awaitLeader( 5L, SECONDS ).database();
                 try ( Transaction tx = coreDB.beginTx() )
                 {
                     workload.doWork( coreDB );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RestartIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RestartIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.consistency.ConsistencyCheckService;
@@ -147,7 +148,7 @@ public class RestartIT
         Cluster cluster = clusterRule.withNumberOfCoreMembers( 2 ).withNumberOfEdgeMembers( 1 ).startCluster();
 
         // when
-        final GraphDatabaseService coreDB = cluster.awaitLeader( 5000 ).database();
+        final GraphDatabaseService coreDB = cluster.awaitLeader( 5, TimeUnit.SECONDS ).database();
 
         try ( Transaction tx = coreDB.beginTx() )
         {

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
@@ -90,7 +90,7 @@ public class CoreEdgeMetricsIT
         cluster = clusterRule.startCluster();
 
         // when
-        CoreGraphDatabase coreDB = cluster.awaitLeader( 5000 ).database();
+        CoreGraphDatabase coreDB = cluster.awaitLeader( 5, TimeUnit.SECONDS ).database();
 
         try ( Transaction tx = coreDB.beginTx() )
         {


### PR DESCRIPTION
Add a longer timeout for waiting for the new leader after having
shutdown the old one. This should make the test more reliable in CI.

Cleanup test code.
Improve `await`s and `awaitEx`s methods in Predicates.
