### PR TITLE
Add common arguments parsing logic to neo4j-admin

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/Util.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/Util.java
@@ -17,10 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.commandline.dbms;
+package org.neo4j.commandline;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -31,6 +33,28 @@ import static java.lang.String.format;
 
 public class Util
 {
+    public static Path canonicalPath( Path path ) throws IllegalArgumentException
+    {
+        return canonicalPath( path.toFile() );
+    }
+
+    public static Path canonicalPath( String path ) throws IllegalArgumentException
+    {
+        return canonicalPath( new File( path ) );
+    }
+
+    public static Path canonicalPath( File file ) throws IllegalArgumentException
+    {
+        try
+        {
+            return Paths.get( file.getCanonicalPath() );
+        }
+        catch ( IOException e )
+        {
+            throw new IllegalArgumentException( "Unable to parse path: " + file, e );
+        }
+    }
+
     public static void checkLock( Path databaseDirectory ) throws CommandFailed
     {
         try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -20,6 +20,8 @@
 package org.neo4j.commandline.admin;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import org.neo4j.commandline.arguments.Arguments;
@@ -62,7 +64,16 @@ public interface AdminCommand
         /**
          * @return The arguments this command accepts.
          */
-        public abstract Arguments arguments();
+        public abstract Arguments allArguments();
+
+        /**
+         *
+         * @return A list of possibly mutually-exclusive argument sets for this command.
+         */
+        public List<Arguments> possibleArguments()
+        {
+            return Arrays.asList( allArguments() );
+        }
 
         /**
          * @return A single-line summary for the command. Should be 70 characters or less.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommand.java
@@ -20,9 +20,9 @@
 package org.neo4j.commandline.admin;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 
+import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.Iterables;
 
@@ -60,9 +60,9 @@ public interface AdminCommand
         }
 
         /**
-         * @return A help string for the command's arguments, if any.
+         * @return The arguments this command accepts.
          */
-        public abstract Optional<String> arguments();
+        public abstract Arguments arguments();
 
         /**
          * @return A single-line summary for the command. Should be 70 characters or less.

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -115,6 +115,7 @@ public class AdminTool
     private void badUsage( AdminCommand.Provider command, IncorrectUsage e )
     {
         outsideWorld.stdErrLine( e.getMessage() );
+        outsideWorld.stdErrLine( "" );
         usage.printUsageForCommand( command, outsideWorld::stdErrLine );
         failure();
     }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -21,8 +21,9 @@ package org.neo4j.commandline.admin;
 
 import java.nio.file.Path;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.function.Consumer;
+
+import org.neo4j.commandline.arguments.Arguments;
 
 import static java.lang.String.format;
 
@@ -39,9 +40,9 @@ public class HelpCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "[<command>]" );
+            return new Arguments().withOptionalPositionalArgument( 0, "command" );
         }
 
         @Override

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -40,7 +40,7 @@ public class HelpCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return new Arguments().withOptionalPositionalArgument( 0, "command" );
         }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -82,13 +82,16 @@ public class Usage
 
         public void printDetailed( Consumer<String> output )
         {
-            Arguments arguments = command.arguments();
+            for (Arguments arguments: command.possibleArguments())
+            {
+                //Arguments arguments = command.arguments();
 
-            String left = format( "usage: %s %s", scriptName, command.name() );
+                String left = format( "usage: %s %s", scriptName, command.name() );
 
-            output.accept( Arguments.rightColumnFormatted( left, arguments.usage(), left.length() + 1 ) );
+                output.accept( Arguments.rightColumnFormatted( left, arguments.usage(), left.length() + 1 ) );
+            }
             output.accept( "" );
-            output.accept( arguments.description( command.description() ) );
+            output.accept( command.allArguments().description( command.description() ) );
         }
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -21,8 +21,9 @@ package org.neo4j.commandline.admin;
 
 import java.util.function.Consumer;
 
+import org.neo4j.commandline.arguments.Arguments;
+
 import static java.lang.String.format;
-import static org.neo4j.helpers.Args.splitLongLine;
 
 public class Usage
 {
@@ -37,9 +38,9 @@ public class Usage
 
     public void print( Consumer<String> output )
     {
-        output.accept( format( "Usage: %s <command>", scriptName ) );
+        output.accept( format( "usage: %s <command>", scriptName ) );
         output.accept( "" );
-        output.accept( "Available commands:" );
+        output.accept( "available commands:" );
 
         for ( AdminCommand.Provider command : commands.getAllProviders() )
         {
@@ -81,9 +82,13 @@ public class Usage
 
         public void printDetailed( Consumer<String> output )
         {
-            output.accept( format( "%s %s %s", scriptName, command.name(), command.arguments().orElse( "" ) ) );
+            Arguments arguments = command.arguments();
+
+            String left = format( "usage: %s %s", scriptName, command.name() );
+
+            output.accept( Arguments.rightColumnFormatted( left, arguments.usage(), left.length() + 1 ) );
             output.accept( "" );
-            output.accept( command.description() );
+            output.accept( arguments.description( command.description() ) );
         }
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.neo4j.commandline.arguments.common.Database;
+import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
+import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
+
+/**
+ * Builder class for constructing a suitable arguments-string for displaying in help messages and alike.
+ * Some common arguments have convenience functions.
+ */
+public class Arguments
+{
+    public static final Arguments NO_ARGS = new Arguments();
+    public static final int LINE_LENGTH = 80;
+    private final Map<String,NamedArgument> namedArgs;
+    private final ArrayList<PositionalArgument> positionalArgs;
+
+    public Arguments()
+    {
+        namedArgs = new LinkedHashMap<>();
+        positionalArgs = new ArrayList<>();
+    }
+
+    public Arguments withDatabase()
+    {
+        return withArgument( new Database() );
+    }
+
+    public Arguments withAdditionalConfig()
+    {
+        return withArgument( new OptionalCanonicalPath( "additional-config", "config-file-path", "",
+                "Configuration file to supply additional configuration in." ) );
+    }
+
+    public Arguments withTo( String description )
+    {
+        return withArgument( new MandatoryCanonicalPath( "to", "destination-path", description ) );
+    }
+
+    public Arguments withOptionalPositionalArgument( int position, String value )
+    {
+        return withPositionalArgument( new OptionalPositionalArgument( position, value ) );
+    }
+
+    public Arguments withMandatoryPositionalArgument( int position, String value )
+    {
+        return withPositionalArgument( new MandatoryPositionalArgument( position, value ) );
+    }
+
+    public Arguments withArgument( NamedArgument namedArgument )
+    {
+        namedArgs.put( namedArgument.name(), namedArgument );
+        return this;
+    }
+
+    public Arguments withPositionalArgument( PositionalArgument arg )
+    {
+        positionalArgs.add( arg );
+        return this;
+    }
+
+    public String usage()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        if ( !namedArgs.isEmpty() )
+        {
+            sb.append( namedArgs.values().stream().map( NamedArgument::usage ).collect( Collectors.joining( " " ) ) );
+        }
+
+        if ( !positionalArgs.isEmpty() )
+        {
+            sb.append( " " );
+            positionalArgs.sort( ( l, r ) -> Integer.compare( l.position(), r.position() ) );
+            sb.append( positionalArgs.stream().map( a -> a.usage() ).collect( Collectors.joining( " " ) ) );
+        }
+
+        return sb.toString().trim();
+    }
+
+    public String description( String text )
+    {
+        String wrappedText = WordUtils.wrap( text, LINE_LENGTH );
+        if ( namedArgs.isEmpty() )
+        {
+            return wrappedText;
+        }
+
+        wrappedText = String.join( "\n\n", wrappedText, "options:" );
+
+        //noinspection OptionalGetWithoutIsPresent handled by if-statement above
+        final int alignLength = namedArgs.values().stream().map( NamedArgument::alignmentLength ).reduce( 0,
+                Integer::max );
+
+        return String.join( "\n", wrappedText,
+                namedArgs.values().stream()
+                        .map( c -> formatArgumentDescription( alignLength, c ) )
+                        .collect( Collectors.joining( "\n" ) ) );
+    }
+
+    public String formatArgumentDescription( final int longestAlignmentLength, final NamedArgument argument )
+    {
+        final String left = String.format( "  --%s=<%s>", argument.name(), argument.exampleValue() );
+        final String right;
+        if ( argument instanceof OptionalNamedArg )
+        {
+            right = String.format( "%s [default:%s]", argument.description(),
+                    ((OptionalNamedArg) argument).defaultValue() );
+        }
+        else
+        {
+            right = argument.description();
+        }
+        return rightColumnFormatted( left, right, longestAlignmentLength + 5 );
+    }
+
+    public static String rightColumnFormatted( final String leftText, final String rightText, int rightAlignIndex )
+    {
+        int rightWidth = Arguments.LINE_LENGTH - rightAlignIndex;
+        boolean startOnNewLine = false;
+        if ( rightWidth < 30 )
+        {
+            startOnNewLine = true;
+            rightWidth = 72;
+        }
+
+        final String[] rightLines = WordUtils.wrap( rightText, rightWidth ).split( "\n" );
+
+        final String fmt = "%-" + (startOnNewLine ? 6 : rightAlignIndex) + "s%s";
+        String firstLine = String.format( fmt, leftText, startOnNewLine ? "" : rightLines[0] );
+
+        String rest = Arrays.stream( rightLines )
+                .skip( startOnNewLine ? 0 : 1 )
+                .map( l -> String.format( fmt, "", l ) )
+                .collect( Collectors.joining( "\n" ) );
+
+        if ( rest.isEmpty() )
+        {
+            return firstLine;
+        }
+        else
+        {
+            return String.join( "\n", firstLine, rest );
+        }
+    }
+
+    public String parse( String argName, String[] args )
+    {
+        if ( namedArgs.containsKey( argName ) )
+        {
+            return namedArgs.get( argName ).parse( args );
+        }
+        throw new IllegalArgumentException( "No such argument available to be parsed: " + argName );
+    }
+
+    public boolean parseBoolean( String argName, String[] args )
+    {
+        return parse( argName, Boolean::parseBoolean, args );
+    }
+
+    public Optional<Path> parseOptionalPath( String argName, String[] args )
+    {
+        String p = parse( argName, args );
+
+        if ( p.isEmpty() )
+        {
+            return Optional.empty();
+        }
+
+        return Optional.of( Paths.get( p ) );
+    }
+
+    public Path parseMandatoryPath( String argName, String[] args )
+    {
+        Optional<Path> p = parseOptionalPath( argName, args );
+        if ( p.isPresent() )
+        {
+            return p.get();
+        }
+        throw new IllegalArgumentException( String.format( "Missing exampleValue for '%s'", argName ) );
+    }
+
+    public <T> T parse( String argName, Function<String,T> converter, String[] args )
+    {
+        return converter.apply( parse( argName, args ) );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -43,6 +43,7 @@ public class Arguments
 {
     public static final Arguments NO_ARGS = new Arguments();
     public static final int LINE_LENGTH = 80;
+    public static final int MIN_RIGHT_COL_WIDTH = 30;
     private final Map<String,NamedArgument> namedArgs;
     private final ArrayList<PositionalArgument> positionalArgs;
 
@@ -143,22 +144,24 @@ public class Arguments
         {
             right = argument.description();
         }
+        // 5 = 2 leading spaces in left + 3 spaces as distance between columns
         return rightColumnFormatted( left, right, longestAlignmentLength + 5 );
     }
 
     public static String rightColumnFormatted( final String leftText, final String rightText, int rightAlignIndex )
     {
+        final int newLineIndent = 6;
         int rightWidth = Arguments.LINE_LENGTH - rightAlignIndex;
         boolean startOnNewLine = false;
-        if ( rightWidth < 30 )
+        if ( rightWidth < MIN_RIGHT_COL_WIDTH )
         {
             startOnNewLine = true;
-            rightWidth = 72;
+            rightWidth = LINE_LENGTH - newLineIndent;
         }
 
         final String[] rightLines = WordUtils.wrap( rightText, rightWidth ).split( "\n" );
 
-        final String fmt = "%-" + (startOnNewLine ? 6 : rightAlignIndex) + "s%s";
+        final String fmt = "%-" + (startOnNewLine ? newLineIndent : rightAlignIndex) + "s%s";
         String firstLine = String.format( fmt, leftText, startOnNewLine ? "" : rightLines[0] );
 
         String rest = Arrays.stream( rightLines )

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -120,8 +120,9 @@ public class Arguments
         wrappedText = String.join( "\n\n", wrappedText, "options:" );
 
         //noinspection OptionalGetWithoutIsPresent handled by if-statement above
-        final int alignLength = namedArgs.values().stream().map( NamedArgument::alignmentLength ).reduce( 0,
-                Integer::max );
+        final int alignLength = namedArgs.values().stream()
+                .map( a -> a.optionsListing().length() )
+                .reduce( 0, Integer::max );
 
         return String.join( "\n", wrappedText,
                 namedArgs.values().stream()
@@ -131,7 +132,7 @@ public class Arguments
 
     public String formatArgumentDescription( final int longestAlignmentLength, final NamedArgument argument )
     {
-        final String left = String.format( "  --%s=<%s>", argument.name(), argument.exampleValue() );
+        final String left = String.format( "  %s", argument.optionsListing() );
         final String right;
         if ( argument instanceof OptionalNamedArg )
         {

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+import org.neo4j.helpers.Args;
+
+import static org.neo4j.kernel.impl.util.Converters.identity;
+import static org.neo4j.kernel.impl.util.Converters.mandatory;
+
+public class MandatoryNamedArg implements NamedArgument
+{
+    private final String name;
+    private final String exampleValue;
+    private final String description;
+
+    public MandatoryNamedArg( String name, String exampleValue, String description )
+    {
+
+        this.name = name;
+        this.exampleValue = exampleValue;
+        this.description = description;
+    }
+
+    @Override
+    public int alignmentLength()
+    {
+        // length of "--NAME=<VALUE>"
+        return 5 + name.length() + exampleValue.length();
+    }
+
+    @Override
+    public String usage()
+    {
+        return String.format( "--%s=<%s>", name, exampleValue );
+    }
+
+    @Override
+    public String description()
+    {
+        return description;
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public String exampleValue()
+    {
+        return exampleValue;
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        return Args.parse( args ).interpretOption( name, mandatory(), identity() );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
@@ -39,10 +39,9 @@ public class MandatoryNamedArg implements NamedArgument
     }
 
     @Override
-    public int alignmentLength()
+    public String optionsListing()
     {
-        // length of "--NAME=<VALUE>"
-        return 5 + name.length() + exampleValue.length();
+        return usage();
     }
 
     @Override

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryPositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryPositionalArgument.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+public class MandatoryPositionalArgument extends OptionalPositionalArgument
+{
+    public MandatoryPositionalArgument( int position, String value )
+    {
+        super( position, value );
+    }
+
+    @Override
+    public String usage()
+    {
+        return String.format( "<%s>", value );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+public interface NamedArgument
+{
+    int alignmentLength();
+
+    String usage();
+
+    String description();
+
+    String name();
+
+    String exampleValue();
+
+    String parse( String... args );
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
@@ -21,15 +21,33 @@ package org.neo4j.commandline.arguments;
 
 public interface NamedArgument
 {
-    int alignmentLength();
+    /**
+     * Represents the option in the options list.
+     */
+    String optionsListing();
 
+    /**
+     * Represents the option in the usage string.
+     */
     String usage();
 
+    /**
+     * An explanation of the option in the options list.
+     */
     String description();
 
+    /**
+     * Name of the option as in '--name=<value>'
+     */
     String name();
 
+    /**
+     * Example value listed in usage between brackets like '--name=<example-value>'
+     */
     String exampleValue();
 
+    /**
+     * Parses the option (or possible default value) out of program arguments.
+     */
     String parse( String... args );
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+import org.neo4j.helpers.Args;
+
+import static org.neo4j.kernel.impl.util.Converters.identity;
+import static org.neo4j.kernel.impl.util.Converters.withDefault;
+
+public class OptionalBooleanArg extends OptionalNamedArg
+{
+
+    public OptionalBooleanArg( String name, boolean defaultValue, String description )
+    {
+        super( name, new String[]{"true", "false"}, Boolean.toString( defaultValue ), description );
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        String value = Args.parse( args ).interpretOption( name, withDefault( defaultValue ), identity() );
+
+        if ( value == null || value.isEmpty() )
+        {
+            return Boolean.toString( true );
+        }
+
+        if ( allowedValues.length > 0 )
+        {
+            for ( String allowedValue : allowedValues )
+            {
+                if ( allowedValue.equalsIgnoreCase( value ) )
+                {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException( String.format( "'%s' must be one of [%s], not: %s", name,
+                    String.join( ",", allowedValues ), value ) );
+        }
+        return value;
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
@@ -19,10 +19,9 @@
  */
 package org.neo4j.commandline.arguments;
 
-import org.neo4j.helpers.Args;
+import org.apache.commons.lang3.text.WordUtils;
 
-import static org.neo4j.kernel.impl.util.Converters.identity;
-import static org.neo4j.kernel.impl.util.Converters.withDefault;
+import org.neo4j.helpers.Args;
 
 public class OptionalBooleanArg extends OptionalNamedArg
 {
@@ -33,27 +32,16 @@ public class OptionalBooleanArg extends OptionalNamedArg
     }
 
     @Override
+    public String usage()
+    {
+        return WordUtils.wrap( String.format( "[--%s[=<%s>]]", name, exampleValue ), 60 );
+    }
+
+    @Override
     public String parse( String... args )
     {
-        String value = Args.parse( args ).interpretOption( name, withDefault( defaultValue ), identity() );
-
-        if ( value == null || value.isEmpty() )
-        {
-            return Boolean.toString( true );
-        }
-
-        if ( allowedValues.length > 0 )
-        {
-            for ( String allowedValue : allowedValues )
-            {
-                if ( allowedValue.equalsIgnoreCase( value ) )
-                {
-                    return value;
-                }
-            }
-            throw new IllegalArgumentException( String.format( "'%s' must be one of [%s], not: %s", name,
-                    String.join( ",", allowedValues ), value ) );
-        }
-        return value;
+        return Boolean.toString( Args.withFlags( name() )
+                .parse( args )
+                .getBoolean( name, Boolean.parseBoolean( defaultValue ) ) );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.commandline.arguments;
 
-import org.apache.commons.lang3.text.WordUtils;
-
 import org.neo4j.helpers.Args;
 
 import static org.neo4j.kernel.impl.util.Converters.identity;
@@ -53,16 +51,15 @@ public class OptionalNamedArg implements NamedArgument
     }
 
     @Override
-    public int alignmentLength()
+    public String optionsListing()
     {
-        // length of "--NAME=<VALUE>"
-        return 5 + name.length() + exampleValue.length();
+        return String.format( "--%s=<%s>", name, exampleValue );
     }
 
     @Override
     public String usage()
     {
-        return WordUtils.wrap( String.format( "[--%s=<%s>]", name, exampleValue ), 60 );
+        return String.format( "[--%s=<%s>]", name, exampleValue );
     }
 
     @Override

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+import org.neo4j.helpers.Args;
+
+import static org.neo4j.kernel.impl.util.Converters.identity;
+import static org.neo4j.kernel.impl.util.Converters.withDefault;
+
+public class OptionalNamedArg implements NamedArgument
+{
+    protected final String name;
+    protected final String exampleValue;
+    protected final String defaultValue;
+    protected final String description;
+    protected final String[] allowedValues;
+
+    public OptionalNamedArg( String name, String exampleValue, String defaultValue, String description )
+    {
+        this.name = name;
+        this.exampleValue = exampleValue;
+        this.defaultValue = defaultValue;
+        this.description = description;
+        allowedValues = new String[]{};
+    }
+
+    public OptionalNamedArg( String name, String[] allowedValues, String defaultValue, String description )
+    {
+        this.name = name;
+        this.allowedValues = allowedValues;
+        this.exampleValue = String.join( "|", allowedValues );
+        this.defaultValue = defaultValue;
+        this.description = description;
+    }
+
+    @Override
+    public int alignmentLength()
+    {
+        // length of "--NAME=<VALUE>"
+        return 5 + name.length() + exampleValue.length();
+    }
+
+    @Override
+    public String usage()
+    {
+        return WordUtils.wrap( String.format( "[--%s=<%s>]", name, exampleValue ), 60 );
+    }
+
+    @Override
+    public String description()
+    {
+        return description;
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public String exampleValue()
+    {
+        return exampleValue;
+    }
+
+    public String defaultValue()
+    {
+        return defaultValue;
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        String value = Args.parse( args ).interpretOption( name, withDefault( defaultValue ), identity() );
+        if ( allowedValues.length > 0 )
+        {
+            for ( String allowedValue : allowedValues )
+            {
+                if ( allowedValue.equals( value ) )
+                {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException( String.format( "'%s' must be one of [%s], not: %s", name,
+                    String.join( ",", allowedValues ), value ) );
+        }
+        return value;
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+public class OptionalPositionalArgument implements PositionalArgument
+{
+    protected final String value;
+    final int position;
+
+    public OptionalPositionalArgument( int position, String value )
+    {
+        this.position = position;
+        this.value = value;
+    }
+
+    @Override
+    public int position()
+    {
+        return position;
+    }
+
+    @Override
+    public String usage()
+    {
+        return String.format( "[<%s>]", value );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
@@ -21,7 +21,13 @@ package org.neo4j.commandline.arguments;
 
 public interface PositionalArgument
 {
+    /**
+     * Index of the argument in arguments listing.
+     */
     int position();
 
+    /**
+     * Represents the option in the usage string.
+     */
     String usage();
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+public interface PositionalArgument
+{
+    int position();
+
+    String usage();
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments.common;
+
+
+import java.io.File;
+
+import org.neo4j.commandline.arguments.OptionalNamedArg;
+
+public class Database extends OptionalNamedArg
+{
+    public Database()
+    {
+        super( "database", "name", "graph.db", "Name of database." );
+    }
+
+    private static String validate( String dbName )
+    {
+        if ( dbName.contains( File.separator ) )
+        {
+            throw new IllegalArgumentException(
+                    "'database' should be a name but you seem to have specified a path: " + dbName );
+        }
+        return dbName;
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        return validate( super.parse( args ) );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments.common;
+
+
+import org.neo4j.commandline.Util;
+import org.neo4j.commandline.arguments.MandatoryNamedArg;
+
+public class MandatoryCanonicalPath extends MandatoryNamedArg
+{
+
+    public MandatoryCanonicalPath( String name, String value, String description )
+    {
+        super( name, value, description );
+    }
+
+    private static String canonicalize( String path )
+    {
+        if ( path.isEmpty() )
+        {
+            return path;
+        }
+
+        return Util.canonicalPath( path ).toString();
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        return canonicalize( super.parse( args ) );
+    }
+}

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments.common;
+
+
+import org.neo4j.commandline.Util;
+import org.neo4j.commandline.arguments.OptionalNamedArg;
+
+public class OptionalCanonicalPath extends OptionalNamedArg
+{
+
+    public OptionalCanonicalPath( String name, String value, String defaultValue, String description )
+    {
+        super( name, value, defaultValue, description );
+    }
+
+    private static String canonicalize( String path )
+    {
+        if ( path.isEmpty() )
+        {
+            return path;
+        }
+
+        return Util.canonicalPath( path ).toString();
+    }
+
+    @Override
+    public String parse( String... args )
+    {
+        return canonicalize( super.parse( args ) );
+    }
+}

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -19,11 +19,10 @@
  */
 package org.neo4j.commandline.admin;
 
-import java.nio.file.Path;
-
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.NoSuchElementException;
@@ -73,7 +72,7 @@ public class AdminToolTest
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new NullCommandLocator(), new NullBlockerLocator(), outsideWorld, false ).execute( null, null );
         verify( outsideWorld ).stdErrLine( "you must provide a command" );
-        verify( outsideWorld ).stdErrLine( "Usage: neo4j-admin <command>" );
+        verify( outsideWorld ).stdErrLine( "usage: neo4j-admin <command>" );
         verify( outsideWorld ).exit( 1 );
     }
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -245,7 +245,7 @@ public class AdminToolTest
         return new CannedLocator( new AdminCommand.Provider( name )
         {
             @Override
-            public Arguments arguments()
+            public Arguments allArguments()
             {
                 return Arguments.NO_ARGS;
             }
@@ -293,7 +293,7 @@ public class AdminToolTest
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return Arguments.NO_ARGS;
         }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.commandline.admin;
 
+import java.nio.file.Path;
+
 import org.junit.Test;
 import org.mockito.InOrder;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
+import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.helpers.collection.Iterables;
 
 import static org.mockito.Matchers.any;
@@ -245,9 +246,9 @@ public class AdminToolTest
         return new CannedLocator( new AdminCommand.Provider( name )
         {
             @Override
-            public Optional<String> arguments()
+            public Arguments arguments()
             {
-                return Optional.empty();
+                return Arguments.NO_ARGS;
             }
 
             @Override
@@ -293,9 +294,9 @@ public class AdminToolTest
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.empty();
+            return Arguments.NO_ARGS;
         }
 
         @Override

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -21,20 +21,21 @@ package org.neo4j.commandline.admin;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.function.Consumer;
+
+import org.neo4j.commandline.arguments.Arguments;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class HelpCommandTest
@@ -105,17 +106,19 @@ public class HelpCommandTest
         CommandLocator commandLocator = mock( CommandLocator.class );
         AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );
         when( commandProvider.name() ).thenReturn( "foobar" );
-        when( commandProvider.arguments() ).thenReturn( Optional.of( "--baz --qux" ) );
+        //when( commandProvider.arguments() ).thenReturn( Optional.of( "--baz --qux" ) );
+        when( commandProvider.arguments() ).thenReturn( new Arguments().withDatabase() );
         when( commandProvider.description() ).thenReturn( "This is a description of the foobar command." );
         when( commandLocator.findProvider( "foobar" ) ).thenReturn( commandProvider );
 
         HelpCommand helpCommand = new HelpCommand( new Usage( "neo4j-admin", commandLocator ), out, commandLocator );
         helpCommand.execute( "foobar" );
 
-        InOrder ordered = inOrder( out );
-        ordered.verify( out ).accept( "neo4j-admin foobar --baz --qux" );
-        ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "This is a description of the foobar command." );
-        ordered.verifyNoMoreInteractions();
+        verify( out ).accept( "usage: neo4j-admin foobar [--database=<name>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept(
+                "This is a description of the foobar command.\n\noptions:\n" +
+                "  --database=<name>   Name of database. [default:graph.db]" );
+        verifyNoMoreInteractions( out );
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -107,7 +107,9 @@ public class HelpCommandTest
         AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );
         when( commandProvider.name() ).thenReturn( "foobar" );
         //when( commandProvider.arguments() ).thenReturn( Optional.of( "--baz --qux" ) );
-        when( commandProvider.arguments() ).thenReturn( new Arguments().withDatabase() );
+        Arguments arguments = new Arguments().withDatabase();
+        when( commandProvider.allArguments() ).thenReturn( arguments );
+        when( commandProvider.possibleArguments() ).thenReturn( Collections.singletonList( arguments ) );
         when( commandProvider.description() ).thenReturn( "This is a description of the foobar command." );
         when( commandLocator.findProvider( "foobar" ) ).thenReturn( commandProvider );
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -26,7 +26,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.neo4j.commandline.arguments.Arguments;
@@ -49,9 +48,8 @@ public class UsageTest
         AdminCommand.Provider[] commands = new AdminCommand.Provider[]
                 {
                         new StubProvider( "restore",
-                                Optional.of( "---from <backup-directory> --database=<database-name> [--force]" ),
                                 "Restores a database backed up using the neo4j-backup tool." ),
-                        new StubProvider( "bam", Optional.empty(), "A summary" )
+                        new StubProvider( "bam", "A summary" )
                 };
         final Usage usage = new Usage( "neo4j-admin", new CannedLocator( commands ) );
         usage.print( out );
@@ -72,13 +70,11 @@ public class UsageTest
 
     private static class StubProvider extends AdminCommand.Provider
     {
-        private final Optional<String> arguments;
         private final String summary;
 
-        public StubProvider( String name, Optional<String> arguments, String summary )
+        public StubProvider( String name, String summary )
         {
             super( name );
-            this.arguments = arguments;
             this.summary = summary;
         }
 

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -19,15 +19,17 @@
  */
 package org.neo4j.commandline.admin;
 
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.function.Consumer;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.neo4j.commandline.arguments.Arguments;
 
 import static org.mockito.Mockito.inOrder;
 
@@ -55,9 +57,9 @@ public class UsageTest
         usage.print( out );
 
         InOrder ordered = inOrder( out );
-        ordered.verify( out ).accept( "Usage: neo4j-admin <command>" );
+        ordered.verify( out ).accept( "usage: neo4j-admin <command>" );
         ordered.verify( out ).accept( "" );
-        ordered.verify( out ).accept( "Available commands:" );
+        ordered.verify( out ).accept( "available commands:" );
         ordered.verify( out )
                 .accept( "    restore" );
         ordered.verify( out ).accept( "        Restores a database backed up using the neo4j-backup tool." );
@@ -81,9 +83,9 @@ public class UsageTest
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return arguments;
+            return Arguments.NO_ARGS;
         }
 
         @Override

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -79,7 +79,7 @@ public class UsageTest
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return Arguments.NO_ARGS;
         }

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ArgumentsTest
+{
+
+    private Arguments builder;
+
+    @Before
+    public void setup()
+    {
+        builder = new Arguments();
+    }
+
+    @Test
+    public void withDatabaseUsage() throws Exception
+    {
+        Assert.assertEquals( "[--database=<name>]", builder.withDatabase().usage() );
+    }
+
+    @Test
+    public void withDatabaseDescription() throws Exception
+    {
+        Assert.assertEquals( "How to use\n\noptions:\n" +
+                        "  --database=<name>   Name of database. [default:graph.db]",
+                builder.withDatabase().description( "How to use" ) );
+    }
+
+    @Test
+    public void withDatabaseToUsage() throws Exception
+    {
+        Assert.assertEquals( "[--database=<name>] --to=<destination-path>", builder.withDatabase().withTo(
+                "Destination file." ).usage() );
+    }
+
+    @Test
+    public void withDatabaseToDescription() throws Exception
+    {
+        Assert.assertEquals( "How to use\n\noptions:\n" +
+                        "  --database=<name>         Name of database. [default:graph.db]\n" +
+                        "  --to=<destination-path>   Destination file.",
+                builder.withDatabase().withTo( "Destination file." ).description( "How to use" ) );
+    }
+
+    @Test
+    public void withDatabaseToMultilineDescription() throws Exception
+    {
+        Assert.assertEquals( "How to use\n\noptions:\n" +
+                        "  --database=<name>         Name of database. [default:graph.db]\n" +
+                        "  --to=<destination-path>   This is a long string which should wrap on right\n" +
+                        "                            col.",
+                builder.withDatabase()
+                        .withTo( "This is a long string which should wrap on right col." )
+                        .description( "How to use" ) );
+    }
+
+    @Test
+    public void longNamesTriggerNewLineFormatting() throws Exception
+    {
+        Assert.assertEquals( "How to use\n\noptions:\n" +
+                        "  --database=<name>\n" +
+                        "      Name of database. [default:graph.db]\n" +
+                        "  --to=<destination-path>\n" +
+                        "      This is a long string which should not wrap on right col.\n" +
+                        "  --loooooooooooooong-variable-name=<loooooooooooooong-variable-value>\n" +
+                        "      This is also a long string which should be printed on a new line because\n" +
+                        "      of long names.",
+                builder.withDatabase()
+                        .withTo( "This is a long string which should not wrap on right col." )
+                        .withArgument( new MandatoryNamedArg( "loooooooooooooong-variable-name",
+                                "loooooooooooooong-variable-value",
+                                "This is also a long string which should be printed on a new line because of long " +
+                                        "names.") )
+                        .description( "How to use" ) );
+    }
+}

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.commandline.arguments;
 
 import org.junit.Test;

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
@@ -1,0 +1,39 @@
+package org.neo4j.commandline.arguments;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OptionalBooleanArgTest
+{
+
+    @Test
+    public void parsesValues1() throws Exception
+    {
+        OptionalBooleanArg arg = new OptionalBooleanArg( "foo", false, "" );
+
+        assertEquals( "false", arg.parse() );
+        assertEquals( "false", arg.parse("--foo=false") );
+        assertEquals( "true", arg.parse("--foo=true") );
+        assertEquals( "true", arg.parse("--foo") );
+    }
+
+    @Test
+    public void parsesValues2() throws Exception
+    {
+        OptionalBooleanArg arg = new OptionalBooleanArg( "foo", true, "" );
+
+        assertEquals( "true", arg.parse() );
+        assertEquals( "false", arg.parse("--foo=false") );
+        assertEquals( "true", arg.parse("--foo=true") );
+        assertEquals( "true", arg.parse("--foo") );
+    }
+
+    @Test
+    public void usageTest() throws Exception
+    {
+        OptionalBooleanArg arg = new OptionalBooleanArg( "foo", true, "" );
+
+        assertEquals( "[--foo[=<true|false>]]", arg.usage() );
+    }
+}

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.arguments.common;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatabaseTest
+{
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    Database arg = new Database();
+
+    @Test
+    public void parseDatabaseShouldThrowOnPath() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage(
+                "'database' should be a name but you seem to have specified a path: /data/databases/graph.db" );
+        arg.parse( "--database=/data/databases/graph.db" );
+    }
+
+    @Test
+    public void parseDatabaseName() throws Exception
+    {
+        assertEquals( "bob.db", arg.parse( "--database=bob.db" ) );
+    }
+}

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -71,7 +71,7 @@ public class CheckConsistencyCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -213,7 +213,7 @@ public class CheckConsistencyCommandTest
         verify( out ).accept(
                 "usage: neo4j-admin check-consistency [--database=<name>]\n" +
                         "                                     [--additional-config=<config-file-path>]\n" +
-                        "                                     [--verbose=<true|false>]\n" +
+                        "                                     [--verbose[=<true|false>]]\n" +
                         "                                     [--report-dir=<directory>]" );
         verify( out ).accept( "" );
         verify( out ).accept( "Check the consistency of a database.\n" +

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -71,7 +71,7 @@ public class ConsistencyCheckServiceIntegrationTest
             try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
             {
                 Node node1 = set( graphDb.createNode() );
-                Node node2 = set( graphDb.createNode(), property( "key", "value" ) );
+                Node node2 = set( graphDb.createNode(), property( "key", "exampleValue" ) );
                 node1.createRelationshipTo( node2, RelationshipType.withName( "C" ) );
                 tx.success();
             }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -64,7 +64,7 @@ public class DumpCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -28,30 +28,32 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.dbms.archive.Dumper;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Args;
 import org.neo4j.kernel.StoreLockException;
+import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.server.configuration.ConfigLoader;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.neo4j.commandline.Util.canonicalPath;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.util.Converters.identity;
-import static org.neo4j.kernel.impl.util.Converters.mandatory;
 
 public class DumpCommand implements AdminCommand
 {
 
+    private static final Arguments arguments = new Arguments()
+            .withDatabase()
+            .withTo( "Destination (file or folder) of database dump." );
     private final StoreLockChecker storeLockChecker;
 
     public static class Provider extends AdminCommand.Provider
@@ -62,9 +64,9 @@ public class DumpCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "--database=<database> --to=<destination-path>" );
+            return arguments;
         }
 
         @Override
@@ -103,9 +105,18 @@ public class DumpCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        String database = parse( args, "database", identity() );
-        Path archive = calculateArchive( database, parse( args, "to", Paths::get ) );
-        Path databaseDirectory = toDatabaseDirectory( database );
+        String database = arguments.parse( "database", args );
+        Path archive = calculateArchive( database, arguments.parseMandatoryPath( "to", args ) );
+        Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
+
+        try
+        {
+            Validators.CONTAINS_EXISTING_DATABASE.validate( databaseDirectory.toFile() );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new CommandFailed( "database does not exist: " + database, e );
+        }
 
         try ( Closeable ignored = storeLockChecker.withLock( databaseDirectory ) )
         {
@@ -124,18 +135,6 @@ public class DumpCommand implements AdminCommand
             throw new CommandFailed(
                     "you do not have permission to dump the database -- is Neo4j running as a " + "different user?",
                     e );
-        }
-    }
-
-    private <T> T parse( String[] args, String argument, Function<String,T> converter ) throws IncorrectUsage
-    {
-        try
-        {
-            return Args.parse( args ).interpretOption( argument, mandatory(), converter );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            throw new IncorrectUsage( e.getMessage() );
         }
     }
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.commandline.dbms;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -32,18 +31,51 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.OptionalNamedArg;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
 
 public class ImportCommand implements AdminCommand
 {
     public static final String DEFAULT_REPORT_FILE_NAME = "import.report";
+    private static final String[] allowedModes = {"database", "csv"};
+    private static final Arguments arguments = new Arguments()
+            .withDatabase()
+            .withAdditionalConfig()
+            .withArgument( new OptionalNamedArg( "mode", allowedModes, "csv",
+                    "Import a collection of CSV files or a pre-3.0 installation." ) )
+            .withArgument( new OptionalNamedArg( "from", "source-directory", "",
+                    "The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db)." ) )
+            .withArgument( new OptionalNamedArg( "report-file", "filename", ImportCommand.DEFAULT_REPORT_FILE_NAME,
+                    "File in which to store the report of the import." ) )
+            .withArgument( new OptionalNamedArg( "nodes[:Label1:Label2]", "\"file1,file2,...\"", "",
+                    "Node CSV header and data. Multiple files will be logically seen as " +
+                            "one big file from the perspective of the importer. The first line " +
+                            "must contain the header. Multiple data sources like these can be " +
+                            "specified in one import, where each data source has its own header. " +
+                            "Note that file groups must be enclosed in quotation marks." ) )
+            .withArgument( new OptionalNamedArg( "relationships[:RELATIONSHIP_TYPE]", "\"file1,file2,...\"", "",
+                    "Relationship CSV header and data. Multiple files will be logically " +
+                            "seen as one big file from the perspective of the importer. The first " +
+                            "line must contain the header. Multiple data sources like these can be " +
+                            "specified in one import, where each data source has its own header. " +
+                            "Note that file groups must be enclosed in quotation marks." ) )
+            .withArgument( new OptionalNamedArg( "id-type", new String[]{"STRING", "INTEGER", "ACTUAL"},
+                    "STRING", "Each node must provide a unique id. This is used to find the correct " +
+                    "nodes when creating relationships. Possible values are " +
+                    "STRING: arbitrary strings for identifying nodes, " +
+                    "INTEGER: arbitrary integer values for identifying nodes, " +
+                    "ACTUAL: (advanced) actual node ids. " +
+                    "For more information on id handling, please see the Neo4j Manual: " +
+                    "http://neo4j.com/docs/operations-manual/current/deployment/#import-tool" ) )
+            .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",
+                    "Character set that input data is encoded in." ) );
 
     public static class Provider extends AdminCommand.Provider
     {
@@ -53,33 +85,16 @@ public class ImportCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional
-                    .of( "--database=<database-name> " +
-                            "[--mode={csv|database}] " +
-                            "[--additional-config=<config-file-path>] " +
-                            DatabaseImporter.arguments() +
-                            " " +
-                            CsvImporter.arguments() );
+            return arguments;
         }
 
         @Override
         public String description()
         {
-            return "Import a collection of CSV files with --mode=csv (default), or a database from\n" +
-                    "a pre-3.0 installation with --mode=database.\n" +
-                    "\n" +
-                    "--database=<database-name>\n" +
-                    "        The name of the new database to import into. This cannot be an existing\n" +
-                    "        database.\n" +
-                    "--additional-config=<config-file-path>\n" +
-                    "        Configuration file to supply additional configuration values to\n" +
-                    "        the import tools.\n" +
-                    "\n" +
-                    DatabaseImporter.description() +
-                    "\n" +
-                    CsvImporter.description();
+            return "Import a collection of CSV files with --mode=csv (default), or a database from " +
+            "a pre-3.0 installation with --mode=database.";
         }
 
         @Override
@@ -99,7 +114,6 @@ public class ImportCommand implements AdminCommand
     private final Path configDir;
     private final OutsideWorld outsideWorld;
     private final ImporterFactory importerFactory;
-    private final String[] allowedModes = {"database", "csv"};
 
     public ImportCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
@@ -117,18 +131,15 @@ public class ImportCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Args parsedArgs = Args.parse( args );
         String mode;
-        File additionalConfigFile;
+        Optional<Path> additionalConfigFile;
         String database;
 
         try
         {
-            mode = parsedArgs.interpretOption( "mode", Converters.withDefault( "csv" ), s -> s,
-                    Validators.inList( allowedModes ) );
-            database = parsedArgs.interpretOption( "database", Converters.mandatory(), s -> s );
-            additionalConfigFile =
-                    parsedArgs.interpretOption( "additional-config", Converters.optional(), Converters.toFile() );
+            mode = arguments.parse("mode", args);
+            database = arguments.parse( "database", args );
+            additionalConfigFile = arguments.parseOptionalPath( "additional-config", args );
         }
         catch ( IllegalArgumentException e )
         {
@@ -142,7 +153,7 @@ public class ImportCommand implements AdminCommand
             Validators.CONTAINS_NO_EXISTING_DATABASE
                     .validate( config.get( DatabaseManagementSystemSettings.database_path ) );
 
-            Importer importer = importerFactory.getImporterForMode( mode, parsedArgs, config, outsideWorld );
+            Importer importer = importerFactory.getImporterForMode( mode, Args.parse( args ), config, outsideWorld );
             importer.doImport();
         }
         catch ( IllegalArgumentException e )
@@ -155,22 +166,22 @@ public class ImportCommand implements AdminCommand
         }
     }
 
-    private Map<String,String> loadAdditionalConfig( File additionalConfigFile )
+    private Map<String,String> loadAdditionalConfig( Optional<Path> additionalConfigFile )
     {
-        if ( additionalConfigFile == null )
+        if ( additionalConfigFile.isPresent() )
         {
-            return new HashMap<>();
+            try
+            {
+                return MapUtil.load( additionalConfigFile.get().toFile() );
+            }
+            catch ( IOException e )
+            {
+                throw new IllegalArgumentException(
+                        String.format( "Could not read configuration file [%s]", additionalConfigFile ), e );
+            }
         }
 
-        try
-        {
-            return MapUtil.load( additionalConfigFile );
-        }
-        catch ( IOException e )
-        {
-            throw new IllegalArgumentException(
-                    String.format( "Could not read configuration file [%s]", additionalConfigFile ), e );
-        }
+        return new HashMap<>();
     }
 
     private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName,

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -66,7 +66,7 @@ public class LoadCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -91,14 +91,14 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldDumpTheDatabaseToTheArchive() throws CommandFailed, IncorrectUsage, IOException
+    public void shouldDumpTheDatabaseToTheArchive() throws Exception
     {
         execute( "foo.db" );
         verify( dumper ).dump( eq( homeDir.resolve( "data/databases/foo.db" ) ), eq( archive ), any() );
     }
 
     @Test
-    public void shouldCalculateTheDatabaseDirectoryFromConfig() throws IOException, CommandFailed, IncorrectUsage
+    public void shouldCalculateTheDatabaseDirectoryFromConfig() throws Exception
     {
         Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
         Path databaseDir = dataDir.resolve( "databases/foo.db" );
@@ -111,7 +111,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldHandleDatabaseSymlink() throws IOException, CommandFailed, IncorrectUsage
+    public void shouldHandleDatabaseSymlink() throws Exception
     {
         Path symDir = testDirectory.directory( "path-to-links" ).toPath();
         Path realDatabaseDir = symDir.resolve( "foo.db" );
@@ -132,7 +132,7 @@ public class DumpCommandTest
 
     @Test
     public void shouldCalculateTheArchiveNameIfPassedAnExistingDirectory()
-            throws CommandFailed, IncorrectUsage, IOException
+            throws Exception
     {
         File to = testDirectory.directory( "some-dir" );
         new DumpCommand( homeDir, configDir, dumper ).execute( new String[]{"--database=" + "foo.db", "--to=" + to} );
@@ -140,7 +140,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldConvertToCanonicalPath() throws CommandFailed, IncorrectUsage, IOException
+    public void shouldConvertToCanonicalPath() throws Exception
     {
         new DumpCommand( homeDir, configDir, dumper )
                 .execute( new String[]{"--database=" + "foo.db", "--to=foo.dump"} );
@@ -149,7 +149,7 @@ public class DumpCommandTest
 
     @Test
     public void shouldNotCalculateTheArchiveNameIfPassedAnExistingFile()
-            throws CommandFailed, IncorrectUsage, IOException
+            throws Exception
     {
         Files.createFile( archive );
         execute( "foo.db" );
@@ -157,7 +157,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldRespectTheStoreLock() throws IOException, IncorrectUsage, CommandFailed
+    public void shouldRespectTheStoreLock() throws Exception
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
 
@@ -168,21 +168,21 @@ public class DumpCommandTest
             execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed | IllegalArgumentException e )
+        catch ( CommandFailed e )
         {
             assertThat( e.getMessage(), equalTo( "the database is in use -- stop Neo4j and try again" ) );
         }
     }
 
     @Test
-    public void shouldReleaseTheStoreLockAfterDumping() throws IOException, IncorrectUsage, CommandFailed
+    public void shouldReleaseTheStoreLockAfterDumping() throws Exception
     {
         execute( "foo.db" );
         assertCanLockStore( databaseDirectory );
     }
 
     @Test
-    public void shouldReleaseTheStoreLockEvenIfThereIsAnError() throws IOException, IncorrectUsage
+    public void shouldReleaseTheStoreLockEvenIfThereIsAnError() throws Exception
     {
         doThrow( IOException.class ).when( dumper ).dump( any(), any(), any() );
 
@@ -190,7 +190,7 @@ public class DumpCommandTest
         {
             execute( "foo.db" );
         }
-        catch ( CommandFailed | IllegalArgumentException ignored )
+        catch ( CommandFailed ignored )
         {
         }
 
@@ -199,7 +199,7 @@ public class DumpCommandTest
 
     @Test
     public void shouldNotAccidentallyCreateTheDatabaseDirectoryAsASideEffectOfStoreLocking()
-            throws CommandFailed, IncorrectUsage, IOException
+            throws Exception
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/accident.db" );
 
@@ -213,7 +213,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldReportAHelpfulErrorIfWeDontHaveWritePermissionsForLock() throws IOException, IncorrectUsage
+    public void shouldReportAHelpfulErrorIfWeDontHaveWritePermissionsForLock() throws Exception
     {
         assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
 
@@ -227,7 +227,7 @@ public class DumpCommandTest
                 execute( "foo.db" );
                 fail( "expected exception" );
             }
-            catch ( CommandFailed | IllegalArgumentException e )
+            catch ( CommandFailed e )
             {
                 assertThat( e.getMessage(), equalTo( "you do not have permission to dump the database -- is Neo4j " +
                         "running as a different user?" ) );
@@ -237,7 +237,7 @@ public class DumpCommandTest
 
     @Test
     public void shouldExcludeTheStoreLockFromTheArchiveToAvoidProblemsWithReadingLockedFilesOnWindows()
-            throws CommandFailed, IncorrectUsage, IOException
+            throws Exception
     {
         doAnswer( invocation ->
         {
@@ -279,7 +279,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldGiveAClearErrorIfTheArchiveAlreadyExists() throws IOException, IncorrectUsage
+    public void shouldGiveAClearErrorIfTheArchiveAlreadyExists() throws Exception
     {
         doThrow( new FileAlreadyExistsException( "the-archive-path" ) ).when( dumper ).dump( any(), any(), any() );
         try
@@ -287,28 +287,28 @@ public class DumpCommandTest
             execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed | IllegalArgumentException e )
+        catch ( CommandFailed e )
         {
             assertThat( e.getMessage(), equalTo( "archive already exists: the-archive-path" ) );
         }
     }
 
     @Test
-    public void shouldGiveAClearMessageIfTheDatabaseDoesntExist() throws IOException, IncorrectUsage
+    public void shouldGiveAClearMessageIfTheDatabaseDoesntExist() throws Exception
     {
         try
         {
             execute( "bobo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed | IllegalArgumentException e )
+        catch ( CommandFailed e )
         {
             assertThat( e.getMessage(), equalTo( "database does not exist: bobo.db" ) );
         }
     }
 
     @Test
-    public void shouldGiveAClearMessageIfTheArchivesParentDoesntExist() throws IOException, IncorrectUsage
+    public void shouldGiveAClearMessageIfTheArchivesParentDoesntExist() throws Exception
     {
         doThrow( new NoSuchFileException( archive.getParent().toString() ) ).when( dumper ).dump( any(), any(), any() );
         try
@@ -316,7 +316,7 @@ public class DumpCommandTest
             execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed | IllegalArgumentException e )
+        catch ( CommandFailed e )
         {
             assertThat( e.getMessage(),
                     equalTo( "unable to dump database: NoSuchFileException: " + archive.getParent() ) );
@@ -325,7 +325,7 @@ public class DumpCommandTest
 
     @Test
     public void shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
-            throws IOException, IncorrectUsage
+            throws Exception
     {
         doThrow( new IOException( "the-message" ) ).when( dumper ).dump( any(), any(), any() );
         try
@@ -340,7 +340,7 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldPrintNiceHelp() throws Throwable
+    public void shouldPrintNiceHelp() throws Exception
     {
         Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
         Consumer<String> out = mock( Consumer.class );

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.Closeable;
 import java.io.File;
@@ -33,12 +34,17 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.dbms.archive.Dumper;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.test.rule.TestDirectory;
 
@@ -56,6 +62,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 
@@ -63,10 +70,14 @@ public class DumpCommandTest
 {
     @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
     private Path homeDir;
     private Path configDir;
     private Path archive;
     private Dumper dumper;
+    private Path databaseDirectory;
 
     @Before
     public void setUp() throws Exception
@@ -75,6 +86,8 @@ public class DumpCommandTest
         configDir = testDirectory.directory( "config-dir" ).toPath();
         archive = testDirectory.file( "some-archive.dump" ).toPath();
         dumper = mock( Dumper.class );
+        putStoreInDirectory( homeDir.resolve( "data/databases/foo.db" ) );
+        databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
     }
 
     @Test
@@ -89,12 +102,32 @@ public class DumpCommandTest
     {
         Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
         Path databaseDir = dataDir.resolve( "databases/foo.db" );
-        Files.createDirectories( databaseDir );
+        putStoreInDirectory( databaseDir );
         Files.write( configDir.resolve( "neo4j.conf" ),
                 asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
 
         execute( "foo.db" );
         verify( dumper ).dump( eq( databaseDir ), any(), any() );
+    }
+
+    @Test
+    public void shouldHandleDatabaseSymlink() throws IOException, CommandFailed, IncorrectUsage
+    {
+        Path symDir = testDirectory.directory( "path-to-links" ).toPath();
+        Path realDatabaseDir = symDir.resolve( "foo.db" );
+
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/foo.db" );
+
+        putStoreInDirectory( realDatabaseDir );
+        Files.createDirectories( dataDir.resolve( "databases" ) );
+
+        Files.createSymbolicLink( databaseDir, realDatabaseDir );
+        Files.write( configDir.resolve( "neo4j.conf" ),
+                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+
+        execute( "foo.db" );
+        verify( dumper ).dump( eq( realDatabaseDir ), any(), any() );
     }
 
     @Test
@@ -104,6 +137,14 @@ public class DumpCommandTest
         File to = testDirectory.directory( "some-dir" );
         new DumpCommand( homeDir, configDir, dumper ).execute( new String[]{"--database=" + "foo.db", "--to=" + to} );
         verify( dumper ).dump( any( Path.class ), eq( to.toPath().resolve( "foo.db.dump" ) ), any() );
+    }
+
+    @Test
+    public void shouldConvertToCanonicalPath() throws CommandFailed, IncorrectUsage, IOException
+    {
+        new DumpCommand( homeDir, configDir, dumper )
+                .execute( new String[]{"--database=" + "foo.db", "--to=foo.dump"} );
+        verify( dumper ).dump( any( Path.class ), eq( Paths.get( new File( "foo.dump" ).getCanonicalPath() ) ), any() );
     }
 
     @Test
@@ -119,7 +160,6 @@ public class DumpCommandTest
     public void shouldRespectTheStoreLock() throws IOException, IncorrectUsage, CommandFailed
     {
         Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
-        Files.createDirectories( databaseDirectory );
 
         try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
@@ -128,7 +168,7 @@ public class DumpCommandTest
             execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed e )
+        catch ( CommandFailed | IllegalArgumentException e )
         {
             assertThat( e.getMessage(), equalTo( "the database is in use -- stop Neo4j and try again" ) );
         }
@@ -137,9 +177,6 @@ public class DumpCommandTest
     @Test
     public void shouldReleaseTheStoreLockAfterDumping() throws IOException, IncorrectUsage, CommandFailed
     {
-        Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
-        Files.createDirectories( databaseDirectory );
-
         execute( "foo.db" );
         assertCanLockStore( databaseDirectory );
     }
@@ -148,14 +185,12 @@ public class DumpCommandTest
     public void shouldReleaseTheStoreLockEvenIfThereIsAnError() throws IOException, IncorrectUsage
     {
         doThrow( IOException.class ).when( dumper ).dump( any(), any(), any() );
-        Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
-        Files.createDirectories( databaseDirectory );
 
         try
         {
             execute( "foo.db" );
         }
-        catch ( CommandFailed ignored )
+        catch ( CommandFailed | IllegalArgumentException ignored )
         {
         }
 
@@ -166,7 +201,7 @@ public class DumpCommandTest
     public void shouldNotAccidentallyCreateTheDatabaseDirectoryAsASideEffectOfStoreLocking()
             throws CommandFailed, IncorrectUsage, IOException
     {
-        Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
+        Path databaseDirectory = homeDir.resolve( "data/databases/accident.db" );
 
         doAnswer( ignored ->
         {
@@ -182,9 +217,6 @@ public class DumpCommandTest
     {
         assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
 
-        Path databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
-        Files.createDirectories( databaseDirectory );
-
         try ( StoreLocker storeLocker = new StoreLocker( new DefaultFileSystemAbstraction() ) )
         {
             storeLocker.checkLock( databaseDirectory.toFile() );
@@ -195,7 +227,7 @@ public class DumpCommandTest
                 execute( "foo.db" );
                 fail( "expected exception" );
             }
-            catch ( CommandFailed e )
+            catch ( CommandFailed | IllegalArgumentException e )
             {
                 assertThat( e.getMessage(), equalTo( "you do not have permission to dump the database -- is Neo4j " +
                         "running as a different user?" ) );
@@ -220,28 +252,27 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldObjectIfTheDatabaseArgumentIsMissing() throws CommandFailed
+    public void shouldDefaultToGraphDB() throws Exception
     {
-        try
-        {
-            new DumpCommand( null, null, null ).execute( new String[]{"--to=something"} );
-            fail( "expected exception" );
-        }
-        catch ( IncorrectUsage e )
-        {
-            assertThat( e.getMessage(), equalTo( "Missing argument 'database'" ) );
-        }
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/graph.db" );
+        putStoreInDirectory( databaseDir );
+        Files.write( configDir.resolve( "neo4j.conf" ),
+                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+
+        new DumpCommand( homeDir, configDir, dumper ).execute( new String[]{"--to=" + archive} );
+        verify( dumper ).dump( eq( databaseDir ), any(), any() );
     }
 
     @Test
-    public void shouldObjectIfTheArchiveArgumentIsMissing() throws CommandFailed
+    public void shouldObjectIfTheArchiveArgumentIsMissing() throws Exception
     {
         try
         {
             new DumpCommand( homeDir, configDir, null ).execute( new String[]{"--database=something"} );
             fail( "expected exception" );
         }
-        catch ( IncorrectUsage e )
+        catch ( IllegalArgumentException e )
         {
             assertThat( e.getMessage(), equalTo( "Missing argument 'to'" ) );
         }
@@ -253,10 +284,10 @@ public class DumpCommandTest
         doThrow( new FileAlreadyExistsException( "the-archive-path" ) ).when( dumper ).dump( any(), any(), any() );
         try
         {
-            execute( null );
+            execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed e )
+        catch ( CommandFailed | IllegalArgumentException e )
         {
             assertThat( e.getMessage(), equalTo( "archive already exists: the-archive-path" ) );
         }
@@ -265,16 +296,14 @@ public class DumpCommandTest
     @Test
     public void shouldGiveAClearMessageIfTheDatabaseDoesntExist() throws IOException, IncorrectUsage
     {
-        doThrow( new NoSuchFileException( homeDir.resolve( "data/databases/foo.db" ).toString() ) ).when( dumper )
-                .dump( any(), any(), any() );
         try
         {
-            execute( "foo.db" );
+            execute( "bobo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed e )
+        catch ( CommandFailed | IllegalArgumentException e )
         {
-            assertThat( e.getMessage(), equalTo( "database does not exist: foo.db" ) );
+            assertThat( e.getMessage(), equalTo( "database does not exist: bobo.db" ) );
         }
     }
 
@@ -287,7 +316,7 @@ public class DumpCommandTest
             execute( "foo.db" );
             fail( "expected exception" );
         }
-        catch ( CommandFailed e )
+        catch ( CommandFailed | IllegalArgumentException e )
         {
             assertThat( e.getMessage(),
                     equalTo( "unable to dump database: NoSuchFileException: " + archive.getParent() ) );
@@ -301,13 +330,32 @@ public class DumpCommandTest
         doThrow( new IOException( "the-message" ) ).when( dumper ).dump( any(), any(), any() );
         try
         {
-            execute( null );
+            execute( "foo.db" );
             fail( "expected exception" );
         }
         catch ( CommandFailed e )
         {
             assertThat( e.getMessage(), equalTo( "unable to dump database: IOException: the-message" ) );
         }
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new DumpCommand.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin dump [--database=<name>] --to=<destination-path>" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Dump a database into a single-file archive. The archive can be used by the load\n" +
+                "command. <destination-path> can be a file or directory (in which case a file\n" +
+                "called <database>.dump will be created). It is not possible to dump a database\n" +
+                "that is mounted in a running Neo4j server.\n" +
+                "\noptions:\n" +
+                "  --database=<name>         Name of database. [default:graph.db]\n" +
+                "  --to=<destination-path>   Destination (file or folder) of database dump." );
+        verifyNoMoreInteractions( out );
     }
 
     private void execute( final String database ) throws IncorrectUsage, CommandFailed, AccessDeniedException
@@ -322,5 +370,12 @@ public class DumpCommandTest
         {
             storeLocker.checkLock( databaseDirectory.toFile() );
         }
+    }
+
+    private void putStoreInDirectory( Path storeDir ) throws IOException
+    {
+        Files.createDirectories( storeDir );
+        Path storeFile = storeDir.resolve( StoreFileType.STORE.augment( MetaDataStore.DEFAULT_NAME ) );
+        Files.createFile( storeFile );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -161,8 +161,7 @@ public class ImportCommandTest
                 "  --additional-config=<config-file-path>\n" +
                 "      Configuration file to supply additional configuration in. [default:]\n" +
                 "  --mode=<database|csv>\n" +
-                "      Import a collection of CSV files or a pre-3.0 installation.\n" +
-                "      [default:csv]\n" +
+                "      Import a collection of CSV files or a pre-3.0 installation. [default:csv]\n" +
                 "  --from=<source-directory>\n" +
                 "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).\n" +
                 "      [default:]\n" +
@@ -170,23 +169,23 @@ public class ImportCommandTest
                 "      File in which to store the report of the csv-import.\n" +
                 "      [default:import.report]\n" +
                 "  --nodes[:Label1:Label2]=<\"file1,file2,...\">\n" +
-                "      Node CSV header and data. Multiple files will be logically seen as one\n" +
-                "      big file from the perspective of the importer. The first line must\n" +
+                "      Node CSV header and data. Multiple files will be logically seen as one big\n" +
+                "      file from the perspective of the importer. The first line must contain the\n" +
+                "      header. Multiple data sources like these can be specified in one import,\n" +
+                "      where each data source has its own header. Note that file groups must be\n" +
+                "      enclosed in quotation marks. [default:]\n" +
+                "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">\n" +
+                "      Relationship CSV header and data. Multiple files will be logically seen as\n" +
+                "      one big file from the perspective of the importer. The first line must\n" +
                 "      contain the header. Multiple data sources like these can be specified in\n" +
                 "      one import, where each data source has its own header. Note that file\n" +
                 "      groups must be enclosed in quotation marks. [default:]\n" +
-                "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">\n" +
-                "      Relationship CSV header and data. Multiple files will be logically seen\n" +
-                "      as one big file from the perspective of the importer. The first line\n" +
-                "      must contain the header. Multiple data sources like these can be\n" +
-                "      specified in one import, where each data source has its own header. Note\n" +
-                "      that file groups must be enclosed in quotation marks. [default:]\n" +
                 "  --id-type=<STRING|INTEGER|ACTUAL>\n" +
-                "      Each node must provide a unique id. This is used to find the correct\n" +
-                "      nodes when creating relationships. Possible values are STRING: arbitrary\n" +
-                "      strings for identifying nodes, INTEGER: arbitrary integer values for\n" +
-                "      identifying nodes, ACTUAL: (advanced) actual node ids. For more\n" +
-                "      information on id handling, please see the Neo4j Manual:\n" +
+                "      Each node must provide a unique id. This is used to find the correct nodes\n" +
+                "      when creating relationships. Possible values are STRING: arbitrary strings\n" +
+                "      for identifying nodes, INTEGER: arbitrary integer values for identifying\n" +
+                "      nodes, ACTUAL: (advanced) actual node ids. For more information on id\n" +
+                "      handling, please see the Neo4j Manual:\n" +
                 "      http://neo4j.com/docs/operations-manual/current/deployment/#import-tool\n" +
                 "      [default:STRING]\n" +
                 "  --input-encoding=<character-set>\n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -141,14 +141,16 @@ public class ImportCommandTest
         Consumer<String> out = mock( Consumer.class );
         usage.printUsageForCommand( new ImportCommand.Provider(), out );
 
-        verify( out ).accept( "usage: neo4j-admin import [--database=<name>]\n" +
+        verify( out ).accept( "usage: neo4j-admin import [--mode=csv] [--database=<name>]\n" +
                 "                          [--additional-config=<config-file-path>]\n" +
-                "                          [--mode=<database|csv>] [--from=<source-directory>]\n" +
                 "                          [--report-file=<filename>]\n" +
                 "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]\n" +
                 "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]\n" +
                 "                          [--id-type=<STRING|INTEGER|ACTUAL>]\n" +
                 "                          [--input-encoding=<character-set>]" );
+        verify( out ).accept( "usage: neo4j-admin import --mode=database [--database=<name>]\n" +
+                "                          [--additional-config=<config-file-path>]\n" +
+                "                          [--from=<source-directory>]" );
         verify( out ).accept( "" );
         verify( out ).accept( "Import a collection of CSV files with --mode=csv (default), or a database from a\n" +
                 "pre-3.0 installation with --mode=database.\n" +
@@ -165,7 +167,8 @@ public class ImportCommandTest
                 "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).\n" +
                 "      [default:]\n" +
                 "  --report-file=<filename>\n" +
-                "      File in which to store the report of the import. [default:import.report]\n" +
+                "      File in which to store the report of the csv-import.\n" +
+                "      [default:import.report]\n" +
                 "  --nodes[:Label1:Label2]=<\"file1,file2,...\">\n" +
                 "      Node CSV header and data. Multiple files will be logically seen as one\n" +
                 "      big file from the perspective of the importer. The first line must\n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -23,17 +23,21 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Consumer;
 
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.NullOutsideWorld;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.admin.RealOutsideWorld;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Transaction;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.helpers.Args;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.Matchers.containsString;
@@ -43,6 +47,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class ImportCommandTest
@@ -116,7 +121,7 @@ public class ImportCommandTest
         ImportCommand importCommand =
                 new ImportCommand( homeDir, testDir.directory( "conf" ).toPath(), new NullOutsideWorld() );
 
-        putStoreInDirectory( homeDir.resolve( "data" ).resolve( "databases" ).resolve( "existing.db" ).toFile() );
+        putStoreInDirectory( homeDir.resolve( "data" ).resolve( "databases" ).resolve( "existing.db" ) );
         String[] arguments = {"--mode=csv", "--database=existing.db"};
         try
         {
@@ -129,26 +134,67 @@ public class ImportCommandTest
         }
     }
 
-    private File putStoreInDirectory( File storeDir )
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
     {
-        GraphDatabaseService db = null;
-        try
-        {
-            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
-            try ( Transaction transaction = db.beginTx() )
-            {
-                db.createNode();
-                transaction.success();
-            }
-        }
-        finally
-        {
-            if ( db != null )
-            {
-                db.shutdown();
-            }
-        }
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new ImportCommand.Provider(), out );
 
-        return storeDir;
+        verify( out ).accept( "usage: neo4j-admin import [--database=<name>]\n" +
+                "                          [--additional-config=<config-file-path>]\n" +
+                "                          [--mode=<database|csv>] [--from=<source-directory>]\n" +
+                "                          [--report-file=<filename>]\n" +
+                "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]\n" +
+                "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]\n" +
+                "                          [--id-type=<STRING|INTEGER|ACTUAL>]\n" +
+                "                          [--input-encoding=<character-set>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Import a collection of CSV files with --mode=csv (default), or a database from a\n" +
+                "pre-3.0 installation with --mode=database.\n" +
+                "\n" +
+                "options:\n" +
+                "  --database=<name>\n" +
+                "      Name of database. [default:graph.db]\n" +
+                "  --additional-config=<config-file-path>\n" +
+                "      Configuration file to supply additional configuration in. [default:]\n" +
+                "  --mode=<database|csv>\n" +
+                "      Import a collection of CSV files or a pre-3.0 installation.\n" +
+                "      [default:csv]\n" +
+                "  --from=<source-directory>\n" +
+                "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).\n" +
+                "      [default:]\n" +
+                "  --report-file=<filename>\n" +
+                "      File in which to store the report of the import. [default:import.report]\n" +
+                "  --nodes[:Label1:Label2]=<\"file1,file2,...\">\n" +
+                "      Node CSV header and data. Multiple files will be logically seen as one\n" +
+                "      big file from the perspective of the importer. The first line must\n" +
+                "      contain the header. Multiple data sources like these can be specified in\n" +
+                "      one import, where each data source has its own header. Note that file\n" +
+                "      groups must be enclosed in quotation marks. [default:]\n" +
+                "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">\n" +
+                "      Relationship CSV header and data. Multiple files will be logically seen\n" +
+                "      as one big file from the perspective of the importer. The first line\n" +
+                "      must contain the header. Multiple data sources like these can be\n" +
+                "      specified in one import, where each data source has its own header. Note\n" +
+                "      that file groups must be enclosed in quotation marks. [default:]\n" +
+                "  --id-type=<STRING|INTEGER|ACTUAL>\n" +
+                "      Each node must provide a unique id. This is used to find the correct\n" +
+                "      nodes when creating relationships. Possible values are STRING: arbitrary\n" +
+                "      strings for identifying nodes, INTEGER: arbitrary integer values for\n" +
+                "      identifying nodes, ACTUAL: (advanced) actual node ids. For more\n" +
+                "      information on id handling, please see the Neo4j Manual:\n" +
+                "      http://neo4j.com/docs/operations-manual/current/deployment/#import-tool\n" +
+                "      [default:STRING]\n" +
+                "  --input-encoding=<character-set>\n" +
+                "      Character set that input data is encoded in. [default:UTF-8]" );
+        verifyNoMoreInteractions( out );
+    }
+
+    private void putStoreInDirectory( Path storeDir ) throws IOException
+    {
+        Files.createDirectories( storeDir );
+        Path storeFile = storeDir.resolve( StoreFileType.STORE.augment( MetaDataStore.DEFAULT_NAME ) );
+        Files.createFile( storeFile );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
@@ -26,13 +31,13 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.dbms.archive.IncorrectFormat;
 import org.neo4j.dbms.archive.Loader;
 import org.neo4j.helpers.ArrayUtil;
@@ -42,7 +47,6 @@ import org.neo4j.test.rule.TestDirectory;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -53,7 +57,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 
 public class LoadCommandTest
@@ -93,6 +97,42 @@ public class LoadCommandTest
 
         execute( "foo.db" );
         verify( loader ).load( any(), eq( databaseDir ) );
+    }
+
+    @Test
+    public void shouldHandleSymlinkToDatabaseDir() throws IOException, CommandFailed, IncorrectUsage, IncorrectFormat
+    {
+        Path symDir = testDirectory.directory( "path-to-links" ).toPath();
+        Path realDatabaseDir = symDir.resolve( "foo.db" );
+
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/foo.db" );
+
+        Files.createDirectories( realDatabaseDir );
+        Files.createDirectories( dataDir.resolve( "databases" ) );
+
+        Files.createSymbolicLink( databaseDir, realDatabaseDir );
+
+        Files.write( configDir.resolve( "neo4j.conf" ),
+                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+
+        execute( "foo.db" );
+        verify( loader ).load( any(), eq( realDatabaseDir ) );
+    }
+
+    @Test
+    public void shouldMakeFromCanonical() throws IOException, CommandFailed, IncorrectUsage, IncorrectFormat
+    {
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/foo.db" );
+        Files.createDirectories( databaseDir );
+        Files.write( configDir.resolve( "neo4j.conf" ),
+                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+
+        new LoadCommand( homeDir, configDir, loader )
+                .execute( ArrayUtil.concat( new String[]{"--database=foo.db", "--from=foo.dump"} ) );
+
+        verify( loader ).load( eq( Paths.get( new File( "foo.dump" ).getCanonicalPath() ) ), any() );
     }
 
     @Test
@@ -146,28 +186,24 @@ public class LoadCommandTest
     }
 
     @Test
-    public void shouldObjectIfTheDatabaseArgumentIsMissing() throws CommandFailed
+    public void shouldDefaultToGraphDb() throws Exception
     {
-        try
-        {
-            new LoadCommand( null, null, null ).execute( new String[]{"--from=something"} );
-            fail( "expected exception" );
-        }
-        catch ( IncorrectUsage e )
-        {
-            assertThat( e.getMessage(), equalTo( "Missing argument 'database'" ) );
-        }
+        Path databaseDir = homeDir.resolve( "data/databases/graph.db" );
+        Files.createDirectories( databaseDir );
+
+        new LoadCommand( homeDir, configDir, loader ).execute( new String[]{"--from=something"} );
+        verify( loader ).load( any(), eq( databaseDir ) );
     }
 
     @Test
-    public void shouldObjectIfTheArchiveArgumentIsMissing() throws CommandFailed
+    public void shouldObjectIfTheArchiveArgumentIsMissing() throws Exception
     {
         try
         {
-            new LoadCommand( homeDir, configDir, null ).execute( new String[]{"--database=something"} );
+            new LoadCommand( homeDir, configDir, loader ).execute( new String[]{"--database=something"} );
             fail( "expected exception" );
         }
-        catch ( IncorrectUsage e )
+        catch ( IllegalArgumentException e )
         {
             assertThat( e.getMessage(), equalTo( "Missing argument 'from'" ) );
         }
@@ -215,14 +251,13 @@ public class LoadCommandTest
         }
         catch ( CommandFailed e )
         {
-            assertThat( e.getMessage(), equalTo( "you do not have permission to load a database -- is Neo4j running " +
-                    "as a different user?" ) );
+            assertThat( e.getMessage(), equalTo(
+                    "you do not have permission to load a database -- is Neo4j running " + "as a different user?" ) );
         }
     }
 
     @Test
-    public void
-    shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
+    public void shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
             throws IOException, IncorrectUsage, IncorrectFormat
     {
         doThrow( new FileSystemException( "the-message" ) ).when( loader ).load( any(), any() );
@@ -251,6 +286,29 @@ public class LoadCommandTest
             assertThat( e.getMessage(), containsString( archive.toString() ) );
             assertThat( e.getMessage(), containsString( "valid Neo4j archive" ) );
         }
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new LoadCommand.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin load --from=<archive-path> [--database=<name>]\n" +
+                "                        [--force=<true|false>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Load a database from an archive. <archive-path> must be an archive created with\n" +
+                "the dump command. <database> is the name of the database to create. Existing\n" +
+                "databases can be replaced by specifying --force. It is not possible to replace a\n" +
+                "database that is mounted in a running Neo4j server.\n" +
+                "\n" +
+                "options:\n" +
+                "  --from=<archive-path>   Path to archive created with the dump command.\n" +
+                "  --database=<name>       Name of database. [default:graph.db]\n" +
+                "  --force=<true|false>    If an existing database should be replaced.\n" +
+                "                          [default:false]" );
+        verifyNoMoreInteractions( out );
     }
 
     private void execute( String database, String... otherArgs ) throws IncorrectUsage, CommandFailed

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -296,7 +296,7 @@ public class LoadCommandTest
         usage.printUsageForCommand( new LoadCommand.Provider(), out );
 
         verify( out ).accept( "usage: neo4j-admin load --from=<archive-path> [--database=<name>]\n" +
-                "                        [--force=<true|false>]" );
+                "                        [--force[=<true|false>]]" );
         verify( out ).accept( "" );
         verify( out ).accept( "Load a database from an archive. <archive-path> must be an archive created with\n" +
                 "the dump command. <database> is the name of the database to create. Existing\n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.Test;
+
+import org.neo4j.commandline.Util;
+
+import static org.junit.Assert.assertNotNull;
+
+public class UtilTest
+{
+    @Test
+    public void canonicalPath() throws Exception
+    {
+        assertNotNull( Util.canonicalPath( "foo" ).getParent() );
+    }
+
+}

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -58,7 +58,7 @@ public class SetDefaultAdminCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -29,6 +29,7 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
@@ -46,6 +47,8 @@ public class SetDefaultAdminCommand implements AdminCommand
 {
     public static final String ADMIN_INI = "admin.ini";
     public static final String COMMAND_NAME = "set-default-admin";
+    public static final Arguments arguments = new Arguments()
+            .withMandatoryPositionalArgument( 0, "username" );
 
     public static class Provider extends AdminCommand.Provider
     {
@@ -55,9 +58,9 @@ public class SetDefaultAdminCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "<username>" );
+            return arguments;
         }
 
         @Override
@@ -70,7 +73,7 @@ public class SetDefaultAdminCommand implements AdminCommand
         @Override
         public String summary()
         {
-            return description();
+            return "Sets the default admin user when no roles are present.";
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
@@ -29,6 +29,7 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
@@ -45,6 +46,10 @@ import static org.neo4j.server.security.auth.UserManager.INITIAL_USER_NAME;
 
 public class SetInitialPasswordCommand implements AdminCommand
 {
+
+    public static final Arguments arguments = new Arguments()
+            .withMandatoryPositionalArgument( 0, "password" );
+
     public static class Provider extends AdminCommand.Provider
     {
 
@@ -54,9 +59,9 @@ public class SetInitialPasswordCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "<password>" );
+            return arguments;
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
@@ -59,7 +59,7 @@ public class SetInitialPasswordCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SetDefaultAdminCommandIT
@@ -87,13 +88,36 @@ public class SetDefaultAdminCommandIT
     }
 
     @Test
-    public void shouldGetUsageOnWrongArguments() throws Throwable
+    public void shouldGetUsageOnWrongArguments1() throws Throwable
     {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN );
+        assertNoAuthIniFile();
+
+        verify( out ).stdErrLine( "No username specified." );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "Sets the user to become admin if users but no roles are present, for example\n" +
+                "when upgrading to neo4j 3.1 enterprise." );
+        verify( out ).exit( 1 );
+        verifyNoMoreInteractions( out );
+        verify( out, times( 0 ) ).stdOutLine( anyString() );
+    }
+
+    @Test
+    public void shouldGetUsageOnWrongArguments2() throws Throwable
+    {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "foo", "bar" );
         assertNoAuthIniFile();
 
-        verify( out, times( 2 ) ).stdErrLine( "neo4j-admin set-default-admin <username>" );
+        verify( out ).stdErrLine( "Too many arguments." );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "Sets the user to become admin if users but no roles are present, for example\n" +
+                "when upgrading to neo4j 3.1 enterprise." );
+        verify( out ).exit( 1 );
+        verifyNoMoreInteractions( out );
         verify( out, times( 0 ) ).stdOutLine( anyString() );
     }
 

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -22,13 +22,15 @@ package org.neo4j.commandline.admin.security;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Consumer;
 
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
@@ -45,6 +47,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.test.assertion.Assert.assertException;
 
@@ -62,7 +67,7 @@ public class SetDefaultAdminCommandTest
     @Before
     public void setup() throws IOException, InvalidArgumentsException
     {
-        OutsideWorld mock = Mockito.mock( OutsideWorld.class );
+        OutsideWorld mock = mock( OutsideWorld.class );
         when( mock.fileSystem() ).thenReturn( fileSystem );
         setDefaultAdmin = new SetDefaultAdminCommand( testDir.directory( "home" ).toPath(),
                 testDir.directory( "conf" ).toPath(), mock );
@@ -116,6 +121,20 @@ public class SetDefaultAdminCommandTest
 
         // Then
         assertAdminIniFile( "noName" );
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new SetDefaultAdminCommand.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin set-default-admin <username>" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Sets the user to become admin if users but no roles are present, for example\n" +
+                "when upgrading to neo4j 3.1 enterprise." );
+        verifyNoMoreInteractions( out );
     }
 
     private void assertAdminIniFile( String username ) throws Throwable

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SetInitialPasswordCommandIT
@@ -98,13 +99,34 @@ public class SetInitialPasswordCommandIT
     }
 
     @Test
-    public void shouldGetUsageOnWrongArguments() throws Throwable
+    public void shouldGetUsageOnWrongArguments1() throws Throwable
     {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD );
+        assertNoAuthIniFile();
+
+        verify( out ).stdErrLine( "No password specified." );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );
+        verify( out ).exit( 1 );
+        verifyNoMoreInteractions( out );
+        verify( out, times( 0 ) ).stdOutLine( anyString() );
+    }
+
+    @Test
+    public void shouldGetUsageOnWrongArguments2() throws Throwable
+    {
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "foo", "bar" );
         assertNoAuthIniFile();
 
-        verify( out, times( 2 ) ).stdErrLine( "neo4j-admin set-initial-password <password>" );
+        verify( out ).stdErrLine( "Too many arguments." );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
+        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );
+        verify( out ).exit( 1 );
+        verifyNoMoreInteractions( out );
         verify( out, times( 0 ) ).stdOutLine( anyString() );
     }
 

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -22,12 +22,14 @@ package org.neo4j.commandline.admin.security;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
+import java.util.function.Consumer;
 
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.NullLogProvider;
@@ -40,6 +42,9 @@ import org.neo4j.test.rule.TestDirectory;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.test.assertion.Assert.assertException;
 
@@ -56,7 +61,7 @@ public class SetInitialPasswordCommandTest
     @Before
     public void setup()
     {
-        OutsideWorld mock = Mockito.mock( OutsideWorld.class );
+        OutsideWorld mock = mock( OutsideWorld.class );
         when(mock.fileSystem()).thenReturn( fileSystem );
         setPasswordCommand = new SetInitialPasswordCommand( testDir.directory( "home" ).toPath(),
                 testDir.directory( "conf" ).toPath(), mock );
@@ -118,18 +123,16 @@ public class SetInitialPasswordCommandTest
     }
 
     @Test
-    public void shouldDoNothingIfAuthFileExists() throws Throwable
+    public void shouldPrintNiceHelp() throws Throwable
     {
-        // Given
-        fileSystem.mkdirs( authFile.getParentFile() );
-        fileSystem.create( authFile );
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new SetInitialPasswordCommand.Provider(), out );
 
-        // When
-        String[] arguments = {"neo4j"};
-        setPasswordCommand.execute( arguments );
-
-        // Then
-        assertFalse( fileSystem.fileExists( authInitFile ) );
+        verify( out ).accept( "usage: neo4j-admin set-initial-password <password>" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Sets the initial password of the initial admin user ('neo4j')." );
+        verifyNoMoreInteractions( out );
     }
 
     private void assertAuthIniFile( String password ) throws Throwable

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -30,6 +30,9 @@ import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.commandline.arguments.OptionalNamedArg;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
@@ -51,6 +54,17 @@ import static org.neo4j.kernel.impl.util.Converters.withDefault;
 public class OnlineBackupCommand implements AdminCommand
 {
 
+    public static final Arguments arguments = new Arguments()
+            .withArgument( new OptionalNamedArg( "from", "address", "localhost:6362",
+                    "Host and port of Neo4j." ) )
+            .withArgument( new MandatoryNamedArg( "to", "backup-path",
+                    "Directory where the backup will be made; if there is already a backup present an " +
+                            "incremental backup will be attempted." ) )
+            .withArgument( new OptionalNamedArg( "check-consistency", "true|false", "true", "If a consistency" +
+                    " check should be made." ) )
+            .withAdditionalConfig()
+            .withArgument( new OptionalNamedArg( "timeout", "timeout", "20m",
+                    "Timeout in the form <time>[ms|s|m|h], where the default unit is seconds." ) );
     private static final String checkConsistencyArg = "check-consistency";
 
     public static class Provider extends AdminCommand.Provider
@@ -61,30 +75,17 @@ public class OnlineBackupCommand implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "[--from=<address>] --to=<backup-path> " +
-                    "[--check-consistency] [--cc-report-dir=<directory>] " +
-                    "[--additional-config=<config-file-path>] [--timeout=<timeout>]" );
+            return arguments;
         }
 
         @Override
         public String description()
         {
             return "Perform a backup, over the network, from a running Neo4j server into a local copy of the " +
-                    "database store (the backup). Neo4j Server must be configured to run a backup service. See " +
-                    "http://neo4j.com/docs/operations-manual/current/backup/ for more details." +
-                    "\n\n" +
-                    "<address> is a <host>:<port> pair like neo4j.example.com:1234; the host defaults to localhost " +
-                    "and the port defaults to 6362, the default backup service port." +
-                    "\n\n" +
-                    "<backup-path> is a directory where the backup will be made; if there is already a backup " +
-                    "present an incremental backup will be made." +
-                    "\n\n" +
-                    "Consistency checking is enabled by default. Report will be written into the working directory " +
-                    "by default." +
-                    "\n\n" +
-                    "<timeout> is in the from <time>[ms|s|m|h]; the default is 20m; the default unit is seconds.";
+                            "database store (the backup). Neo4j Server must be configured to run a backup service. " +
+                            "See http://neo4j.com/docs/operations-manual/current/backup/ for more details.";
         }
 
         @Override

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -29,10 +29,12 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
-import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
+import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
@@ -41,15 +43,8 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.configuration.ConfigLoader;
 
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
-
-import static org.neo4j.kernel.impl.util.Converters.mandatory;
-import static org.neo4j.kernel.impl.util.Converters.optional;
-import static org.neo4j.kernel.impl.util.Converters.toFile;
 import static org.neo4j.kernel.impl.util.Converters.toHostnamePort;
-import static org.neo4j.kernel.impl.util.Converters.toPath;
-import static org.neo4j.kernel.impl.util.Converters.withDefault;
 
 public class OnlineBackupCommand implements AdminCommand
 {
@@ -60,12 +55,13 @@ public class OnlineBackupCommand implements AdminCommand
             .withArgument( new MandatoryNamedArg( "to", "backup-path",
                     "Directory where the backup will be made; if there is already a backup present an " +
                             "incremental backup will be attempted." ) )
-            .withArgument( new OptionalNamedArg( "check-consistency", "true|false", "true", "If a consistency" +
-                    " check should be made." ) )
+            .withArgument( new OptionalBooleanArg( "check-consistency", true,
+                    "If a consistency check should be made." ) )
+            .withArgument( new OptionalCanonicalPath( "cc-report-dir", "directory", ".",
+                    "Directory where consistency report will be written.") )
             .withAdditionalConfig()
             .withArgument( new OptionalNamedArg( "timeout", "timeout", "20m",
                     "Timeout in the form <time>[ms|s|m|h], where the default unit is seconds." ) );
-    private static final String checkConsistencyArg = "check-consistency";
 
     public static class Provider extends AdminCommand.Provider
     {
@@ -120,19 +116,25 @@ public class OnlineBackupCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Args parsedArgs = Args.withFlags( checkConsistencyArg ).parse( args );
         HostnamePort address;
         File destination;
-        ConsistencyCheck consistencyCheck;
+        ConsistencyCheck consistencyCheck = ConsistencyCheck.NONE;
         Optional<Path> additionalConfig;
         long timeout;
         try
         {
-            address = parseAddress( parsedArgs );
-            destination = parseDestination( parsedArgs );
-            consistencyCheck = parseConsistencyCheck( parsedArgs );
-            additionalConfig = parseAdditionalConfig( parsedArgs );
-            timeout = parseTimeout( parsedArgs );
+            address = toHostnamePort( new HostnamePort( "localhost", 6362 ) )
+                    .apply( arguments.parse( "from", args ) );
+            destination = arguments.parseMandatoryPath( "to", args ).toFile();
+            timeout = parseTimeout( args );
+            additionalConfig = arguments.parseOptionalPath( "additional-config", args );
+            if ( arguments.parseBoolean( "check-consistency", args ) )
+            {
+                Path reportDir = arguments.parseOptionalPath( "cc-report-dir", args )
+                        .orElseThrow( () ->
+                        new IllegalArgumentException( "cc-report-dir must be a path" ) );
+                consistencyCheck = ConsistencyCheck.full( reportDir.toFile(), consistencyCheckService );
+            }
         }
         catch ( IllegalArgumentException e )
         {
@@ -150,42 +152,9 @@ public class OnlineBackupCommand implements AdminCommand
         }
     }
 
-    private HostnamePort parseAddress( Args args )
+    private long parseTimeout( String[] args )
     {
-        HostnamePort defaultAddress = new HostnamePort( "localhost", 6362 );
-        return args.interpretOption( "from", withDefault( defaultAddress ), toHostnamePort( defaultAddress ) );
-    }
-
-    private File parseDestination( Args parsedArgs )
-    {
-        return parsedArgs.interpretOption( "to", mandatory(), toFile() );
-    }
-
-    private ConsistencyCheck parseConsistencyCheck( Args args ) throws CommandFailed
-    {
-        File reportDir;
-        try
-        {
-            reportDir = args.interpretOption( "cc-report-dir", withDefault( new File(".") ), File::new )
-                    .getCanonicalFile();
-        }
-        catch ( IOException e )
-        {
-            throw new CommandFailed( format( "cannot access report directory: %s: %s",
-                    e.getClass().getSimpleName(), e.getMessage() ), e );
-        }
-        return args.getBoolean( checkConsistencyArg, true, true ) ?
-                ConsistencyCheck.full( reportDir, consistencyCheckService ) : ConsistencyCheck.NONE;
-    }
-
-    private Optional<Path> parseAdditionalConfig( Args args )
-    {
-        return Optional.ofNullable( args.interpretOption( "additional-config", optional(), toPath() ) );
-    }
-
-    private long parseTimeout( Args parsedArgs )
-    {
-        return parsedArgs.getDuration( "timeout", TimeUnit.MINUTES.toMillis( 20 ) );
+        return Args.parse( args ).getDuration( "timeout", TimeUnit.MINUTES.toMillis( 20 ) );
     }
 
     private Config loadConfig( Optional<Path> additionalConfig ) throws CommandFailed

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -71,7 +71,7 @@ public class OnlineBackupCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -114,7 +114,7 @@ public class RestoreDatabaseCli implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -80,7 +80,6 @@ public class RestoreDatabaseCli implements AdminCommand
         String fromPath;
         boolean forceOverwrite;
 
-        //Args args = Args.parse( incomingArguments );
         try
         {
             databaseName = arguments.parse( "database", incomingArguments );

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
@@ -22,7 +21,6 @@ package org.neo4j.restore;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,20 +30,82 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Args;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.server.configuration.ConfigLoader;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class RestoreDatabaseCli implements AdminCommand
 {
+    private static final Arguments arguments = new Arguments()
+            .withArgument( new MandatoryNamedArg( "from", "backup-directory", "Path to backup to restore from." ) )
+            .withDatabase()
+            .withArgument( new OptionalBooleanArg( "force", false, "If an existing database should be replaced." ) );
     private final Path homeDir;
     private final Path configDir;
+
+    public RestoreDatabaseCli( Path homeDir, Path configDir )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+    }
+
+    private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName )
+    {
+        ConfigLoader configLoader = new ConfigLoader( settings() );
+        Config config = configLoader.loadOfflineConfig( Optional.of( homeDir.toFile() ),
+                Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ) );
+
+        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
+    }
+
+    private static List<Class<?>> settings()
+    {
+        List<Class<?>> settings = new ArrayList<>();
+        settings.add( GraphDatabaseSettings.class );
+        settings.add( DatabaseManagementSystemSettings.class );
+        return settings;
+    }
+
+    @Override
+    public void execute( String[] incomingArguments ) throws IncorrectUsage, CommandFailed
+    {
+        String databaseName;
+        String fromPath;
+        boolean forceOverwrite;
+
+        //Args args = Args.parse( incomingArguments );
+        try
+        {
+            databaseName = arguments.parse( "database", incomingArguments );
+            fromPath = arguments.parse("from", incomingArguments);
+            forceOverwrite = arguments.parseBoolean("force", incomingArguments);
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new IncorrectUsage( e.getMessage() );
+        }
+
+        Config config = loadNeo4jConfig( homeDir, configDir, databaseName );
+
+        RestoreDatabaseCommand restoreDatabaseCommand = new RestoreDatabaseCommand( new DefaultFileSystemAbstraction(),
+                new File( fromPath ), config, databaseName, forceOverwrite );
+
+        try
+        {
+            restoreDatabaseCommand.execute();
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( "Failed to restore database", e );
+        }
+    }
 
     public static class Provider extends AdminCommand.Provider
     {
@@ -55,9 +115,9 @@ public class RestoreDatabaseCli implements AdminCommand
         }
 
         @Override
-        public Optional<String> arguments()
+        public Arguments arguments()
         {
-            return Optional.of( "--from=<backup-directory> --database=<database-name> [--force]" );
+            return arguments;
         }
 
         @Override
@@ -77,84 +137,5 @@ public class RestoreDatabaseCli implements AdminCommand
         {
             return new RestoreDatabaseCli( homeDir, configDir );
         }
-    }
-
-    public RestoreDatabaseCli( Path homeDir, Path configDir )
-    {
-
-        this.homeDir = homeDir;
-        this.configDir = configDir;
-    }
-
-    private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName )
-    {
-        ConfigLoader configLoader = new ConfigLoader( settings() );
-        Config config = configLoader.loadOfflineConfig(
-                Optional.of( homeDir.toFile() ),
-                Optional.of( configDir.resolve( "neo4j.conf" ).toFile() ));
-
-        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
-    }
-
-    @Override
-    public void execute( String[] incomingArguments ) throws IncorrectUsage, CommandFailed
-    {
-        String databaseName;
-        String fromPath;
-        boolean forceOverwrite;
-
-        Args args = Args.parse( incomingArguments );
-        try
-        {
-            databaseName = args.interpretOption( "database", Converters.mandatory(), s -> s );
-            fromPath = args.interpretOption( "from", Converters.mandatory(), s -> s );
-            forceOverwrite = args.getBoolean( "force", Boolean.FALSE, true );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            throw new IncorrectUsage( e.getMessage() );
-        }
-
-        Config config = loadNeo4jConfig( homeDir, configDir, databaseName );
-
-        RestoreDatabaseCommand restoreDatabaseCommand = new RestoreDatabaseCommand(
-                new DefaultFileSystemAbstraction(),
-                new File( fromPath ),
-                config,
-                databaseName,
-                forceOverwrite );
-
-        try
-        {
-            restoreDatabaseCommand.execute();
-        }
-        catch ( IOException e )
-        {
-            throw new CommandFailed( "Failed to restore database", e );
-        }
-    }
-
-    private static List<Class<?>> settings()
-    {
-        List<Class<?>> settings = new ArrayList<>();
-        settings.add( GraphDatabaseSettings.class );
-        settings.add( DatabaseManagementSystemSettings.class );
-        return settings;
-    }
-
-    private static void printUsage( PrintStream out )
-    {
-        out.println( "Neo4j Restore Tool" );
-        for ( String line : Args.splitLongLine( "The restore tool is used to restore a backed up database", 80 ) )
-        {
-            out.println( "\t" + line );
-        }
-
-        out.println( "Usage:" );
-        out.println("--home-dir <path-to-neo4j>");
-        out.println("--from <path-to-backup-directory>");
-        out.println("--database <database-name>");
-        out.println("--config <path-to-config-directory>");
-        out.println("--force");
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
@@ -27,7 +27,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 
 import static java.lang.String.format;
-import static org.neo4j.commandline.dbms.Util.checkLock;
+import static org.neo4j.commandline.Util.checkLock;
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 
 public class RestoreDatabaseCommand

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -19,20 +19,23 @@
  */
 package org.neo4j.backup;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
@@ -43,7 +46,6 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -58,6 +60,7 @@ import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 
 import static org.neo4j.consistency.ConsistencyCheckService.Result.success;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cypher_planner;
 
 public class OnlineBackupCommandTest
@@ -273,6 +276,41 @@ public class OnlineBackupCommandTest
         execute( "--timeout=10h", "--to=/" );
 
         verify( tool ).executeBackup( any(), any(), any(), any(), eq( HOURS.toMillis( 10 ) ), anyBoolean() );
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new OnlineBackupCommand.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin backup [--from=<address>] --to=<backup-path>\n" +
+                "                          [--check-consistency=<true|false>]\n" +
+                "                          [--additional-config=<config-file-path>]\n" +
+                "                          [--timeout=<timeout>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Perform a backup, over the network, from a running Neo4j server into a local\n" +
+                "copy of the database store (the backup). Neo4j Server must be configured to run\n" +
+                "a backup service. See http://neo4j.com/docs/operations-manual/current/backup/\n" +
+                "for more details.\n" +
+                "\n" +
+                "options:\n" +
+                "  --from=<address>                         Host and port of Neo4j.\n" +
+                "                                           [default:localhost:6362]\n" +
+                "  --to=<backup-path>                       Directory where the backup will be\n" +
+                "                                           made; if there is already a backup\n" +
+                "                                           present an incremental backup will be\n" +
+                "                                           attempted.\n" +
+                "  --check-consistency=<true|false>         If a consistency check should be\n" +
+                "                                           made. [default:true]\n" +
+                "  --additional-config=<config-file-path>   Configuration file to supply\n" +
+                "                                           additional configuration in.\n" +
+                "                                           [default:]\n" +
+                "  --timeout=<timeout>                      Timeout in the form <time>[ms|s|m|h],\n" +
+                "                                           where the default unit is seconds.\n" +
+                "                                           [default:20m]" );
+        verifyNoMoreInteractions( out );
     }
 
     private void execute( String... args ) throws IncorrectUsage, CommandFailed

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -286,7 +286,8 @@ public class OnlineBackupCommandTest
         usage.printUsageForCommand( new OnlineBackupCommand.Provider(), out );
 
         verify( out ).accept( "usage: neo4j-admin backup [--from=<address>] --to=<backup-path>\n" +
-                "                          [--check-consistency=<true|false>]\n" +
+                "                          [--check-consistency[=<true|false>]]\n" +
+                "                          [--cc-report-dir=<directory>]\n" +
                 "                          [--additional-config=<config-file-path>]\n" +
                 "                          [--timeout=<timeout>]" );
         verify( out ).accept( "" );
@@ -304,6 +305,8 @@ public class OnlineBackupCommandTest
                 "                                           attempted.\n" +
                 "  --check-consistency=<true|false>         If a consistency check should be\n" +
                 "                                           made. [default:true]\n" +
+                "  --cc-report-dir=<directory>              Directory where consistency report\n" +
+                "                                           will be written. [default:.]\n" +
                 "  --additional-config=<config-file-path>   Configuration file to supply\n" +
                 "                                           additional configuration in.\n" +
                 "                                           [default:]\n" +

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -175,7 +175,7 @@ public class RestoreDatabaseCommandTest
         usage.printUsageForCommand( new RestoreDatabaseCli.Provider(), out );
 
         verify( out ).accept( "usage: neo4j-admin restore --from=<backup-directory> [--database=<name>]\n" +
-                "                           [--force=<true|false>]" );
+                "                           [--force[=<true|false>]]" );
         verify( out ).accept( "" );
         verify( out ).accept( "Restore a backed up database.\n" +
                 "\n" +

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -23,7 +23,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.function.Consumer;
 
+import org.neo4j.commandline.admin.CommandLocator;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
@@ -40,6 +43,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class RestoreDatabaseCommandTest
@@ -159,6 +165,26 @@ public class RestoreDatabaseCommandTest
         }
 
         copiedDb.shutdown();
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new RestoreDatabaseCli.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin restore --from=<backup-directory> [--database=<name>]\n" +
+                "                           [--force=<true|false>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Restore a backed up database.\n" +
+                "\n" +
+                "options:\n" +
+                "  --from=<backup-directory>   Path to backup to restore from.\n" +
+                "  --database=<name>           Name of database. [default:graph.db]\n" +
+                "  --force=<true|false>        If an existing database should be replaced.\n" +
+                "                              [default:false]" );
+        verifyNoMoreInteractions( out );
     }
 
     public static Config configWith( Config config, String databaseName, String dataDirectory )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -139,7 +139,7 @@ public class UnbindFromClusterCommand implements AdminCommand
         }
 
         @Override
-        public Arguments arguments()
+        public Arguments allArguments()
         {
             return arguments;
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
@@ -29,10 +29,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.Usage;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -44,40 +47,16 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.kernel.internal.StoreLocker.STORE_LOCK_FILENAME;
 
 public class UnbindFromClusterCommandTest
 {
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
-
-    @Test
-    public void shouldFailIfDatabaseNotSpecified() throws Exception
-    {
-        // given
-        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
-        fsa.mkdir( testDir.directory() );
-
-        UnbindFromClusterCommand command =
-                new UnbindFromClusterCommand( testDir.directory().toPath(), testDir.directory( "conf" ).toPath(),
-                        mock( OutsideWorld.class ) );
-
-        try
-        {
-            // when
-            command.execute( noArgs() );
-            fail();
-        }
-        catch ( IncorrectUsage e )
-        {
-            // then
-            assertThat( e.getMessage(), containsString( "Missing argument 'database'" ) );
-        }
-    }
 
     @Test
     public void shouldFailIfSpecifiedDatabaseDoesNotExist() throws Exception
@@ -173,6 +152,23 @@ public class UnbindFromClusterCommandTest
         command.execute( databaseName( "graph.db" ) );
 
         verify( outsideWorld ).stdErrLine( startsWith( "No cluster state found in" ) );
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Throwable
+    {
+        Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+        Consumer<String> out = mock( Consumer.class );
+        usage.printUsageForCommand( new UnbindFromClusterCommand.Provider(), out );
+
+        verify( out ).accept( "usage: neo4j-admin unbind [--database=<name>]" );
+        verify( out ).accept( "" );
+        verify( out ).accept( "Removes cluster state data from the specified database making it suitable for\n" +
+                "use in single instance database, or for seeding a new cluster.\n" +
+                "\n" +
+                "options:\n" +
+                "  --database=<name>   Name of database. [default:graph.db]" );
+        verifyNoMoreInteractions( out );
     }
 
     private String[] databaseName( String databaseName )


### PR DESCRIPTION
This adds logic to parse some common arguments, but primarily it deals
with formatting usage and description strings in a consistent way
across all commands.

As a side-effect it also

- makes sure paths are canonicalized
- make sure `Dump` requires an existing database
- lists missing arguments from certain commands

## Outputs and comparisons between new vs old

### help

```
usage: neo4j-admin <command>

available commands:
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').
    restore
        Restore a backed up database.
    dump
        Dump a database into a single-file archive.
    backup
        Perform a backup, over the network, from a running Neo4j server.
    unbind
        Removes cluster state data from the specified database.
    load
        Load a database from an archive created with the dump command.
    check-consistency
        Check the consistency of a database.
    set-default-admin
        Sets the default admin user when no roles are present.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    help
        This help text, or help for the command specified in <command>.

Use neo4j-admin help <command> for more details.
```

### set-initial-password

```
usage: neo4j-admin set-initial-password <password>

Sets the initial password of the initial admin user ('neo4j').
```

vs

```
neo4j-admin set-initial-password <password>

    Sets the initial password of the initial admin user ('neo4j').
```

### restore

```
usage: neo4j-admin restore --from=<backup-directory> [--database=<name>]
                           [--force=<true|false>]

Restore a backed up database.

options:
  --from=<backup-directory>   Path to backup to restore from.
  --database=<name>           Name of database. [default:graph.db]
  --force=<true|false>        If an existing database should be replaced.
                              [default:false]
```

vs

```
neo4j-admin restore --from=<backup-directory> --database=<database-name> [--force]

    Restore a backed up database.
```

### dump

```
usage: neo4j-admin dump [--database=<name>] --to=<destination-path>

Dump a database into a single-file archive. The archive can be used by the load
command. <destination-path> can be a file or directory (in which case a file
called <database>.dump will be created). It is not possible to dump a database
that is mounted in a running Neo4j server.

options:
  --database=<name>         Name of database. [default:graph.db]
  --to=<destination-path>   Destination (file or folder) of database dump.
```

vs

```
neo4j-admin dump --database=<database> --to=<destination-path>

    Dump a database into a single-file archive. The archive can be used by the load
    command. <destination-path> can be a file or directory (in which case a file
    called <database>.dump will be created). It is not possible to dump a database
    that is mounted in a running Neo4j server.
```

### backup

```
usage: neo4j-admin backup [--from=<address>] --to=<backup-path>
                          [--check-consistency=<true|false>]
                          [--additional-config=<config-file-path>]
                          [--timeout=<timeout>]

Perform a backup, over the network, from a running Neo4j server into a local
copy of the database store (the backup). Neo4j Server must be configured to run
a backup service. See http://neo4j.com/docs/operations-manual/current/backup/
for more details.

options:
  --from=<address>                         Host and port of Neo4j.
                                           [default:localhost:6362]
  --to=<backup-path>                       Directory where the backup will be
                                           made; if there is already a backup
                                           present an incremental backup will be
                                           attempted.
  --check-consistency=<true|false>         If a consistency check should be
                                           made. [default:true]
  --additional-config=<config-file-path>   Configuration file to supply
                                           additional configuration in.
                                           [default:]
  --timeout=<timeout>                      Timeout in the form <time>[ms|s|m|h],
                                           where the default unit is seconds.
                                           [default:20m]
```

vs

```
neo4j-admin backup [--from=<address>] --to=<backup-path> [--check-consistency] [--additional-config=<config-file-path>] [--timeout=<timeout>]

    Perform a backup, over the network, from a running Neo4j server into a local
    copy of the database store (the backup). Neo4j Server must be configured to run
    a backup service. See http://neo4j.com/docs/operations-manual/current/backup/
    for more details.

    <address> is a <host>:<port> pair like neo4j.example.com:1234; the host defaults
    to localhost and the port defaults to 6362, the default backup service port.

    <backup-path> is a directory where the backup will be made; if there is already
    a backup present an incremental backup will be made.

    Consistency checking is enabled by default.

    <timeout> is in the from <time>[ms|s|m|h]; the default is 20m; the default unit
    is seconds.
```

### unbind

```
usage: neo4j-admin unbind [--database=<name>]

Removes cluster state data from the specified database making it suitable for
use in single instance database, or for seeding a new cluster.

options:
  --database=<name>   Name of database. [default:graph.db]
```

### load

```
usage: neo4j-admin load --from=<archive-path> [--database=<name>]
                        [--force=<true|false>]

Load a database from an archive. <archive-path> must be an archive created with
the dump command. <database> is the name of the database to create. Existing
databases can be replaced by specifying --force. It is not possible to replace a
database that is mounted in a running Neo4j server.

options:
  --from=<archive-path>   Path to archive created with the dump command.
  --database=<name>       Name of database. [default:graph.db]
  --force=<true|false>    If an existing database should be replaced.
                          [default:false]
```

vs

```
neo4j-admin load --from=<archive-path> --database=<database> [--force]

    Load a database from an archive. <archive-path> must be an archive created with
    the dump command. <database> is the name of the database to create. Existing
    databases can be replaced by specifying --force. It is not possible to replace a
    database that is mounted in a running Neo4j server.
```

### check-consistency

```
usage: neo4j-admin check-consistency [--database=<name>]
                                     [--additional-config=<config-file-path>]
                                     [--verbose=<true|false>]
                                     [--report-dir=<directory>]

Check the consistency of a database.

options:
  --database=<name>                        Name of database. [default:graph.db]
  --additional-config=<config-file-path>   Configuration file to supply
                                           additional configuration in.
                                           [default:]
  --verbose=<true|false>                   Enable verbose output.
                                           [default:false]
  --report-dir=<directory>                 Directory to write report file in.
                                           [default:.]
```

vs

```
neo4j-admin check-consistency --database=<database> [--additional-config=<file>] [--verbose]

    Check the consistency of a database.
```

### set-default-admin

```
usage: neo4j-admin set-default-admin <username>

Sets the user to become admin if users but no roles are present, for example
when upgrading to neo4j 3.1 enterprise.
```

### import

```
usage: neo4j-admin import [--mode=csv] [--database=<name>]
                          [--additional-config=<config-file-path>]
                          [--report-file=<filename>]
                          [--nodes[:Label1:Label2]=<"file1,file2,...">]
                          [--relationships[:RELATIONSHIP_TYPE]=<"file1,file2,...">]
                          [--id-type=<STRING|INTEGER|ACTUAL>]
                          [--input-encoding=<character-set>]
usage: neo4j-admin import --mode=database [--database=<name>]
                          [--additional-config=<config-file-path>]
                          [--from=<source-directory>]

Import a collection of CSV files with --mode=csv (default), or a database from a
pre-3.0 installation with --mode=database.

options:
  --database=<name>
      Name of database. [default:graph.db]
  --additional-config=<config-file-path>
      Configuration file to supply additional configuration in. [default:]
  --mode=<database|csv>
      Import a collection of CSV files or a pre-3.0 installation.
      [default:csv]
  --from=<source-directory>
      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).
      [default:]
  --report-file=<filename>
      File in which to store the report of the csv-import.
      [default:import.report]
  --nodes[:Label1:Label2]=<"file1,file2,...">
      Node CSV header and data. Multiple files will be logically seen as one
      big file from the perspective of the importer. The first line must
      contain the header. Multiple data sources like these can be specified in
      one import, where each data source has its own header. Note that file
      groups must be enclosed in quotation marks. [default:]
  --relationships[:RELATIONSHIP_TYPE]=<"file1,file2,...">
      Relationship CSV header and data. Multiple files will be logically seen
      as one big file from the perspective of the importer. The first line
      must contain the header. Multiple data sources like these can be
      specified in one import, where each data source has its own header. Note
      that file groups must be enclosed in quotation marks. [default:]
  --id-type=<STRING|INTEGER|ACTUAL>
      Each node must provide a unique id. This is used to find the correct
      nodes when creating relationships. Possible values are STRING: arbitrary
      strings for identifying nodes, INTEGER: arbitrary integer values for
      identifying nodes, ACTUAL: (advanced) actual node ids. For more
      information on id handling, please see the Neo4j Manual:
      http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
      [default:STRING]
  --input-encoding=<character-set>
      Character set that input data is encoded in. [default:UTF-8]
```

vs

```
neo4j-admin import --database=<database-name> [--mode={csv|database}] [--additional-config=<config-file-path>] [--from=<source-directory>] [--report-file=<filename>] [--nodes[:Label1:Label2]="<file1>,<file2>,..."] [--relationships[:RELATIONSHIP_TYPE]="<file1>,<file2>,..."] [--input-encoding=<character-set>] [--id-type=<id-type>]

    Import a collection of CSV files with --mode=csv (default), or a database from a
    pre-3.0 installation with --mode=database.
    --mode=database        Import a database from a pre-3.0 Neo4j installation.
            <source-directory> is the database location
            (e.g. <neo4j-root>/data/graph.db).


    --mode=csv Import a database from a collection of CSV files.
    --report-file <filename>
            File name in which to store the report of the import.
            Defaults to import.report in the current directory.
    --nodes[:Label1:Label2]="<file1>,<file2>,..."
            Node CSV header and data. Multiple files will be logically seen as
            one big file from the perspective of the importer. The first line
            must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --relationships[:RELATIONSHIP_TYPE] "<file1>,<file2>,..."
            Relationship CSV header and data. Multiple files will be logically
            seen as one big file from the perspective of the importer. The first
            line must contain the header. Multiple data sources like these can be
            specified in one import, where each data source has its own header.
            Note that file groups must be enclosed in quotation marks.
    --id-type <id-type>
            Each node must provide a unique id. This is used to find the correct
            nodes when creating relationships. Must be one of:
                STRING: (default) arbitrary strings for identifying nodes.
                INTEGER: arbitrary integer values for identifying nodes.
                ACTUAL: (advanced) actual node ids. The default option is STRING.
            For more information on id handling, please see the Neo4j Manual:
            http://neo4j.com/docs/operations-manual/current/deployment/#import-tool
    --input-encoding <character-set>
            Character set that input data is encoded in. Defaults to UTF-8.
    --page-size <page-size>
            Page size to use for import in bytes. (e. g. 4M or 8k)
```

changelog: Fixed path calculations in `neo4j-admin dump` and `neo4j-admin load`
- specifying `--to=foo` which previously didn't work is now equivalent to `--to=./foo`
- now follows symlinks, in case the database directory is a symlink for example
- improved formatting of all help texts