### PR TITLE
Add new config settings for `allowed`

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -38,15 +38,12 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.NeoStoreDataSource;
-import org.neo4j.kernel.api.security.SecurityContext;
-import org.neo4j.kernel.impl.proc.TerminationGuardProvider;
-import org.neo4j.procedure.TerminationGuard;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.legacyindex.AutoIndexing;
-import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.builtinprocs.SpecialBuiltInProcedures;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.guard.Guard;
@@ -66,8 +63,10 @@ import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.proc.ProcedureAllowedConfig;
 import org.neo4j.kernel.impl.proc.ProcedureGDSFactory;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.proc.TerminationGuardProvider;
 import org.neo4j.kernel.impl.proc.TypeMappers.SimpleConverter;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -83,9 +82,10 @@ import org.neo4j.kernel.internal.Version;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
 
-import static org.neo4j.kernel.api.proc.Context.SECURITY_CONTEXT;
 import static org.neo4j.kernel.api.proc.Context.KERNEL_TRANSACTION;
+import static org.neo4j.kernel.api.proc.Context.SECURITY_CONTEXT;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTGeometry;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
@@ -352,7 +352,7 @@ public class DataSourceModule
         Procedures procedures = new Procedures(
                 new SpecialBuiltInProcedures( Version.getNeo4jVersion(),
                         platform.databaseInfo.edition.toString() ),
-                pluginDir, internalLog );
+                pluginDir, internalLog, new ProcedureAllowedConfig( platform.config ) );
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfig.java
@@ -33,6 +33,9 @@ public class ProcedureAllowedConfig
     public static final String PROC_ALLOWED_SETTING_DEFAULT_NAME = "dbms.security.procedures.default_allowed";
     public static final String PROC_ALLOWED_SETTING_ROLES = "dbms.security.procedures.roles";
 
+    private static final String SETTING_DELIMITER = ";";
+    private static final String MAPPING_DELIMITER = ":";
+
     private final String defaultValue;
     private final List<ProcMatcher> matchers;
 
@@ -48,9 +51,9 @@ public class ProcedureAllowedConfig
         this.defaultValue = params.get( PROC_ALLOWED_SETTING_DEFAULT_NAME );
         if ( params.containsKey( PROC_ALLOWED_SETTING_ROLES ) )
         {
-            this.matchers = Stream.of( params.get( PROC_ALLOWED_SETTING_ROLES ).split( "," ) )
+            this.matchers = Stream.of( params.get( PROC_ALLOWED_SETTING_ROLES ).split( SETTING_DELIMITER ) )
                     .map( procToRoleSpec -> {
-                        String[] spec = procToRoleSpec.split( ":" );
+                        String[] spec = procToRoleSpec.split( MAPPING_DELIMITER );
                         return new ProcMatcher( spec[0].trim(), spec[1].trim() );
                     } ).collect( Collectors.toList() );
         }
@@ -60,7 +63,7 @@ public class ProcedureAllowedConfig
         }
     }
 
