### PR TITLE
Support for default admin on upgrade

### DIFF
--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -45,13 +45,13 @@ import org.neo4j.server.security.auth.UserRepository;
 public class SetDefaultAdminCommand implements AdminCommand
 {
     public static final String ADMIN_INI = "admin.ini";
+    public static final String COMMAND_NAME = "set-default-admin";
 
     public static class Provider extends AdminCommand.Provider
     {
-
         public Provider()
         {
-            super( "set-default-admin" );
+            super( COMMAND_NAME );
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin.security;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.configuration.ConfigLoader;
+import org.neo4j.server.security.auth.CommunitySecurityModule;
+import org.neo4j.server.security.auth.Credential;
+import org.neo4j.server.security.auth.FileUserRepository;
+import org.neo4j.server.security.auth.User;
+import org.neo4j.server.security.auth.UserRepository;
+
+public class SetDefaultAdminCommand implements AdminCommand
+{
+    public static final String ADMIN_INI = "admin.ini";
+
+    public static class Provider extends AdminCommand.Provider
+    {
+
+        public Provider()
+        {
+            super( "set-default-admin" );
+        }
+
+        @Override
+        public Optional<String> arguments()
+        {
+            return Optional.of( "<username>" );
+        }
+
+        @Override
+        public String description()
+        {
+            return "Sets the user to become admin if users but no roles are present, " +
+                    "for example when upgrading to neo4j 3.1 enterprise.";
+        }
+
+        @Override
+        public String summary()
+        {
+            return description();
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new SetDefaultAdminCommand( homeDir, configDir, outsideWorld );
+        }
+    }
+
+    private final Path homeDir;
+    private final Path configDir;
+    private OutsideWorld outsideWorld;
+
+    SetDefaultAdminCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+        this.outsideWorld = outsideWorld;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        Args parsedArgs = validateArgs(args);
+
+        try
+        {
+            setDefaultAdmin( parsedArgs.orphans().get( 0 ) );
+        }
+        catch ( IncorrectUsage e )
+        {
+            throw e;
+        }
+        catch ( Throwable throwable )
+        {
+            throw new CommandFailed( "Failed to execute 'set-default-admin' command: " + throwable.getMessage(),
+                    new RuntimeException( throwable ) );
+        }
+    }
+
+    private Args validateArgs( String[] args ) throws IncorrectUsage
+    {
+        Args parsedArgs = Args.parse( args );
+        if ( parsedArgs.orphans().size() < 1 )
+        {
+            throw new IncorrectUsage( "No username specified." );
+        }
+        if ( parsedArgs.orphans().size() > 1 )
+        {
+            throw new IncorrectUsage( "Too many arguments." );
+        }
+        return parsedArgs;
+    }
+
+    private void setDefaultAdmin( String username ) throws Throwable
+    {
+        Config config = loadNeo4jConfig();
+        File adminIniFile = new File( CommunitySecurityModule.getUserRepositoryFile( config ).getParentFile(),
+                ADMIN_INI );
+        FileSystemAbstraction fileSystem = outsideWorld.fileSystem();
+        if ( fileSystem.fileExists( adminIniFile ) )
+        {
+            fileSystem.deleteFile( adminIniFile );
+        }
+        UserRepository users = new FileUserRepository( fileSystem, adminIniFile, NullLogProvider.getInstance() );
+        users.init();
+        users.start();
+        users.create( new User.Builder( username, Credential.INACCESSIBLE ).build() );
+        users.stop();
+        users.shutdown();
+
+        outsideWorld.stdOutLine( "Set default admin to '" + username + "'." );
+    }
+
+    Config loadNeo4jConfig()
+    {
+        ConfigLoader configLoader = new ConfigLoader( settings() );
+        return configLoader.loadOfflineConfig(
+                Optional.of( homeDir.toFile() ),
+                Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) );
+    }
+
+    private static List<Class<?>> settings()
+    {
+        List<Class<?>> settings = new ArrayList<>();
+        settings.add( GraphDatabaseSettings.class );
+        settings.add( DatabaseManagementSystemSettings.class );
+        return settings;
+    }
+}

--- a/community/security/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/security/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,1 +1,2 @@
 org.neo4j.commandline.admin.security.SetInitialPasswordCommand$Provider
+org.neo4j.commandline.admin.security.SetDefaultAdminCommand$Provider

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin.security;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.commandline.admin.AdminTool;
+import org.neo4j.commandline.admin.CommandLocator;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.security.auth.FileUserRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SetDefaultAdminCommandIT
+{
+    private FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+    private File confDir;
+    private File homeDir;
+    private OutsideWorld out;
+    private AdminTool tool;
+
+    private static final String SET_ADMIN = "set-default-admin";
+
+    @Before
+    public void setup()
+    {
+        File graphDir = new File( "graph-db" );
+        confDir = new File( graphDir, "conf" );
+        homeDir = new File( graphDir, "home" );
+        out = mock( OutsideWorld.class );
+        resetOutsideWorldMock();
+        tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
+    }
+
+    @Test
+    public void shouldSetDefaultAdmin() throws Throwable
+    {
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
+        assertAdminIniFile( "jane" );
+
+        verify( out ).stdOutLine( "Set default admin to 'jane'." );
+    }
+
+    @Test
+    public void shouldOverwrite() throws Throwable
+    {
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
+        assertAdminIniFile( "jane" );
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "janette" );
+        assertAdminIniFile( "janette" );
+
+        verify( out ).stdOutLine( "Set default admin to 'jane'." );
+        verify( out ).stdOutLine( "Set default admin to 'janette'." );
+    }
+
+    @Test
+    public void shouldGetUsageOnWrongArguments() throws Throwable
+    {
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN );
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "foo", "bar" );
+        assertNoAuthIniFile();
+
+        verify( out, times( 2 ) ).stdErrLine( "neo4j-admin set-default-admin <username>" );
+        verify( out, times( 0 ) ).stdOutLine( anyString() );
+    }
+
+    private void assertAdminIniFile( String username ) throws Throwable
+    {
+        File adminIniFile = getAuthFile( SetDefaultAdminCommand.ADMIN_INI );
+        assertTrue( fileSystem.fileExists( adminIniFile ) );
+        FileUserRepository userRepository = new FileUserRepository( fileSystem, adminIniFile,
+                NullLogProvider.getInstance() );
+        userRepository.start();
+        assertThat( userRepository.getAllUsernames(), containsInAnyOrder( username ) );
+    }
+
+    private void assertNoAuthIniFile()
+    {
+        assertFalse( fileSystem.fileExists( getAuthFile( SetDefaultAdminCommand.ADMIN_INI ) ) );
+    }
+
+    private File getAuthFile( String name )
+    {
+        return new File( new File( new File( homeDir, "data" ), "dbms" ), name );
+    }
+
+    private void resetOutsideWorldMock()
+    {
+        reset(out);
+        when( out.fileSystem() ).thenReturn( fileSystem );
+    }
+}

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.io.File;
 
 import org.neo4j.commandline.admin.AdminTool;
