### PR TITLE
Fix flaky LoadCommandTest

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -39,13 +39,11 @@ import org.neo4j.dbms.archive.Dumper;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.kernel.StoreLockException;
-import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.server.configuration.ConfigLoader;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.Converters.identity;
@@ -117,12 +115,13 @@ public class DumpCommand implements AdminCommand
         }
         catch ( CannotWriteException e )
         {
-            throw new CommandFailed( "you do not have permission to dump the database -- is Neo4j running as a " +
-                    "different user?", e );
+            throw new CommandFailed(
+                    "you do not have permission to dump the database -- is Neo4j running as a " + "different user?",
+                    e );
         }
     }
 
-    private <T> T parse( String[] args, String argument, Function<String, T> converter ) throws IncorrectUsage
+    private <T> T parse( String[] args, String argument, Function<String,T> converter ) throws IncorrectUsage
     {
         try
         {
@@ -138,8 +137,7 @@ public class DumpCommand implements AdminCommand
     {
         //noinspection unchecked
         return new ConfigLoader( asList( DatabaseManagementSystemSettings.class, GraphDatabaseSettings.class ) )
-                .loadOfflineConfig(
-                        Optional.of( homeDir.toFile() ),
+                .loadOfflineConfig( Optional.of( homeDir.toFile() ),
                         Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) )
                 .with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) )
                 .get( database_path ).toPath();

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreLockChecker.java
@@ -40,7 +40,7 @@ class StoreLockChecker
 
                 storeLocker.checkLock( databaseDirectory.toFile() );
 
-                return storeLocker::release;
+                return storeLocker;
             }
             else
             {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
@@ -33,11 +33,9 @@ public class Util
 {
     public static void checkLock( Path databaseDirectory ) throws CommandFailed
     {
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
-            StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
             storeLocker.checkLock( databaseDirectory.toFile() );
-            storeLocker.release();
         }
         catch ( StoreLockException e )
         {

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -30,11 +35,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Predicate;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.dbms.archive.Dumper;
@@ -45,7 +45,6 @@ import org.neo4j.test.rule.TestDirectory;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -57,7 +56,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 
@@ -122,21 +120,17 @@ public class DumpCommandTest
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
         Files.createDirectories( databaseDirectory );
-        StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
-        storeLocker.checkLock( databaseDirectory.toFile() );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
+            storeLocker.checkLock( databaseDirectory.toFile() );
+
             execute( "foo.db" );
             fail( "expected exception" );
         }
         catch ( CommandFailed e )
         {
             assertThat( e.getMessage(), equalTo( "the database is in use -- stop Neo4j and try again" ) );
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 
@@ -184,30 +178,28 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldReportAHelpfulErrorIfWeDontHaveWritePermissionsForLock()
-            throws IOException, IncorrectUsage
+    public void shouldReportAHelpfulErrorIfWeDontHaveWritePermissionsForLock() throws IOException, IncorrectUsage
     {
         assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
 
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
         Files.createDirectories( databaseDirectory );
-        StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
-        storeLocker.checkLock( databaseDirectory.toFile() );
 
-        try ( Closeable ignored =
-                      withPermissions( databaseDirectory.resolve( StoreLocker.STORE_LOCK_FILENAME ), emptySet() ) )
+        try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
-            execute( "foo.db" );
-            fail( "expected exception" );
-        }
-        catch ( CommandFailed e )
-        {
-            assertThat( e.getMessage(), equalTo( "you do not have permission to dump the database -- is Neo4j " +
-                    "running as a different user?" ) );
-        }
-        finally
-        {
-            storeLocker.release();
+            storeLocker.checkLock( databaseDirectory.toFile() );
+
+            try ( Closeable ignored = withPermissions( databaseDirectory.resolve( StoreLocker.STORE_LOCK_FILENAME ),
+                    emptySet() ) )
+            {
+                execute( "foo.db" );
+                fail( "expected exception" );
+            }
+            catch ( CommandFailed e )
+            {
+                assertThat( e.getMessage(), equalTo( "you do not have permission to dump the database -- is Neo4j " +
+                        "running as a different user?" ) );
+            }
         }
     }
 
@@ -273,8 +265,8 @@ public class DumpCommandTest
     @Test
     public void shouldGiveAClearMessageIfTheDatabaseDoesntExist() throws IOException, IncorrectUsage
     {
-        doThrow( new NoSuchFileException( homeDir.resolve( "data/databases/foo.db" ).toString() ) )
-                .when( dumper ).dump( any(), any(), any() );
+        doThrow( new NoSuchFileException( homeDir.resolve( "data/databases/foo.db" ).toString() ) ).when( dumper )
+                .dump( any(), any(), any() );
         try
         {
             execute( "foo.db" );
@@ -303,8 +295,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void
-    shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
+    public void shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
             throws IOException, IncorrectUsage
     {
         doThrow( new IOException( "the-message" ) ).when( dumper ).dump( any(), any(), any() );
@@ -327,8 +318,9 @@ public class DumpCommandTest
 
     private void assertCanLockStore( Path databaseDirectory ) throws IOException
     {
-        StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() );
-        storeLocker.checkLock( databaseDirectory.toFile() );
-        storeLocker.release();
+        try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
+        {
+            storeLocker.checkLock( databaseDirectory.toFile() );
+        }
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -132,10 +132,10 @@ public class LoadCommandTest
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
         Files.createDirectories( databaseDirectory );
-        new StoreLocker( new DefaultFileSystemAbstraction() ).checkLock( databaseDirectory.toFile() );
 
-        try
+        try ( StoreLocker locker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
+            locker.checkLock( databaseDirectory.toFile() );
             execute( "foo.db", "--force" );
             fail( "expected exception" );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/StoreLockerLifecycleAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/StoreLockerLifecycleAdapter.java
@@ -43,6 +43,6 @@ public class StoreLockerLifecycleAdapter extends LifecycleAdapter
     @Override
     public void stop() throws Throwable
     {
-        storeLocker.release();
+        storeLocker.close();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -976,7 +976,7 @@ public class BatchInserterImpl implements BatchInserter
 
             try
             {
-                storeLocker.release();
+                storeLocker.close();
             }
             catch ( IOException e )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/StoreLockerTest.java
@@ -60,9 +60,8 @@ public class StoreLockerTest
                 return true;
             }
         };
-        StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction ) )
         {
             storeLocker.checkLock( target.directory( "unused" ) );
 
@@ -71,10 +70,6 @@ public class StoreLockerTest
         catch ( StoreLockException e )
         {
             fail();
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 
@@ -89,16 +84,11 @@ public class StoreLockerTest
                 return false;
             }
         };
-        StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction ) )
         {
             storeLocker.checkLock( target.directory( "unused" ) );
             // Ok
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 
@@ -119,22 +109,20 @@ public class StoreLockerTest
                 return false;
             }
         };
