### PR TITLE
Backport fix for `isolateAggregation`

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -19,10 +19,23 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{SyntaxException, NewPlannerTestSupport, ExecutionEngineFunSuite}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
 import org.neo4j.graphdb.Node
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("should handle aggregations that are aliased to the same name as another aggregation") {
+    createLabeledNode("L")
+    createLabeledNode("M")
+
+    val query = """MATCH (:L) WITH count(*) AS stats
+                  |MATCH (:M) RETURN stats + count(*) AS stats
+                """.stripMargin
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("stats" -> 2)))
+  }
 
   test("should handle aggregates inside non aggregate expressions") {
     executeWithAllPlanners(

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
@@ -1,0 +1,73 @@
+package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
+
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import org.neo4j.cypher.internal.frontend.v2_3.Foldable._
+import org.neo4j.cypher.internal.frontend.v2_3.Rewritable._
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{AliasedReturnItem, Expression}
+import org.neo4j.cypher.internal.frontend.v2_3.{InternalException, Rewriter}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/*
+This rewriter is an alternative to the topDown rewriter that does the same thing,
+but does not rewrite ReturnItem alias, only the projected expression
+*/
+case class ReturnItemSafeTopDownRewriter(inner: Rewriter) extends Rewriter {
+
+  override def apply(that: AnyRef): AnyRef = {
+    val initialStack = mutable.ArrayStack((List(that), new mutable.MutableList[AnyRef]()))
+    val result = tailrecApply(initialStack)
+    assert(result.size == 1)
+    result.head
+  }
+
+  @tailrec
+  private def tailrecApply(stack: mutable.ArrayStack[(List[AnyRef], mutable.MutableList[AnyRef])]): mutable.MutableList[AnyRef] = {
+    val (currentJobs, _) = stack.top
+    if (currentJobs.isEmpty) {
+      val (_, newChildren) = stack.pop()
+      if (stack.isEmpty) {
+        newChildren
+      } else {
+        stack.pop() match {
+          case (Nil, _) => throw new InternalException("only to stop warnings. should never happen")
+          case ((returnItem@AliasedReturnItem(expression, variable)) :: jobs, doneJobs) =>
+            val newExpression = newChildren.head.asInstanceOf[Expression]
+            val newReturnItem = returnItem.copy(expression = newExpression)(returnItem.position)
+            stack.push((jobs, doneJobs += newReturnItem))
+          case (job :: jobs, doneJobs) =>
+            val doneJob = job.dup(newChildren)
+            stack.push((jobs, doneJobs += doneJob))
+        }
+
+        tailrecApply(stack)
+      }
+    } else {
+      val (newJob :: jobs, doneJobs) = stack.pop()
+      val rewrittenJob = newJob.rewrite(inner)
+      stack.push((rewrittenJob :: jobs, doneJobs))
+      stack.push((rewrittenJob.children.toList, new mutable.MutableList()))
+      tailrecApply(stack)
+    }
+  }
+
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/IsolateAggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/IsolateAggregationTest.scala
@@ -38,34 +38,34 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
       "MATCH (n) WITH n.name AS `  AGGREGATION27`, count(*) AS `  AGGREGATION40` RETURN { name: `  AGGREGATION27`, count: `  AGGREGATION40` } AS result")
   }
 
-  test("MATCH n RETURN n.foo + count(*) AS result") {
+  test("MATCH (n) RETURN n.foo + count(*) AS result") {
     assertRewrite(
-      "MATCH n RETURN n.foo + count(*) AS result",
-      "MATCH n WITH n.foo AS `  AGGREGATION17`, count(*) AS `  AGGREGATION23` RETURN `  AGGREGATION17` + `  AGGREGATION23` AS result")
+      "MATCH (n) RETURN n.foo + count(*) AS result",
+      "MATCH (n) WITH n.foo AS `  AGGREGATION19`, count(*) AS `  AGGREGATION25` RETURN `  AGGREGATION19` + `  AGGREGATION25` AS result")
   }
 
-  test("MATCH n RETURN count(*)/60/42 AS result") {
+  test("MATCH (n) RETURN count(*)/60/42 AS result") {
     assertRewrite(
-      "MATCH n RETURN count(*)/60/42 AS result",
-      "MATCH n WITH count(*) AS `  AGGREGATION15` RETURN `  AGGREGATION15`/60/42 AS result")
+      "MATCH (n) RETURN count(*)/60/42 AS result",
+      "MATCH (n) WITH count(*) AS `  AGGREGATION17` RETURN `  AGGREGATION17`/60/42 AS result")
   }
 
-  test("MATCH n-->() RETURN (n)-->({k: count(*)}) AS result") {
+  test("MATCH (n)-->() RETURN (n)-->({k: count(*)}) AS result") {
     assertRewrite(
-      "MATCH n-->() RETURN (n)-->({k: count(*)}) AS result",
-      "MATCH n-->() WITH n, count(*) AS `  AGGREGATION31` RETURN (n)-->({k:`  AGGREGATION31`}) AS result")
+      "MATCH (n)-->() RETURN (n)-->({k: count(*)}) AS result",
+      "MATCH (n)-->() WITH n as `  AGGREGATION23`, count(*) AS `  AGGREGATION33` RETURN (`  AGGREGATION23`)-->({k:`  AGGREGATION33`}) AS result")
   }
 
-  test("MATCH n RETURN n.prop AS prop, n.foo + count(*) AS count") {
+  test("MATCH (n) RETURN n.prop AS prop, n.foo + count(*) AS count") {
     assertRewrite(
-      "MATCH n RETURN n.prop AS prop, n.foo + count(*) AS count",
-      "MATCH n WITH n.prop AS `  AGGREGATION17`, n.foo AS `  AGGREGATION33`, count(*) AS `  AGGREGATION39` RETURN `  AGGREGATION17` AS prop, `  AGGREGATION33` + `  AGGREGATION39` AS count")
+      "MATCH (n) RETURN n.prop AS prop, n.foo + count(*) AS count",
+      "MATCH (n) WITH n.prop AS `  AGGREGATION19`, n.foo AS `  AGGREGATION35`, count(*) AS `  AGGREGATION41` RETURN `  AGGREGATION19` AS prop, `  AGGREGATION35` + `  AGGREGATION41` AS count")
   }
 
-  test("MATCH n RETURN n AS n, count(n) + 3 AS count") {
+  test("MATCH (n) RETURN n AS n, count(n) + 3 AS count") {
     assertRewrite(
-      "MATCH n RETURN n AS n, count(n) + 3 AS count",
-      "MATCH n WITH n AS n, count(n) as `  AGGREGATION23`  RETURN n AS n, `  AGGREGATION23` + 3 AS count")
+      "MATCH (n) RETURN n AS n, count(n) + 3 AS count",
+      "MATCH (n) WITH n AS `  AGGREGATION17`, count(n) as `  AGGREGATION25`  RETURN `  AGGREGATION17` AS n, `  AGGREGATION25` + 3 AS count")
   }
 
   test("UNWIND [1,2,3] AS a RETURN reduce(y=0, x IN collect(a) | x) AS z") {
@@ -92,10 +92,10 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
       "UNWIND [1,2,3] AS a WITH collect(a) AS `  AGGREGATION33` RETURN [x IN `  AGGREGATION33` | x] AS z")
   }
 
