### PR TITLE
Ephemeral file system file buffer allocation simplification

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -534,7 +534,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     public long checksum()
     {
         Checksum checksum = new CRC32();
-        byte[] data = new byte[4096];
+        byte[] data = new byte[(int) ByteUnit.kibiBytes( 1 )];
 
         // Go through file name list in sorted order, so that checksum is consistent
         List<File> names = new ArrayList<>( files.size() );

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -47,6 +47,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -54,6 +55,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -62,6 +64,7 @@ import java.util.zip.Checksum;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.neo4j.io.ByteUnit;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.fs.StoreFileChannel;
@@ -136,9 +139,8 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     {
         for ( EphemeralFileData file : files.values() )
         {
-            free( file );
+            file.free();
         }
-
         files.clear();
 
         for ( ThirdPartyFileSystem thirdPartyFileSystem : thirdPartyFileSystems.values() )
@@ -240,14 +242,6 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         }
     }
 
-    private void free( EphemeralFileData file )
-    {
-        if ( file != null )
-        {
-            file.fileAsBuffer.free();
-        }
-    }
-
     @Override
     public synchronized StoreChannel open( File fileName, String mode ) throws IOException
     {
@@ -295,7 +289,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         }
 
         EphemeralFileData data = new EphemeralFileData( clock );
-        free( files.put( canonicalFile( fileName ), data ) );
+        Optional.ofNullable( files.put( canonicalFile( fileName ), data ) ).ifPresent( EphemeralFileData::free );
         return new StoreFileChannel(
                 new EphemeralFileChannel( data, new FileStillOpenException( fileName.getPath() ) ) );
     }