+import org.neo4j.commandline.admin.BlockerLocator;
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
@@ -61,7 +62,7 @@ public class SetDefaultAdminCommandIT
         homeDir = new File( graphDir, "home" );
         out = mock( OutsideWorld.class );
         resetOutsideWorldMock();
-        tool = new AdminTool( CommandLocator.fromServiceLocator(), out, true );
+        tool = new AdminTool( CommandLocator.fromServiceLocator(), BlockerLocator.fromServiceLocator(), out, true );
     }
 
     @Test

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.admin.security;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.security.auth.CommunitySecurityModule;
+import org.neo4j.server.security.auth.Credential;
+import org.neo4j.server.security.auth.FileUserRepository;
+import org.neo4j.server.security.auth.User;
+import org.neo4j.server.security.auth.UserRepository;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.neo4j.test.assertion.Assert.assertException;
+
+public class SetDefaultAdminCommandTest
+{
+    private SetDefaultAdminCommand setDefaultAdmin;
+    private File adminIniFile;
+    private FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+    private Config config;
+
+    @Rule
+    public TestDirectory testDir = TestDirectory.testDirectory( fileSystem );
+    private UserRepository users;
+
+    @Before
+    public void setup() throws IOException, InvalidArgumentsException
+    {
+        OutsideWorld mock = Mockito.mock( OutsideWorld.class );
+        when( mock.fileSystem() ).thenReturn( fileSystem );
+        setDefaultAdmin = new SetDefaultAdminCommand( testDir.directory( "home" ).toPath(),
+                testDir.directory( "conf" ).toPath(), mock );
+        config = setDefaultAdmin.loadNeo4jConfig();
+        users = CommunitySecurityModule.getUserRepository( config, NullLogProvider.getInstance(), fileSystem );
+        users.create(
+                new User.Builder( "jake", Credential.forPassword( "123" ) )
+                        .withRequiredPasswordChange( false )
+                        .build()
+            );
+        adminIniFile = new File( CommunitySecurityModule.getUserRepositoryFile( config ).getParentFile(), "admin.ini" );
+    }
+
+    @Test
+    public void shouldFailForNoArguments() throws Exception
+    {
+        assertException( () -> setDefaultAdmin.execute( new String[0] ), IncorrectUsage.class,
+                "No username specified." );
+    }
+
+    @Test
+    public void shouldFailForTooManyArguments() throws Exception
+    {
+        String[] arguments = {"", "123", "321"};
+        assertException( () -> setDefaultAdmin.execute( arguments ), IncorrectUsage.class, "Too many arguments." );
+    }
+
+    @Test
+    public void shouldSetDefaultAdmin() throws Throwable
+    {
+        // Given
+        assertFalse( fileSystem.fileExists( adminIniFile ) );
+
+        // When
+        String[] arguments = {"jake"};
+        setDefaultAdmin.execute( arguments );
+
+        // Then
+        assertAdminIniFile( "jake" );
+    }
+
+    @Test
+    public void shouldSetDefaultAdminEvenForNonExistentUser() throws Throwable
+    {
+        // Given
+        assertFalse( fileSystem.fileExists( adminIniFile ) );
+
+        // When
+        String[] arguments = {"noName"};
+        setDefaultAdmin.execute( arguments );
+
+        // Then
+        assertAdminIniFile( "noName" );
+    }
+
+    private void assertAdminIniFile( String username ) throws Throwable
+    {
+        assertTrue( fileSystem.fileExists( adminIniFile ) );
+        FileUserRepository userRepository = new FileUserRepository( fileSystem, adminIniFile,
+            NullLogProvider.getInstance() );
+        userRepository.start();
+        assertThat( userRepository.getAllUsernames(), containsInAnyOrder( username ) );
+    }
+}

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -38,11 +38,13 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.commandline.admin.security.SetDefaultAdminCommand;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
@@ -78,6 +80,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final UserRepository initialUserRepository;
+    private final UserRepository defaultAdminRepository;
     private final PasswordPolicy passwordPolicy;
     private final AuthenticationStrategy authenticationStrategy;
     private final boolean authenticationEnabled;
