### PR TITLE
Fix lock test which fails on Windows

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.restore;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -52,7 +52,7 @@ public class RestoreDatabaseCommandTest
     {
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = configWith(  Config.empty(), databaseName);
+        Config config = configWith( Config.empty(), databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -86,7 +86,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = configWith(  Config.empty(), databaseName);
+        Config config = configWith( Config.empty(), databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -104,8 +104,8 @@ public class RestoreDatabaseCommandTest
         catch ( IllegalArgumentException exception )
         {
             // then
-            assertTrue( exception.getMessage(), exception.getMessage().contains(
-                    "Database with name [to] already exists" ) );
+            assertTrue( exception.getMessage(),
+                    exception.getMessage().contains( "Database with name [to] already exists" ) );
         }
     }
 
@@ -115,7 +115,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = configWith(  Config.empty(), databaseName);
+        Config config = configWith( Config.empty(), databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -132,8 +132,7 @@ public class RestoreDatabaseCommandTest
         catch ( IllegalArgumentException exception )
         {
             // then
-            assertTrue( exception.getMessage(),
-                    exception.getMessage().contains( "Source directory does not exist" ) );
+            assertTrue( exception.getMessage(), exception.getMessage().contains( "Source directory does not exist" ) );
         }
     }
 
@@ -143,7 +142,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = configWith(  Config.empty(), databaseName);
+        Config config = configWith( Config.empty(), databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -159,17 +158,18 @@ public class RestoreDatabaseCommandTest
         // then
         GraphDatabaseService copiedDb = new GraphDatabaseFactory().newEmbeddedDatabase( toPath );
 
-        try(Transaction ignored = copiedDb.beginTx())
+        try ( Transaction ignored = copiedDb.beginTx() )
         {
-            assertEquals(fromNodeCount, Iterables.count( copiedDb.getAllNodes() ) );
+            assertEquals( fromNodeCount, Iterables.count( copiedDb.getAllNodes() ) );
         }
 
         copiedDb.shutdown();
     }
 
-    public static Config configWith( Config config, String databaseName )
+    public static Config configWith( Config config, String databaseName, String dataDirectory )
     {
-        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
+        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName,
+                DatabaseManagementSystemSettings.data_directory.name(), dataDirectory ) );
     }
 
     private void createDbAt( File fromPath, int nodesToCreate )
@@ -178,7 +178,7 @@ public class RestoreDatabaseCommandTest
 
         GraphDatabaseService db = factory.newEmbeddedDatabase( fromPath );
 
-        try(Transaction tx = db.beginTx())
+        try ( Transaction tx = db.beginTx() )
         {
             for ( int i = 0; i < nodesToCreate; i++ )
             {


### PR DESCRIPTION
Problem here was that both `forceShouldRespectStoreLock` and `shouldAllowForcedCopyOverAnExistingDatabase` implicitly defined the same destination database directory. This caused a file locking conflict on Windows which holds on to file mappings in a strict way.
