### PR TITLE
Optimization of isGraphKernelResultValue

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/isGraphKernelResultValue.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/isGraphKernelResultValue.scala
@@ -19,13 +19,9 @@
  */
 package org.neo4j.cypher.internal
 
-import org.neo4j.graphdb.{Path, Node, Relationship}
+import org.neo4j.graphdb.{Path, PropertyContainer}
 
 object isGraphKernelResultValue extends (Any => Boolean) {
-  override def apply(v: Any): Boolean = v match {
-    case node: Node => true
-    case rel: Relationship => true
-    case path: Path => true
-    case _ => false
-  }
+
+  override def apply(v: Any): Boolean = v.isInstanceOf[PropertyContainer] || v.isInstanceOf[Path]
 }


### PR DESCRIPTION
`isGraphKernelResultValue` is used a lot and shows up in profiling.
This change makes it roughly 30 percent faster assuming an even distribution of
types (`Node`, 'Relationship', `Path`, `String`, `Integer`, `Float`, `Boolean`)
