### PR TITLE
Fix buf leak in encoders

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -41,7 +41,6 @@ import org.neo4j.causalclustering.VersionDecoder;
 import org.neo4j.causalclustering.VersionPrepender;
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
 import org.neo4j.causalclustering.catchup.storecopy.FileHeaderEncoder;
-import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequest;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequestHandler;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestDecoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestHandler;
@@ -53,7 +52,6 @@ import org.neo4j.causalclustering.catchup.tx.TxStreamFinishedResponseEncoder;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.state.CoreState;
 import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshotEncoder;
-import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshotRequest;
 import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshotRequestHandler;
 import org.neo4j.causalclustering.handlers.ExceptionLoggingHandler;
 import org.neo4j.causalclustering.handlers.ExceptionMonitoringHandler;
@@ -195,8 +193,8 @@ public class CatchupServer extends LifecycleAdapter
                 new RequestDecoderDispatcher<>( protocol, logProvider );
         decoderDispatcher.register( State.TX_PULL, new TxPullRequestDecoder() );
         decoderDispatcher.register( State.GET_STORE, new GetStoreRequestDecoder() );
-        decoderDispatcher.register( State.GET_STORE_ID, new SimpleRequestDecoder( GetStoreIdRequest::new ) );
-        decoderDispatcher.register( State.GET_CORE_SNAPSHOT, new SimpleRequestDecoder( CoreSnapshotRequest::new) );
+        decoderDispatcher.register( State.GET_STORE_ID, new GetStoreIdRequestDecoder() );
+        decoderDispatcher.register( State.GET_CORE_SNAPSHOT, new CoreSnapshotRequestDecoder() );
         return decoderDispatcher;
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -42,6 +42,7 @@ import org.neo4j.causalclustering.VersionPrepender;
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
 import org.neo4j.causalclustering.catchup.storecopy.FileHeaderEncoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequestHandler;
+import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdResponseEncoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestDecoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestHandler;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponseEncoder;
@@ -145,6 +146,7 @@ public class CatchupServer extends LifecycleAdapter
 
                         pipeline.addLast( new TxPullResponseEncoder() );
                         pipeline.addLast( new CoreSnapshotEncoder() );
