### PR TITLE
Handle network partitions: send heartbeat acknowledgements from the follower back to the leader

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
@@ -44,6 +44,7 @@ public interface RaftMessages
         APPEND_ENTRIES_RESPONSE,
 
         HEARTBEAT,
+        HEARTBEAT_RESPONSE,
         LOG_COMPACTION_INFO,
 
         // Timeouts
@@ -87,6 +88,27 @@ public interface RaftMessages
         public String toString()
         {
             return format( "Directed{to=%s, message=%s}", to, message );
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            Directed directed = (Directed) o;
+            return Objects.equals( to, directed.to ) && Objects.equals( message, directed.message );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( to, message );
         }
     }
 
@@ -443,6 +465,15 @@ public interface RaftMessages
         {
             return format( "Heartbeat from %s {leaderTerm=%d, commitIndex=%d, commitIndexTerm=%d}", from, leaderTerm,
                     commitIndex, commitIndexTerm );
+        }
+    }
+
+    class HeartbeatResponse extends BaseRaftMessage
+    {
+
+        public HeartbeatResponse( MemberId from, Type type )
+        {
+            super( from, type );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -28,7 +28,8 @@ import org.neo4j.logging.Log;
 
 class Heart
 {
-    static void beat( ReadableRaftState state, Outcome outcome, RaftMessages.Heartbeat request, Log log ) throws IOException
+    static void beat( ReadableRaftState state, Outcome outcome, RaftMessages.Heartbeat request, Log log )
+            throws IOException
     {
         if ( request.leaderTerm() < state.term() )
         {
@@ -39,6 +40,8 @@ class Heart
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );
         outcome.setLeaderCommit( request.commitIndex() );
+        outcome.addOutgoingMessage( new RaftMessages.Directed( request.from(),
+                new RaftMessages.HeartbeatResponse( state.myself(), RaftMessages.Type.HEARTBEAT_RESPONSE ) ) );
 
         if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm(), log ) )
         {


### PR DESCRIPTION
This is a step towards making the leader step down if that leader
doesn't have a quorum following their lead. This doesn't affect
or is required for raft, but it does lead to less confusion when
by having defunct leaders step down.
