### PR TITLE
Swallow NPE from Hazelcast on shutdown

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -117,7 +117,13 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
                 {
                     throw e;
                 }
-                log.info( "Unable to shutdown Hazelcast", e );
+                log.warn( "Unable to shutdown Hazelcast", e );
+            }
+            catch ( NullPointerException e )
+            {
+                // Hazelcast is not able to stop correctly sometimes and throws a NPE
+                // let's log it but go on with our shutdown
+                log.warn( "Stopping Hazelcast failed with a NPE", e );
             }
         }
 


### PR DESCRIPTION
In this way the rest of the code will have a chance to stop correctly.