-  test("MATCH n WITH 60/60/count(*) AS x RETURN x AS x") {
+  test("MATCH (n) WITH 60/60/count(*) AS x RETURN x AS x") {
     assertRewrite(
-      "MATCH n WITH 60/60/count(*) AS x RETURN x AS x",
-      "MATCH n WITH count(*) AS `  AGGREGATION19` WITH 60/60/`  AGGREGATION19` AS x RETURN x AS x")
+      "MATCH (n) WITH 60/60/count(*) AS x RETURN x AS x",
+      "MATCH (n) WITH count(*) AS `  AGGREGATION21` WITH 60/60/`  AGGREGATION21` AS x RETURN x AS x")
   }
 
   test("MATCH (a:Start)<-[:R]-(b) RETURN { foo:a.prop=42, bar:collect(b.prop2) } AS result") {
@@ -108,34 +108,34 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
         "RETURN { foo:`  AGGREGATION45`, bar:`  AGGREGATION54`} AS result")
   }
 
-  test("MATCH n RETURN count(*) + max(id(n)) AS r") {
+  test("MATCH (n) RETURN count(*) + max(id(n)) AS r") {
     assertRewrite(
-      "MATCH n RETURN count(*) + max(id(n)) AS r",
-      "MATCH n WITH count(*) AS `  AGGREGATION15`, max(id(n)) AS `  AGGREGATION26` RETURN `  AGGREGATION15`+`  AGGREGATION26` AS r")
+      "MATCH (n) RETURN count(*) + max(id(n)) AS r",
+      "MATCH (n) WITH count(*) AS `  AGGREGATION17`, max(id(n)) AS `  AGGREGATION28` RETURN `  AGGREGATION17`+`  AGGREGATION28` AS r")
   }
 
-  test("MATCH a RETURN length(collect(a)) AS length") {
+  test("MATCH (a) RETURN length(collect(a)) AS length") {
     assertRewrite(
-      "MATCH a RETURN length(collect(a)) AS length",
-      "MATCH a WITH collect(a) AS `  AGGREGATION22` RETURN length(`  AGGREGATION22`) AS length")
+      "MATCH (a) RETURN length(collect(a)) AS length",
+      "MATCH (a) WITH collect(a) AS `  AGGREGATION24` RETURN length(`  AGGREGATION24`) AS length")
   }
 
-  test("MATCH a RETURN count(a) > 0 AS bool") {
+  test("MATCH (a) RETURN count(a) > 0 AS bool") {
     assertRewrite(
-      "MATCH a RETURN count(a) > 0 AS bool",
-      "MATCH a WITH count(a) AS `  AGGREGATION15` RETURN `  AGGREGATION15` > 0 AS bool")
+      "MATCH (a) RETURN count(a) > 0 AS bool",
+      "MATCH (a) WITH count(a) AS `  AGGREGATION17` RETURN `  AGGREGATION17` > 0 AS bool")
   }
 
