### PR TITLE
Improve the help output for `neo4j-admin import`.

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -68,22 +68,24 @@ class CsvImporter implements Importer
 
     public static String description()
     {
-        return "--mode=csv Import a database from a collection of CSV files.\n" + "--report-file <filename>\n" +
+        return "--mode=csv\n" +
+                "        Import a database from a collection of CSV files.\n" +
+                "--report-file=<filename>\n" +
                 "        File name in which to store the report of the import.\n" +
-                "        Defaults to " + ImportCommand.DEFAULT_REPORT_FILE_NAME +
-                " in the current directory.\n" +
+                "        Defaults to " + ImportCommand.DEFAULT_REPORT_FILE_NAME + " in the current directory.\n" +
                 "--nodes[:Label1:Label2]=\"<file1>,<file2>,...\"\n" +
                 "        Node CSV header and data. Multiple files will be logically seen as\n" +
                 "        one big file from the perspective of the importer. The first line\n" +
                 "        must contain the header. Multiple data sources like these can be\n" +
                 "        specified in one import, where each data source has its own header.\n" +
                 "        Note that file groups must be enclosed in quotation marks.\n" +
-                "--relationships[:RELATIONSHIP_TYPE] \"<file1>,<file2>,...\"\n" +
+                "--relationships[:RELATIONSHIP_TYPE]=\"<file1>,<file2>,...\"\n" +
                 "        Relationship CSV header and data. Multiple files will be logically\n" +
                 "        seen as one big file from the perspective of the importer. The first\n" +
                 "        line must contain the header. Multiple data sources like these can be\n" +
                 "        specified in one import, where each data source has its own header.\n" +
-                "        Note that file groups must be enclosed in quotation marks.\n" + "--id-type <id-type>\n" +
+                "        Note that file groups must be enclosed in quotation marks.\n" +
+                "--id-type=<id-type>\n" +
                 "        Each node must provide a unique id. This is used to find the correct\n" +
                 "        nodes when creating relationships. Must be one of:\n" +
                 "            STRING: (default) arbitrary strings for identifying nodes.\n" +
@@ -91,16 +93,20 @@ class CsvImporter implements Importer
                 "            ACTUAL: (advanced) actual node ids. The default option is STRING.\n" +
                 "        For more information on id handling, please see the Neo4j Manual:\n" +
                 "        http://neo4j.com/docs/operations-manual/current/deployment/#import-tool\n" +
-                "--input-encoding <character-set>\n" +
+                "--input-encoding=<character-set>\n" +
                 "        Character set that input data is encoded in. Defaults to UTF-8.\n" +
-                "--page-size <page-size>\n" + "        Page size to use for import in bytes. (e. g. 4M or 8k)\n";
+                "--page-size=<page-size>\n" +
+                "        Page size to use for import in bytes. (e. g. 4M or 8k)\n";
     }
 
     public static String arguments()
     {
-        return "[--report-file=<filename>] [--nodes[:Label1:Label2]=\"<file1>,<file2>,...\"] " +
+        return "[--report-file=<filename>] " +
+                "[--nodes[:Label1:Label2]=\"<file1>,<file2>,...\"] " +
                 "[--relationships[:RELATIONSHIP_TYPE]=\"<file1>,<file2>,...\"] " +
-                "[--input-encoding=<character-set>] " + "[--id-type=<id-type>] ";
+                "[--id-type=<id-type>] " +
+                "[--input-encoding=<character-set>] " +
+                "[--page-size=<page-size>]";
     }
 
     CsvImporter( Args args, Config config, OutsideWorld outsideWorld ) throws IncorrectUsage

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
@@ -41,9 +41,10 @@ class DatabaseImporter implements Importer
 
     public static String description()
     {
-        return "--mode=database" +
-                "        Import a database from a pre-3.0 Neo4j installation. \n" +
-                "        <source-directory> is the database location\n" +
+        return "--mode=database\n" +
+                "        Import a database from a pre-3.0 Neo4j installation.\n" +
+                "--from=<source-directory>\n" +
+                "        <source-directory> is the location of the pre-3.0 database\n" +
                 "        (e.g. <neo4j-root>/data/graph.db).\n";
     }
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -56,15 +56,29 @@ public class ImportCommand implements AdminCommand
         public Optional<String> arguments()
         {
             return Optional
-                    .of( "--database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>]" +
-                            " " + DatabaseImporter.arguments() + " " + CsvImporter.arguments() );
+                    .of( "--database=<database-name> " +
+                            "[--mode={csv|database}] " +
+                            "[--additional-config=<config-file-path>] " +
+                            DatabaseImporter.arguments() +
+                            " " +
+                            CsvImporter.arguments() );
         }
 
         @Override
         public String description()
         {
-            return "Import a collection of CSV files with --mode=csv (default), or a database from a " +
-                    "pre-3.0 installation with --mode=database." + "\n" + DatabaseImporter.description() + "\n\n" +
+            return "Import a collection of CSV files with --mode=csv (default), or a database from\n" +
+                    "a pre-3.0 installation with --mode=database.\n" +
+                    "\n" +
+                    "--database=<database-name>\n" +
+                    "        The name of the new database to import into. This cannot be an existing\n" +
+                    "        database.\n" +
+                    "--additional-config=<config-file-path>\n" +
+                    "        Configuration file to supply additional configuration values to\n" +
+                    "        the import tools.\n" +
+                    "\n" +
+                    DatabaseImporter.description() +
+                    "\n" +
                     CsvImporter.description();
         }
 


