### PR TITLE
Fix: bug with streaming of store files that grow during the streaming process

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
@@ -87,8 +87,10 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
     private void sendFile( ChannelHandlerContext ctx, File file ) throws FileNotFoundException
     {
         ctx.writeAndFlush( ResponseMessageType.FILE );
-        ctx.writeAndFlush( new FileHeader( file.getName(), file.length() ) );
-        ctx.writeAndFlush( new ChunkedNioStream( new FileInputStream( file ).getChannel() ) );
+        long initialLength = file.length();
+        ctx.writeAndFlush( new FileHeader( file.getName(), initialLength ) );
+        ctx.writeAndFlush( new ChunkedNioStream( new LimitedLengthReadableByteChannel(
+                new FileInputStream( file ).getChannel(), initialLength ) ) );
     }
 
     private void endStoreCopy( Status status, ChannelHandlerContext ctx, long lastCommittedTxBeforeStoreCopy )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LimitedLengthReadableByteChannel.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LimitedLengthReadableByteChannel.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+public class LimitedLengthReadableByteChannel implements ReadableByteChannel
+{
+    private final ReadableByteChannel channel;
+    private final long lengthLimit;
+    private long position = 0;
+
+    public LimitedLengthReadableByteChannel( ReadableByteChannel channel, long lengthLimit )
+    {
+        this.channel = channel;
+        this.lengthLimit = lengthLimit;
+    }
+
+    @Override
+    public int read( ByteBuffer dst ) throws IOException
+    {
+        long bytesLeftInFile = lengthLimit - position;
+        if ( bytesLeftInFile == 0 )
+        {
+            return -1;
+        }
+
+        int bytesLeftInBuffer = dst.limit() - dst.position();
+        int maxReadable = (int) Math.min( bytesLeftInFile, bytesLeftInBuffer );
+        dst.limit( dst.position() + maxReadable);
+        int read = channel.read( dst );
+        if ( read < 0 )
+        {
+            return read;
+        }
+
+        position += read;
+
+        return read;
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        channel.close();
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/BatchingMessageHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/BatchingMessageHandler.java
@@ -68,7 +68,7 @@ class BatchingMessageHandler extends LifecycleAdapter
     {
         if ( stopped )
         {
-            log.warn( "This handler has been stopped, dropping the message: %s", message );
+            log.debug( "This handler has been stopped, dropping the message: %s", message );
             return;
         }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -112,6 +112,7 @@ public class CoreStateDownloader
 
                 if ( catchupResult == E_TRANSACTION_PRUNED )
                 {
+                    log.info( "Failed to pull transactions from " + source + ". They may have been pruned away." );
                     localDatabase.delete();
                     new CopyStoreSafely( fs, localDatabase, copiedStoreRecovery, log ).
                         copyWholeStoreFrom( source, localStoreId, storeFetcher );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LimitedLengthReadableByteChannelTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LimitedLengthReadableByteChannelTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.stream.ChunkedNioStream;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LimitedLengthReadableByteChannelTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldLimitSize() throws Exception
+    {
+        // given
+        File sourceFile = sourceFileWithBytes( 1024 );
+        File destinationFile = testDirectory.file( "destination" );
+
+        // when
+        int bytesToRead = 500;
+        LimitedLengthReadableByteChannel readChannel = new LimitedLengthReadableByteChannel( new FileInputStream( sourceFile ).getChannel(), bytesToRead );
+        ByteBuffer byteBuffer = ByteBuffer.allocate( 32 );
+
+        FileChannel writeChannel = new FileOutputStream( destinationFile ).getChannel();
+        for (;;)
+        {
+            int read = readChannel.read( byteBuffer );
+            if ( read < 0 )
+            {
+                break;
+            }
+
+            byteBuffer.flip();
+            writeChannel.write( byteBuffer );
+            byteBuffer.clear();
+        }
+
+        // then
+        assertEquals( bytesToRead, destinationFile.length() );
+    }
+
+    @Test
+    public void shouldReadWhenBufferEmptyAndMoreFileToRead() throws Exception
+    {
+        // given
+        File sourceFile = sourceFileWithBytes( 32 );
+        File destinationFile = testDirectory.file( "destination" );
+
+        // when
+        int bytesToRead = 32;
+        LimitedLengthReadableByteChannel readChannel = new LimitedLengthReadableByteChannel( new
+                FileInputStream( sourceFile ).getChannel(), bytesToRead );
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate( 32 );
+
+        // then fills the whole buffer
+        FileChannel writeChannel = new FileOutputStream( destinationFile ).getChannel();
+        assertEquals( 32, readChannel.read( byteBuffer ) );
+
+        // then writes to a file
+        byteBuffer.flip();
+        writeChannel.write( byteBuffer );
+        assertEquals( bytesToRead, destinationFile.length() );
+    }
+
+    @Test
+    public void shouldNotReadWhenNoMoreFileToRead() throws Exception
+    {
+        // given
+        File sourceFile = sourceFileWithBytes( 32 );
+
+        // when
+        int bytesToRead = 32;
+        LimitedLengthReadableByteChannel readChannel = new LimitedLengthReadableByteChannel( new
+                FileInputStream( sourceFile ).getChannel(), bytesToRead );
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate( 32 );
+
+        // read the whole file
+        readChannel.read( byteBuffer );
+
+        // then read with full buffer
+        assertEquals( -1, readChannel.read( byteBuffer ) );
+
+        // then read with empty buffer
+        byteBuffer.clear();
+        assertEquals( -1, readChannel.read( byteBuffer ) );
+    }
+
+    @Test
+    public void shouldSomethingWhenBufferNotFull() throws Exception
+    {
+        // given
+        File sourceFile = sourceFileWithBytes( 48 );
+
+        // when
+        int bytesToRead = 48;
+        LimitedLengthReadableByteChannel readChannel = new LimitedLengthReadableByteChannel( new
+                FileInputStream( sourceFile ).getChannel(), bytesToRead );
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate( 32 );
+
+        // read the first bit of the file
+        assertEquals(32, readChannel.read( byteBuffer ) );
+
+        // buffer full but still file to read
+        assertEquals(0, readChannel.read( byteBuffer ) );
+
+        // read the rest of the file
+        byteBuffer.clear();
+        assertEquals(16, readChannel.read( byteBuffer ) );
+
+        // then nothing else to read
+        assertEquals(-1, readChannel.read( byteBuffer ) );
+    }
+
+    @Test
+    public void shouldReadLikeAChunkedNioStream() throws Exception
+    {
+        // given
+        File sourceFile = sourceFileWithBytes( 1024 );
+        File destinationFile = testDirectory.file( "destination" );
+
+        // when
+        int bytesToRead = 33;
+        LimitedLengthReadableByteChannel jc = new LimitedLengthReadableByteChannel( new FileInputStream( sourceFile ).getChannel(), bytesToRead );
+
+        ChunkedNioStream chunks = new ChunkedNioStream( jc, 32 );
+
+        // when
+        ChannelHandlerContext context = mock( ChannelHandlerContext.class );
+        when( context.alloc() ).thenReturn( new UnpooledByteBufAllocator( false ) );
+
+        FileOutputStream outputStream = new FileOutputStream( destinationFile );
+
+        while (true)
+        {
+            ByteBuf message = chunks.readChunk( context );
+
+            if(message == null)
+            {
+                break;
+            }
+            message.readBytes( outputStream, message.readableBytes() );
+
+            boolean endOfInput = chunks.isEndOfInput();
+            if (endOfInput)
+            {
+                break;
+            }
+
+        }
+
+        // then
+        assertEquals( bytesToRead, destinationFile.length() );
+    }
+
+    private File sourceFileWithBytes( int numberOfBytes ) throws IOException
+    {
+        File sourceFile = testDirectory.file( "source" );
+        byte[] bytes = new byte[numberOfBytes];
+        for ( int i = 0; i < numberOfBytes; i++ )
+        {
+            bytes[i] = (byte) i;
+        }
+        Files.write( sourceFile.toPath(), bytes );
+        return sourceFile;
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/server/BatchingMessageHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/server/BatchingMessageHandlerTest.java
@@ -182,7 +182,7 @@ public class BatchingMessageHandlerTest
         // then
         verifyZeroInteractions( raftStateMachine );
         logProvider.assertAtLeastOnce( AssertableLogProvider.inLog( BatchingMessageHandler.class )
-                .warn( "This handler has been stopped, dropping the message: %s", message ) );
+                .debug( "This handler has been stopped, dropping the message: %s", message ) );
     }
 
     @Test( timeout = 5_000 /* 5 seconds */)


### PR DESCRIPTION
At the moment when a follower/read replica gets sent
store files we tell it how many bytes it should expect
to receive.

If the file size changes during the copy process we can
end up sending more bytes than we promised and the
client doesn't handle that very well and story copy fails.

With this commit we introduce our own implementation of
ReadableByteChannel which will only send the portion of the
file that we promised when we first determined its size.
