### PR TITLE
Add config settings for LDAP timeouts

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -32,8 +32,8 @@ import org.neo4j.bolt.v1.runtime.cypher.StatementMetadata;
 import org.neo4j.bolt.v1.runtime.cypher.StatementProcessor;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.function.ThrowingConsumer;
-import org.neo4j.graphdb.security.AuthExpirationException;
-import org.neo4j.graphdb.security.AuthTimeoutException;
+import org.neo4j.graphdb.security.AuthorizationExpiredException;
+import org.neo4j.graphdb.security.AuthProviderTimeoutException;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -351,7 +351,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             }
                             return READY;
                         }
-                        catch ( AuthenticationException | AuthTimeoutException e )
+                        catch ( AuthenticationException | AuthProviderTimeoutException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e.status(), e.getMessage() ) );
                             throw new BoltConnectionAuthFatality( e.getMessage() );
@@ -384,7 +384,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             machine.ctx.onMetadata( "fields", statementMetadata.fieldNames() );
                             return STREAMING;
                         }
-                        catch ( AuthExpirationException e )
+                        catch ( AuthorizationExpiredException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e ) );
                             throw new BoltConnectionAuthFatality( e.getMessage() );
@@ -438,7 +438,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
                             return READY;
                         }
-                        catch ( AuthExpirationException e )
+                        catch ( AuthorizationExpiredException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e ) );
                             throw new BoltConnectionAuthFatality( e.getMessage() );
@@ -460,7 +460,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
                             return READY;
                         }
-                        catch ( AuthExpirationException e )
+                        catch ( AuthorizationExpiredException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e ) );
                             throw new BoltConnectionAuthFatality( e.getMessage() );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -33,6 +33,7 @@ import org.neo4j.bolt.v1.runtime.cypher.StatementProcessor;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.graphdb.security.AuthExpirationException;
+import org.neo4j.graphdb.security.AuthTimeoutException;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -350,7 +351,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
                             }
                             return READY;
                         }
