### PR TITLE
Plan description fails for NestedExpression

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/NestedPipeExpression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/NestedPipeExpression.scala
@@ -37,4 +37,6 @@ case class NestedPipeExpression(pipe: Pipe, path: ProjectedPath) extends Express
   def calculateType(symbols: SymbolTable): CypherType = CTList(CTPath)
 
   def symbolTableDependencies = Set()
+
+  override def toString: String = s"NestedExpression(${pipe.planDescription.flatten.map(_.name).mkString("-")})"
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -19,8 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planDescription
 
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{ExpandExpression,
-EstimatedRows, DbHits, Rows}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.ProjectedPath.{nilProjector, singleNodeProjector}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{NestedPipeExpression, ProjectedPath}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ArgumentPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments._
+import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
@@ -36,5 +39,14 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
 
   test("ExpandExpression should look like Cypher syntax") {
     serialize(new ExpandExpression("a", "r", Seq("LIKES", "LOVES"), "b", SemanticDirection.OUTGOING, false)) should equal ("(a)-[r:LIKES|:LOVES]->(b)")
+  }
+
+  test("serialize nested pipe expression") {
+    val nested = NestedPipeExpression(ArgumentPipe(SymbolTable())(None)(mock[PipeMonitor]), ProjectedPath(
+      Set("a"),
+      singleNodeProjector("a", nilProjector)
+    ))
+
+    serialize(LegacyExpression(nested)) should equal("NestedExpression(Argument)")
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExplainAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExplainAcceptanceTest.scala
@@ -55,4 +55,32 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite {
 
     plan.toString should include(MergePattern("second").toString)
   }
+
+  test("should handle query with nested expression") {
+    val query = """EXPLAIN
+                  |WITH
+                  |   ['Herfstvakantie Noord'] AS periodName
+                  |MATCH (perStart:Day)<-[:STARTS]-(per:Periode)-[:ENDS]->(perEnd:Day) WHERE per.naam=periodName
+                  |WITH perStart,perEnd
+                  |
+                  |MATCH perDays=shortestPath((perStart)-[:NEXT*]->(perEnd))
+                  |UNWIND nodes(perDays) as perDay
+                  |WITH perDay ORDER by perDay.day
+                  |
+                  |MATCH (bknStart:Day)-[:NEXT*0..]->(perDay)
+                  |WHERE (bknStart)<-[:FROM_DATE]-(:Boeking)
+                  |WITH distinct bknStart, collect(distinct perDay) as perDays
+                  |
+                  |MATCH (bknStart)<-[:FROM_DATE]-(bkn:Boeking)-[:TO_DATE]->(bknEnd)
+                  |WITH bknEnd, collect(bkn) as bookings, perDays
+                  |WHERE any(perDay IN perDays WHERE perDays = bknEnd OR exists((perDay)-[:NEXT*]->(bknEnd)))
+                  |
+                  |RETURN count(*), count(distinct bknEnd), avg(size(bookings)),avg(size(perDays));""".stripMargin
+
+    val result = execute(query)
+    val plan = result.executionPlanDescription()
+    result.close()
+
+    plan.toString should include("NestedExpression(VarLengthExpand(Into)-Argument)")
+  }
 }


### PR DESCRIPTION
changelog: Fixes a bug whereby the plan description for NestedExpression would fail

Missing implementation of `toString` in `NestedPipeExpression` leads to regex-failure when trying to remove generated variables from the plan description and ending up with a `java.lang.IllegalArgumentException: Illegal group reference` instead of showing the plan.