@@ -364,9 +358,9 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     {
         fileName = canonicalFile( fileName );
         EphemeralFileData removed = files.remove( fileName );
-        free( removed );
         if ( removed != null )
         {
+            removed.free();
             return true;
         }
         else
@@ -546,7 +540,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         List<File> names = new ArrayList<>( files.size() );
         names.addAll( files.keySet() );
 
-        Collections.sort( names, ( o1, o2 ) -> o1.getAbsolutePath().compareTo( o2.getAbsolutePath() ) );
+        names.sort( Comparator.comparing( File::getAbsolutePath ) );
 
         for ( File name : names )
         {
@@ -565,7 +559,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
     private ByteBuffer newCopyBuffer()
     {
-        return ByteBuffer.allocate( 1024 * 1024 );
+        return ByteBuffer.allocate( (int) ByteUnit.mebiBytes( 1 ) );
     }
 
     private void copyRecursivelyFromOtherFs( File from, FileSystemAbstraction fromFs, File to, ByteBuffer buffer )
@@ -666,7 +660,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     {
         private long position;
 
-        public LocalPosition( long position )
+        LocalPosition( long position )
         {
             this.position = position;
         }
@@ -798,7 +792,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             try
             {
                 long transferred = 0;
-                ByteBuffer intermediary = ByteBuffer.allocateDirect( 8096 );
+                ByteBuffer intermediary = ByteBuffer.allocateDirect( (int) ByteUnit.mebiBytes( 8 ) );
                 while ( transferred < count )
                 {
                     intermediary.clear();
@@ -888,14 +882,8 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
     private static class EphemeralFileData
     {
-        private static final ThreadLocal<byte[]> SCRATCH_PAD = new ThreadLocal<byte[]>()
-        {
-            @Override
-            protected byte[] initialValue()
-            {
-                return new byte[1024];
-            }
-        };
+        private static final ThreadLocal<byte[]> SCRATCH_PAD =
+                ThreadLocal.withInitial( () -> new byte[(int) ByteUnit.kibiBytes( 1 )] );
         private DynamicByteBuffer fileAsBuffer;
         private DynamicByteBuffer forcedBuffer;
         private final Collection<WeakReference<EphemeralFileChannel>> channels = new LinkedList<>();
@@ -976,6 +964,11 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             EphemeralFileData copy = new EphemeralFileData( fileAsBuffer.copy(), clock );
             copy.size = size;
             return copy;
+        }
+
+        void free()
+        {
+            fileAsBuffer.free();
         }
 
         void open( EphemeralFileChannel channel )
@@ -1103,16 +1096,15 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
      * Dynamically expanding ByteBuffer substitute/wrapper. This will allocate ByteBuffers on the go
      * so that we don't have to allocate too big of a buffer up-front.
      */
-    private static class DynamicByteBuffer
+    static class DynamicByteBuffer
     {
-        private static final int[] SIZES;
-        private static final byte[] zeroBuffer = new byte[1024];
+        private static final byte[] zeroBuffer = new byte[(int) ByteUnit.kibiBytes( 1 )];
         private ByteBuffer buf;
         private Exception freeCall;
 
         public DynamicByteBuffer()
         {
-            buf = allocate( 0 );
+            buf = allocate( ByteUnit.kibiBytes( 1 ) );
         }
 
         public ByteBuffer buf()
@@ -1124,41 +1116,13 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         /** This is a copying constructor, the input buffer is just read from, never stored in 'this'. */
         private DynamicByteBuffer( ByteBuffer toClone )
         {
-            int sizeIndex = sizeIndexFor( toClone.capacity() );
-            buf = allocate( sizeIndex );
+            buf = allocate( toClone.capacity() );
             copyByteBufferContents( toClone, buf );
-        }
-
-        private static int sizeIndexFor( int capacity )
-        {
-            // Double size each time, but after 1M only increase by 1M at a time, until required amount is reached.
-            int sizeIndex = capacity / SIZES[SIZES.length - 1];
-            if ( sizeIndex == 0 )
-            {
-                for (; sizeIndex < SIZES.length; sizeIndex++ )
-                {
-                    if ( capacity == SIZES[sizeIndex] )
-                    {
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                sizeIndex += SIZES.length - 1;
-            }
-            return sizeIndex;
         }
 
         synchronized DynamicByteBuffer copy()
         {
             return new DynamicByteBuffer( buf() ); // invoke "copy constructor"
-        }
-
-        static
-        {
-            int K = 1024;
-            SIZES = new int[]{64 * K, 128 * K, 256 * K, 512 * K, 1024 * K};
         }
 
         private void copyByteBufferContents( ByteBuffer from, ByteBuffer to )
@@ -1176,24 +1140,17 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             }
         }
 
-        /**
-         * Tries to allocate a buffer of at least the specified size.
-         * If no free buffers are available of the available capacity, we
-         * check for buffers up to two sizes larger. If still no buffers
-         * are found we allocate a new buffer of the specified size.
-         */
-        private ByteBuffer allocate( int sizeIndex )
+        private ByteBuffer allocate( long capacity )
         {
-            int capacity = capacity( sizeIndex );
             try
             {
-                return ByteBuffer.allocateDirect( capacity );
+                return ByteBuffer.allocateDirect( Math.toIntExact( capacity ) );
             }
             catch ( OutOfMemoryError oom )
             {
                 try
                 {
-                    return ByteBuffer.allocate( capacity );
+                    return ByteBuffer.allocate( Math.toIntExact( capacity ) );
                 }
                 catch ( OutOfMemoryError secondOom )
                 {
@@ -1201,12 +1158,6 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
                     throw oom;
                 }
             }
-        }
-
-        private int capacity( int sizeIndex )
-        {
-            return (sizeIndex < SIZES.length) ?
-                           SIZES[sizeIndex] : ((sizeIndex - SIZES.length + 1) * SIZES[SIZES.length - 1]);
         }
 
         void free()
@@ -1273,16 +1224,14 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 
             // Double size each time, but after 1M only increase by 1M at a time, until required amount is reached.
             int newSize = buf.capacity();
-            int sizeIndex = sizeIndexFor( newSize );
-            while ( capacity( sizeIndex ) < totalAmount )
+            while ( newSize < totalAmount )
             {
-                newSize += Math.min( newSize, 1024 * 1024 );
-                sizeIndex++;
+                newSize = newSize << 1;
             }
             int oldPosition = buf.position();
 
             // allocate new buffer
-            ByteBuffer newBuf = allocate( sizeIndex );
+            ByteBuffer newBuf = allocate( newSize );
 
             // copy contents of current buffer into new buffer
             buf.position( 0 );

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -1222,11 +1222,13 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
                 return;
             }
 
-            // Double size each time, but after 1M only increase by 1M at a time, until required amount is reached.
             int newSize = buf.capacity();
+            long maxSize = ByteUnit.gibiBytes( 1 );
+            checkAllowedSize( totalAmount, maxSize );
             while ( newSize < totalAmount )
             {
                 newSize = newSize << 1;
+                checkAllowedSize( newSize, maxSize );
             }
             int oldPosition = buf.position();
 
@@ -1240,6 +1242,14 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
             // re-assign buffer to new buffer
             newBuf.position( oldPosition );
             this.buf = newBuf;
+        }
+
+        private void checkAllowedSize( long size, long maxSize )
+        {
+            if ( size > maxSize )
+            {
+                throw new RuntimeException( "Requested file size is too big for ephemeral file system." );
+            }
         }
 
         public void clear()

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionCrashTest.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionCrashTest.java
@@ -53,7 +53,7 @@ public class EphemeralFileSystemAbstractionCrashTest
     }
 
     @Test
-    public void allowStoreThatExceedPredefinedSizes() throws IOException
+    public void allowStoreThatExceedDefaultSize() throws IOException
     {
         File aFile = new File( "test" );
         StoreChannel channel = fs.open( aFile, "rw" );
@@ -68,6 +68,27 @@ public class EphemeralFileSystemAbstractionCrashTest
             buffer.clear();
         }
         channel.close();
+    }
+
+    @Test
+    public void growEphemeralFileBuffer()
+    {
+        EphemeralFileSystemAbstraction.DynamicByteBuffer byteBuffer =
+                new EphemeralFileSystemAbstraction.DynamicByteBuffer();
+
+        byte[] testBytes = {1, 2, 3, 4};
+        int length = testBytes.length;
+        byteBuffer.put( 0, testBytes, 0, length );
+        assertEquals( (int) ByteUnit.kibiBytes( 1 ), byteBuffer.buf().capacity() );
+
+        byteBuffer.put( (int) (ByteUnit.kibiBytes( 1 ) + 2), testBytes, 0, length );
+        assertEquals( (int) ByteUnit.kibiBytes( 2 ), byteBuffer.buf().capacity() );
+
+        byteBuffer.put( (int) (ByteUnit.kibiBytes( 5 ) + 2), testBytes, 0, length );
+        assertEquals( (int) ByteUnit.kibiBytes( 8 ), byteBuffer.buf().capacity() );
+
+        byteBuffer.put( (int) (ByteUnit.mebiBytes( 2 ) + 2), testBytes, 0, length );
+        assertEquals( (int) ByteUnit.mebiBytes( 4 ), byteBuffer.buf().capacity() );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -66,11 +66,11 @@ import static org.neo4j.test.rule.fs.EphemeralFileSystemRule.shutdownDbAction;
  */
 public class TestCrashWithRebuildSlow
 {
-    @Rule
-    public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
     // for dumping data about failing build
     @Rule
     public final TestDirectory testDir = TestDirectory.testDirectory();
+    @Rule
+    public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 
     @Test
     public void crashAndRebuildSlowWithDynamicStringDeletions() throws Exception


### PR DESCRIPTION
Update ephemeral file system to use 1KB buffer for new file by default.
In case if file data size over exceed available buffer capacity it will be doubled till enough space will be available.