### PR TITLE
Fix typo in default setting value in neo4j.conf

### DIFF
--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -366,7 +366,7 @@ dbms.connector.https.enabled=true
 # conforms with the LDAP directory's schema from the user principal that is submitted with the
 # authentication token when logging in.
 # The special token {0} is a placeholder where the user principal will be substituted into the DN string.
-#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com"
+#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com
 
 # Determines if the result of authentication via the LDAP server should be cached or not.
 # Caching is used to limit the number of LDAP requests that have to be made over the network


### PR DESCRIPTION
The commented-out default value of `dbms.security.ldap.user_dn_template`
had a trailing qoute that would lead to syntax error if uncommented.

changelog: Fixed trailing quote in default value in neo4j.conf which leads to syntax error if uncommented