-  test("MATCH a RETURN count(a) > {param} AS bool") {
+  test("MATCH (a) RETURN count(a) > {param} AS bool") {
     assertRewrite(
-      "MATCH a RETURN count(a) > {param} AS bool",
-      "MATCH a WITH count(a) AS `  AGGREGATION15` RETURN `  AGGREGATION15` > {param} AS bool")
+      "MATCH (a) RETURN count(a) > {param} AS bool",
+      "MATCH (a) WITH count(a) AS `  AGGREGATION17` RETURN `  AGGREGATION17` > {param} AS bool")
   }
 
   test("should not introduce multiple return items for the same expression") {
     assertRewrite(
       "WITH 1 AS x, 2 AS y RETURN sum(x)*y AS a, sum(x)*y AS b",
-      "WITH 1 AS x, 2 AS y WITH sum(x) as `  AGGREGATION27`, y as y RETURN `  AGGREGATION27`*y AS a, `  AGGREGATION27`*y AS b")
+      "WITH 1 AS x, 2 AS y WITH sum(x) as `  AGGREGATION27`, y as `  AGGREGATION34` RETURN `  AGGREGATION27`* `  AGGREGATION34` AS a, `  AGGREGATION27`*`  AGGREGATION34` AS b")
   }
 
   test("MATCH (a), (b) RETURN coalesce(a.prop, b.prop), b.prop, { x: count(b) }") {
@@ -151,14 +151,14 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
         |       { x: `  AGGREGATION61` } AS `{ x: count(b) }`""".stripMargin)
   }
 
-  test("should not axtract expressions that do not contain on variables as implicit grouping key") {
+  test("should not extract expressions that do not contain on variables as implicit grouping key") {
     assertRewrite(
       """MATCH (user:User {userId: 11})-[friendship:FRIEND]-()
         |WITH user AS user, collect(friendship)[toInt(rand() * count(friendship))] AS selectedFriendship
         |RETURN id(selectedFriendship) AS friendshipId, selectedFriendship.propFive AS propertyValue""".stripMargin,
       """MATCH (user:User {userId: 11})-[friendship:FRIEND]-()
-        |WITH user AS user, collect(friendship) AS `  AGGREGATION73`, count(friendship) AS `  AGGREGATION108`
-        |WITH user AS user, `  AGGREGATION73`[toInt(rand() * `  AGGREGATION108`)] AS selectedFriendship
+        |WITH user AS `  AGGREGATION59`, collect(friendship) AS `  AGGREGATION73`, count(friendship) AS `  AGGREGATION108`
+        |WITH `  AGGREGATION59` AS user, `  AGGREGATION73`[toInt(rand() * `  AGGREGATION108`)] AS selectedFriendship
         |RETURN id(selectedFriendship) AS friendshipId, selectedFriendship.propFive AS propertyValue""".stripMargin
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ReturnItemSafeTopDownRewriterTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ReturnItemSafeTopDownRewriterTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v2_3.Rewriter
+import org.neo4j.cypher.internal.frontend.v2_3.ast._
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+
+class ReturnItemSafeTopDownRewriterTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  val rewriter = ReturnItemSafeTopDownRewriter(Rewriter.lift { case v@Identifier("foo") => Identifier("bar")(v.position) })
+
+  test("works with where") {
+    val original = Where(Equals(ident("foo"), literalInt(42))(pos))(pos)
+    val result = original.endoRewrite(rewriter)
+
+    result should equal(Where(Equals(ident("bar"), literalInt(42))(pos))(pos))
+  }
+
+  test("does not rewrite return item alias") {
+
+    def createWith(item: ReturnItem) = {
+      val returnItems = ReturnItems(includeExisting = false, Seq(item))(pos)
+      With(distinct = false, returnItems, None, None, None, None)(pos)
+    }
+
+
+    val originalReturnItem = AliasedReturnItem(Equals(ident("foo"), literalInt(42))(pos), ident("foo"))(pos)
+    val expectedReturnItem = AliasedReturnItem(Equals(ident("bar"), literalInt(42))(pos), ident("foo"))(pos)
+
+    createWith(originalReturnItem).endoRewrite(rewriter) should equal(createWith(expectedReturnItem))
+  }
+}

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/AstConstructionTestSupport.scala
@@ -37,4 +37,7 @@ trait AstConstructionTestSupport extends CypherTestSupport {
     val literal: Expression = SignedDecimalIntegerLiteral(intValue.toString)(pos)
     Equals(prop, literal)(pos)
   }
+
+  def literalInt(intValue: Int): SignedDecimalIntegerLiteral =
+    SignedDecimalIntegerLiteral(intValue.toString)(pos)
 }


### PR DESCRIPTION
The `isolateAggregation` rewriter was shaped up in `3.1` when
map projections were introduced. This commit backports the rewriter
updates to fix an issue that was fixed as part of that work.

changelog: Fix a bug where aliasing of aggregations caused queries to fail in semantic checking.