-                        catch ( AuthenticationException e )
+                        catch ( AuthenticationException | AuthTimeoutException e )
                         {
                             fail( machine, Neo4jError.fatalFrom( e.status(), e.getMessage() ) );
                             throw new BoltConnectionAuthFatality( e.getMessage() );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltStateMachineTest.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import org.neo4j.bolt.testing.BoltResponseRecorder;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.graphdb.security.AuthExpirationException;
+import org.neo4j.graphdb.security.AuthorizationExpiredException;
 import org.neo4j.kernel.api.exceptions.Status;
 
 import static java.util.Collections.emptyMap;
@@ -425,7 +425,7 @@ public class BoltStateMachineTest
     {
         // Given
         TransactionStateMachine.SPI transactionSPI = mock( TransactionStateMachine.SPI.class );
-        doThrow( new AuthExpirationException( "Auth expired!" ) ).when( transactionSPI ).beginTransaction( any() );
+        doThrow( new AuthorizationExpiredException( "Auth expired!" ) ).when( transactionSPI ).beginTransaction( any() );
 
         BoltStateMachine machine = newMachineWithTransactionSPI( transactionSPI );
         machine.state = READY;
@@ -441,7 +441,7 @@ public class BoltStateMachineTest
     {
         // Given
         BoltResponseHandler responseHandler = mock( BoltResponseHandler.class );
-        doThrow( new AuthExpirationException( "Auth expired!" ) ).when( responseHandler )
+        doThrow( new AuthorizationExpiredException( "Auth expired!" ) ).when( responseHandler )
                 .onRecords( any(), anyBoolean() );
         BoltStateMachine machine = newMachine( STREAMING );
         // We assume the only implementation of statement processor is TransactionStateMachine

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -413,7 +413,8 @@ public interface Status
         EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
         Forbidden( ClientError, "An attempt was made to perform an unauthorized action." ),
         AuthorizationExpired( ClientError, "The stored authorization info has expired. Please reconnect." ),
-        Timeout( TransientError, "An auth provider request timed out." );
+        AuthProviderTimeout( TransientError, "An auth provider request timed out." ),
+        AuthProviderFailed( TransientError, "An auth provider request failed." );
 
         private final Code code;
 

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -412,7 +412,8 @@ public interface Status
         ModifiedConcurrently( TransientError, "The user was modified concurrently to this request." ),
         EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
         Forbidden( ClientError, "An attempt was made to perform an unauthorized action." ),
-        AuthorizationExpired( ClientError, "The stored authorization info has expired. Please reconnect." );
+        AuthorizationExpired( ClientError, "The stored authorization info has expired. Please reconnect." ),
+        Timeout( TransientError, "An authorization request timed out." );
 
         private final Code code;
 

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -413,7 +413,7 @@ public interface Status
         EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
         Forbidden( ClientError, "An attempt was made to perform an unauthorized action." ),
         AuthorizationExpired( ClientError, "The stored authorization info has expired. Please reconnect." ),
-        Timeout( TransientError, "An authorization request timed out." );
+        Timeout( TransientError, "An auth provider request timed out." );
 
         private final Code code;
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public class AuthProviderFailedException extends RuntimeException implements Status.HasStatus
 {
-    private final Status statusCode = Status.Security.AuthProviderFailed;
+    private static final Status statusCode = Status.Security.AuthProviderFailed;
 
     public AuthProviderFailedException( String msg )
     {

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderFailedException.java
@@ -22,15 +22,24 @@ package org.neo4j.graphdb.security;
 import org.neo4j.kernel.api.exceptions.Status;
 
 /**
- * Thrown when needed authorization or authentication info has expired in the neo4j auth cache
+ * Thrown when a request for authentication or authorization against an external server failed.
+ *
+ * <p>This is not used for expected failures like wrong principal, credentials or authorization information,
+ * but for failures where such information could not be established because of an external server problem,
+ * misconfiguration etc.
  */
-public class AuthExpirationException extends RuntimeException implements Status.HasStatus
+public class AuthProviderFailedException extends RuntimeException implements Status.HasStatus
 {
-    private Status statusCode = Status.Security.AuthorizationExpired;
+    private final Status statusCode = Status.Security.AuthProviderFailed;
 
-    public AuthExpirationException( String msg )
+    public AuthProviderFailedException( String msg )
     {
         super( msg );
+    }
+
+    public AuthProviderFailedException( String msg, Throwable cause )
+    {
+        super( msg, cause );
     }
 
     /** The Neo4j status code associated with this exception type. */

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
@@ -24,22 +24,16 @@ import org.neo4j.kernel.api.exceptions.Status;
 /**
  * Thrown when a request for authentication or authorization against an external server timed out.
  */
-public class AuthTimeoutException extends RuntimeException implements Status.HasStatus
+public class AuthProviderTimeoutException extends RuntimeException implements Status.HasStatus
 {
-    private Status statusCode = Status.Security.Timeout;
+    private final Status statusCode = Status.Security.AuthProviderTimeout;
 
-    public AuthTimeoutException( String msg, Status statusCode )
-    {
-        super( msg );
-        this.statusCode = statusCode;
-    }
-
-    public AuthTimeoutException( String msg )
+    public AuthProviderTimeoutException( String msg )
     {
         super( msg );
     }
 
-    public AuthTimeoutException( String msg, Throwable cause )
+    public AuthProviderTimeoutException( String msg, Throwable cause )
     {
         super( msg, cause );
     }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthProviderTimeoutException.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public class AuthProviderTimeoutException extends RuntimeException implements Status.HasStatus
 {
-    private final Status statusCode = Status.Security.AuthProviderTimeout;
+    private static final Status statusCode = Status.Security.AuthProviderTimeout;
 
     public AuthProviderTimeoutException( String msg )
     {

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthTimeoutException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthTimeoutException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.security;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Thrown when a request for authentication or authorization against an external server timed out.
+ */
+public class AuthTimeoutException extends RuntimeException implements Status.HasStatus
+{
+    private Status statusCode = Status.Security.Timeout;
+
+    public AuthTimeoutException( String msg, Status statusCode )
+    {
+        super( msg );
+        this.statusCode = statusCode;
+    }
+
+    public AuthTimeoutException( String msg )
+    {
+        super( msg );
+    }
+
+    public AuthTimeoutException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    /** The Neo4j status code associated with this exception type. */
+    @Override
+    public Status status()
+    {
+        return statusCode;
+    }
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.security;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Thrown when required authorization info has expired in the Neo4j auth cache
+ */
+public class AuthorizationExpiredException extends RuntimeException implements Status.HasStatus
+{
+    private final Status statusCode = Status.Security.AuthorizationExpired;
+
+    public AuthorizationExpiredException( String msg )
+    {
+        super( msg );
+    }
+
+    public AuthorizationExpiredException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    /** The Neo4j status code associated with this exception type. */
+    @Override
+    public Status status()
+    {
+        return statusCode;
+    }
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationExpiredException.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public class AuthorizationExpiredException extends RuntimeException implements Status.HasStatus
 {
-    private final Status statusCode = Status.Security.AuthorizationExpired;
+    private static final Status statusCode = Status.Security.AuthorizationExpired;
 
     public AuthorizationExpiredException( String msg )
     {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -369,7 +369,7 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
     }
 
     // Unfortunately we need to identify timeouts by looking at the exception messages, which is not very robust.
-    // To make it slightly more robust we look for a key part the actual message
+    // To make it slightly more robust we look for a key part of the actual message
     private boolean isExceptionAnLdapReadTimeout( Exception e )
     {
         return e instanceof NamingException &&

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -412,6 +412,7 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
         contextFactory.setReferral( config.get( SecuritySettings.ldap_referral ) );
         contextFactory.setSystemUsername( config.get( SecuritySettings.ldap_authorization_system_username ) );
         contextFactory.setSystemPassword( config.get( SecuritySettings.ldap_authorization_system_password ) );
+        contextFactory.setPoolingEnabled( config.get( SecuritySettings.ldap_authorization_connection_pooling ) );
 
         setContextFactory( contextFactory );
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -35,6 +35,7 @@ import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.util.CollectionUtils;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -58,8 +59,9 @@ import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.StartTlsRequest;
 import javax.naming.ldap.StartTlsResponse;
 
-import org.neo4j.graphdb.security.AuthExpirationException;
-import org.neo4j.graphdb.security.AuthTimeoutException;
+import org.neo4j.graphdb.security.AuthorizationExpiredException;
+import org.neo4j.graphdb.security.AuthProviderFailedException;
+import org.neo4j.graphdb.security.AuthProviderTimeoutException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
@@ -81,9 +83,12 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
 
     private static final String JNDI_LDAP_CONNECT_TIMEOUT = "com.sun.jndi.ldap.connect.timeout";
     private static final String JNDI_LDAP_READ_TIMEOUT = "com.sun.jndi.ldap.read.timeout";
-    private static final String JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART = "LDAP response read timed out";
+    private static final String JNDI_LDAP_CONNECTION_TIMEOUT_MESSAGE_PART = "timed out"; // "connect timed out"
+    private static final String JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART = "timed out"; // "LDAP response read timed out"
+
     public static final String LDAP_CONNECTION_TIMEOUT_CLIENT_MESSAGE = "LDAP connection timed out.";
     public static final String LDAP_READ_TIMEOUT_CLIENT_MESSAGE = "LDAP response timed out.";
+    public static final String LDAP_AUTHORIZATION_FAILURE_CLIENT_MESSAGE = "LDAP authorization request failed.";
 
     private Boolean authenticationEnabled;
     private Boolean authorizationEnabled;
@@ -151,15 +156,18 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
             {
                 securityLog.error( withRealm( "Failed to authenticate user '%s' against %s: %s",
                         token.getPrincipal(), serverString, e.getMessage() ) );
-                if ( e instanceof CommunicationException )
+
+                if ( isExceptionAnLdapConnectionTimeout( e ) )
                 {
-                    throw new AuthTimeoutException( LDAP_CONNECTION_TIMEOUT_CLIENT_MESSAGE, e );
+                    securityLog.error( withRealm( "LDAP connection to %s timed out.", serverString ) );
+                    throw new AuthProviderTimeoutException( LDAP_CONNECTION_TIMEOUT_CLIENT_MESSAGE, e );
                 }
-                else if (e instanceof NamingException &&
-                         e.getMessage().contains( JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART ) )
+                else if ( isExceptionAnLdapReadTimeout( e ) )
                 {
-                    throw new AuthTimeoutException( LDAP_READ_TIMEOUT_CLIENT_MESSAGE, e );
+                    securityLog.error( withRealm( "LDAP response from %s timed out.", serverString ) );
+                    throw new AuthProviderTimeoutException( LDAP_READ_TIMEOUT_CLIENT_MESSAGE, e );
                 }
+                // This exception will be caught and rethrown by Shiro, and then by us, so we do not need to wrap it here
                 throw e;
             }
         }
@@ -271,7 +279,7 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
                         // Since we do not have the subject's credentials we cannot perform a new LDAP search
                         // for authorization info. Instead we need to fail with a special status,
                         // so that the client can react by re-authenticating.
-                        throw new AuthExpirationException( "LDAP authorization info expired." );
+                        throw new AuthorizationExpiredException( "LDAP authorization info expired." );
                     }
                     return authorizationInfo;
                 }
@@ -352,15 +360,35 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
         {
             securityLog.error( withRealm( "Failed to get authorization info: '%s' caused by '%s'",
                     e.getMessage(), e.getCause().getMessage() ) );
-            // Shiro's doGetAuthorizationInfo() wraps a NamingException in an AuthorizationException
-            if ( e.getCause() != null && e.getCause() instanceof NamingException &&
-                 e.getCause().getMessage().contains( JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART ) )
+            if ( isAuthorizationExceptionAnLdapReadTimeout( e ) )
             {
-                throw new AuthTimeoutException( LDAP_READ_TIMEOUT_CLIENT_MESSAGE, e );
+                throw new AuthProviderTimeoutException( LDAP_READ_TIMEOUT_CLIENT_MESSAGE, e );
             }
-            // TODO: Should we define a Neo4j exception with a status for this so it doesn't become Unknown Error?
-            throw e;
+            throw new AuthProviderFailedException( LDAP_AUTHORIZATION_FAILURE_CLIENT_MESSAGE, e );
         }
+    }
+
+    // Unfortunately we need to identify timeouts by looking at the exception messages, which is not very robust.
+    // To make it slightly more robust we look for a key part the actual message
+    private boolean isExceptionAnLdapReadTimeout( Exception e )
+    {
+        return e instanceof NamingException &&
+               e.getMessage().contains( JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART );
+    }
+
+    private boolean isExceptionAnLdapConnectionTimeout( Exception e )
+    {
+        return e instanceof CommunicationException &&
+               (((CommunicationException) e).getRootCause() instanceof SocketTimeoutException ||
+                ((CommunicationException) e).getRootCause().getMessage().contains(
+                        JNDI_LDAP_CONNECTION_TIMEOUT_MESSAGE_PART ) );
+    }
+
+    private boolean isAuthorizationExceptionAnLdapReadTimeout( AuthorizationException e )
+    {
+        // Shiro's doGetAuthorizationInfo() wraps a NamingException in an AuthorizationException
+        return e.getCause() != null && e.getCause() instanceof NamingException &&
+               e.getCause().getMessage().contains( JNDI_LDAP_READ_TIMEOUT_MESSAGE_PART );
     }
 
     private void cacheAuthorizationInfo( String username, Set<String> roleNames )

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -43,7 +43,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.graphdb.security.AuthTimeoutException;
+import org.neo4j.graphdb.security.AuthProviderTimeoutException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.SecurityContext;
@@ -120,11 +120,11 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         }
         catch ( AuthenticationException e )
         {
-            if ( e.getCause() != null && e.getCause() instanceof AuthTimeoutException )
+            if ( e.getCause() != null && e.getCause() instanceof AuthProviderTimeoutException )
             {
                 securityLog.error( "[%s]: failed to log in: auth server timeout",
                         escape( token.getPrincipal().toString() ) );
-                throw new AuthTimeoutException( e.getCause().getMessage(), e.getCause() );
+                throw new AuthProviderTimeoutException( e.getCause().getMessage(), e.getCause() );
             }
             securityContext = new StandardEnterpriseSecurityContext( this,
                     new ShiroSubject( securityManager, AuthenticationResult.FAILURE ) );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.graphdb.security.AuthTimeoutException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.SecurityContext;
@@ -119,6 +120,12 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         }
         catch ( AuthenticationException e )
         {
+            if ( e.getCause() != null && e.getCause() instanceof AuthTimeoutException )
+            {
+                securityLog.error( "[%s]: failed to log in: auth server timeout",
+                        escape( token.getPrincipal().toString() ) );
+                throw new AuthTimeoutException( e.getCause().getMessage(), e.getCause() );
+            }
             securityContext = new StandardEnterpriseSecurityContext( this,
                     new ShiroSubject( securityManager, AuthenticationResult.FAILURE ) );
             securityLog.error( "[%s]: failed to log in: invalid principal or credentials",

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthenticationException.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthenticationException.java
@@ -29,4 +29,9 @@ public class AuthenticationException extends Exception
     {
         super( message );
     }
+
+    public AuthenticationException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpiredException.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthorizationExpiredException.java
@@ -32,10 +32,15 @@ package org.neo4j.server.security.enterprise.auth.plugin.api;
  *
  * @see org.neo4j.server.security.enterprise.auth.plugin.spi.AuthorizationPlugin
  */
-public class AuthorizationExpired extends RuntimeException
+public class AuthorizationExpiredException extends RuntimeException
 {
-    public AuthorizationExpired( String message )
+    public AuthorizationExpiredException( String message )
     {
         super( message );
+    }
+
+    public AuthorizationExpiredException( String message, Throwable cause )
+    {
+        super( message, cause );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/spi/AuthorizationPlugin.java
@@ -21,6 +21,8 @@ package org.neo4j.server.security.enterprise.auth.plugin.spi;
 
 import java.util.Collection;
 
+import org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpiredException;
+
 /**
  * An authorization provider plugin for the Neo4j enterprise security module.
  *
@@ -32,7 +34,7 @@ import java.util.Collection;
  *
  * @see AuthenticationPlugin
  * @see AuthPlugin
- * @see org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpired
+ * @see AuthorizationExpiredException
  */
 public interface AuthorizationPlugin extends AuthProviderLifecycle
 {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -317,4 +317,13 @@ public class SecuritySettings
                   "role specified in `" + PROC_ALLOWED_SETTING_DEFAULT_NAME + "` or be subject to the security " +
                   "rules of normal Cypher statements." )
     public static final Setting<String> procedure_roles = setting( PROC_ALLOWED_SETTING_ROLES, STRING, "" );
+
+    //=========================================================================
+    // Misc settings
+    //=========================================================================
+
+    @Description( "Set to true if connection pooling should be used for authorization searches using the " +
+                  "system account." )
+    public static final Setting<Boolean> ldap_authorization_connection_pooling =
+            setting( "unsupported.dbms.security.ldap.authorization.connection_pooling", BOOLEAN, "true" );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -139,6 +139,17 @@ public class SecuritySettings
     public static final Setting<String> ldap_referral =
             setting( "dbms.security.ldap.referral", STRING, "follow" );
 
+    @Description( "The timeout for establishing an LDAP connection. If a connection with the LDAP server cannot be " +
+                  "established within the given time the attempt is aborted. " +
+                  "A value of 0 means to use the network protocol's (i.e., TCP's) timeout value." )
+    public static Setting<Long> ldap_connection_timeout =
+            setting( "dbms.security.ldap.connection_timeout", DURATION, "30s" );
+
+    @Description( "The timeout for an LDAP read request (i.e. search). If the LDAP server does not respond within " +
+                  "the given time the request will be aborted. A value of 0 means wait for a response indefinitely." )
+    public static Setting<Long> ldap_read_timeout =
+            setting( "dbms.security.ldap.read_timeout", DURATION, "30s" );
+
     //-----------------------------------------------------
     // LDAP authentication settings
     //-----------------------------------------------------

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
@@ -47,6 +47,7 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 
+import org.neo4j.graphdb.security.AuthProviderFailedException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
@@ -86,6 +87,9 @@ public class LdapRealmTest
         when( config.get( SecuritySettings.ldap_authentication_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.ldap_authorization_enabled ) ).thenReturn( true );
         when( config.get( SecuritySettings.ldap_authentication_cache_enabled ) ).thenReturn( false );
+        when( config.get( SecuritySettings.ldap_connection_timeout ) ).thenReturn( 1000L );
+        when( config.get( SecuritySettings.ldap_read_timeout ) ).thenReturn( 1000L );
+        when( config.get( SecuritySettings.ldap_authorization_connection_pooling ) ).thenReturn( true );
     }
 
     @Test
@@ -435,7 +439,7 @@ public class LdapRealmTest
 
         // When
         assertException( () -> realm.doGetAuthorizationInfo( new SimplePrincipalCollection( "olivia", "LdapRealm" ) ),
-                AuthorizationException.class, "" );
+                AuthProviderFailedException.class, "" );
 
         // Then
         verify( securityLog ).error( contains( "{LdapRealm}: Failed to get authorization info: " +

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
@@ -63,7 +63,6 @@ import org.neo4j.test.DoubleLatch;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.neo4j.bolt.v1.messaging.message.InitMessage.init;
 import static org.neo4j.bolt.v1.messaging.message.PullAllMessage.pullAll;
 import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
@@ -911,7 +910,7 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
 
         // Then
         assertThat( client, eventuallyReceives(
-                msgFailure( Status.Security.Timeout, LDAP_READ_TIMEOUT_CLIENT_MESSAGE ) ) );
+                msgFailure( Status.Security.AuthProviderTimeout, LDAP_READ_TIMEOUT_CLIENT_MESSAGE ) ) );
     }
 
     private void assertConnectionTimeout( Map<String,Object> authToken, String message ) throws Exception
@@ -922,7 +921,7 @@ public class LdapAuthenticationIT extends EnterpriseAuthenticationTestBase
                         init( "TestClient/1.1", authToken ) ) );
 
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives( msgFailure( Status.Security.Timeout, message ) ) );
+        assertThat( client, eventuallyReceives( msgFailure( Status.Security.AuthProviderTimeout, message ) ) );
     }
 
     private void testClearAuthCache() throws Exception

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/TestCombinedAuthPlugin.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.neo4j.server.security.enterprise.auth.plugin.api.AuthToken;
-import org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpired;
+import org.neo4j.server.security.enterprise.auth.plugin.api.AuthorizationExpiredException;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthenticationInfo;
 import org.neo4j.server.security.enterprise.auth.plugin.spi.AuthenticationPlugin;
@@ -65,7 +65,7 @@ public class TestCombinedAuthPlugin extends AuthenticationPlugin.Adapter impleme
         }
         else if ( principals.stream().anyMatch( p -> "authorization_expired_user".equals( p.principal() ) ) )
         {
-            throw new AuthorizationExpired( "authorization_expired_user needs to re-authenticate." );
+            throw new AuthorizationExpiredException( "authorization_expired_user needs to re-authenticate." );
         }
         return null;
     }

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -357,6 +357,15 @@ dbms.connector.https.enabled=true
 # `throw` throws an exception, which will lead to authentication failure
 #dbms.security.ldap.referral=follow
 
+# The timeout for establishing an LDAP connection. If a connection with the LDAP server cannot be
+# established within the given time the attempt is aborted.
+# A value of 0 means to use the network protocol's (i.e., TCP's) timeout value.
+#dbms.security.ldap.connection_timeout=30s
+
+# The timeout for an LDAP read request (i.e. search). If the LDAP server does not respond within
+# the given time the request will be aborted. A value of 0 means wait for a response indefinitely.
+#dbms.security.ldap.read_timeout=30s
+
 #----------------------------------
 # LDAP Authentication Configuration
 #----------------------------------


### PR DESCRIPTION
- Adds two config settings `dbms.security.ldap.connection_timeout` and
  `dbms.security.ldap.read_timeout`.
- Adds exception `AuthProviderTimeoutException` with a new status code
  `Security.AuthProviderTimeout`, which is mapped to 504 in HTTP.
- Adds exception `AuthProviderFailedException` with a new status code
  `Security.AuthProviderFailed`, which is mapped to 502 in HTTP.

The config settings are mapped to the corresponding JNDI environment properties.

changelog: Added config settings for LDAP connection and read timeouts