-        StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction );
+
         File storeDir = target.directory( "unused" );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction ) )
         {
             storeLocker.checkLock( storeDir );
             fail();
         }
         catch ( StoreLockException e )
         {
-            String msg = format( "Unable to create path for store dir: %s. Please ensure no other process is using this database, and that the directory is writable (required even for read-only access)", storeDir );
+            String msg = format( "Unable to create path for store dir: %s. " +
+                    "Please ensure no other process is using this database, and that " +
+                    "the directory is writable (required even for read-only access)", storeDir );
             assertThat( e.getMessage(), is( msg ) );
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 
@@ -155,23 +143,21 @@ public class StoreLockerTest
                 return false;
             }
         };
-        StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction );
+
         File storeDir = target.directory( "unused" );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction ) )
         {
             storeLocker.checkLock( storeDir );
             fail();
         }
         catch ( StoreLockException e )
         {
-            String msg = format( "Unable to obtain lock on store lock file: %s. Please ensure no other process is using this database, and that the directory is writable (required even for read-only access)", new File( storeDir,
-                    STORE_LOCK_FILENAME ) );
+            String msg = format( "Unable to obtain lock on store lock file: %s. " +
+                            "Please ensure no other process is using this database, and that the " +
+                            "directory is writable (required even for read-only access)",
+                    new File( storeDir, STORE_LOCK_FILENAME ) );
             assertThat( e.getMessage(), is( msg ) );
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 
@@ -199,20 +185,16 @@ public class StoreLockerTest
                 };
             }
         };
-        StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction );
 
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fileSystemAbstraction ) )
         {
             storeLocker.checkLock( target.directory( "unused" ) );
             fail();
         }
         catch ( StoreLockException e )
         {
-            assertThat( e.getMessage(), containsString( "Store and its lock file has been locked by another process" ) );
-        }
-        finally
-        {
-            storeLocker.release();
+            assertThat( e.getMessage(),
+                    containsString( "Store and its lock file has been locked by another process" ) );
         }
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.restore;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -62,21 +62,16 @@ public class RestoreDatabaseCommandTest
         createDbAt( fromPath, fromNodeCount );
         createDbAt( toPath, toNodeCount );
 
-        StoreLocker storeLocker = new StoreLocker( fs );
-        storeLocker.checkLock( toPath );
-
-        try
+        try ( StoreLocker storeLocker = new StoreLocker( fs ) )
         {
+            storeLocker.checkLock( toPath );
+
             new RestoreDatabaseCommand( fs, fromPath, config, databaseName, true ).execute();
             fail( "expected exception" );
         }
         catch ( Exception e )
         {
             assertThat( e.getMessage(), equalTo( "the database is in use -- stop Neo4j and try again" ) );
-        }
-        finally
-        {
-            storeLocker.release();
         }
     }
 


### PR DESCRIPTION
Since the lock was not assigned to anything the garbage collector was free to GC the lock at any time. This happened infrequently (something like 1/1000 to 1/100 runs as I recreated it).

To encourage better usage of the lock I also made it implement `Closeable` so that try-with-resources could be used. All usages were changed so that the prior art is clear for future tests.
