### PR TITLE
Fixed path calculations in `neo4j-admin dump` and `neo4j-admin load`

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -44,6 +44,7 @@ import org.neo4j.server.configuration.ConfigLoader;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.neo4j.commandline.dbms.Util.canonicalPath;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.Converters.identity;
@@ -104,8 +105,8 @@ public class DumpCommand implements AdminCommand
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
         String database = parse( args, "database", identity() );
-        Path archive = calculateArchive( database, parse( args, "to", Paths::get ) );
-        Path databaseDirectory = toDatabaseDirectory( database );
+        Path archive = calculateArchive( database, parse( args, "to", Util::canonicalPath ) );
+        Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
 
         try ( Closeable ignored = storeLockChecker.withLock( databaseDirectory ) )
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -41,6 +41,7 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.server.configuration.ConfigLoader;
 
 import static java.util.Arrays.asList;
+import static org.neo4j.commandline.dbms.Util.canonicalPath;
 import static org.neo4j.commandline.dbms.Util.checkLock;
 import static org.neo4j.commandline.dbms.Util.wrapIOException;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
@@ -98,11 +99,11 @@ public class LoadCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Path archive = parse( args, "from", Paths::get );
+        Path archive = parse( args, "from", Util::canonicalPath );
         String database = parse( args, "database", identity() );
         boolean force = Args.parse( args ).getBoolean( "force" );
 
-        Path databaseDirectory = toDatabaseDirectory( database );
+        Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
 
         deleteIfNecessary( databaseDirectory, force );
         load( archive, database, databaseDirectory );

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
@@ -51,7 +51,7 @@ public class Util
         }
         catch ( IOException e )
         {
-            throw new IllegalArgumentException( "Unable to parse path: " + file );
+            throw new IllegalArgumentException( "Unable to parse path: " + file, e );
         }
     }
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/Util.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.commandline.dbms;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -31,6 +33,28 @@ import static java.lang.String.format;
 
 public class Util
 {
+    public static Path canonicalPath( Path path ) throws IllegalArgumentException
+    {
+        return canonicalPath( path.toFile() );
+    }
+
+    public static Path canonicalPath( String path ) throws IllegalArgumentException
+    {
+        return canonicalPath( new File( path ) );
+    }
+
+    public static Path canonicalPath( File file ) throws IllegalArgumentException
+    {
+        try
+        {
+            return Paths.get( file.getCanonicalPath() );
+        }
+        catch ( IOException e )
+        {
+            throw new IllegalArgumentException( "Unable to parse path: " + file );
+        }
+    }
+
     public static void checkLock( Path databaseDirectory ) throws CommandFailed
     {
         try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class UtilTest
+{
+    @Test
+    public void canonicalPath() throws Exception
+    {
+        assertNotNull( Util.canonicalPath( "foo" ).getParent() );
+    }
+
+}


### PR DESCRIPTION
changelog: Fixed path calculations in `neo4j-admin dump` and `neo4j-admin load`
- specifying `--to=foo` which previously didn't work is now equivalent to `--to=./foo`
- now follows symlinks, in case the database directory is a symlink for example