@@ -87,16 +90,17 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
 
     public InternalFlatFileRealm( UserRepository userRepository, RoleRepository roleRepository,
             PasswordPolicy passwordPolicy, AuthenticationStrategy authenticationStrategy,
-            JobScheduler jobScheduler, UserRepository initialUserRepository )
+            JobScheduler jobScheduler, UserRepository initialUserRepository,
+            UserRepository defaultAdminRepository)
     {
         this( userRepository, roleRepository, passwordPolicy, authenticationStrategy, true, true,
-                jobScheduler, initialUserRepository );
+                jobScheduler, initialUserRepository, defaultAdminRepository );
     }
 
     InternalFlatFileRealm( UserRepository userRepository, RoleRepository roleRepository,
             PasswordPolicy passwordPolicy, AuthenticationStrategy authenticationStrategy,
             boolean authenticationEnabled, boolean authorizationEnabled, JobScheduler jobScheduler,
-            UserRepository initialUserRepository )
+            UserRepository initialUserRepository, UserRepository defaultAdminRepository )
     {
         super();
 
@@ -104,6 +108,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.initialUserRepository = initialUserRepository;
+        this.defaultAdminRepository = defaultAdminRepository;
         this.passwordPolicy = passwordPolicy;
         this.authenticationStrategy = authenticationStrategy;
         this.authenticationEnabled = authenticationEnabled;
@@ -121,6 +126,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     public void initialize() throws Throwable
     {
         initialUserRepository.init();
+        defaultAdminRepository.init();
         userRepository.init();
         roleRepository.init();
     }
@@ -129,6 +135,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     public void start() throws Throwable
     {
         initialUserRepository.start();
+        defaultAdminRepository.start();
         userRepository.start();
         roleRepository.start();
 
@@ -231,14 +238,48 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     {
         if ( authenticationEnabled || authorizationEnabled )
         {
+            List<String> newAdmins = new LinkedList<>( addedDefaultUsers );
+
             if ( numberOfRoles() == 0 )
             {
                 for ( String role : PredefinedRolesBuilder.roles.keySet() )
                 {
                     newRole( role );
                 }
+
+                if ( newAdmins.isEmpty() )
+                {
+                    Set<String> usernames = userRepository.getAllUsernames();
+                    if ( defaultAdminRepository.numberOfUsers() > 0 )
+                    {
+                        // We currently support only one default admin
+                        String newAdminUsername = defaultAdminRepository.getAllUsernames().iterator().next();
+                        if ( userRepository.getUserByName( newAdminUsername ) == null )
+                        {
+                            throw new InvalidArgumentsException(
+                                    "No roles defined, and default admin user '" + newAdminUsername + "' does not exist. " +
+                                    "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+                        }
+                        newAdmins.addAll( defaultAdminRepository.getAllUsernames() );
+                    }
+                    else if ( usernames.size() == 1 )
+                    {
+                        newAdmins.add( usernames.iterator().next() );
+                    }
+                    else if ( usernames.contains( INITIAL_USER_NAME ) )
+                    {
+                        newAdmins.add( INITIAL_USER_NAME );
+                    }
+                    else
+                    {
+                        throw new InvalidArgumentsException(
+                                "No roles defined, and cannot determine which user should be admin. " +
+                                "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
+                    }
+                }
             }
-            for ( String username : addedDefaultUsers )
+
+            for ( String username : newAdmins )
             {
                 addRoleToUser( PredefinedRoles.ADMIN, username );
             }
@@ -249,6 +290,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     public void stop() throws Throwable
     {
         initialUserRepository.stop();
+        defaultAdminRepository.stop();
         userRepository.stop();
         roleRepository.stop();
 
@@ -263,6 +305,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     public void shutdown() throws Throwable
     {
         initialUserRepository.shutdown();
+        defaultAdminRepository.shutdown();
         userRepository.shutdown();
         roleRepository.shutdown();
         setCacheManager( null );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmIT.java
@@ -79,11 +79,13 @@ public class InternalFlatFileRealmIT
         final RoleRepository roleRepository = new FileRoleRepository( fs, roleStoreFile, logProvider );
         final UserRepository initialUserRepository = CommunitySecurityModule.getInitialUserRepository( Config
                 .defaults(), logProvider, fs );
+        final UserRepository defaultAdminRepository = EnterpriseSecurityModule.getDefaultAdminRepository( Config
+                .defaults(), logProvider, fs );
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
         AuthenticationStrategy authenticationStrategy = new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 );
 
         realm = new InternalFlatFileRealm( userRepository, roleRepository, passwordPolicy, authenticationStrategy,
-                        true, true, jobScheduler, initialUserRepository );
+                        true, true, jobScheduler, initialUserRepository, defaultAdminRepository );
         realm.init();
         realm.start();
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -74,6 +74,7 @@ public class InternalFlatFileRealmTest
                         new BasicPasswordPolicy(),
                         new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ),
                         mock( JobScheduler.class ),
+                        new InMemoryUserRepository(),
                         new InMemoryUserRepository()
                     );
 
@@ -136,6 +137,7 @@ public class InternalFlatFileRealmTest
         final UserRepository userRepository = mock( UserRepository.class );
         final RoleRepository roleRepository = mock( RoleRepository.class );
         final UserRepository initialUserRepository = mock( UserRepository.class );
+        final UserRepository defaultAdminRepository = mock( UserRepository.class );
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
         AuthenticationStrategy authenticationStrategy = new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 );
         InternalFlatFileRealmIT.TestJobScheduler jobScheduler = new InternalFlatFileRealmIT.TestJobScheduler();
@@ -146,7 +148,8 @@ public class InternalFlatFileRealmTest
                         passwordPolicy,
                         authenticationStrategy,
                         jobScheduler,
-                        initialUserRepository
+                        initialUserRepository,
+                        defaultAdminRepository
                     );
 
         when( userRepository.getPersistedSnapshot() ).thenReturn(
@@ -172,9 +175,10 @@ public class InternalFlatFileRealmTest
 
         public TestRealm( UserRepository userRepository, RoleRepository roleRepository, PasswordPolicy passwordPolicy,
                 AuthenticationStrategy authenticationStrategy, JobScheduler jobScheduler,
-                UserRepository initialUserRepository )
+                UserRepository initialUserRepository, UserRepository defaultAdminRepository )
         {
-            super( userRepository, roleRepository, passwordPolicy, authenticationStrategy, jobScheduler, initialUserRepository );
+            super( userRepository, roleRepository, passwordPolicy, authenticationStrategy, jobScheduler,
+                    initialUserRepository, defaultAdminRepository );
         }
 
         boolean takeAuthenticationFlag()

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -72,6 +72,7 @@ public class LdapCachingTest
                 new BasicPasswordPolicy(),
                 new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ),
                 mock( JobScheduler.class ),
+                new InMemoryUserRepository(),
                 new InMemoryUserRepository()
             );
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -76,6 +76,7 @@ public class MultiRealmAuthManagerRule implements TestRule
                         new BasicPasswordPolicy(),
                         authStrategy,
                         mock( JobScheduler.class ),
+                        new InMemoryUserRepository(),
                         new InMemoryUserRepository()
                     );
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
@@ -85,6 +85,7 @@ public class UserManagementProceduresLoggingTest
                                             new BasicPasswordPolicy(),
                                             mock( AuthenticationStrategy.class ),
                                             mock( JobScheduler.class ),
