### PR TITLE
Change order of rewriters - fixes #8249

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -259,4 +259,10 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
       Map("n" -> b, "list" -> Seq(0, 1))
     ))
   }
+
+  test("pattern comprehension in RETURN following a WITH") {
+    val query = """MATCH (e:X) WITH e LIMIT 5 RETURN [(e) --> (t) | t { .amount }]"""
+
+    executeWithCostPlannerOnly(query).toList //does not throw
+  }
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ASTRewriter.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ASTRewriter.scala
@@ -36,8 +36,8 @@ class ASTRewriter(rewriterSequencer: (String) => RewriterStepSequencer, shouldEx
       (Rewriter.lift(PartialFunction.empty), Map.empty[String, Any])
 
     val contract = rewriterSequencer("ASTRewriter")(
-      desugarMapProjection(semanticState),
       recordScopes(semanticState),
+      desugarMapProjection(semanticState),
       normalizeComparisons,
       enableCondition(noReferenceEqualityAmongVariables),
       enableCondition(containsNoNodesOfType[UnaliasedReturnItem]),


### PR DESCRIPTION
changelog: Fixes [#8249](https://github.com/neo4j/neo4j/issues/8249) - resolves a pattern comprehension bug

After desugaring the map projection, it was not possible to find the original
PatternComprehension object in the recorded scopes, and the rewriter would
fail. By just changing the order, we can record the scope before desugaring
the map projections.