+                        pipeline.addLast( new GetStoreIdResponseEncoder() );
                         pipeline.addLast( new StoreCopyFinishedResponseEncoder() );
                         pipeline.addLast( new TxStreamFinishedResponseEncoder() );
                         pipeline.addLast( new FileHeaderEncoder() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CoreSnapshotRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CoreSnapshotRequestDecoder.java
@@ -21,25 +21,18 @@ package org.neo4j.causalclustering.catchup;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-import org.neo4j.causalclustering.messaging.Message;
-import org.neo4j.function.Factory;
+import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshotRequest;
 
-class SimpleRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+class CoreSnapshotRequestDecoder extends ByteToMessageDecoder
 {
-    private Factory<? extends Message> factory;
-
-    SimpleRequestDecoder( Factory<? extends Message> factory )
-    {
-        this.factory = factory;
-    }
-
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
     {
-        out.add( factory.newInstance() );
+        msg.readByte();
+        out.add( new CoreSnapshotRequest() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/GetStoreIdRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/GetStoreIdRequestDecoder.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.catchup.storecopy;
+package org.neo4j.causalclustering.catchup;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -25,16 +25,14 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-import org.neo4j.causalclustering.identity.StoreId;
-import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
-import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
+import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequest;
 
-public class GetStoreIdResponseDecoder extends ByteToMessageDecoder
+class GetStoreIdRequestDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
     {
-        StoreId storeId = StoreIdMarshal.INSTANCE.unmarshal( new NetworkReadableClosableChannelNetty4( msg ) );
-        out.add( new GetStoreIdResponse( storeId ) );
+        msg.readByte();
+        out.add( new GetStoreIdRequest() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.catchup;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +49,9 @@ class RequestDecoderDispatcher<E extends Enum<E>> extends ChannelInboundHandlerA
         if ( delegate == null )
         {
             log.warn( "Unregistered handler for protocol %s", protocol );
+            // since we cannot process this message further we need to release the message as per netty doc
+            // see http://netty.io/wiki/reference-counted-objects.html#inbound-messages
+            ReferenceCountUtil.release( msg );
             return;
         }
         delegate.channelRead( ctx, msg );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.catchup;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class RequestMessageTypeEncoder extends MessageToMessageEncoder<RequestMessageType>
+class RequestMessageTypeEncoder extends MessageToByteEncoder<RequestMessageType>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, RequestMessageType request, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, RequestMessageType request, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeByte( request.messageType() );
-        out.add( encoded );
+        out.writeByte( request.messageType() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.catchup;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class ResponseMessageTypeEncoder extends MessageToMessageEncoder<ResponseMessageType>
+class ResponseMessageTypeEncoder extends MessageToByteEncoder<ResponseMessageType>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, ResponseMessageType response, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, ResponseMessageType response, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeByte( response.messageType() );
-        out.add( encoded );
+        out.writeByte( response.messageType() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContent.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContent.java
@@ -19,31 +19,21 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import io.netty.buffer.ByteBuf;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class FileContent implements AutoCloseable
+public class FileContent
 {
-    private final ByteBuf msg;
+    private final byte[] bytes;
 
-    FileContent( ByteBuf msg )
+    FileContent( byte[] bytes )
     {
-        msg.retain();
-        this.msg = msg;
+        this.bytes = bytes;
     }
 
     int writeTo( OutputStream stream ) throws IOException
     {
-        int bytes = msg.readableBytes();
-        msg.readBytes( stream, bytes );
-        return bytes;
-    }
-
-    @Override
-    public void close()
-    {
-        msg.release();
+        stream.write( bytes );
+        return bytes.length;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContentDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContentDecoder.java
@@ -21,15 +21,17 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-public class FileContentDecoder extends MessageToMessageDecoder<ByteBuf>
+public class FileContentDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
     {
-        out.add( new FileContent( msg ) );
+        byte[] dst = new byte[msg.readableBytes()];
+        msg.readBytes( dst );
+        out.add( new FileContent( dst ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
@@ -21,11 +21,11 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-public class FileHeaderDecoder extends MessageToMessageDecoder<ByteBuf>
+public class FileHeaderDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
@@ -19,25 +19,18 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class FileHeaderEncoder extends MessageToMessageEncoder<FileHeader>
+public class FileHeaderEncoder extends MessageToByteEncoder<FileHeader>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, FileHeader msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, FileHeader msg, ByteBuf buffer ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-
         String name = msg.fileName();
-
         buffer.writeInt( name.length() );
         buffer.writeBytes( name.getBytes() );
         buffer.writeLong( msg.fileLength() );
-
-        out.add( buffer );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
@@ -21,17 +21,13 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-import java.util.List;
-
-public class GetStoreIdRequestEncoder extends MessageToMessageEncoder<GetStoreIdRequest>
+public class GetStoreIdRequestEncoder extends MessageToByteEncoder<GetStoreIdRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, GetStoreIdRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, GetStoreIdRequest msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        buffer.writeByte( 0 );
-        out.add( buffer );
+        out.writeByte( 0 );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
@@ -19,35 +19,20 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.function.Supplier;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
-import org.neo4j.causalclustering.catchup.ResponseMessageType;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-import static org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
-
-public class GetStoreIdRequestHandler extends SimpleChannelInboundHandler<GetStoreIdRequest>
+public class GetStoreIdResponseEncoder extends MessageToByteEncoder<StoreId>
 {
-    private final CatchupServerProtocol protocol;
-    private final Supplier<StoreId> storeIdSupplier;
-
-    public GetStoreIdRequestHandler( CatchupServerProtocol protocol, Supplier<StoreId> storeIdSupplier )
-    {
-        this.protocol = protocol;
-        this.storeIdSupplier = storeIdSupplier;
-    }
-
     @Override
-    protected void channelRead0( ChannelHandlerContext ctx, GetStoreIdRequest msg ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, StoreId storeId, ByteBuf out ) throws Exception
     {
-        ctx.writeAndFlush( ResponseMessageType.STORE_ID );
-        ctx.writeAndFlush( storeIdSupplier.get() );
-        protocol.expect( State.MESSAGE_TYPE );
+        StoreIdMarshal.INSTANCE.marshal( storeId, new NetworkFlushableByteBuf( out ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestDecoder.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToMessageDecoder;
 
 import java.util.List;
@@ -29,7 +30,7 @@ import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class GetStoreRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+public class GetStoreRequestDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestEncoder.java
@@ -21,20 +21,16 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
-
-import java.util.List;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class GetStoreRequestEncoder extends MessageToMessageEncoder<GetStoreRequest>
+public class GetStoreRequestEncoder extends MessageToByteEncoder<GetStoreRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, GetStoreRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, GetStoreRequest msg, ByteBuf buffer ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
         StoreIdMarshal.INSTANCE.marshal( msg.expectedStoreId(), new NetworkFlushableChannelNetty4( buffer ) );
-        out.add( buffer );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -59,12 +59,10 @@ public class StoreCopyClient
                         public boolean onFileContent( CompletableFuture<Long> signal, FileContent fileContent )
                                 throws IOException
                         {
-                            try ( FileContent content = fileContent;
-                                  OutputStream outputStream = storeFileStreams.createStream( destination ) )
+                            try ( OutputStream outputStream = storeFileStreams.createStream( destination ) )
                             {
-                                expectedBytes -= content.writeTo( outputStream );
+                                expectedBytes -= fileContent.writeTo( outputStream );
                             }
-
                             return expectedBytes <= 0;
                         }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponse.Status;
 
-public class StoreCopyFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class StoreCopyFinishedResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
@@ -19,20 +19,16 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class StoreCopyFinishedResponseEncoder extends MessageToMessageEncoder<StoreCopyFinishedResponse>
+public class StoreCopyFinishedResponseEncoder extends MessageToByteEncoder<StoreCopyFinishedResponse>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, StoreCopyFinishedResponse msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, StoreCopyFinishedResponse msg, ByteBuf buffer ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
         buffer.writeInt( msg.status().ordinal() );
         buffer.writeLong( msg.lastCommittedTxBeforeStoreCopy() );
-        out.add( buffer );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseHandler.java
@@ -32,8 +32,7 @@ public class StoreCopyFinishedResponseHandler extends SimpleChannelInboundHandle
     private final CatchupClientProtocol protocol;
     private CatchUpResponseHandler handler;
 
-    public StoreCopyFinishedResponseHandler( CatchupClientProtocol protocol,
-                                             CatchUpResponseHandler handler )
+    public StoreCopyFinishedResponseHandler( CatchupClientProtocol protocol, CatchUpResponseHandler handler )
     {
         this.protocol = protocol;
         this.handler = handler;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class TxPullRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxPullRequestDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
@@ -19,23 +19,20 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class TxPullRequestEncoder extends MessageToMessageEncoder<TxPullRequest>
+public class TxPullRequestEncoder extends MessageToByteEncoder<TxPullRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxPullRequest request, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, TxPullRequest request, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeLong( request.previousTxId() );
-        StoreIdMarshal.INSTANCE.marshal( request.expectedStoreId(), new NetworkFlushableChannelNetty4( encoded ) );
-        out.add( encoded );
+        out.writeLong( request.previousTxId() );
+        StoreIdMarshal.INSTANCE.marshal( request.expectedStoreId(), new NetworkFlushableChannelNetty4( out ) );
+
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 
-public class TxPullResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxPullResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
@@ -19,26 +19,21 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-import org.neo4j.com.CommittedTransactionSerializer;
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
+import org.neo4j.com.CommittedTransactionSerializer;
 
-public class TxPullResponseEncoder extends MessageToMessageEncoder<TxPullResponse>
+public class TxPullResponseEncoder extends MessageToByteEncoder<TxPullResponse>
 {
-
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxPullResponse response, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, TxPullResponse response, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( encoded );
+        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( out );
         StoreIdMarshal.INSTANCE.marshal( response.storeId(), channel );
         new CommittedTransactionSerializer( channel ).visit( response.tx() );
-        out.add( encoded );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseHandler.java
@@ -30,8 +30,7 @@ public class TxPullResponseHandler extends SimpleChannelInboundHandler<TxPullRes
     private final CatchupClientProtocol protocol;
     private final CatchUpResponseHandler handler;
 
-    public TxPullResponseHandler( CatchupClientProtocol protocol,
-                                  CatchUpResponseHandler handler )
+    public TxPullResponseHandler( CatchupClientProtocol protocol, CatchUpResponseHandler handler )
     {
         this.protocol = protocol;
         this.handler = handler;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.catchup.CatchupResult;
 
-public class TxStreamFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxStreamFinishedResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
@@ -19,20 +19,15 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class TxStreamFinishedResponseEncoder extends MessageToMessageEncoder<TxStreamFinishedResponse>
+public class TxStreamFinishedResponseEncoder extends MessageToByteEncoder<TxStreamFinishedResponse>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxStreamFinishedResponse response, List<Object> out ) throws
-            Exception
+    protected void encode( ChannelHandlerContext ctx, TxStreamFinishedResponse response, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeInt( response.status().ordinal() );
-        out.add( encoded );
+        out.writeInt( response.status().ordinal() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
@@ -21,13 +21,14 @@ package org.neo4j.causalclustering.core.state.snapshot;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 
-public class CoreSnapshotDecoder extends MessageToMessageDecoder<ByteBuf>
+public class CoreSnapshotDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
@@ -19,21 +19,17 @@
  */
 package org.neo4j.causalclustering.core.state.snapshot;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 
-public class CoreSnapshotEncoder extends MessageToMessageEncoder<CoreSnapshot>
+public class CoreSnapshotEncoder extends MessageToByteEncoder<CoreSnapshot>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, CoreSnapshot coreSnapshot, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, CoreSnapshot coreSnapshot, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        new CoreSnapshot.Marshal().marshal( coreSnapshot, new NetworkFlushableByteBuf( encoded ) );
-        out.add( encoded );
+        new CoreSnapshot.Marshal().marshal( coreSnapshot, new NetworkFlushableByteBuf( out ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.core.state.snapshot;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class CoreSnapshotRequestEncoder extends MessageToMessageEncoder<CoreSnapshotRequest>
+public class CoreSnapshotRequestEncoder extends MessageToByteEncoder<CoreSnapshotRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, CoreSnapshotRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, CoreSnapshotRequest msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        buffer.writeByte( 0 );
-        out.add( buffer );
+        out.writeByte( 0 );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.messaging.marshalling;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,7 +44,7 @@ import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.NEW_EN
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_REQUEST;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_RESPONSE;
 
-public class RaftMessageDecoder extends MessageToMessageDecoder<ByteBuf>
+public class RaftMessageDecoder extends ByteToMessageDecoder
 {
     private final ChannelMarshal<ReplicatedContent> marshal;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncoder.java
@@ -19,10 +19,9 @@
  */
 package org.neo4j.causalclustering.messaging.marshalling;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
-
-import java.util.List;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
@@ -31,7 +30,7 @@ import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 
-public class RaftMessageEncoder extends MessageToMessageEncoder<RaftMessages.ClusterIdAwareMessage>
+public class RaftMessageEncoder extends MessageToByteEncoder<RaftMessages.ClusterIdAwareMessage>
 {
     private final ChannelMarshal<ReplicatedContent> marshal;
 
@@ -41,15 +40,14 @@ public class RaftMessageEncoder extends MessageToMessageEncoder<RaftMessages.Clu
     }
 
     @Override
-    protected synchronized void encode( ChannelHandlerContext ctx,
-            RaftMessages.ClusterIdAwareMessage decoratedMessage,
-            List<Object> list ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, RaftMessages.ClusterIdAwareMessage decoratedMessage, ByteBuf out )
+            throws Exception
     {
         RaftMessages.RaftMessage message = decoratedMessage.message();
         ClusterId clusterId = decoratedMessage.clusterId();
         MemberId.Marshal memberMarshal = new MemberId.Marshal();
 
-        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( ctx.alloc().buffer() );
+        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( out );
         ClusterId.Marshal.INSTANCE.marshal( clusterId, channel );
         channel.putInt( message.type().ordinal() );
         memberMarshal.marshal( message.from(), channel );
@@ -123,7 +121,5 @@ public class RaftMessageEncoder extends MessageToMessageEncoder<RaftMessages.Clu
         {
             throw new IllegalArgumentException( "Unknown message type: " + message );
         }
-
-        list.add( channel.buffer() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncodingDecodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageEncodingDecodingTest.java
@@ -29,13 +29,13 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.UUID;
 
-import org.neo4j.causalclustering.core.consensus.roles.AppendEntriesRequestBuilder;
-import org.neo4j.causalclustering.core.consensus.roles.AppendEntriesResponseBuilder;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.ReplicatedInteger;
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+import org.neo4j.causalclustering.core.consensus.roles.AppendEntriesRequestBuilder;
+import org.neo4j.causalclustering.core.consensus.roles.AppendEntriesResponseBuilder;
 import org.neo4j.causalclustering.core.consensus.vote.VoteRequestBuilder;
 import org.neo4j.causalclustering.core.consensus.vote.VoteResponseBuilder;
-import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
 import org.neo4j.causalclustering.core.replication.ReplicatedContent;
 import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
 import org.neo4j.causalclustering.identity.ClusterId;
@@ -96,8 +96,6 @@ public class RaftMessageEncodingDecodingTest
         RaftMessageEncoder encoder = new RaftMessageEncoder( marshal );
         RaftMessageDecoder decoder = new RaftMessageDecoder( marshal );
 
-        // Netty puts buffers with serialized content in this list
-        LinkedList<Object> resultingBuffers = new LinkedList<>();
         // Deserialization adds read objects in this list
         ArrayList<Object> thingsRead = new ArrayList<>( 1 );
 
@@ -105,17 +103,27 @@ public class RaftMessageEncodingDecodingTest
         MemberId sender = new MemberId( UUID.randomUUID() );
         RaftMessages.ClusterIdAwareMessage message = new RaftMessages.ClusterIdAwareMessage( clusterId,
         new RaftMessages.Heartbeat( sender, 1, 2, 3 ) );
-        encoder.encode( setupContext(), message, resultingBuffers );
+        ChannelHandlerContext ctx = setupContext();
+        ByteBuf buffer = null;
+        try
+        {
+            buffer = ctx.alloc().buffer();
+            encoder.encode( ctx, message, buffer );
 
-        // Then
-        assertEquals( 1, resultingBuffers.size() );
+            // When
+            decoder.decode( null, buffer, thingsRead );
 
-        // When
-        decoder.decode( null, (ByteBuf) resultingBuffers.get( 0 ), thingsRead );
-
-        // Then
-        assertEquals( 1, thingsRead.size() );
-        assertEquals( message, thingsRead.get( 0 ) );
+            // Then
+            assertEquals( 1, thingsRead.size() );
+            assertEquals( message, thingsRead.get( 0 ) );
+        }
+        finally
+        {
+            if ( buffer != null )
+            {
+                buffer.release();
+            }
+        }
     }
 
     @Test
@@ -150,25 +158,34 @@ public class RaftMessageEncodingDecodingTest
         RaftMessageEncoder encoder = new RaftMessageEncoder( marshal );
         RaftMessageDecoder decoder = new RaftMessageDecoder( marshal );
 
-        // Netty puts buffers with serialized content in this list
-        LinkedList<Object> resultingBuffers = new LinkedList<>();
         // Deserialization adds read objects in this list
         ArrayList<Object> thingsRead = new ArrayList<>( 1 );
 
         // When
         RaftMessages.ClusterIdAwareMessage decoratedMessage =
                 new RaftMessages.ClusterIdAwareMessage( clusterId, message );
-        encoder.encode( setupContext(), decoratedMessage, resultingBuffers );
 
-        // Then
-        assertEquals( 1, resultingBuffers.size() );
+        ChannelHandlerContext ctx = setupContext();
+        ByteBuf buffer = null;
+        try
+        {
+            buffer = ctx.alloc().buffer();
+            encoder.encode( ctx, decoratedMessage, buffer );
 
-        // When
-        decoder.decode( null, (ByteBuf) resultingBuffers.get( 0 ), thingsRead );
+            // When
+            decoder.decode( null, buffer, thingsRead );
 
-        // Then
-        assertEquals( 1, thingsRead.size() );
-        assertEquals( decoratedMessage, thingsRead.get( 0 ) );
+            // Then
+            assertEquals( 1, thingsRead.size() );
+            assertEquals( decoratedMessage, thingsRead.get( 0 ) );
+        }
+        finally
+        {
+            if ( buffer != null )
+            {
+                buffer.release();
+            }
+        }
     }
 
     private static ChannelHandlerContext setupContext()


### PR DESCRIPTION
Do not allocate buffers by hand but ask netty to allocate them for us,
so they can do the tracking and release them when they are not needed
anymore.