-    public String[] rolesFor( String procedureName )
+    String[] rolesFor( String procedureName )
     {
         String[] wildCardRoles =
                 matchers.stream().filter( matcher -> matcher.matches( procedureName ) ).map( ProcMatcher::role )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.neo4j.kernel.configuration.Config;
+
+public class ProcedureAllowedConfig
+{
+    public static final String PROC_ALLOWED_SETTING_DEFAULT_NAME = "dbms.security.procedures.default_allowed";
+
+    private final String defaultValue;
+
+    private ProcedureAllowedConfig()
+    {
+        this.defaultValue = "";
+    }
+
+    public ProcedureAllowedConfig( Config config )
+    {
+        this.defaultValue = config.getParams().get( PROC_ALLOWED_SETTING_DEFAULT_NAME );
+    }
+
+    public String[] getDefaultValue()
+    {
+        return defaultValue == null || defaultValue.isEmpty() ? new String[0]: new String[]{defaultValue};
+    }
+
+    static final ProcedureAllowedConfig DEFAULT = new ProcedureAllowedConfig();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -55,15 +55,16 @@ public class Procedures extends LifecycleAdapter
 
     public Procedures()
     {
-        this( new SpecialBuiltInProcedures( "N/A", "N/A" ), null, NullLog.getInstance() );
+        this( new SpecialBuiltInProcedures( "N/A", "N/A" ), null, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
-    public Procedures( ThrowingConsumer<Procedures, ProcedureException> builtin, File pluginDir, Log log )
+    public Procedures( ThrowingConsumer<Procedures,ProcedureException> builtin, File pluginDir, Log log,
+            ProcedureAllowedConfig config )
     {
         this.builtin = builtin;
         this.pluginDir = pluginDir;
         this.log = log;
-        this.compiler = new ReflectiveProcedureCompiler(typeMappers, components, log);
+        this.compiler = new ReflectiveProcedureCompiler( typeMappers, components, log, config );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -177,7 +177,7 @@ public class ReflectiveProcedureCompiler
         Optional<String> deprecated = deprecated( method, procedure::deprecatedBy,
                 "Use of @Procedure(deprecatedBy) without @Deprecated in " + procName );
 
-        String[] allowed = procedure.allowed().length == 0 ? config.getDefaultValue() : procedure.allowed();
+        String[] allowed = procedure.allowed().length == 0 ? config.rolesFor( procName.toString() ) : procedure.allowed();
         ProcedureSignature signature =
                 new ProcedureSignature( procName, inputSignature, outputMapper.signature(),
                         mode, deprecated, allowed, description );
@@ -211,7 +211,7 @@ public class ReflectiveProcedureCompiler
         Optional<String> deprecated = deprecated( method, function::deprecatedBy,
                 "Use of @UserFunction(deprecatedBy) without @Deprecated in " + procName );
 
-        String[] allowed = function.allowed().length == 0 ? config.getDefaultValue() : function.allowed();
+        String[] allowed = function.allowed().length == 0 ? config.rolesFor( procName.toString() ) : function.allowed();
         UserFunctionSignature signature =
                 new UserFunctionSignature( procName, inputSignature, valueConverter.type(), deprecated,
                         allowed, description );

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -45,13 +45,13 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.proc.BasicContext;
-import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Key;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.factory.Edition;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.proc.TypeMappers;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.storageengine.api.Token;
 
 import static java.util.Collections.emptyIterator;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
@@ -91,18 +91,36 @@ public class ProcedureAllowedConfigTest
         Config config = Config.defaults()
                 .with( genericMap(
                         ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES,
-                        "apoc.convert.*:reader,apoc.load.json:writer,apoc.trigger.add:TriggerHappy"
+                        "apoc.convert.*:apoc_reader,apoc.load.json:apoc_writer,apoc.trigger.add:TriggerHappy"
                 ) );
         ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( EMPTY ) );
-        assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "reader" ) ) );
-        assertThat( procConfig.rolesFor( "apoc.convert.json" ), equalTo( arrayOf( "reader" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "apoc_reader" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.convert.json" ), equalTo( arrayOf( "apoc_reader" ) ) );
         assertThat( procConfig.rolesFor( "apoc.load.xml" ), equalTo( EMPTY ) );
-        assertThat( procConfig.rolesFor( "apoc.load.json" ), equalTo( arrayOf( "writer" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.load.json" ), equalTo( arrayOf( "apoc_writer" ) ) );
         assertThat( procConfig.rolesFor( "apoc.trigger.add" ), equalTo( arrayOf( "TriggerHappy" ) ) );
         assertThat( procConfig.rolesFor( "apoc.convert-json" ), equalTo( EMPTY ) );
         assertThat( procConfig.rolesFor( "apoc.load-xml" ), equalTo( EMPTY ) );
         assertThat( procConfig.rolesFor( "apoc.load-json" ), equalTo( EMPTY ) );
         assertThat( procConfig.rolesFor( "apoc.trigger-add" ), equalTo( EMPTY ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithOverlappingMatchingWildcards()
+    {
+        Config config = Config.defaults()
+                .with( genericMap(
+                        ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME, "default",
+                        ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES,
+                        "apoc.*:apoc,apoc.load.*:loader,apoc.trigger.*:trigger,apoc.trigger.add:TriggerHappy"
+                ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "xyz" ), equalTo( arrayOf( "default" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "apoc" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.load.xml" ), equalTo( arrayOf( "apoc", "loader" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.trigger.add" ), equalTo( arrayOf( "apoc", "trigger", "TriggerHappy" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.trigger.remove" ), equalTo( arrayOf( "apoc", "trigger" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.load-xml" ), equalTo( arrayOf( "apoc" ) ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.genericMap;
+
+public class ProcedureAllowedConfigTest
+{
+    private static final String[] EMPTY = new String[]{};
+
+    private static String[] arrayOf( String... values )
+    {
+        return values;
+    }
+
+    @Test
+    public void shouldHaveEmptyDefaultConfigs()
+    {
+        Config config = Config.defaults();
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "x" ), equalTo( EMPTY ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithDefaultProcedureAllowed()
+    {
+        Config config = Config.defaults()
+                .with( genericMap( ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1" ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "x" ), equalTo( arrayOf( "role1" ) ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithExactMatchProcedureAllowed()
+    {
+        Config config = Config.defaults()
+                .with( genericMap( ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1",
+                        ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES, "xyz:anotherRole" ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "xyz" ), equalTo( arrayOf( "anotherRole" ) ) );
+        assertThat( procConfig.rolesFor( "abc" ), equalTo( arrayOf( "role1" ) ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithWildcardProcedureAllowed()
+    {
+        Config config = Config.defaults()
+                .with( genericMap( ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1",
+                        ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES, "xyz*:anotherRole" ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "xyzabc" ), equalTo( arrayOf( "anotherRole" ) ) );
+        assertThat( procConfig.rolesFor( "abcxyz" ), equalTo( arrayOf( "role1" ) ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithWildcardProcedureAllowedAndNoDefault()
+    {
+        Config config = Config.defaults()
+                .with( genericMap( ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES, "xyz*:anotherRole" ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "xyzabc" ), equalTo( arrayOf( "anotherRole" ) ) );
+        assertThat( procConfig.rolesFor( "abcxyz" ), equalTo( EMPTY ) );
+    }
+
+    @Test
+    public void shouldHaveConfigsWithMultipleWildcardProcedureAllowedAndNoDefault()
+    {
+        Config config = Config.defaults()
+                .with( genericMap(
+                        ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES,
+                        "apoc.convert.*:reader,apoc.load.json:writer,apoc.trigger.add:TriggerHappy"
+                ) );
+        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        assertThat( procConfig.rolesFor( "xyz" ), equalTo( EMPTY ) );
+        assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "reader" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.convert.json" ), equalTo( arrayOf( "reader" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.load.xml" ), equalTo( EMPTY ) );
+        assertThat( procConfig.rolesFor( "apoc.load.json" ), equalTo( arrayOf( "writer" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.trigger.add" ), equalTo( arrayOf( "TriggerHappy" ) ) );
+        assertThat( procConfig.rolesFor( "apoc.convert-json" ), equalTo( EMPTY ) );
+        assertThat( procConfig.rolesFor( "apoc.load-xml" ), equalTo( EMPTY ) );
+        assertThat( procConfig.rolesFor( "apoc.load-json" ), equalTo( EMPTY ) );
+        assertThat( procConfig.rolesFor( "apoc.trigger-add" ), equalTo( EMPTY ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAllowedConfigTest.java
@@ -91,7 +91,7 @@ public class ProcedureAllowedConfigTest
         Config config = Config.defaults()
                 .with( genericMap(
                         ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES,
-                        "apoc.convert.*:apoc_reader,apoc.load.json:apoc_writer,apoc.trigger.add:TriggerHappy"
+                        "apoc.convert.*:apoc_reader;apoc.load.json:apoc_writer;apoc.trigger.add:TriggerHappy"
                 ) );
         ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( EMPTY ) );
@@ -113,7 +113,7 @@ public class ProcedureAllowedConfigTest
                 .with( genericMap(
                         ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME, "default",
                         ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES,
-                        "apoc.*:apoc,apoc.load.*:loader,apoc.trigger.*:trigger,apoc.trigger.add:TriggerHappy"
+                        "apoc.*:apoc;apoc.load.*:loader;apoc.trigger.*:trigger;apoc.trigger.add:TriggerHappy"
                 ) );
         ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( arrayOf( "default" ) ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -57,7 +57,7 @@ public class ProcedureJarLoaderTest
 
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
-                    NullLog.getInstance() ), NullLog.getInstance() );
+                    NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -66,7 +66,7 @@ public class ReflectiveProcedureTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -271,7 +271,8 @@ public class ReflectiveProcedureTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log,
+                ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableProcedure> procs = procedureCompiler.compileProcedure( ProcedureWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -214,6 +214,6 @@ public class ReflectiveProcedureWithArgumentsTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), NullLog.getInstance() ).compileProcedure( clazz );
+        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -65,7 +65,7 @@ public class ReflectiveUserFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -249,7 +249,7 @@ public class ReflectiveUserFunctionTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableUserFunction> funcs = procedureCompiler.compileFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -128,6 +128,6 @@ public class ResourceInjectionTest
     {
         ComponentRegistry components = new ComponentRegistry();
         components.register( MyAwesomeAPI.class, (ctx) -> new MyAwesomeAPI() );
-        return new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance() ).compileProcedure( clazz );
+        return new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -53,8 +53,6 @@ public class SecuritySettings
     public static final String LDAP_REALM_NAME = "ldap";
     public static final String PLUGIN_REALM_NAME_PREFIX = "plugin-";
 
-    @SuppressWarnings( "unused" ) // accessed by reflection
-
     //=========================================================================
     // Realm settings
     //=========================================================================
@@ -63,13 +61,13 @@ public class SecuritySettings
                   "This can be one of the built-in `" + NATIVE_REALM_NAME + "` or `" + LDAP_REALM_NAME + "` providers, " +
                   "or it can be an externally provided plugin, with a custom name prefixed by `" +
                   PLUGIN_REALM_NAME_PREFIX + "`, i.e. `" + PLUGIN_REALM_NAME_PREFIX + "<AUTH_PROVIDER_NAME>`." )
-    public static Setting<String> auth_provider =
+    public static final Setting<String> auth_provider =
             setting( "dbms.security.auth_provider", STRING, NATIVE_REALM_NAME );
 
     @Description( "A list of security authentication and authorization providers containing the users and roles. " +
                   "They will be queried in the given order when login is attempted." )
     @Internal
-    public static Setting<List<String>> auth_providers =
+    public static final Setting<List<String>> auth_providers =
             derivedSetting( "dbms.security.auth_providers", auth_provider,
                     ( r ) -> Arrays.asList( r ), STRING_LIST );
 
@@ -211,18 +209,18 @@ public class SecuritySettings
     @Description( "The name of the base object or named context to search for user objects when " +
                   "LDAP authorization is enabled. A common case is that this matches the last part " +
                   "of `dbms.security.ldap.authentication.user_dn_template`." )
-    public static Setting<String> ldap_authorization_user_search_base =
+    public static final Setting<String> ldap_authorization_user_search_base =
             setting( "dbms.security.ldap.authorization.user_search_base", STRING, "ou=users,dc=example,dc=com" );
 
     @Description( "The LDAP search filter to search for a user principal when LDAP authorization is " +
                   "enabled. The filter should contain the placeholder token {0} which will be substituted for the " +
                   "user principal." )
-    public static Setting<String> ldap_authorization_user_search_filter =
+    public static final Setting<String> ldap_authorization_user_search_filter =
             setting( "dbms.security.ldap.authorization.user_search_filter", STRING, "(&(objectClass=*)(uid={0}))" );
 
     @Description( "A list of attribute names on a user object that contains groups to be used for mapping to roles " +
                   "when LDAP authorization is enabled." )
-    public static Setting<List<String>> ldap_authorization_group_membership_attribute_names =
+    public static final Setting<List<String>> ldap_authorization_group_membership_attribute_names =
             setting( "dbms.security.ldap.authorization.group_membership_attributes", STRING_LIST, "memberOf" );
 
     @Description( "An authorization mapping from LDAP group names to Neo4j role names. " +
@@ -235,7 +233,7 @@ public class SecuritySettings
                   "         \"cn=Neo4j Read-Write,cn=users,dc=example,dc=com\"     = publisher; \\\n" +
                   "         \"cn=Neo4j Schema Manager,cn=users,dc=example,dc=com\" = architect; \\\n" +
                   "         \"cn=Neo4j Administrator,cn=users,dc=example,dc=com\"  = admin" )
-    public static Setting<String> ldap_authorization_group_to_role_mapping =
+    public static final Setting<String> ldap_authorization_group_to_role_mapping =
             setting( "dbms.security.ldap.authorization.group_to_role_mapping", STRING, NO_DEFAULT );
 
     //=========================================================================
@@ -244,11 +242,11 @@ public class SecuritySettings
 
     @Description( "The time to live (TTL) for cached authentication and authorization info when using " +
                   "external auth providers (LDAP or plugin). Setting the TTL to 0 will disable auth caching." )
-    public static Setting<Long> auth_cache_ttl =
+    public static final Setting<Long> auth_cache_ttl =
             setting( "dbms.security.auth_cache_ttl", DURATION, "10m" );
 
     @Description( "The maximum capacity for authentication and authorization caches (respectively)." )
-    public static Setting<Integer> auth_cache_max_capacity =
+    public static final Setting<Integer> auth_cache_max_capacity =
             setting( "dbms.security.auth_cache_max_capacity", INTEGER, "10000" );
 
     //=========================================================================

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -43,6 +43,7 @@ import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
+import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES;
 
 /**
  * Settings for security module
@@ -294,4 +295,15 @@ public class SecuritySettings
                   "If this setting is the empty string (default), procedures will be executed according to the same " +
                   "security rules as normal Cypher statements." )
     public static final Setting<String> default_allowed = setting( PROC_ALLOWED_SETTING_DEFAULT_NAME, STRING, "" );
+
+    @Description( "The default role to assign to matching procedures with empty `allowed` annotation fields. " +
+                  "This provides a finer level of control over which roles are assigned to which procedures than the " +
+                  "`" + PROC_ALLOWED_SETTING_DEFAULT_NAME + "` setting. For example: `dbms.security.procedures" +
+                  ".roles=apoc.convert.*:reader,apoc.load.json:writer,apoc.trigger.add:TriggerHappy` will assign" +
+                  "the role `reader` to all procedures in the `apoc.convert` namespace, the role `writer` to " +
+                  "the `apoc.load.json` namespace and the role `TriggerHappy` to the the specific procedure " +
+                  "`apoc.trigger.add`. Procedures not matching any of these patterns will either be assigned the " +
+                  "role specified in `" + PROC_ALLOWED_SETTING_DEFAULT_NAME + "` or be subject to the security " +
+                  "rules of normal Cypher statements." )
+    public static final Setting<String> procedure_roles = setting( PROC_ALLOWED_SETTING_ROLES, STRING, "" );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -42,6 +42,7 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.setting;
+import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
 
 /**
  * Settings for security module
@@ -281,4 +282,16 @@ public class SecuritySettings
     @Description( "Maximum number of history files for the security log." )
     public static final Setting<Integer> store_security_log_max_archives =
             setting( "dbms.logs.security.rotation.keep_number", INTEGER, "7", min(1) );
+
+    //=========================================================================
+    // Procedure security settings
+    //=========================================================================
+
+    @Description( "The default role to assign to each procedure and user-defined function with an empty `allowed` " +
+                  "annotation field. This can be used to enable fine grained permission " +
+                  "control over third-party procedures and functions for which modifying source code is not possible. " +
+                  "Procedures with non-empty `allowed` fields will be unaffected by this setting. " +
+                  "If this setting is the empty string (default), procedures will be executed according to the same " +
+                  "security rules as normal Cypher statements." )
+    public static final Setting<String> default_allowed = setting( PROC_ALLOWED_SETTING_DEFAULT_NAME, STRING, "" );
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Map;
@@ -27,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
-import org.neo4j.test.rule.concurrent.ThreadingRule;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,9 +49,6 @@ import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRol
 public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInteractionTestBase<S>
 {
     private static final String PWD_CHANGE = PASSWORD_CHANGE_REQUIRED.name().toLowerCase();
-
-    @Rule
-    public final ThreadingRule threading = new ThreadingRule();
 
     //---------- General tests over all procedures -----------
 
@@ -997,11 +992,5 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
         testSuccessfulSchema( schemaSubject );
         testFailCreateUser( schemaSubject, PERMISSION_DENIED );
         assertEmpty( schemaSubject, "CALL dbms.security.changePassword( '321' )" );
-    }
-
-    @Override
-    protected ThreadingRule threading()
-    {
-        return threading;
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosInteractionTestBase.java
@@ -20,7 +20,6 @@
 package org.neo4j.server.security.enterprise.auth;
 
 import org.apache.commons.io.Charsets;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -34,21 +33,18 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.test.DoubleLatch;
-import org.neo4j.test.rule.concurrent.ThreadingRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
-import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.*;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ADMIN;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.READER;
 
 public abstract class AuthScenariosInteractionTestBase<S> extends ProcedureInteractionTestBase<S>
 {
-    @Rule
-    public final ThreadingRule threading = new ThreadingRule();
 
     //---------- User creation -----------
 
@@ -779,11 +775,5 @@ public abstract class AuthScenariosInteractionTestBase<S> extends ProcedureInter
                 r -> assertKeyIs( r, "c", "1" ) );
         assertSuccess( readSubject, "MATCH (n:MyNode) WHERE n.nonExistent = 'foo' RETURN toString(count(*)) AS c",
                 r -> assertKeyIs( r, "c", "1" ) );
-    }
-
-    @Override
-    protected ThreadingRule threading()
-    {
-        return threading;
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltConfiguredProceduresTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import java.util.Map;
+
+public class BoltConfiguredProceduresTest extends ConfiguredProceduresTestBase<BoltInteraction.BoltSubject>
+{
+
+    public BoltConfiguredProceduresTest()
+    {
+        super();
+        IS_EMBEDDED = false;
+        IS_BOLT = true;
+    }
+
+    @Override
+    public NeoInteractionLevel<BoltInteraction.BoltSubject> setUpNeoServer( Map<String, String> config ) throws
+            Throwable
+    {
+        return new BoltInteraction( config );
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -24,7 +24,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.OffsetDateTime;
@@ -42,7 +41,6 @@ import org.neo4j.kernel.enterprise.builtinprocs.QueryId;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.test.Barrier;
 import org.neo4j.test.DoubleLatch;
-import org.neo4j.test.rule.concurrent.ThreadingRule;
 
 import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
@@ -66,8 +64,6 @@ import static org.neo4j.test.matchers.CommonMatchers.matchesOneToOneInAnyOrder;
 
 public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureInteractionTestBase<S>
 {
-    @Rule
-    public final ThreadingRule threading = new ThreadingRule();
 
     /*
     This surface is hidden in 3.1, to possibly be completely removed or reworked later
@@ -1109,12 +1105,6 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
                             )
                         ).collect( Collectors.toList() )
                 ) );
-    }
-
-    @Override
-    protected ThreadingRule threading()
-    {
-        return threading;
     }
 
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+import org.neo4j.test.rule.concurrent.ThreadingRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteractionTestBase<S>
+{
+    @Rule
+    public final ThreadingRule threading = new ThreadingRule();
+
+    @Override
+    protected ThreadingRule threading()
+    {
+        return threading;
+    }
+
+    @Override
+    public void setUp() throws Throwable
+    {
+        // tests are required to setup database with specific configs
+    }
+
+    @Test
+    public void shouldTerminateLongRunningProcedureThatChecksTheGuardRegularlyOnTimeout() throws Throwable
+    {
+        configuredSetup( stringMap( GraphDatabaseSettings.transaction_timeout.name(), "2s" ) );
+
+        assertFail( adminSubject, "CALL test.loop", "Transaction guard check failed" );
+
+        Result result = neo.getLocalGraph().execute(
+                "CALL dbms.listQueries() YIELD query WITH * WHERE NOT query CONTAINS 'listQueries' RETURN *" );
+
+        assertFalse( result.hasNext() );
+        result.close();
+    }
+
+    @Test
+    public void shouldSetAllowedToConfigSetting() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "nonEmpty" ) );
+        Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
+
+        ProcedureSignature numNodes = procedures.procedure( new QualifiedName( new String[]{"test"}, "numNodes" ) );
+        assertThat( Arrays.asList( numNodes.allowed() ), containsInAnyOrder( "nonEmpty" ) );
+
+        ProcedureSignature allowedRead =
+                procedures.procedure( new QualifiedName( new String[]{"test"}, "allowedReadProcedure" ) );
+        assertThat( Arrays.asList( allowedRead.allowed() ), containsInAnyOrder( "role1" ) );
+    }
+
+    @Test
+    public void shouldSetAllowedToDefaultValueAndRunningWorks() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "role1" ) );
+
+        userManager.newRole( "role1", "noneSubject" );
+        assertSuccess( noneSubject, "CALL test.numNodes", itr -> assertKeyIs( itr, "count", "3" ) );
+    }
+
+    @Test
+    public void shouldRunProcedureWithMatchingWildcardAllowed() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:role1" ) );
+
+        userManager.newRole( "role1", "noneSubject" );
+        assertSuccess( noneSubject, "CALL test.numNodes", itr -> assertKeyIs( itr, "count", "3" ) );
+    }
+
+    @Test
+    public void shouldNotRunProcedureWithMismatchingWildCardAllowed() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "tes.*:role1" ) );
+
+        userManager.newRole( "role1", "noneSubject" );
+        Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
+
+        ProcedureSignature numNodes = procedures.procedure( new QualifiedName( new String[]{"test"}, "numNodes" ) );
+        assertThat( Arrays.asList( numNodes.allowed() ), empty() );
+        assertFail( noneSubject, "CALL test.numNodes", "Read operations are not allowed" );
+    }
+
+    @Test
+    public void shouldNotSetProcedureAllowedIfSettingNotSet() throws Throwable
+    {
+        configuredSetup( defaultConfiguration() );
+        Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
+
+        ProcedureSignature numNodes = procedures.procedure( new QualifiedName( new String[]{"test"}, "numNodes" ) );
+        assertThat( Arrays.asList( numNodes.allowed() ), empty() );
+    }
+
+    @SuppressWarnings( "OptionalGetWithoutIsPresent" )
+    @Test
+    public void shouldSetAllowedToConfigSettingForUDF() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "nonEmpty" ) );
+        Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
+
+        UserFunctionSignature funcSig = procedures.function(
+                new QualifiedName( new String[]{"test"}, "nonAllowedFunc" ) ).get();
+        assertThat( Arrays.asList( funcSig.allowed() ), containsInAnyOrder( "nonEmpty" ) );
+
+        UserFunctionSignature f2 =
+                procedures.function( new QualifiedName( new String[]{"test"}, "allowedFunc" ) ).get();
+        assertThat( Arrays.asList( f2.allowed() ), containsInAnyOrder( "role1" ) );
+    }
+
+    @Test
+    public void shouldSetAllowedToDefaultValueAndRunningWorksForUDF() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "role1" ) );
+
+        userManager.newRole( "role1", "noneSubject" );
+        assertSuccess( neo.login( "noneSubject", "abc" ), "RETURN test.allowedFunc() AS c",
+                itr -> assertKeyIs( itr, "c", "success for role1" ) );
+    }
+
+    @SuppressWarnings( "OptionalGetWithoutIsPresent" )
+    @Test
+    public void shouldNotSetProcedureAllowedIfSettingNotSetForUDF() throws Throwable
+    {
+        configuredSetup( defaultConfiguration() );
+        Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
+
+        UserFunctionSignature funcSig = procedures.function(
+                new QualifiedName( new String[]{"test"}, "nonAllowedFunc" ) ).get();
+        assertThat( Arrays.asList( funcSig.allowed() ), empty() );
+    }
+
+    @Test
+    public void shouldHandleWriteAfterAllowedReadProcedureWithAuthDisabled() throws Throwable
+    {
+        neo = setUpNeoServer( stringMap( GraphDatabaseSettings.auth_enabled.name(), "false" ) );
+
+        neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class )
+                .registerProcedure( ClassWithProcedures.class );
+
+        S subject = neo.login( "no_auth", "" );
+        assertEmpty( subject, "CALL test.allowedReadProcedure() YIELD value CREATE (:NEWNODE {name:value})" );
+    }
+
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,7 +30,6 @@ import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
-import org.neo4j.test.rule.concurrent.ThreadingRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -41,14 +39,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteractionTestBase<S>
 {
-    @Rule
-    public final ThreadingRule threading = new ThreadingRule();
-
-    @Override
-    protected ThreadingRule threading()
-    {
-        return threading;
-    }
 
     @Override
     public void setUp() throws Throwable

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -205,6 +205,21 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 .registerProcedure( ClassWithProcedures.class );
 
         S subject = neo.login( "no_auth", "" );
-        assertEmpty( subject, "CALL test.allowedReadProcedure() YIELD value CREATE (:NEWNODE {name:value})" );
+        assertEmpty( subject, "CALL test.allowedReadProcedure() YIELD value CREATE (:NewNode {name: value})" );
+    }
+
+    @Test
+    public void shouldHandleMultipleRolesSpecifiedForMapping() throws Throwable
+    {
+        // Given
+        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:tester, other" ) );
+
+        // When
+        userManager.newRole( "tester", "noneSubject" );
+        userManager.newRole( "other", "readSubject" );
+
+        // Then
+        assertSuccess( readSubject, "CALL test.createNode", ResourceIterator::close );
+        assertSuccess( noneSubject, "CALL test.numNodes", itr -> assertKeyIs( itr, "count", "4" ) );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -168,7 +168,7 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
     @Test
     public void shouldSetAllMatchingWildcardRoleConfigs() throws Throwable
     {
-        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:tester,test.create*:other" ) );
+        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:tester;test.create*:other" ) );
 
         userManager.newRole( "tester", "noneSubject" );
         userManager.newRole( "other", "readSubject" );
@@ -183,7 +183,7 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
     @Test
     public void shouldSetAllMatchingWildcardRoleConfigsWithDefaultForUDFs() throws Throwable
     {
-        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:tester,test.create*:other",
+        configuredSetup( stringMap( SecuritySettings.procedure_roles.name(), "test.*:tester;test.create*:other",
                                     SecuritySettings.default_allowed.name(), "default" ) );
 
         userManager.newRole( "tester", "noneSubject" );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredProceduresTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import java.util.Map;
+
+import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+
+public class EmbeddedConfiguredProceduresTest extends ConfiguredProceduresTestBase<EnterpriseSecurityContext>
+{
+
+    @Override
+    protected NeoInteractionLevel<EnterpriseSecurityContext> setUpNeoServer( Map<String, String> config ) throws Throwable
+    {
+        return new EmbeddedInteraction( config );
+    }
+
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 
 import java.io.File;
 import java.io.IOException;
@@ -114,7 +115,13 @@ public abstract class ProcedureInteractionTestBase<S>
         "writeSubject", "pwdSubject", "noneSubject", "neo4j" };
     String[] initialRoles = { ADMIN, ARCHITECT, PUBLISHER, READER, EMPTY_ROLE };
 
-    protected abstract ThreadingRule threading();
+    @Rule
+    public final ThreadingRule threading = new ThreadingRule();
+
+    private ThreadingRule threading()
+    {
+        return threading;
+    }
 
     EnterpriseUserManager userManager;
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -665,6 +665,18 @@ public abstract class ProcedureInteractionTestBase<S>
         @Context
         public GraphDatabaseService db;
 
+        @UserFunction( name = "test.nonAllowedFunc" )
+        public String nonAllowedFunc()
+        {
+            return "success";
+        }
+
+        @UserFunction( name = "test.allowedFunc", allowed = {"role1"} )
+        public String allowedFunc()
+        {
+            return "success for role1";
+        }
+
         @UserFunction( name = "test.allowedFunction1", allowed = {"role1"} )
         public String allowedFunction1()
         {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -56,6 +56,7 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
 import org.neo4j.procedure.UserFunction;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.rule.concurrent.ThreadingRule;
@@ -120,7 +121,7 @@ public abstract class ProcedureInteractionTestBase<S>
     protected NeoInteractionLevel<S> neo;
     File securityLog;
 
-    private Map<String,String> configure() throws IOException
+    Map<String,String> defaultConfiguration() throws IOException
     {
         Path homeDir = Files.createTempDirectory( "logs" );
         securityLog = new File( homeDir.toFile(), "security.log" );
@@ -130,12 +131,12 @@ public abstract class ProcedureInteractionTestBase<S>
     @Before
     public void setUp() throws Throwable
     {
-        neo = setUpNeoServer( configure() );
-        reSetUp();
+        configuredSetup( defaultConfiguration() );
     }
 
-    void reSetUp() throws Exception
+    void configuredSetup( Map<String,String> config ) throws Throwable
     {
+        neo = setUpNeoServer( config );
         Procedures procedures = neo.getLocalGraph().getDependencyResolver().resolveDependency( Procedures.class );
         procedures.registerProcedure( ClassWithProcedures.class );
         procedures.registerFunction( ClassWithFunctions.class );
@@ -500,7 +501,7 @@ public abstract class ProcedureInteractionTestBase<S>
         }
     }
 
-    @SuppressWarnings( "unused" )
+    @SuppressWarnings( {"unused", "WeakerAccess"} )
     public static class ClassWithProcedures
     {
         @Context
@@ -512,6 +513,45 @@ public abstract class ProcedureInteractionTestBase<S>
         private static final AtomicReference<LatchedRunnables> testLatch = new AtomicReference<>();
 
         static DoubleLatch doubleLatch = null;
+
+        public static volatile DoubleLatch volatileLatch = null;
+
+        @Context
+        public TerminationGuard guard;
+
+        @Procedure(name = "test.loop")
+        public void loop()
+        {
+            DoubleLatch latch = volatileLatch;
+
+            if ( latch != null )
+            {
+                latch.startAndWaitForAllToStart();
+            }
+            try
+            {
+                //noinspection InfiniteLoopStatement
+                while ( true )
+                {
+                    try
+                    {
+                        Thread.sleep( 250 );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        Thread.interrupted();
+                    }
+                    guard.check();
+                }
+            }
+            finally
+            {
+                if ( latch != null )
+                {
+                    latch.finish();
+                }
+            }
+        }
 
         @Procedure( name = "test.neverEnding" )
         public void neverEndingWithLock()

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTConfiguredProceduresTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/CypherRESTConfiguredProceduresTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.security;
+
+import org.junit.Rule;
+
+import java.util.Map;
+
+import org.neo4j.server.security.enterprise.auth.ConfiguredProceduresTestBase;
+import org.neo4j.server.security.enterprise.auth.NeoInteractionLevel;
+import org.neo4j.test.rule.SuppressOutput;
+
+import static org.neo4j.test.rule.SuppressOutput.suppressAll;
+
+public class CypherRESTConfiguredProceduresTest extends ConfiguredProceduresTestBase<RESTSubject>
+{
+    @Rule
+    public SuppressOutput suppressOutput = suppressAll();
+
+    public CypherRESTConfiguredProceduresTest()
+    {
+        super();
+        CHANGE_PWD_ERR_MSG = "User is required to change their password.";
+        PWD_CHANGE_CHECK_FIRST = true;
+        IS_EMBEDDED = false;
+    }
+
+    @Override
+    public NeoInteractionLevel<RESTSubject> setUpNeoServer( Map<String, String> config ) throws Throwable
+    {
+        return new CypherRESTInteraction( config );
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTConfiguredProceduresTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTConfiguredProceduresTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.security;
+
+import org.junit.Rule;
+
+import java.util.Map;
+
+import org.neo4j.server.security.enterprise.auth.ConfiguredProceduresTestBase;
+import org.neo4j.server.security.enterprise.auth.NeoInteractionLevel;
+import org.neo4j.test.rule.SuppressOutput;
+
+import static org.neo4j.test.rule.SuppressOutput.suppressAll;
+
+public class RESTConfiguredProceduresTest extends ConfiguredProceduresTestBase<RESTSubject>
+{
+    @Rule
+    public SuppressOutput suppressOutput = suppressAll();
+
+    public RESTConfiguredProceduresTest()
+    {
+        super();
+        CHANGE_PWD_ERR_MSG = "User is required to change their password.";
+        PWD_CHANGE_CHECK_FIRST = true;
+        IS_EMBEDDED = false;
+    }
+
+    @Override
+    public NeoInteractionLevel<RESTSubject> setUpNeoServer( Map<String, String> config ) throws Throwable
+    {
+        return new RESTInteraction( config );
+    }
+}


### PR DESCRIPTION
When procedures and UDFs come from a third party, where modifying source code
is not possible, it was previously not possible to assign an `allowed` role to them.
This PR introduces two new config settings that may be used to set specific roles
to any procedures and UDFs that do not have their `allowed` annotation set.

In detail, wildcard mappings between procedure names and allowed roles are supported. All matching mappings are returned as roles. If no roles are found, the default is used.

changelog: Add config options for default and wildcard procedure `allowed` roles
