### PR TITLE
Fixed `neo4j install-service` on Windows 7

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Merge-Neo4jJavaSettings.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Merge-Neo4jJavaSettings.ps1
@@ -65,31 +65,26 @@ Function Merge-Neo4jJavaSettings
 
   $Additional | ForEach-Object -Process {
     $thisSetting = $_
-    If (-not $Source.contains($thisSetting)) {
-      if ($matches -ne $null) { $matches.Clear() }
-      if ($thisSetting -match $SettingNameRegEx) {
-        $thisSettingName = $matches[1]
+    if ($matches -ne $null) { $matches.Clear() }
+    if ($thisSetting -match $SettingNameRegEx) {
+      $thisSettingName = $matches[1]
 
-        $oldValue = $null
-        $SettingOutput.GetEnumerator() | ForEach-Object -Process {
-          if ($_.Value -eq $thisSettingName) { $oldValue = $_.Key}
-        }
-
-        if ($oldValue -eq $null) {
-          Write-Verbose "Adding '$thisSetting'"
-          $SettingOutput.Add($thisSetting,'')
-        } else {
-          Write-Verbose "Merging '$thisSetting'"
-          $SettingOutput.Remove($oldValue)
-          $SettingOutput.Add($thisSetting,$thisSettingName)
-        }
-      } else {
-        Write-Verbose "Adding '$thisSetting'"
-        $SettingOutput.Add($thisSetting,'')
+      $oldValue = $null
+      $SettingOutput.GetEnumerator() | ForEach-Object -Process {
+        if ($_.Value -eq $thisSettingName) { $oldValue = $_.Key}
       }
 
+      if ($oldValue -eq $null) {
+        Write-Verbose "Adding '$thisSetting'"
+        $SettingOutput.Add($thisSetting,'')
+      } else {
+        Write-Verbose "Merging '$thisSetting'"
+        $SettingOutput.Remove($oldValue)
+        $SettingOutput.Add($thisSetting,$thisSettingName)
+      }
     } else {
-      Write-Verbose "Ignoring '$thisSetting' as it is already defined"
+      Write-Verbose "Adding '$thisSetting'"
+      $SettingOutput.Add($thisSetting,'')
     }
   }
 


### PR DESCRIPTION
This would throw a powershell exception on Windows 7. Should be
compatible with all versions of Windows now.
