### PR TITLE
Fix netty buffers leaks in CC message encoders

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -43,6 +43,7 @@ import org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
 import org.neo4j.causalclustering.catchup.storecopy.FileHeaderEncoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequest;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdRequestHandler;
+import org.neo4j.causalclustering.catchup.storecopy.GetStoreIdResponseEncoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestDecoder;
 import org.neo4j.causalclustering.catchup.storecopy.GetStoreRequestHandler;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponseEncoder;
@@ -147,6 +148,7 @@ public class CatchupServer extends LifecycleAdapter
 
                         pipeline.addLast( new TxPullResponseEncoder() );
                         pipeline.addLast( new CoreSnapshotEncoder() );
+                        pipeline.addLast( new GetStoreIdResponseEncoder() );
                         pipeline.addLast( new StoreCopyFinishedResponseEncoder() );
                         pipeline.addLast( new TxStreamFinishedResponseEncoder() );
                         pipeline.addLast( new FileHeaderEncoder() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -158,7 +158,8 @@ public class CatchupServer extends LifecycleAdapter
                         pipeline.addLast(
                                 new TxPullRequestHandler( protocol, storeIdSupplier, dataSourceAvailabilitySupplier,
                                         transactionIdStoreSupplier, logicalTransactionStoreSupplier, monitors,
-                                        logProvider ) ); pipeline.addLast( new ChunkedWriteHandler() );
+                                        logProvider ) );
+                        pipeline.addLast( new ChunkedWriteHandler() );
                         pipeline.addLast( new GetStoreRequestHandler( protocol, dataSourceSupplier,
                                 checkPointerSupplier ) );
                         pipeline.addLast( new GetStoreIdRequestHandler( protocol, storeIdSupplier ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestDecoderDispatcher.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.catchup;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +49,12 @@ class RequestDecoderDispatcher<E extends Enum<E>> extends ChannelInboundHandlerA
         if ( delegate == null )
         {
             log.warn( "Unregistered handler for protocol %s", protocol );
+
+            /*
+             * Since we cannot process this message further we need to release the message as per netty doc
+             * see http://netty.io/wiki/reference-counted-objects.html#inbound-messages
+             */
+            ReferenceCountUtil.release( msg );
             return;
         }
         delegate.channelRead( ctx, msg );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/RequestMessageTypeEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.catchup;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class RequestMessageTypeEncoder extends MessageToMessageEncoder<RequestMessageType>
+public class RequestMessageTypeEncoder extends MessageToByteEncoder<RequestMessageType>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, RequestMessageType request, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, RequestMessageType request, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeByte( request.messageType() );
-        out.add( encoded );
+        out.writeByte( request.messageType() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/ResponseMessageTypeEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.catchup;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class ResponseMessageTypeEncoder extends MessageToMessageEncoder<ResponseMessageType>
+public class ResponseMessageTypeEncoder extends MessageToByteEncoder<ResponseMessageType>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, ResponseMessageType response, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, ResponseMessageType response, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeByte( response.messageType() );
-        out.add( encoded );
+        out.writeByte( response.messageType() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/SimpleRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/SimpleRequestDecoder.java
@@ -28,6 +28,11 @@ import java.util.List;
 import org.neo4j.causalclustering.messaging.Message;
 import org.neo4j.function.Factory;
 
+/**
+ * This class extends {@link MessageToMessageDecoder} because if it extended
+ * {@link io.netty.handler.codec.ByteToMessageDecoder} instead the decode method would fail as no
+ * bytes are consumed from the ByteBuf but an object is added in the out list.
+ */
 class SimpleRequestDecoder extends MessageToMessageDecoder<ByteBuf>
 {
     private Factory<? extends Message> factory;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContentDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileContentDecoder.java
@@ -25,6 +25,12 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 
 import java.util.List;
 
+/**
+ * This class does not consume bytes during the decode method. Instead, it puts a {@link FileContent} object with
+ * a reference to the buffer, to be consumed later. This is the reason it does not extend
+ * {@link io.netty.handler.codec.ByteToMessageDecoder}, since that class fails if an object is added in the out
+ * list but no bytes have been consumed.
+ */
 public class FileContentDecoder extends MessageToMessageDecoder<ByteBuf>
 {
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderDecoder.java
@@ -21,11 +21,11 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-public class FileHeaderDecoder extends MessageToMessageDecoder<ByteBuf>
+public class FileHeaderDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileHeaderEncoder.java
@@ -19,25 +19,19 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class FileHeaderEncoder extends MessageToMessageEncoder<FileHeader>
+public class FileHeaderEncoder extends MessageToByteEncoder<FileHeader>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, FileHeader msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, FileHeader msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-
         String name = msg.fileName();
 
-        buffer.writeInt( name.length() );
-        buffer.writeBytes( name.getBytes() );
-        buffer.writeLong( msg.fileLength() );
-
-        out.add( buffer );
+        out.writeInt( name.length() );
+        out.writeBytes( name.getBytes() );
+        out.writeLong( msg.fileLength() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestEncoder.java
@@ -21,17 +21,13 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-import java.util.List;
-
-public class GetStoreIdRequestEncoder extends MessageToMessageEncoder<GetStoreIdRequest>
+public class GetStoreIdRequestEncoder extends MessageToByteEncoder<GetStoreIdRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, GetStoreIdRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, GetStoreIdRequest msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        buffer.writeByte( 0 );
-        out.add( buffer );
+        out.writeByte( 0 );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdRequestHandler.java
@@ -19,16 +19,14 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.function.Supplier;
-
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+
+import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
 import org.neo4j.causalclustering.catchup.ResponseMessageType;
 import org.neo4j.causalclustering.identity.StoreId;
-import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
-import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
 import static org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
 
@@ -46,11 +44,8 @@ public class GetStoreIdRequestHandler extends SimpleChannelInboundHandler<GetSto
     @Override
     protected void channelRead0( ChannelHandlerContext ctx, GetStoreIdRequest msg ) throws Exception
     {
-        StoreId storeId = storeIdSupplier.get();
         ctx.writeAndFlush( ResponseMessageType.STORE_ID );
-        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( ctx.alloc().buffer() );
-        StoreIdMarshal.INSTANCE.marshal( storeId, channel );
-        ctx.writeAndFlush( channel.buffer() );
+        ctx.writeAndFlush( storeIdSupplier.get() );
         protocol.expect( State.MESSAGE_TYPE );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class GetStoreIdResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class GetStoreIdResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreIdResponseEncoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
+import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
+
+public class GetStoreIdResponseEncoder extends MessageToByteEncoder<StoreId>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, StoreId storeId, ByteBuf out ) throws Exception
+    {
+        StoreIdMarshal.INSTANCE.marshal( storeId, new NetworkFlushableByteBuf( out ) );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class GetStoreRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+public class GetStoreRequestDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestEncoder.java
@@ -21,20 +21,16 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
-
-import java.util.List;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class GetStoreRequestEncoder extends MessageToMessageEncoder<GetStoreRequest>
+public class GetStoreRequestEncoder extends MessageToByteEncoder<GetStoreRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, GetStoreRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, GetStoreRequest msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        StoreIdMarshal.INSTANCE.marshal( msg.expectedStoreId(), new NetworkFlushableChannelNetty4( buffer ) );
-        out.add( buffer );
+        StoreIdMarshal.INSTANCE.marshal( msg.expectedStoreId(), new NetworkFlushableChannelNetty4( out ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseDecoder.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponse.Status;
 
-public class StoreCopyFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class StoreCopyFinishedResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyFinishedResponseEncoder.java
@@ -19,20 +19,16 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class StoreCopyFinishedResponseEncoder extends MessageToMessageEncoder<StoreCopyFinishedResponse>
+public class StoreCopyFinishedResponseEncoder extends MessageToByteEncoder<StoreCopyFinishedResponse>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, StoreCopyFinishedResponse msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, StoreCopyFinishedResponse msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        buffer.writeInt( msg.status().ordinal() );
-        buffer.writeLong( msg.lastCommittedTxBeforeStoreCopy() );
-        out.add( buffer );
-    }
+        out.writeInt( msg.status().ordinal() );
+        out.writeLong( msg.lastCommittedTxBeforeStoreCopy() );
+     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class TxPullRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxPullRequestDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullRequestEncoder.java
@@ -19,23 +19,19 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableChannelNetty4;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
 
-public class TxPullRequestEncoder extends MessageToMessageEncoder<TxPullRequest>
+public class TxPullRequestEncoder extends MessageToByteEncoder<TxPullRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxPullRequest request, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, TxPullRequest request, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeLong( request.previousTxId() );
-        StoreIdMarshal.INSTANCE.marshal( request.expectedStoreId(), new NetworkFlushableChannelNetty4( encoded ) );
-        out.add( encoded );
+        out.writeLong( request.previousTxId() );
+        StoreIdMarshal.INSTANCE.marshal( request.expectedStoreId(), new NetworkFlushableChannelNetty4( out ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 
-public class TxPullResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxPullResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullResponseEncoder.java
@@ -19,26 +19,21 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-import org.neo4j.com.CommittedTransactionSerializer;
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 import org.neo4j.causalclustering.messaging.marshalling.storeid.StoreIdMarshal;
+import org.neo4j.com.CommittedTransactionSerializer;
 
-public class TxPullResponseEncoder extends MessageToMessageEncoder<TxPullResponse>
+public class TxPullResponseEncoder extends MessageToByteEncoder<TxPullResponse>
 {
-
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxPullResponse response, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, TxPullResponse response, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( encoded );
+        NetworkFlushableByteBuf channel = new NetworkFlushableByteBuf( out );
         StoreIdMarshal.INSTANCE.marshal( response.storeId(), channel );
         new CommittedTransactionSerializer( channel ).visit( response.tx() );
-        out.add( encoded );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseDecoder.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.catchup.tx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.catchup.CatchupResult;
 
-public class TxStreamFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+public class TxStreamFinishedResponseDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxStreamFinishedResponseEncoder.java
@@ -19,20 +19,16 @@
  */
 package org.neo4j.causalclustering.catchup.tx;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class TxStreamFinishedResponseEncoder extends MessageToMessageEncoder<TxStreamFinishedResponse>
+public class TxStreamFinishedResponseEncoder extends MessageToByteEncoder<TxStreamFinishedResponse>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, TxStreamFinishedResponse response, List<Object> out ) throws
+    protected void encode( ChannelHandlerContext ctx, TxStreamFinishedResponse response, ByteBuf out ) throws
             Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        encoded.writeInt( response.status().ordinal() );
-        out.add( encoded );
+        out.writeInt( response.status().ordinal() );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotDecoder.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.core.state.snapshot;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import org.neo4j.causalclustering.messaging.NetworkReadableClosableChannelNetty4;
 
-public class CoreSnapshotDecoder extends MessageToMessageDecoder<ByteBuf>
+public class CoreSnapshotDecoder extends ByteToMessageDecoder
 {
     @Override
     protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotEncoder.java
@@ -19,21 +19,17 @@
  */
 package org.neo4j.causalclustering.core.state.snapshot;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 import org.neo4j.causalclustering.messaging.NetworkFlushableByteBuf;
 
-public class CoreSnapshotEncoder extends MessageToMessageEncoder<CoreSnapshot>
+public class CoreSnapshotEncoder extends MessageToByteEncoder<CoreSnapshot>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, CoreSnapshot coreSnapshot, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, CoreSnapshot coreSnapshot, ByteBuf out ) throws Exception
     {
-        ByteBuf encoded = ctx.alloc().buffer();
-        new CoreSnapshot.Marshal().marshal( coreSnapshot, new NetworkFlushableByteBuf( encoded ) );
-        out.add( encoded );
+        new CoreSnapshot.Marshal().marshal( coreSnapshot, new NetworkFlushableByteBuf( out ) );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreSnapshotRequestEncoder.java
@@ -19,19 +19,15 @@
  */
 package org.neo4j.causalclustering.core.state.snapshot;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.MessageToByteEncoder;
 
-public class CoreSnapshotRequestEncoder extends MessageToMessageEncoder<CoreSnapshotRequest>
+public class CoreSnapshotRequestEncoder extends MessageToByteEncoder<CoreSnapshotRequest>
 {
     @Override
-    protected void encode( ChannelHandlerContext ctx, CoreSnapshotRequest msg, List<Object> out ) throws Exception
+    protected void encode( ChannelHandlerContext ctx, CoreSnapshotRequest msg, ByteBuf out ) throws Exception
     {
-        ByteBuf buffer = ctx.alloc().buffer();
-        buffer.writeByte( 0 );
-        out.add( buffer );
+        out.writeByte( 0 );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.messaging.marshalling;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,7 +44,7 @@ import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.NEW_EN
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_REQUEST;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_RESPONSE;
 
-public class RaftMessageDecoder extends MessageToMessageDecoder<ByteBuf>
+public class RaftMessageDecoder extends ByteToMessageDecoder
 {
     private final ChannelMarshal<ReplicatedContent> marshal;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/storeid/StoreIdMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/storeid/StoreIdMarshal.java
@@ -51,7 +51,6 @@ public final class StoreIdMarshal extends SafeChannelMarshal<StoreId>
 
     protected StoreId unmarshal0( ReadableChannel channel ) throws IOException
     {
-
         byte exists = channel.get();
         if ( exists == 0 )
         {
@@ -59,7 +58,7 @@ public final class StoreIdMarshal extends SafeChannelMarshal<StoreId>
         }
         else if ( exists != 1 )
         {
-            throw new DecoderException( "Unexpected value" );
+            throw new DecoderException( "Unexpected value: " + exists );
         }
 
         long creationTime = channel.getLong();


### PR DESCRIPTION
This is a more conservative version of https://github.com/neo4j/neo4j/pull/8273, where some decoders are left as MessageToMessageDecoders, removing all "manual" buffer allocations but leaving all store copy handling code as is.