### PR TITLE
Fixed a `NullPointerException` in `LabelsFunction`

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -108,7 +108,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
       if (nodeOps.isDeletedInThisTx(node))
         throw new EntityNotFoundException(s"Node with id $node has been deleted in this transaction", e)
       else
-        null
+        Iterator.empty
   }
 
   override def getPropertiesForNode(node: Long) =


### PR DESCRIPTION
changelog: Fixes [#8239](https://github.com/neo4j/neo4j/issues/8239) - resolves an issue when attempting to access the labels of a node that has just been deleted

If the node is deleted at the same time as we are trying to access the labels
of that node there is a significant risk that we will have a `NullPointerException`.
Instead of an error we should just return an empty iterator for that case.
