### PR TITLE
Inlining of the file contents caused poor formatting.

### DIFF
--- a/packaging/installer-linux/installer-debian/build.xml
+++ b/packaging/installer-linux/installer-debian/build.xml
@@ -60,13 +60,9 @@
                      value="dbms.directories.import=/var/lib/neo4j/import"/>
 
             <concat destfile="${project.build.outputDirectory}/@{name}/server/conf/neo4j.conf"
-                    append="true">
-
-# Directory settings.
-dbms.directories.logs=/var/log/neo4j
-dbms.directories.run=/var/run/neo4j
-dbms.directories.lib=/usr/share/neo4j/lib
-dbms.directories.certificates=/var/lib/neo4j/certificates
+                    append="true"
+                    fixlastline="true">
+                <fileset file="${project.build.sourceDirectory}/../resources/common/directories.conf" />
             </concat>
 
             <chmod perm="700">

--- a/packaging/installer-linux/installer-debian/src/main/resources/common/directories.conf
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/directories.conf
@@ -1,0 +1,6 @@
+
+# Directory settings.
+dbms.directories.logs=/var/log/neo4j
+dbms.directories.run=/var/run/neo4j
+dbms.directories.lib=/usr/share/neo4j/lib
+dbms.directories.certificates=/var/lib/neo4j/certificates


### PR DESCRIPTION
Because of XML formatting, we were putting 12 blank spaces at the end of the config file.