### PR TITLE
Fix tests for Windows path handling

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -193,7 +193,7 @@ public class CheckConsistencyCommandTest
 
         verify( consistencyCheckService )
                 .runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(), anyObject(),
-                        anyBoolean(), eq( new File( "/some-dir-or-other" ) ) );
+                        anyBoolean(), eq( new File( "/some-dir-or-other" ).getCanonicalFile() ) );
     }
 
     @Test
@@ -216,6 +216,6 @@ public class CheckConsistencyCommandTest
 
         verify( consistencyCheckService )
                 .runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(), anyObject(),
-                        anyBoolean(), eq( new File( "/bar" ) ) );
+                        anyBoolean(), eq( new File( "/bar" ).getCanonicalFile() ) );
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -193,7 +193,7 @@ public class OnlineBackupCommandTest
         captor.getValue().runFull( null, null, null, null, null, null, false );
 
         verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(), any(),
-                anyBoolean(), eq( new File("/some/dir") ) );
+                anyBoolean(), eq( new File("/some/dir").getCanonicalFile() ) );
     }
 
     @Test


### PR DESCRIPTION
The errors that this fixes are all of the form:

```
org.mockito.exceptions.verification.junit.ArgumentsAreDifferent: 
Argument(s) are different! 
Wanted: 
consistencyCheckService.runFullConsistencyCheck( <any>, <any>, <any>, <any>, <any>, <any>, <any>, \some\dir ); 
-> at org.neo4j.backup.OnlineBackupCommandTest.shouldSpecifyReportDirIfSpecified(OnlineBackupCommandTest.java:195) 
Actual invocation has different arguments: 
consistencyCheckService.runFullConsistencyCheck( null, null, null, null, null, null, false, Z:\some\dir ); 
-> at org.neo4j.backup.ConsistencyCheck$3.runFull(ConsistencyCheck.java:109) 
```