### PR TITLE
Fix eagerness bug on property reads in the horizon

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
@@ -29,7 +29,7 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
       val from = fromPipe.effects
       val to = toPipe.localEffects
       if (wouldConflict(from, to)) {
-        new EagerPipe(fromPipe)()(fromPipe.monitor)
+        EagerPipe(fromPipe)()(fromPipe.monitor)
       } else {
         fromPipe
       }
@@ -179,6 +179,14 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
   }
 
   private def nodePropertiesConflict(from: Effects, to: Effects): Boolean = {
+    nodeReadWriteProps(from, to) || nodeWriteReadProps(from, to)
+  }
+
+  private def nodeWriteReadProps(from: Effects, to: Effects) = {
+    nodeReadWriteProps(to, from)
+  }
+
+  private def nodeReadWriteProps(from: Effects, to: Effects): Boolean = {
     val propertyReads = from.effectsSet.collect {
       case property: ReadsNodeProperty => property
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
@@ -107,7 +107,8 @@ object Eagerness {
   def headWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                        (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    if (alwaysEager || query.tail.isDefined && writeReadConflictInHead(query, query.tail.get))
+    val conflictInHorizon = query.queryGraph.horizonOverlap(query.horizon)
+    if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInHead(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else
       inputPlan

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -44,6 +44,23 @@ class EagerizationAcceptanceTest
 
   val EagerRegEx: Regex = "Eager(?!(Aggregation))".r
 
+  test("should be eager between property writes in QG and reads in horizon") {
+    val n1 = createNode("val" -> 1)
+    val n2 = createNode("val" -> 1)
+    relate(n1, n2)
+
+    val query = """MATCH (n)--(m)
+                  |SET n.val = n.val + 1
+                  |RETURN n.val AS nv, m.val AS mv
+                """.stripMargin
+
+    val result = updateWithBothPlanners(query)
+
+    result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
+                                    Map("nv" -> 2, "mv" -> 2)))
+    assertStats(result, propertiesWritten = 2)
+  }
+
   test("should handle detach deleting the same node twice") {
     val a = createLabeledNode("A")
     relate(a, createNode())


### PR DESCRIPTION
changelog: Fixes a bug with eagerness on property reads.

Previous to this commit, the eagerness analysis system has been working with
the assumption that the `QueryGraph` encodes all reads being done in a
`PlannerQuery`. This is not correct, the `QueryHorizon` may also encode reads.
This commit fixes eagerness issues related to property reads in the horizon,
when those conflict with writes being done in the `QueryGraph`.

Still left to do are reads made by functions in the horizon (`labels()`, `properties()`).
Additionally, potential conflicts between reads in horizon and subsequent
writes in the tail(s) of the PQs.

Also fixed for the rule planner.