### PR TITLE
set-initial-password does nothing if real users exist

### DIFF
--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -69,8 +69,9 @@ public class SetInitialPasswordCommandIT
     public void shouldSetPassword() throws Throwable
     {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "abc" );
-        verify( out ).stdOutLine( "Changed password for user 'neo4j'." );
         assertAuthIniFile( "abc" );
+
+        verify( out ).stdOutLine( "Changed password for user 'neo4j'." );
     }
 
     @Test
@@ -79,8 +80,9 @@ public class SetInitialPasswordCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "abc" );
         assertAuthIniFile( "abc" );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "muchBetter" );
-        verify( out, times( 2 ) ).stdOutLine( "Changed password for user 'neo4j'." );
         assertAuthIniFile( "muchBetter" );
+
+        verify( out, times( 2 ) ).stdOutLine( "Changed password for user 'neo4j'." );
     }
 
     @Test
@@ -89,8 +91,9 @@ public class SetInitialPasswordCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "neo4j" );
         assertAuthIniFile( "neo4j" );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "neo4j" );
-        verify( out, times( 2 ) ).stdOutLine( "Changed password for user 'neo4j'." );
         assertAuthIniFile( "neo4j" );
+
+        verify( out, times( 2 ) ).stdOutLine( "Changed password for user 'neo4j'." );
     }
 
     @Test
@@ -98,13 +101,33 @@ public class SetInitialPasswordCommandIT
     {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "foo", "bar" );
+        assertNoAuthIniFile();
+
         verify( out, times( 2 ) ).stdErrLine( "neo4j-admin set-initial-password <password>" );
         verify( out, times( 0 ) ).stdOutLine( anyString() );
     }
 
+    @Test
+    public void shouldDoNothingAndWarnIfRealUsersAlreadyExist() throws Throwable
+    {
+        // Given
+        File authFile = getAuthFile( "auth" );
+        fileSystem.mkdirs( authFile.getParentFile() );
+        fileSystem.create( authFile );
+
+        // When
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "will-be-ignored" );
+
+        // Then
+        assertNoAuthIniFile();
+        verify( out, times( 1 ) ).stdOutLine( "Warning: Initial password was not set because live Neo4j-users were " +
+                "detected, so the initial password has no effect." );
+        verify( out, times( 0 ) ).stdErrLine( anyString() );
+    }
+
     private void assertAuthIniFile(String password) throws Throwable
     {
-        File authIniFile = new File( new File( new File( homeDir, "data" ), "dbms" ), "auth.ini" );
+        File authIniFile = getAuthFile( "auth.ini" );
         assertTrue( fileSystem.fileExists( authIniFile ) );
         FileUserRepository userRepository = new FileUserRepository( fileSystem, authIniFile, NullLogProvider.getInstance() );
         userRepository.start();
@@ -112,6 +135,16 @@ public class SetInitialPasswordCommandIT
         assertNotNull( neo4j );
         assertTrue( neo4j.credentials().matchesPassword( password ) );
         assertFalse( neo4j.hasFlag( User.PASSWORD_CHANGE_REQUIRED ) );
+    }
+
+    private void assertNoAuthIniFile()
+    {
+        assertFalse( fileSystem.fileExists( getAuthFile( "auth.ini" ) ) );
+    }
+
+    private File getAuthFile( String name )
+    {
+        return new File( new File( new File( homeDir, "data" ), "dbms" ), name );
     }
 
     private void resetOutsideWorldMock()

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -26,7 +26,6 @@ import org.mockito.Mockito;
 
 import java.io.File;
 
-import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
@@ -48,6 +47,7 @@ public class SetInitialPasswordCommandTest
 {
     private SetInitialPasswordCommand setPasswordCommand;
     private File authInitFile;
+    private File authFile;
     private FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
 
     @Rule
@@ -61,6 +61,7 @@ public class SetInitialPasswordCommandTest
         setPasswordCommand = new SetInitialPasswordCommand( testDir.directory( "home" ).toPath(),
                 testDir.directory( "conf" ).toPath(), mock );
         authInitFile = CommunitySecurityModule.getInitialUserRepositoryFile( setPasswordCommand.loadNeo4jConfig() );
+        authFile = CommunitySecurityModule.getUserRepositoryFile( setPasswordCommand.loadNeo4jConfig() );
     }
 
     @Test
@@ -114,6 +115,21 @@ public class SetInitialPasswordCommandTest
 
         // Then
         assertAuthIniFile( "neo4j" );
+    }
+
+    @Test
+    public void shouldDoNothingIfAuthFileExists() throws Throwable
+    {
+        // Given
+        fileSystem.mkdirs( authFile.getParentFile() );
+        fileSystem.create( authFile );
+
+        // When
+        String[] arguments = {"neo4j"};
+        setPasswordCommand.execute( arguments );
+
+        // Then
+        assertFalse( fileSystem.fileExists( authInitFile ) );
     }
 
     private void assertAuthIniFile( String password ) throws Throwable


### PR DESCRIPTION
Neo4j-admin command `set-initial-password` does nothing if real users exist
- Gives warning to stdout that nothing was changed