### PR DESCRIPTION
Before: 

```
neo4j-admin import --database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>] [--from=<source-directory>] [--report-file=<filename>] [--nodes[:Label1:Label2]="<file1>,<file2>,..."] [--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."] [--input-encoding=<character-set>] [--id-type=<id-type>] 

    Import a collection of CSV files with --mode=csv (default), or a database from a 
    pre-3.0 installation with --mode=database.
    --mode=database        Import a database from a pre-3.0 Neo4j installation. 
            <source-directory> is the database location
            (e.g. <neo4j-root>/data/graph.db).


    --mode=csv Import a database from a collection of CSV files.
    --report-file <filename>
            File name in which to store the report of the import.
            Defaults to import.report in the current directory.
    --nodes[:Label1:Label2]="<file1>,<file2>,..."
            Node CSV header and data. Multiple files will be logically seen as
            one big file from the perspective of the importer. The first line
            must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --relationships[:RELATIONSHIP_TYPE] "<file1>,<file2>,..."
            Relationship CSV header and data. Multiple files will be logically
            seen as one big file from the perspective of the importer. The first
            line must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --id-type <id-type>
            Each node must provide a unique id. This is used to find the correct
            nodes when creating relationships. Must be one of:
                STRING: (default) arbitrary strings for identifying nodes.
                INTEGER: arbitrary integer values for identifying nodes.
                ACTUAL: (advanced) actual node ids. The default option is STRING.
            For more information on id handling, please see the Neo4j Manual:
            http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
    --input-encoding <character-set>
            Character set that input data is encoded in. Defaults to UTF-8.
    --page-size <page-size>
            Page size to use for import in bytes. (e. g. 4M or 8k)
```

After:

```
neo4j-admin import --database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>] [--from=<source-directory>] [--report-file=<filename>] [--nodes[:Label1:Label2]="<file1>,<file2>,..."] [--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."] [--id-type=<id-type>] [--input-encoding=<character-set>] [--page-size=<page-size>]

    Import a collection of CSV files with --mode=csv (default), or a database from
    a pre-3.0 installation with --mode=database.

    --database=<database-name>
            The name of the new database to import into. This cannot be an existing
            database.
    --additional-config=<config-file-path>
            Configuration file to supply additional configuration values to
            the import tools.

    --mode=database
            Import a database from a pre-3.0 Neo4j installation.
    --from=<source-directory>
            <source-directory> is the location of the pre-3.0 database
            (e.g. <neo4j-root>/data/graph.db).

    --mode=csv
            Import a database from a collection of CSV files.
    --report-file=<filename>
            File name in which to store the report of the import.
            Defaults to import.report in the current directory.
    --nodes[:Label1:Label2]="<file1>,<file2>,..."
            Node CSV header and data. Multiple files will be logically seen as
            one big file from the perspective of the importer. The first line
            must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."
            Relationship CSV header and data. Multiple files will be logically
            seen as one big file from the perspective of the importer. The first
            line must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --id-type=<id-type>
            Each node must provide a unique id. This is used to find the correct
            nodes when creating relationships. Must be one of:
                STRING: (default) arbitrary strings for identifying nodes.
                INTEGER: arbitrary integer values for identifying nodes.
                ACTUAL: (advanced) actual node ids. The default option is STRING.
            For more information on id handling, please see the Neo4j Manual:
            http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
    --input-encoding=<character-set>
            Character set that input data is encoded in. Defaults to UTF-8.
    --page-size=<page-size>
            Page size to use for import in bytes. (e. g. 4M or 8k)
```
