### PR TITLE
Change security setting names

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -120,7 +120,7 @@ public class EnterpriseSecurityModule extends SecurityModule
     public EnterpriseAuthAndUserManager newAuthManager( Config config, LogProvider logProvider, SecurityLog securityLog,
             FileSystemAbstraction fileSystem, JobScheduler jobScheduler )
     {
-        List<String> configuredRealms = config.get( SecuritySettings.active_realms );
+        List<String> configuredRealms = config.get( SecuritySettings.auth_providers );
         List<Realm> realms = new ArrayList<>( configuredRealms.size() + 1 );
 
         SecureHasher secureHasher = new SecureHasher();

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -353,14 +353,14 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
     {
         JndiLdapContextFactory contextFactory = new JndiLdapContextFactory();
         contextFactory.setUrl( parseLdapServerUrl( config.get( SecuritySettings.ldap_server ) ) );
-        contextFactory.setAuthenticationMechanism( config.get( SecuritySettings.ldap_auth_mechanism ) );
+        contextFactory.setAuthenticationMechanism( config.get( SecuritySettings.ldap_authentication_mechanism ) );
         contextFactory.setReferral( config.get( SecuritySettings.ldap_referral ) );
-        contextFactory.setSystemUsername( config.get( SecuritySettings.ldap_system_username ) );
-        contextFactory.setSystemPassword( config.get( SecuritySettings.ldap_system_password ) );
+        contextFactory.setSystemUsername( config.get( SecuritySettings.ldap_authorization_system_username ) );
+        contextFactory.setSystemPassword( config.get( SecuritySettings.ldap_authorization_system_password ) );
 
         setContextFactory( contextFactory );
 
-        String userDnTemplate = config.get( SecuritySettings.ldap_user_dn_template );
+        String userDnTemplate = config.get( SecuritySettings.ldap_authentication_user_dn_template );
         if ( userDnTemplate != null )
         {
             setUserDnTemplate( userDnTemplate );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
@@ -58,7 +58,7 @@ public class EnterpriseSecurityModuleTest
         when( config.get( SecuritySettings.ldap_authorization_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.plugin_authentication_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.plugin_authorization_enabled ) ).thenReturn( true );
-        when( config.get( SecuritySettings.active_realms ) ).thenReturn( Arrays.asList( "this-realm-does-not-exist" ) );
+        when( config.get( SecuritySettings.auth_providers ) ).thenReturn( Arrays.asList( "this-realm-does-not-exist" ) );
         thrown.expect( IllegalArgumentException.class );
 
         // When
@@ -84,7 +84,7 @@ public class EnterpriseSecurityModuleTest
         when( config.get( SecuritySettings.ldap_authorization_enabled ) ).thenReturn( false );
         when( config.get( SecuritySettings.plugin_authentication_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.plugin_authorization_enabled ) ).thenReturn( true );
-        when( config.get( SecuritySettings.active_realms ) ).thenReturn(
+        when( config.get( SecuritySettings.auth_providers ) ).thenReturn(
                 Arrays.asList(
                         SecuritySettings.NATIVE_REALM_NAME,
                         SecuritySettings.LDAP_REALM_NAME )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/ActiveDirectoryAuthenticationIT.java
@@ -104,7 +104,7 @@ public class ActiveDirectoryAuthenticationIT
             settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
             settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
             settings.put( SecuritySettings.ldap_server, "activedirectory.neohq.net:389" );
-            settings.put( SecuritySettings.ldap_user_dn_template, "CN={0},CN=Users,DC=neo4j,DC=com" );
+            settings.put( SecuritySettings.ldap_authentication_user_dn_template, "CN={0},CN=Users,DC=neo4j,DC=com" );
             settings.put( SecuritySettings.ldap_authorization_use_system_account, "false" );
             settings.put( SecuritySettings.ldap_authorization_user_search_base, "cn=Users,dc=neo4j,dc=com" );
             settings.put( SecuritySettings.ldap_authorization_user_search_filter, "(&(objectClass=*)(CN={0}))" );
@@ -119,8 +119,8 @@ public class ActiveDirectoryAuthenticationIT
 
     private Consumer<Map<Setting<?>,String>> useSystemAccountSettings = settings -> {
         settings.put( SecuritySettings.ldap_authorization_use_system_account, "true" );
-        settings.put( SecuritySettings.ldap_system_username, "Neo4j System" );
-        settings.put( SecuritySettings.ldap_system_password, "ProudListingsMedia1" );
+        settings.put( SecuritySettings.ldap_authorization_system_username, "Neo4j System" );
+        settings.put( SecuritySettings.ldap_authorization_system_password, "ProudListingsMedia1" );
     };
 
     public Factory<TransportConnection> cf = (Factory<TransportConnection>) SecureSocketConnection::new;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationTestBase.java
@@ -27,27 +27,18 @@ import org.junit.Rule;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 import org.neo4j.bolt.v1.transport.integration.Neo4jWithSocket;
 import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
 import org.neo4j.function.Factory;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.logging.Log;
-import org.neo4j.procedure.Context;
-import org.neo4j.procedure.Mode;
-import org.neo4j.procedure.Procedure;
-import org.neo4j.server.security.enterprise.auth.AuthProceduresBase;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
-import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -59,7 +50,6 @@ import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgFailure;
 import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgSuccess;
 import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyReceives;
 import static org.neo4j.helpers.collection.MapUtil.map;
-import static org.neo4j.procedure.Mode.READ;
 
 public abstract class EnterpriseAuthenticationTestBase extends AbstractLdapTestUnit
 {
@@ -128,7 +118,7 @@ public abstract class EnterpriseAuthenticationTestBase extends AbstractLdapTestU
 
     protected static Consumer<Map<Setting<?>,String>> ldapOnlyAuthSettings = settings ->
     {
-        settings.put( SecuritySettings.active_realm, SecuritySettings.LDAP_REALM_NAME );
+        settings.put( SecuritySettings.auth_provider, SecuritySettings.LDAP_REALM_NAME );
     };
 
     protected void testCreateReaderUser() throws Exception

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
@@ -117,8 +117,8 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
         server.shutdownDatabase();
         server.ensureDatabase( asSettings( ldapOnlyAuthSettings.andThen(
                 settings -> {
-                    settings.put( SecuritySettings.ldap_auth_mechanism, "DIGEST-MD5" );
-                    settings.put( SecuritySettings.ldap_user_dn_template, "{0}" );
+                    settings.put( SecuritySettings.ldap_authentication_mechanism, "DIGEST-MD5" );
+                    settings.put( SecuritySettings.ldap_authentication_user_dn_template, "{0}" );
                 }
         ) ) );
     }
@@ -128,8 +128,8 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
         server.shutdownDatabase();
         server.ensureDatabase( asSettings( ldapOnlyAuthSettings.andThen(
                 settings -> {
-                    settings.put( SecuritySettings.ldap_auth_mechanism, "CRAM-MD5" );
-                    settings.put( SecuritySettings.ldap_user_dn_template, "{0}" );
+                    settings.put( SecuritySettings.ldap_authentication_mechanism, "CRAM-MD5" );
+                    settings.put( SecuritySettings.ldap_authentication_user_dn_template, "{0}" );
                 }
         ) ) );
     }
@@ -139,10 +139,10 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
     {
         return super.getSettingsFunction().andThen( ldapOnlyAuthSettings ).andThen( settings -> {
             settings.put( SecuritySettings.ldap_server, "0.0.0.0:10389" );
-            settings.put( SecuritySettings.ldap_user_dn_template, "cn={0},ou=users,dc=example,dc=com" );
+            settings.put( SecuritySettings.ldap_authentication_user_dn_template, "cn={0},ou=users,dc=example,dc=com" );
             settings.put( SecuritySettings.ldap_authentication_cache_enabled, "true" );
-            settings.put( SecuritySettings.ldap_system_username, "uid=admin,ou=system" );
-            settings.put( SecuritySettings.ldap_system_password, "secret" );
+            settings.put( SecuritySettings.ldap_authorization_system_username, "uid=admin,ou=system" );
+            settings.put( SecuritySettings.ldap_authorization_system_password, "secret" );
             settings.put( SecuritySettings.ldap_authorization_use_system_account, "true" );
             settings.put( SecuritySettings.ldap_authorization_user_search_base, "dc=example,dc=com" );
             settings.put( SecuritySettings.ldap_authorization_user_search_filter, "(&(objectClass=*)(uid={0}))" );
@@ -384,7 +384,7 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
     {
         // When
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms,
+            settings.put( SecuritySettings.auth_providers,
                     SecuritySettings.NATIVE_REALM_NAME + "," + SecuritySettings.LDAP_REALM_NAME );
             settings.put( SecuritySettings.native_authentication_enabled, "false" );
             settings.put( SecuritySettings.native_authorization_enabled, "true" );
@@ -730,7 +730,7 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
     public void shouldBeAbleToLoginWithLdapWhenSelectingRealmFromClient() throws Throwable
     {
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms,
+            settings.put( SecuritySettings.auth_providers,
                     SecuritySettings.NATIVE_REALM_NAME + "," + SecuritySettings.LDAP_REALM_NAME );
             settings.put( SecuritySettings.native_authentication_enabled, "true" );
             settings.put( SecuritySettings.native_authorization_enabled, "true" );
@@ -968,7 +968,7 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
 
     private static Consumer<Map<Setting<?>,String>> ldapOnlyAuthSettings = settings ->
     {
-        settings.put( SecuritySettings.active_realm, SecuritySettings.LDAP_REALM_NAME );
+        settings.put( SecuritySettings.auth_provider, SecuritySettings.LDAP_REALM_NAME );
         settings.put( SecuritySettings.native_authentication_enabled, "false" );
         settings.put( SecuritySettings.native_authorization_enabled, "false" );
         settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
@@ -976,10 +976,10 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
     };
 
     private static Consumer<Map<Setting<?>,String>> activeDirectoryOnEc2Settings = settings -> {
-        settings.put( SecuritySettings.active_realm, SecuritySettings.LDAP_REALM_NAME );
+        settings.put( SecuritySettings.auth_provider, SecuritySettings.LDAP_REALM_NAME );
         //settings.put( SecuritySettings.ldap_server, "ec2-176-34-79-113.eu-west-1.compute.amazonaws.com:389" );
         settings.put( SecuritySettings.ldap_server, "henrik.neohq.net:389" );
-        settings.put( SecuritySettings.ldap_user_dn_template, "cn={0},cn=Users,dc=neo4j,dc=com" );
+        settings.put( SecuritySettings.ldap_authentication_user_dn_template, "cn={0},cn=Users,dc=neo4j,dc=com" );
         settings.put( SecuritySettings.ldap_authorization_user_search_base, "cn=Users,dc=neo4j,dc=com" );
         settings.put( SecuritySettings.ldap_authorization_user_search_filter, "(&(objectClass=*)(CN={0}))" );
         settings.put( SecuritySettings.ldap_authorization_group_membership_attribute_names, "memberOf" );
@@ -999,8 +999,8 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
     private static Consumer<Map<Setting<?>,String>> activeDirectoryOnEc2UsingSystemAccountSettings =
             activeDirectoryOnEc2Settings.andThen( settings -> {
                 settings.put( SecuritySettings.ldap_authorization_use_system_account, "true" );
-                settings.put( SecuritySettings.ldap_system_username, "Petra Selmer" );
-                settings.put( SecuritySettings.ldap_system_password, "S0uthAfrica" );
+                settings.put( SecuritySettings.ldap_authorization_system_username, "Petra Selmer" );
+                settings.put( SecuritySettings.ldap_authorization_system_password, "S0uthAfrica" );
             } );
 
     //-------------------------------------------------------------------------

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapExamplePluginAuthenticationIT.java
@@ -86,7 +86,7 @@ public class LdapExamplePluginAuthenticationIT extends EnterpriseAuthenticationT
     protected Consumer<Map<Setting<?>, String>> getSettingsFunction()
     {
         return super.getSettingsFunction().andThen( settings -> {
-            settings.put( SecuritySettings.active_realm,
+            settings.put( SecuritySettings.auth_provider,
                     SecuritySettings.PLUGIN_REALM_NAME_PREFIX + new LdapGroupHasUsersAuthPlugin().name() );
         } );
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/PluginAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/PluginAuthenticationIT.java
@@ -67,7 +67,7 @@ public class PluginAuthenticationIT extends EnterpriseAuthenticationTestBase
     protected Consumer<Map<Setting<?>, String>> getSettingsFunction()
     {
         return super.getSettingsFunction().andThen( settings -> {
-            settings.put( SecuritySettings.active_realms, DEFAULT_TEST_PLUGIN_REALMS );
+            settings.put( SecuritySettings.auth_providers, DEFAULT_TEST_PLUGIN_REALMS );
         });
     }
 
@@ -188,7 +188,7 @@ public class PluginAuthenticationIT extends EnterpriseAuthenticationTestBase
     public void shouldAuthenticateAndAuthorizeWithTestCombinedAuthPlugin() throws Throwable
     {
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms, "plugin-TestCombinedAuthPlugin" );
+            settings.put( SecuritySettings.auth_providers, "plugin-TestCombinedAuthPlugin" );
         });
 
         assertConnectionSucceeds( authToken( "neo4j", "neo4j", "plugin-TestCombinedAuthPlugin" ) );
@@ -200,7 +200,7 @@ public class PluginAuthenticationIT extends EnterpriseAuthenticationTestBase
     public void shouldAuthenticateAndAuthorizeWithTwoSeparateTestPlugins() throws Throwable
     {
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms,
+            settings.put( SecuritySettings.auth_providers,
                     "plugin-TestAuthenticationPlugin,plugin-TestAuthorizationPlugin" );
         });
 
@@ -213,7 +213,7 @@ public class PluginAuthenticationIT extends EnterpriseAuthenticationTestBase
     public void shouldFailIfAuthorizationExpiredWithAuthPlugin() throws Throwable
     {
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms, "plugin-TestCacheableAdminAuthPlugin" );
+            settings.put( SecuritySettings.auth_providers, "plugin-TestCacheableAdminAuthPlugin" );
         });
 
         assertConnectionSucceeds( authToken( "neo4j", "neo4j", "plugin-TestCacheableAdminAuthPlugin" ) );
@@ -236,7 +236,7 @@ public class PluginAuthenticationIT extends EnterpriseAuthenticationTestBase
     public void shouldSucceedIfAuthorizationExpiredWithinTransactionWithAuthPlugin() throws Throwable
     {
         restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.active_realms, "plugin-TestCacheableAdminAuthPlugin" );
+            settings.put( SecuritySettings.auth_providers, "plugin-TestCacheableAdminAuthPlugin" );
         });
 
         // Then

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -345,12 +345,6 @@ dbms.connector.https.enabled=true
 # will be issued to negotiate an upgrade of the connection to TLS before initiating authentication.
 #dbms.security.ldap.use_starttls=false
 
-# LDAP authentication mechanism. This is one of `simple` or a SASL mechanism supported by JNDI,
-# e.g. `DIGEST-MD5`. `simple` is basic username
-# and password authentication and SASL is used for more advanced mechanisms. See RFC 2251 LDAPv3
-# documentation for more details.
-#dbms.security.ldap.auth_mechanism=simple
-
 # The LDAP referral behavior when creating a connection. This is one of `follow`, `ignore` or `throw`.
 # `follow` automatically follows any referrals
 # `ignore` ignores any referrals
@@ -361,12 +355,18 @@ dbms.connector.https.enabled=true
 # LDAP Authentication Configuration
 #----------------------------------
 
+# LDAP authentication mechanism. This is one of `simple` or a SASL mechanism supported by JNDI,
+# e.g. `DIGEST-MD5`. `simple` is basic username
+# and password authentication and SASL is used for more advanced mechanisms. See RFC 2251 LDAPv3
+# documentation for more details.
+#dbms.security.ldap.authentication.mechanism=simple
+
 # LDAP user DN template. An LDAP object is referenced by its distinguished name (DN), and a user DN is
 # an LDAP fully-qualified unique user identifier. This setting is used to generate an LDAP DN that
 # conforms with the LDAP directory's schema from the user principal that is submitted with the
 # authentication token when logging in.
 # The special token {0} is a placeholder where the user principal will be substituted into the DN string.
-#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com
+#dbms.security.ldap.authentication.user_dn_template=uid={0},ou=users,dc=example,dc=com
 
 # Determines if the result of authentication via the LDAP server should be cached or not.
 # Caching is used to limit the number of LDAP requests that have to be made over the network
@@ -378,7 +378,7 @@ dbms.connector.https.enabled=true
 # matching. This hashing is done using a cryptographic hash function together with a random salt.
 # Preferably a conscious decision should be made if this method is considered acceptable by
 # the security standards of the organization in which this Neo4j instance is deployed.
-#dbms.security.ldap.authentication_cache_enabled=true
+#dbms.security.ldap.authentication.cache_enabled=true
 
 #----------------------------------
 # LDAP Authorization Configuration
@@ -407,11 +407,11 @@ dbms.connector.https.enabled=true
 # `dbms.security.ldap.authorization.use_system_account` is `true`.
 # Note that the `dbms.security.ldap.user_dn_template` will not be applied to this username,
 # so you may have to specify a full DN.
-#dbms.security.ldap.system_username=
+#dbms.security.ldap.authorization.system_username=
 
 # An LDAP system account password to use for authorization searches when
 # `dbms.security.ldap.authorization.use_system_account` is `true`.
-#dbms.security.ldap.system_password=
+#dbms.security.ldap.authorization.system_password=
 
 # The name of the base object or named context to search for user objects when LDAP authorization is enabled.
 # A common case is that this matches the last part of `dbms.security.ldap.user_dn_template`.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -366,7 +366,7 @@ dbms.connector.https.enabled=true
 # conforms with the LDAP directory's schema from the user principal that is submitted with the
 # authentication token when logging in.
 # The special token {0} is a placeholder where the user principal will be substituted into the DN string.
-#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com"
+#dbms.security.ldap.user_dn_template=uid={0},ou=users,dc=example,dc=com
 
 # Determines if the result of authentication via the LDAP server should be cached or not.
 # Caching is used to limit the number of LDAP requests that have to be made over the network


### PR DESCRIPTION
This is based on demands from product management to have more consistent naming of settings
- Change the security setting names to have a more consistent differentiation
  between authentication and authorization settings.
- Change the internal setting variable names to be more consistent with
  the real setting names.

Builds on https://github.com/neo4j/neo4j/pull/8206

changelog: Changed security setting names to have more consistent differentiation between authentication and authorization settings