### PR TITLE
Fail on missing configured auth plugin

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -177,7 +177,7 @@ public abstract class EditionModule
                     } );
                     return;
                 }
-                catch ( KernelException e )
+                catch ( Exception e )
                 {
                     String errorMessage = "Failed to load security module.";
                     log.error( errorMessage );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.helpers.Service;
@@ -55,6 +56,7 @@ import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.time.Clocks;
 
+import static java.lang.String.format;
 import static org.neo4j.kernel.api.proc.Context.SECURITY_CONTEXT;
 
 @Service.Implementation( SecurityModule.class )
@@ -143,16 +145,18 @@ public class EnterpriseSecurityModule extends SecurityModule
             realms.add( new LdapRealm( config, securityLog, secureHasher ) );
         }
 
-        // Load plugin realms if we have any
-        realms.addAll( createPluginRealms( config, securityLog, secureHasher ) );
+        // Load plugin realms if a plugin provider in configured
+        if ( configuredRealms.stream().anyMatch( ( r ) -> r.startsWith( SecuritySettings.PLUGIN_REALM_NAME_PREFIX ) ) )
+        {
+            realms.addAll( createPluginRealms( config, securityLog, secureHasher, configuredRealms ) );
+        }
 
         // Select the active realms in the order they are configured
         List<Realm> orderedActiveRealms = selectOrderedActiveRealms( configuredRealms, realms );
 
         if ( orderedActiveRealms.isEmpty() )
         {
-            String message = "Illegal configuration: No valid security realm is active.";
-            throw new IllegalArgumentException( message );
+            throw new IllegalArgumentException( "Illegal configuration: No valid auth provider is active." );
         }
 
         return new MultiRealmAuthManager( internalRealm, orderedActiveRealms, createCacheManager( config ),
@@ -198,9 +202,10 @@ public class EnterpriseSecurityModule extends SecurityModule
         return new ShiroCaffeineCache.Manager( Ticker.systemTicker(), ttl, maxCapacity );
     }
 
-    private static List<Realm> createPluginRealms( Config config, SecurityLog securityLog, SecureHasher secureHasher )
+    private static List<PluginRealm> createPluginRealms(
+            Config config, SecurityLog securityLog, SecureHasher secureHasher, List<String> configuredRealms )
     {
-        List<Realm> realms = new ArrayList<>();
+        List<PluginRealm> availablePluginRealms = new ArrayList<>();
         Set<Class> excludedClasses = new HashSet<>();
 
         Boolean pluginAuthenticationEnabled = config.get( SecuritySettings.plugin_authentication_enabled );
@@ -215,7 +220,7 @@ public class EnterpriseSecurityModule extends SecurityModule
             {
                 PluginRealm pluginRealm =
                         new PluginRealm( plugin, config, securityLog, Clocks.systemClock(), secureHasher );
-                realms.add( pluginRealm );
+                availablePluginRealms.add( pluginRealm );
             }
         }
 
@@ -243,7 +248,7 @@ public class EnterpriseSecurityModule extends SecurityModule
                     pluginRealm =
                             new PluginRealm( plugin, null, config, securityLog, Clocks.systemClock(), secureHasher );
                 }
-                realms.add( pluginRealm );
+                availablePluginRealms.add( pluginRealm );
             }
         }
 
@@ -258,9 +263,28 @@ public class EnterpriseSecurityModule extends SecurityModule
                 {
                     PluginRealm pluginRealm =
                             new PluginRealm( null, plugin, config, securityLog, Clocks.systemClock(), secureHasher );
-                    realms.add( pluginRealm );
+                    availablePluginRealms.add( pluginRealm );
                 }
             }
+        }
+
+        List<PluginRealm> realms =
+                availablePluginRealms.stream()
+                        .filter( realm -> configuredRealms.contains( realm.getName() ) )
+                        .collect( Collectors.toList() );
+        boolean missingAuthenticationRealm = pluginAuthenticationEnabled &&
+                !realms.stream().anyMatch( PluginRealm::canAuthenticate );
+        boolean missingAuthorizingRealm = pluginAuthorizationEnabled &&
+                !realms.stream().anyMatch( PluginRealm::canAuthorize );
+
+        if ( missingAuthenticationRealm || missingAuthorizingRealm )
+        {
+            String missingProvider =
+                    ( missingAuthenticationRealm && missingAuthorizingRealm ) ? "authentication or authorization" :
+                    ( missingAuthenticationRealm ) ? "authentication" : "authorization";
+
+            throw new IllegalArgumentException( format( "Illegal configuration: No plugin %s provider loaded even " +
+                    "though required by configuration.", missingProvider ) );
         }
 
         return realms;


### PR DESCRIPTION
If plugin authentication of authorization is enabled, but no respective auth plugin is found during service loading, the server will fail to start and give an appropriate error message.