### PR TITLE
List allowed roles per procedure in enterprise

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.builtinprocs;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
@@ -45,7 +46,29 @@ public class BuiltInDbmsProcedures
                 .map( ProcedureResult::new );
     }
 
-    @SuppressWarnings( "WeakerAccess" )
+    @Description( "List all user functions in the DBMS." )
+    @Procedure(name = "dbms.functions", mode = DBMS)
+    public Stream<FunctionResult> listFunctions()
+    {
+        return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllFunctions().stream()
+                .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
+                .map( FunctionResult::new );
+    }
+
+    public static class FunctionResult
+    {
+        public final String name;
+        public final String signature;
+        public final String description;
+
+        private FunctionResult( UserFunctionSignature signature )
+        {
+            this.name = signature.name().toString();
+            this.signature = signature.toString();
+            this.description = signature.description().orElse( "" );
+        }
+    }
+
     public static class ProcedureResult
     {
         public final String name;

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import java.util.stream.Stream;
+
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Procedure;
+
+import static org.neo4j.procedure.Mode.DBMS;
+
+@SuppressWarnings( "unused" )
+public class BuiltInDbmsProcedures
+{
+    @Context
+    public GraphDatabaseAPI graph;
+
+    @Description( "List all procedures in the DBMS." )
+    @Procedure( name = "dbms.procedures", mode = DBMS )
+    public Stream<ProcedureResult> listProcedures()
+    {
+        return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllProcedures().stream()
+                .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
+                .map( ProcedureResult::new );
+    }
+
+    @SuppressWarnings( "WeakerAccess" )
+    public static class ProcedureResult
+    {
+        public final String name;
+        public final String signature;
+        public final String description;
+
+        private ProcedureResult( ProcedureSignature signature )
+        {
+            this.name = signature.name().toString();
+            this.signature = signature.toString();
+            this.description = signature.description().orElse( "" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -184,19 +184,6 @@ public class BuiltInProcedures
                 .onClose( statement::close );
     }
 
-    @Description( "List all procedures in the DBMS." )
-    @Procedure( name = "dbms.procedures", mode = READ )
-    public Stream<ProcedureResult> listProcedures()
-    {
-        try ( Statement statement = tx.acquireStatement() )
-        {
-            return statement.readOperations().proceduresGetAll()
-                    .stream()
-                    .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
-                    .map( ProcedureResult::new );
-        }
-    }
-
     @Description( "List all user functions in the DBMS." )
     @Procedure(name = "dbms.functions", mode = READ)
     public Stream<FunctionResult> listFunctions()
@@ -271,20 +258,6 @@ public class BuiltInProcedures
         private ConstraintResult( String description )
         {
             this.description = description;
-        }
-    }
-
-    public class ProcedureResult
-    {
-        public final String name;
-        public final String signature;
-        public final String description;
-
-        private ProcedureResult( ProcedureSignature signature )
-        {
-            this.name = signature.name().toString();
-            this.signature = signature.toString();
-            this.description = signature.description().orElse( "" );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -184,19 +184,6 @@ public class BuiltInProcedures
                 .onClose( statement::close );
     }
 
-    @Description( "List all user functions in the DBMS." )
-    @Procedure(name = "dbms.functions", mode = READ)
-    public Stream<FunctionResult> listFunctions()
-    {
-        try ( Statement statement = tx.acquireStatement() )
-        {
-            return statement.readOperations().functionsGetAll()
-                    .stream()
-                    .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
-                    .map( FunctionResult::new );
-        }
-    }
-
     private IndexProcedures indexProcedures()
     {
         return new IndexProcedures( tx, resolver.resolveDependency( IndexingService.class ) );
@@ -258,21 +245,6 @@ public class BuiltInProcedures
         private ConstraintResult( String description )
         {
             this.description = description;
-        }
-    }
-
-    @SuppressWarnings( "unused" )
-    public class FunctionResult
-    {
-        public final String name;
-        public final String signature;
-        public final String description;
-
-        private FunctionResult( UserFunctionSignature signature )
-        {
-            this.name = signature.name().toString();
-            this.signature = signature.toString();
-            this.description = signature.description().orElse( "" );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -61,9 +61,10 @@ import static java.util.Collections.singletonMap;
  */
 public abstract class EditionModule
 {
-    public void registerProcedures( Procedures procedures ) throws KernelException
+    void registerProcedures( Procedures procedures ) throws KernelException
     {
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInProcedures.class );
+        procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInDbmsProcedures.class );
 
         registerEditionSpecificProcedures( procedures );
     }
@@ -121,7 +122,7 @@ public abstract class EditionModule
 
     public abstract void setupSecurityModule( PlatformModule platformModule, Procedures procedures );
 
-    public static void setupSecurityModule( PlatformModule platformModule, Log log, Procedures procedures,
+    protected static void setupSecurityModule( PlatformModule platformModule, Log log, Procedures procedures,
             String key )
     {
         for ( SecurityModule candidate : Service.load( SecurityModule.class ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -289,6 +289,7 @@ public class BuiltInProceduresTest
 
         new SpecialBuiltInProcedures("1.3.37", Edition.enterprise.toString() ).accept( procs );
         procs.registerProcedure( BuiltInProcedures.class );
+        procs.registerProcedure( BuiltInDbmsProcedures.class );
 
         when(tx.acquireStatement()).thenReturn( statement );
         when(statement.readOperations()).thenReturn( read );
@@ -332,6 +333,8 @@ public class BuiltInProceduresTest
         ctx.put( KERNEL_TRANSACTION, tx );
         ctx.put( DEPENDENCY_RESOLVER, resolver );
         ctx.put( GRAPHDATABASEAPI, graphDatabaseAPI);
+        when( graphDatabaseAPI.getDependencyResolver() ).thenReturn( resolver );
+        when( resolver.resolveDependency( Procedures.class ) ).thenReturn( procs );
         return Iterators.asList( procs.callProcedure( ctx, ProcedureSignature.procedureName( name.split( "\\." ) ), args ) );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -60,6 +60,7 @@ import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
@@ -107,7 +108,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
+        procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
         procedures.register(
                 new GetServersProcedure( topologyService, consensusModule.raftMachine(), config, logProvider ) );
         procedures.register(

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -107,7 +107,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class );
+        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
         procedures.register(
                 new GetServersProcedure( topologyService, consensusModule.raftMachine(), config, logProvider ) );
         procedures.register(

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.DatabaseAvailability;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
 import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
@@ -99,7 +100,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
+        procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
         procedures.register( new ReadReplicaRoleProcedure() );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -99,7 +99,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class );
+        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
         procedures.register( new ReadReplicaRoleProcedure() );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -65,6 +65,7 @@ import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.ha.BranchDetectingTxVerifier;
 import org.neo4j.kernel.ha.BranchedDataMigrator;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
@@ -132,7 +133,6 @@ import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
 import org.neo4j.kernel.impl.enterprise.EnterpriseConstraintSemantics;
 import org.neo4j.kernel.impl.enterprise.EnterpriseEditionModule;
 import org.neo4j.kernel.impl.enterprise.StandardBoltConnectionTracker;
-import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.enterprise.id.EnterpriseIdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.enterprise.transaction.log.checkpoint.ConfigurableIOLimiter;
 import org.neo4j.kernel.impl.factory.CanWrite;
@@ -187,7 +187,7 @@ public class HighlyAvailableEditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
+        procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
     }
 
     public HighlyAvailableEditionModule( final PlatformModule platformModule )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -187,7 +187,7 @@ public class HighlyAvailableEditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class );
+        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
     }
 
     public HighlyAvailableEditionModule( final PlatformModule platformModule )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/BuiltInProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/BuiltInProcedures.java
@@ -174,7 +174,7 @@ public class BuiltInProcedures
     {
         return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllProcedures().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
-                .map( sig -> new ProcedureResult( sig, isAdmin() ) );
+                .map( sig -> new ProcedureResult( sig ) );
     }
 
     @SuppressWarnings( "WeakerAccess" )
@@ -185,33 +185,26 @@ public class BuiltInProcedures
         public final String description;
         public final List<String> roles;
 
-        public ProcedureResult( ProcedureSignature signature, boolean isAdmin )
+        public ProcedureResult( ProcedureSignature signature )
         {
             this.name = signature.name().toString();
             this.signature = signature.toString();
             this.description = signature.description().orElse( "" );
-            if ( isAdmin )
+            roles = new ArrayList<>();
+            switch ( signature.mode() )
             {
-                roles = new ArrayList<>();
-                switch ( signature.mode() )
-                {
-                case DBMS:
-                    roles.add( "admin" );
-                    break;
-                case READ_ONLY:
-                    roles.add( "reader" );
-                case READ_WRITE:
-                    roles.add( "publisher" );
-                case SCHEMA_WRITE:
-                    roles.add( "architect" );
-                default:
-                    roles.add( "admin" );
-                    roles.addAll( Arrays.asList( signature.allowed() ) );
-                }
-            }
-            else
-            {
-                roles = Collections.emptyList();
+            case DBMS:
+                roles.add( "admin" );
+                break;
+            case READ_ONLY:
+                roles.add( "reader" );
+            case READ_WRITE:
+                roles.add( "publisher" );
+            case SCHEMA_WRITE:
+                roles.add( "architect" );
+            default:
+                roles.add( "admin" );
+                roles.addAll( Arrays.asList( signature.allowed() ) );
             }
         }
     }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +73,7 @@ import static org.neo4j.kernel.enterprise.builtinprocs.QueryId.ofInternalId;
 import static org.neo4j.procedure.Mode.DBMS;
 
 @SuppressWarnings( "unused" )
-public class BuiltInProcedures
+public class EnterpriseBuiltInDbmsProcedures
 {
     private static Clock clock = Clocks.systemClock();
     private static final int HARD_CHAR_LIMIT = 2048;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
+import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.enterprise.id.EnterpriseIdTypeConfigurationProvider;
@@ -48,7 +49,7 @@ public class EnterpriseEditionModule extends CommunityEditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
+        procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
     }
 
     public EnterpriseEditionModule( PlatformModule platformModule )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -48,7 +48,7 @@ public class EnterpriseEditionModule extends CommunityEditionModule
     @Override
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
-        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class );
+        procedures.registerProcedure( org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures.class, true );
     }
 
     public EnterpriseEditionModule( PlatformModule platformModule )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -246,7 +246,7 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 "test.staticReadProcedure", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
                 "test.staticWriteProcedure", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ),
                 "test.staticSchemaProcedure", newSet( "default", ARCHITECT, ADMIN ),
-                "test.allowedWriteProcedure", newSet( "otherRole", "role1", PUBLISHER, ARCHITECT, ADMIN ),
+                "test.annotatedProcedure", newSet( "annotated", READER, PUBLISHER, ARCHITECT, ADMIN ),
                 "test.numNodes", newSet( "counter", "user", READER, PUBLISHER, ARCHITECT, ADMIN ),
                 "db.labels", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
                 "dbms.security.changePassword", newSet( ADMIN ),
@@ -257,10 +257,10 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
         assertListProceduresHasRoles( adminSubject, expected );
         assertListProceduresHasRoles( schemaSubject, expected );
         assertListProceduresHasRoles( writeSubject, expected );
-        assertListProceduresHasRoles( writeSubject, expected );
+        assertListProceduresHasRoles( readSubject, expected );
     }
 
-    private void assertListProceduresHasRoles(S subject, Map<String,Set<String>> expected)
+    private void assertListProceduresHasRoles( S subject, Map<String,Set<String>> expected )
     {
         assertSuccess( subject, "CALL dbms.procedures", itr ->
         {

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -253,7 +253,16 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 "dbms.procedures", newSet( ADMIN ),
                 "dbms.listQueries", newSet( ADMIN ),
                 "dbms.security.createUser", newSet( ADMIN ) );
-        assertSuccess( adminSubject, "CALL dbms.procedures", itr ->
+
+        assertListProceduresHasRoles( adminSubject, expected );
+        assertListProceduresHasRoles( schemaSubject, expected );
+        assertListProceduresHasRoles( writeSubject, expected );
+        assertListProceduresHasRoles( writeSubject, expected );
+    }
+
+    private void assertListProceduresHasRoles(S subject, Map<String,Set<String>> expected)
+    {
+        assertSuccess( subject, "CALL dbms.procedures", itr ->
         {
             List<String> failures = itr.stream().filter( record ->
             {
@@ -267,14 +276,6 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
             } ).collect( toList() );
 
             assertThat( "Expectations violated: " + failures.toString(), failures.isEmpty() );
-        } );
-
-        assertSuccess( schemaSubject, "CALL dbms.procedures", itr ->
-        {
-            List<String> failures = itr.stream().filter( record ->
-                    !((List<?>) record.get( "roles" )).isEmpty() ).map( record ->
-                    record.get( "name" ).toString() ).collect( toList() );
-            assertThat( "Some procedures listed roles: " + failures.toString(), failures.isEmpty() );
         } );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -50,7 +50,7 @@ import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
-import org.neo4j.kernel.enterprise.builtinprocs.BuiltInProcedures;
+import org.neo4j.kernel.enterprise.builtinprocs.EnterpriseBuiltInDbmsProcedures;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
@@ -462,8 +462,8 @@ public abstract class ProcedureInteractionTestBase<S>
 
     private Map<String,Long> countTransactionsByUsername()
     {
-        return BuiltInProcedures.countTransactionByUsername(
-                    BuiltInProcedures.getActiveTransactions(
+        return EnterpriseBuiltInDbmsProcedures.countTransactionByUsername(
+                    EnterpriseBuiltInDbmsProcedures.getActiveTransactions(
                             neo.getLocalGraph().getDependencyResolver()
                     ).stream()
                             .filter( tx -> !tx.terminationReason().isPresent() )
@@ -473,9 +473,9 @@ public abstract class ProcedureInteractionTestBase<S>
 
     Map<String,Long> countBoltConnectionsByUsername()
     {
-        BoltConnectionTracker boltConnectionTracker = BuiltInProcedures.getBoltConnectionTracker(
+        BoltConnectionTracker boltConnectionTracker = EnterpriseBuiltInDbmsProcedures.getBoltConnectionTracker(
                 neo.getLocalGraph().getDependencyResolver() );
-        return BuiltInProcedures.countConnectionsByUsername(
+        return EnterpriseBuiltInDbmsProcedures.countConnectionsByUsername(
                 boltConnectionTracker
                         .getActiveConnections()
                         .stream()


### PR DESCRIPTION
The `dbms.procedures` procedure will now contain an additional
column `roles` that lists the roles that are allowed to execute it
(enterprise only). This column is only populated if the executing user
is an administrator, otherwise it will be empty.

changelog: Added column to `dbms.procedures` in enterprise, listing roles allowed to execute the procedure