### PR TITLE
asPrivateType not handling lists and maps

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -71,6 +71,7 @@ object typeConversionsFor3_0 extends RuntimeTypeConverter {
   override def asPrivateType = {
     case map: Map[_, _] => asPrivateMap(map.asInstanceOf[Map[String, Any]])
     case seq: Seq[_] => seq.map(asPrivateType)
+    case javaMap: java.util.Map[_, _] => Eagerly.immutableMapValues(javaMap.asScala, asPrivateType)
     case javaIterable: java.lang.Iterable[_] => javaIterable.asScala.map(asPrivateType)
     case arr: Array[Any] => arr.map(asPrivateType)
     case point: spatial.Point => asPrivatePoint(point)
@@ -105,7 +106,7 @@ object typeConversionsFor3_0 extends RuntimeTypeConverter {
     override def getCode: Int = crs.code
   }
 
-  def asPrivateMap(incoming: Map[String, Any]): Map[String, Any] = Eagerly.immutableMapValues(incoming, asPrivateType)
+  def asPrivateMap(incoming: Map[String, Any]): Map[String, Any] = Eagerly.immutableMapValues[String,Any, Any](incoming, asPrivateType)
 
   private def asPrivatePoint(point: spatial.Point) = new Point {
     override def x: Double = point.getCoordinate.getCoordinate.get(0)

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -131,6 +131,21 @@ public class ExecutionResultTest
         assertThat( Math.round( distance ), equalTo( 86107L ) );
     }
 
+
+    @Test
+    public void shouldHandleMapWithPointsAsInput()
+    {
+        // Given
+        Point point1 = (Point) db.execute( "RETURN point({latitude: 12.78, longitude: 56.7}) as point"  ).next().get( "point" );
+        Point point2 = (Point) db.execute( "RETURN point({latitude: 12.18, longitude: 56.2}) as point"  ).next().get( "point" );
+
+        // When
+        double distance = (double) db.execute( "RETURN distance({points}['p1'], {points}['p2']) as dist",
+                map( "points", map("p1", point1, "p2", point2) ) ).next().get( "dist" );
+        // Then
+        assertThat(Math.round( distance ), equalTo(86107L));
+    }
+
     private TopLevelTransaction activeTransaction()
     {
         ThreadToStatementContextBridge bridge = db.getDependencyResolver().resolveDependency(


### PR DESCRIPTION
The conversion method for private types wasn't properly handling Java collections properly.
Meaning that whenever lists or maps are used as parameters they weren't converting correctly.
