### PR TITLE
Don't close transaction from separate thread

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -23,6 +23,7 @@ package org.neo4j.bolt.v1.runtime;
 import java.time.Clock;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.bolt.security.auth.AuthenticationException;
@@ -84,7 +85,10 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
     private void before( BoltResponseHandler handler ) throws BoltConnectionFatality
     {
-        if ( ctx.interruptCounter.get() > 0 )
+        if (ctx.isTerminated.get())
+        {
+            close();
+        } else if ( ctx.interruptCounter.get() > 0 )
         {
             state = state.interrupt( this );
         }
@@ -290,14 +294,20 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
     @Override
     public void terminate()
     {
-        close();
+        /*
+         * This is a side-channel call and we should not close anything directly.
+         * Just mark the transaction and set isTerminated to true and then the session
+         * thread will close down the connection eventually.
+         */
+        ctx.isTerminated.set( true );
+        ctx.statementProcessor.markCurrentTransactionForTermination();
         spi.onTerminate( this );
     }
 
     @Override
-    public boolean hasTerminated()
+    public boolean willTerminate()
     {
-        return isClosed();
+        return ctx.isTerminated.get();
     }
 
     public enum State
@@ -674,6 +684,8 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
          * can be called to "purge" all the messages ahead of the reset message.
          */
         final AtomicInteger interruptCounter = new AtomicInteger();
+
+        final AtomicBoolean isTerminated = new AtomicBoolean( false );
 
         StatementProcessor statementProcessor = NULL_STATEMENT_PROCESSOR;
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -85,10 +85,11 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
     private void before( BoltResponseHandler handler ) throws BoltConnectionFatality
     {
-        if (ctx.isTerminated.get())
+        if ( ctx.isTerminated.get() )
         {
             close();
-        } else if ( ctx.interruptCounter.get() > 0 )
+        }
+        else if ( ctx.interruptCounter.get() > 0 )
         {
             state = state.interrupt( this );
         }
@@ -278,6 +279,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
         }
         finally
         {
+            spi.onTerminate( this );
             ctx.closed = true;
             //However a new transaction may have been created
             //so we must always to reset

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/ManagedBoltStateMachine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/bolt/ManagedBoltStateMachine.java
@@ -25,5 +25,5 @@ public interface ManagedBoltStateMachine
 
     void terminate();
 
-    boolean hasTerminated();
+    boolean willTerminate();
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/BuiltInProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/BuiltInProcedures.java
@@ -145,7 +145,7 @@ public class BuiltInProcedures
             boltConnectionTracker
                 .getActiveConnections()
                 .stream()
-                .filter( session -> !session.hasTerminated() )
+                .filter( session -> !session.willTerminate() )
                 .map( ManagedBoltStateMachine::owner )
         );
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -20,7 +20,6 @@
 package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.directory.api.util.Strings;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,7 +64,6 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -472,7 +470,7 @@ public abstract class ProcedureInteractionTestBase<S>
                 boltConnectionTracker
                         .getActiveConnections()
                         .stream()
-                        .filter( session -> !session.hasTerminated() )
+                        .filter( session -> !session.willTerminate() )
                         .map( ManagedBoltStateMachine::owner )
                 ).collect( Collectors.toMap( r -> r.username, r -> r.connectionCount ) );
     }

--- a/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.harness.junit.Neo4jRule;
+import org.neo4j.io.fs.FileUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.neo4j.driver.v1.AuthTokens.basic;
+
+public class DeleteUserStressIT
+{
+    @Rule
+    public Neo4jRule db = new Neo4jRule().withConfig( GraphDatabaseSettings.auth_enabled, "true" );
+    private Driver adminDriver;
+    private final Set<Throwable> errors = ConcurrentHashMap.newKeySet();
+
+    @Before
+    public void setup() throws Exception
+    {
+        File knownHosts = new File( System.getProperty( "user.home" ) + "/.neo4j/known_hosts" );
+        FileUtils.deleteFile( knownHosts );
+        adminDriver = GraphDatabase.driver( db.boltURI(), basic( "neo4j", "neo4j" ) );
+    }
+
+    @Test
+    public void shouldRun() throws InterruptedException
+    {
+        ExecutorService service = Executors.newFixedThreadPool( 3 );
+        service.submit( createUserWork );
+        service.submit( deleteUserWork );
+        service.submit( transactionWork );
+
+        service.awaitTermination( 30, TimeUnit.SECONDS );
+
+        String msg = String.join( System.lineSeparator(),
+                errors.stream().map( Throwable::getMessage ).collect( Collectors.toList() ) );
+        assertThat( msg, errors, empty());
+    }
+
+    @SuppressWarnings( "InfiniteLoopStatement" )
+    private final Runnable transactionWork = () -> {
+
+        for (; ; )
+        {
+            try ( Driver driver = GraphDatabase.driver( db.boltURI(), basic( "pontus", "sutnop" ) ) )
+            {
+
+                try ( Session session = driver.session();
+                      Transaction tx = session.beginTransaction() )
+                {
+                    tx.run( "UNWIND range(1, 100000) AS n RETURN n" ).consume();
+                    tx.success();
+                }
+            }
+            catch ( ClientException e )
+            {
+                if ( !e.getMessage().equals( "The client is unauthorized due to authentication failure." ) )
+                {
+                    errors.add( e );
+                }
+
+            }
+        }
+
+    };
+
+
+    @SuppressWarnings( "InfiniteLoopStatement" )
+    private final Runnable deleteUserWork = () -> {
+
+        for (; ; )
+        {
+            try ( Session session = adminDriver.session();
+                  Transaction tx = session.beginTransaction() )
+            {
+                tx.run( "CALL dbms.security.deleteUser('pontus')" ).consume();
+                tx.success();
+            }
+            catch ( ClientException e )
+            {
+                if ( !e.getMessage().equals( "User 'pontus' does not exist." ) )
+                {
+                    errors.add( e );
+                }
+            }
+        }
+    };
+
+    @SuppressWarnings( "InfiniteLoopStatement" )
+    private final Runnable createUserWork = () -> {
+        for (; ; )
+        {
+            try ( Session session = adminDriver.session();
+                  Transaction tx = session.beginTransaction() )
+            {
+                tx.run( "CALL dbms.security.createUser('pontus', 'sutnop', false)" ).consume();
+                tx.success();
+            }
+            catch ( ClientException e )
+            {
+                if ( !e.getMessage().equals( "The specified user 'pontus' already exists." ) )
+                {
+                    errors.add( e );
+                }
+            }
+        }
+    };
+}

--- a/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/DeleteUserStressIT.java
@@ -95,12 +95,9 @@ public class DeleteUserStressIT
                 {
                     errors.add( e );
                 }
-
             }
         }
-
     };
-
 
     @SuppressWarnings( "InfiniteLoopStatement" )
     private final Runnable deleteUserWork = () -> {


### PR DESCRIPTION
The side-channel method `terminate` on `BoltStateMachine` shouldn't kill the
transaction directly but just mark it and then we close down the machine from
the session thread on next call instead.
