### PR TITLE
Limit number of meta items shown in database sidebar drawer

### DIFF
--- a/community/browser/app/index.jade
+++ b/community/browser/app/index.jade
@@ -190,4 +190,5 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     script(src='scripts/directives/playSrc.js')
     script(src='lib/helpers.js')
     script(src='lib/serializer.js')
+    script(src='scripts/controllers/DatabaseDrawer.js')
     //endbuild     

--- a/community/browser/app/scripts/controllers/DatabaseDrawer.coffee
+++ b/community/browser/app/scripts/controllers/DatabaseDrawer.coffee
@@ -1,0 +1,67 @@
+###!
+Copyright (c) 2002-2016 "Neo Technology,"
+Network Engine for Objects in Lund AB [http://neotechnology.com]
+
+This file is part of Neo4j.
+
+Neo4j is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+'use strict'
+
+angular.module('neo4jApp.controllers')
+  .controller 'DatabaseDrawerCtrl', [
+    '$scope'
+    '$rootScope'
+    ($scope, $rootScope) ->
+      seedList = {}
+      $scope.limitStep = 50
+      $scope.labels = null
+      $scope.relationships = null
+      $scope.propertyKeys = null
+
+      $scope.showMore = (type) -> load(type, $scope[type].showing + $scope.limitStep)
+      $scope.showAll = (type) -> load(type, $scope[type].total)
+
+      setSeedList = (type, list) -> 
+        seedList[type] = [].concat(list).sort()
+
+      setup = (type) ->
+        $scope.$watch(
+          -> $rootScope[type]
+          , 
+          -> 
+            numToShow = $scope.limitStep
+            if $scope[type] and $scope[type].showing >= $scope.limitStep 
+              numToShow = $scope[type].showing
+            setSeedList type, $rootScope[type]
+            load(type, numToShow)
+          ,
+          yes
+        )
+
+      load = (type, num = $scope.limitStep) ->
+        list = seedList[type]?.slice(0, num)
+        showing = list?.length || 0
+        total = seedList[type]?.length
+        $scope[type] =
+          list: list
+          showing: showing
+          total: total
+          nextStepSize: (if total - showing < $scope.limitStep then total - showing else $scope.limitStep) 
+
+      setup('labels')
+      setup('relationships')
+      setup('propertyKeys')
+  ]

--- a/community/browser/app/views/partials/drawer-database.jade
+++ b/community/browser/app/views/partials/drawer-database.jade
@@ -1,28 +1,42 @@
-.inner
+.inner(ng-controller="DatabaseDrawerCtrl")
   h4 Database Information
+
   h5 Node labels
-
-  a.token.token-label(ng-show="labels.length", ng-click="editor.execScript('MATCH (n) RETURN n LIMIT 25')") *
-
-  span(ng-show="!labels.length").
+    span.count(ng-show="labels.showing") &nbsp;({{labels.total}})
+   a.token.token-label(ng-show="labels.showing", ng-click="editor.execScript('MATCH (n) RETURN n LIMIT 25')") *
+  span(ng-show="!labels.showing").
     No labels in database
-  span(ng-repeat='label in labels | orderBy: identity')
+  span(ng-repeat='label in labels.list')
     a.token.token-label(ng-click="editor.execScript(substituteToken('MATCH (n:<token>) RETURN n LIMIT 25', label))") {{label}}
+  div(ng-show="labels.showing && labels.showing < labels.total")
+    a(ng-click="showMore('labels')") Show {{labels.nextStepSize}} more
+    | &nbsp;|&nbsp;
+    a(ng-click="showAll('labels')") Show all
 
   h5 Relationship types
-  a.token.token-relationship-type(ng-show="relationships.length", ng-click="editor.execScript('MATCH ()-[r]->() RETURN r LIMIT 25')") *
-  span(ng-show="!relationships.length").
+    span.count(ng-show="relationships.showing") &nbsp;({{relationships.total}})
+  a.token.token-relationship-type(ng-show="relationships.showing", ng-click="editor.execScript('MATCH ()-[r]->() RETURN r LIMIT 25')") *
+  span(ng-show="!relationships.showing").
     No relationships in database
-  span(ng-repeat='relationshipType in relationships | orderBy: identity')
+  span(ng-repeat='relationshipType in relationships.list')
     a.token.token-relationship-type(ng-click="editor.execScript(substituteToken('MATCH ()-[r:<token>]->() RETURN r LIMIT 25', relationshipType))") {{relationshipType}}
+  div(ng-show="relationships.showing && relationships.showing < relationships.total")
+    a(ng-click="showMore('relationships')") Show {{relationships.nextStepSize}} more
+    | &nbsp;|&nbsp;
+    a(ng-click="showAll('relationships')") Show all
 
-  div(ng-show='propertyKeys')
+  div(ng-show='propertyKeys.showing')
     h5 Property keys
-    span(ng-show="!propertyKeys.length").
+      span.count &nbsp;({{propertyKeys.total}}) 
+    span(ng-show="!propertyKeys.showing").
       No property keys in database
-    span(ng-repeat='propertyKey in propertyKeys | orderBy: identity')
+    span(ng-repeat='propertyKey in propertyKeys.list')
       a.token.token-property-key(ng-click="editor.execScript(substituteToken('MATCH (n) WHERE has(n.<token>) RETURN DISTINCT \"node\" as element, n.<token> AS <token> LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE has(r.<token>) RETURN DISTINCT \"relationship\" AS element, r.<token> AS <token> LIMIT 25', propertyKey))") {{propertyKey}}
-
+    div(ng-show="propertyKeys.showing && propertyKeys.showing < propertyKeys.total")
+      a(ng-click="showMore('propertyKeys')") Show {{propertyKeys.nextStepSize}} more
+      | &nbsp;|&nbsp;
+      a(ng-click="showAll('propertyKeys')") Show all
+      
   h5 Database
   ul
     li.pair


### PR DESCRIPTION
Meta items effected by this: labels, relationships and propertyKeys.
Show 50 each by default and let users step to show 50 more at a time or click to show all.
Resets on drawer close to free up resources.

This is a backport of https://github.com/neo4j/neo4j-browser/pull/308 as requested.

changelog [2.3] Performance improvement - Limit default number of meta items shown in database sidebar drawer