### PR TITLE
Change AuthToken parameters to not return null

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.security;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
@@ -52,13 +53,20 @@ public interface AuthToken
             throws InvalidAuthTokenException
     {
         Object value = authToken.get( key );
-        if ( value != null && !(value instanceof Map) )
+        if ( value == null )
+        {
+            return Collections.emptyMap();
+        }
+        else if ( value instanceof Map )
+        {
+            return (Map<String,Object>) value;
+        }
+        else
         {
             throw new InvalidAuthTokenException(
                     "The value associated with the key `" + key + "` must be a Map but was: " +
                     value.getClass().getSimpleName() );
         }
-        return (Map<String,Object>) value;
     }
 
     static Map<String,Object> newBasicAuthToken( String username, String password )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginApiAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginApiAuthToken.java
@@ -59,11 +59,6 @@ public class PluginApiAuthToken implements AuthToken
         return parameters;
     }
 
-    public static AuthToken of( String principal, char[] credentials )
-    {
-        return new PluginApiAuthToken( principal, credentials, null );
-    }
-
     public static AuthToken of( String principal, char[] credentials, Map<String,Object> parameters )
     {
         return new PluginApiAuthToken( principal, credentials, parameters );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthToken.java
@@ -58,7 +58,7 @@ public interface AuthToken
      * <p>This can be used as a vehicle to send arbitrary auth data from a client application
      * to a server-side auth plugin. Neo4j will act as a pure transport and will not touch the contents of this map.
      *
-     * @return a custom parameter map if provided by the client, otherwise <tt>null</tt>
+     * @return a custom parameter map (or an empty map if no parameters where provided by the client)
      */
     Map<String,Object> parameters();
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomParametersAuthenticationPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCustomParametersAuthenticationPlugin.java
@@ -40,14 +40,11 @@ public class TestCustomParametersAuthenticationPlugin extends AuthenticationPlug
     {
         Map<String,Object> parameters = authToken.parameters();
 
-        if ( parameters != null )
-        {
-            List<Long> myCredentials = (List<Long>) parameters.get( "my_credentials" );
+        List<Long> myCredentials = (List<Long>) parameters.get( "my_credentials" );
 
-            if ( myCredentials.containsAll( Arrays.asList( 1L, 2L, 3L, 4L ) ) )
-            {
-                return (AuthenticationInfo) () -> "neo4j";
-            }
+        if ( myCredentials.containsAll( Arrays.asList( 1L, 2L, 3L, 4L ) ) )
+        {
+            return (AuthenticationInfo) () -> "neo4j";
         }
         return null;
     }


### PR DESCRIPTION
Return empty map instead of null so that auth plugin writers do not have
to check for null.