+                                            new InMemoryUserRepository(),
                                             new InMemoryUserRepository()
                                         );
         realm.start(); // creates default user and roles

--- a/integrationtests/src/test/java/org/neo4j/auth/FlatFileStressBase.java
+++ b/integrationtests/src/test/java/org/neo4j/auth/FlatFileStressBase.java
@@ -87,7 +87,8 @@ abstract class FlatFileStressBase
                 new BasicPasswordPolicy(),
                 new RateLimitedAuthenticationStrategy( Clock.systemUTC(), 3 ),
                 jobScheduler,
-                CommunitySecurityModule.getInitialUserRepository( config, logProvider, getFileSystem() )
+                CommunitySecurityModule.getInitialUserRepository( config, logProvider, getFileSystem() ),
+                EnterpriseSecurityModule.getDefaultAdminRepository( config, logProvider, getFileSystem() )
             );
 
         flatFileRealm.init();


### PR DESCRIPTION
When upgrading from community edition to enterprise edition with existing users, 
we need support for selecting one of them as `admin`.

The default admin will be selected in the following order:
- An existing user set with the admin command `set-default-admin`
- The only existing (single) user
- An existing user named `neo4j` among several existing users

Otherwise we will fail hard with an error message advising you to run `set-default-admin`.

changelog: Added `neo4j-admin set-default-admin` command for selecting default admin when upgrading from multi-user community to enterprise