### PR TITLE
Add a version command to neo4j-admin

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
@@ -34,6 +34,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.FormatFamily;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
@@ -128,7 +129,8 @@ public class VersionCommand implements AdminCommand
 
         for ( RecordFormats candidate : RecordFormatSelector.allFormats() )
         {
-            if ( candidate.generation() <= format.generation() )
+            if ( !(FormatFamily.isSameFamily( format, candidate )) ||
+                    candidate.generation() <= format.generation() )
             {
                 continue;
             }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
@@ -103,16 +103,17 @@ public class VersionCommand implements AdminCommand
                             () -> new CommandFailed( String.format( "Could not find version metadata in store '%s'",
                                     storeDir ) ) );
 
-            final String fmt = "%-20s%s";
-            out.accept( String.format( fmt, "Store version:", storeVersion ) );
+            final String fmt = "%-25s%s";
+            out.accept( String.format( fmt, "Store format version:", storeVersion ) );
 
             RecordFormats format = RecordFormatSelector.selectForVersion( storeVersion );
-            out.accept( String.format( fmt, "Introduced in:", format.firstNeo4jVersion() ) );
+            out.accept( String.format( fmt, "Introduced in version:", format.introductionVersion() ) );
 
-            out.accept(
-                    findSuccessor( format )
-                            .map( next -> String.format( fmt, "Superseded in:", next.firstNeo4jVersion() ) )
-                            .orElse( String.format( fmt, "Used in:", Version.getNeo4jVersion() + " (current)" ) ) );
+            findSuccessor( format )
+                    .map( next -> String.format( fmt, "Superseded in version:", next.introductionVersion() ) )
+                    .ifPresent( out );
+
+            out.accept( String.format( fmt, "Current version:", Version.getNeo4jVersion() ) );
         }
         catch ( IOException e )
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
+import org.neo4j.kernel.impl.util.Validators;
+
+public class VersionCommand implements AdminCommand
+{
+    private static final Arguments arguments = new Arguments()
+            .withArgument( new MandatoryCanonicalPath( "store", "path-to-dir",
+                    "Path to database store to check version of." ) );
+
+    public static class Provider extends AdminCommand.Provider
+    {
+
+        public Provider()
+        {
+            super( "version" );
+        }
+
+        @Override
+        public Arguments allArguments()
+        {
+            return arguments;
+        }
+
+        @Override
+        public String summary()
+        {
+            return "Check the version of a Neo4j database store.";
+        }
+
+        @Override
+        public String description()
+        {
+            return "Checks the version of a Neo4j database store. Note that this command expects a path to a store " +
+                    "directory, for example --store=data/databases/graph.db.";
+        }
+
+        @Override
+        public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+        {
+            return new VersionCommand( outsideWorld::stdOutLine );
+        }
+    }
+
+    private Consumer<String> out;
+
+    public VersionCommand( Consumer<String> out )
+    {
+        this.out = out;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage, CommandFailed
+    {
+        final Path storeDir = arguments.parseMandatoryPath( "store", args );
+
+        Validators.CONTAINS_EXISTING_DATABASE.validate( storeDir.toFile() );
+
+        try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( new DefaultFileSystemAbstraction() ) )
+        {
+            final String storeVersion = new StoreVersionCheck( pageCache )
+                    .getVersion( storeDir.resolve( MetaDataStore.DEFAULT_NAME ).toFile() )
+                    .orElseThrow(
+                            () -> new CommandFailed( String.format( "Could not find a version in '%s'", storeDir ) ) );
+
+            final String fmt = "%-20s%s";
+            out.accept( String.format( fmt, "Store version:", storeVersion ) );
+
+            RecordFormats format = RecordFormatSelector.selectForVersion( storeVersion );
+            out.accept( String.format( fmt, "Introduced in:", format.neo4jVersion() ) );
+
+            Optional<RecordFormats> nextFormat = findSuccessor( format );
+            if ( nextFormat.isPresent() )
+            {
+                out.accept( String.format( fmt, "Superceded in:", nextFormat.get().neo4jVersion() ) );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( e.getMessage(), e );
+        }
+    }
+
+    /**
+     * @param format to find successor to.
+     * @return the format with the lowest generation > format.generation, or None if no such format is known.
+     */
+    private Optional<RecordFormats> findSuccessor( final RecordFormats format )
+    {
+        RecordFormats successor = null;
+
+        for ( RecordFormats candidate : RecordFormatSelector.allFormats() )
+        {
+            if ( candidate.generation() <= format.generation() )
+            {
+                continue;
+            }
+            if ( successor == null || candidate.generation() < successor.generation() )
+            {
+                successor = candidate;
+            }
+        }
+
+        return Optional.ofNullable( successor );
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
@@ -34,11 +34,12 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
 import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.format.FormatFamily;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.util.Validators;
+
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.findSuccessor;
 
 public class VersionCommand implements AdminCommand
 {
@@ -117,29 +118,5 @@ public class VersionCommand implements AdminCommand
         {
             throw new CommandFailed( e.getMessage(), e );
         }
-    }
-
-    /**
-     * @param format to find successor to.
-     * @return the format with the lowest generation > format.generation, or None if no such format is known.
-     */
-    private Optional<RecordFormats> findSuccessor( final RecordFormats format )
-    {
-        RecordFormats successor = null;
-
-        for ( RecordFormats candidate : RecordFormatSelector.allFormats() )
-        {
-            if ( !(FormatFamily.isSameFamily( format, candidate )) ||
-                    candidate.generation() <= format.generation() )
-            {
-                continue;
-            }
-            if ( successor == null || candidate.generation() < successor.generation() )
-            {
-                successor = candidate;
-            }
-        }
-
-        return Optional.ofNullable( successor );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/VersionCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/VersionCommandTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.neo4j.commandline.admin.CommandLocator;
+import org.neo4j.commandline.admin.Usage;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.STORE_VERSION;
+
+public class VersionCommandTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    private Path databaseDirectory;
+    private ByteArrayOutputStream baos;
+    private VersionCommand command;
+    private DefaultFileSystemAbstraction fs;
+    private PageCache pageCache;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        fs = new DefaultFileSystemAbstraction();
+        pageCache = StandalonePageCacheFactory.createPageCache( fs );
+        Path homeDir = testDirectory.directory( "home-dir" ).toPath();
+        databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
+        Files.createDirectories( databaseDirectory );
+        baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream( baos );
+        command = new VersionCommand( printStream::println );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        baos.close();
+        pageCache.close();
+    }
+
+    @Test
+    public void shouldPrintNiceHelp() throws Exception
+    {
+        try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
+        {
+            PrintStream ps = new PrintStream( baos );
+            Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
+            usage.printUsageForCommand( new VersionCommand.Provider(), ps::println );
+
+            assertEquals( String.format( "usage: neo4j-admin version --store=<path-to-dir>%n" +
+                            "%n" +
+                            "Checks the version of a Neo4j database store. Note that this command expects a%n" +
+                            "path to a store directory, for example --store=data/databases/graph.db.%n" +
+                            "%n" +
+                            "options:%n" +
+                            "  --store=<path-to-dir>   Path to database store to check version of.%n" ),
+                    baos.toString() );
+        }
+    }
+
+    @Test
+    public void noArgFails() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( "Missing argument 'store'" );
+
+        command.execute( new String[]{} );
+    }
+
+    @Test
+    public void emptyArgFails() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( "Missing argument 'store'" );
+
+        command.execute( new String[]{"--store="} );
+    }
+
+    @Test
+    public void nonExistingDatabaseShouldThrow() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( matches( "Directory '.+?' does not contain a database" ) );
+
+        execute( Paths.get( "yaba", "daba", "doo" ).toString() );
+    }
+
+    @Test
+    public void readsLatestStoreVersionCorrectly() throws Exception
+    {
+        RecordFormats currentFormat = RecordFormatSelector.defaultFormat();
+        prepareNeoStoreFile( currentFormat.storeVersion() );
+
+        execute( databaseDirectory.toString() );
+
+        assertEquals(
+                String.format( "Store version:      %s%n" +
+                                "Introduced in:      %s%n",
+                        currentFormat.storeVersion(),
+                        currentFormat.neo4jVersion() ),
+                baos.toString() );
+    }
+
+    @Test
+    public void readsOlderStoreVersionCorrectly() throws Exception
+    {
+        prepareNeoStoreFile( StandardV2_2.RECORD_FORMATS.storeVersion() );
+
+        execute( databaseDirectory.toString() );
+
+        assertEquals(
+                String.format( "Store version:      v0.A.5%n" +
+                        "Introduced in:      2.2.0%n" +
+                        "Superceded in:      2.3.0%n" ),
+                baos.toString() );
+    }
+
+    @Test
+    public void throwsOnUnknownVersion() throws Exception
+    {
+        prepareNeoStoreFile( "v9.9.9" );
+
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( "Unknown store version 'v9.9.9'" );
+
+        execute( databaseDirectory.toString() );
+    }
+
+    private void execute( String storePath ) throws Exception
+    {
+        command.execute( new String[]{"--store=" + storePath} );
+    }
+
+    private void prepareNeoStoreFile( String storeVersion ) throws IOException
+    {
+        File neoStoreFile = createNeoStoreFile();
+        long value = MetaDataStore.versionStringToLong( storeVersion );
+        MetaDataStore.setRecord( pageCache, neoStoreFile, STORE_VERSION, value );
+    }
+
+    private File createNeoStoreFile() throws IOException
+    {
+        fs.mkdir( databaseDirectory.toFile() );
+        File neoStoreFile = new File( databaseDirectory.toFile(), MetaDataStore.DEFAULT_NAME );
+        fs.create( neoStoreFile ).close();
+        return neoStoreFile;
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/VersionCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/VersionCommandTest.java
@@ -139,9 +139,9 @@ public class VersionCommandTest
 
         assertEquals(
                 Arrays.asList(
-                        String.format( "Store version:      %s", currentFormat.storeVersion() ),
-                        String.format( "Introduced in:      %s", currentFormat.firstNeo4jVersion() ),
-                        String.format( "Used in:            %s (current)", Version.getNeo4jVersion() ) ),
+                        String.format( "Store format version:    %s", currentFormat.storeVersion() ),
+                        String.format( "Introduced in version:   %s", currentFormat.introductionVersion() ),
+                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
                 outCaptor.getAllValues() );
     }
 
@@ -152,13 +152,14 @@ public class VersionCommandTest
 
         execute( databaseDirectory.toString() );
 
-        verify( out, times( 3 ) ).accept( outCaptor.capture() );
+        verify( out, times( 4 ) ).accept( outCaptor.capture() );
 
         assertEquals(
                 Arrays.asList(
-                        "Store version:      v0.A.5",
-                        "Introduced in:      2.2.0",
-                        "Superseded in:      2.3.0" ),
+                        "Store format version:    v0.A.5",
+                        "Introduced in version:   2.2.0",
+                        "Superseded in version:   2.3.0",
+                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
                 outCaptor.getAllValues() );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
@@ -36,18 +36,27 @@ public abstract class BaseRecordFormats implements RecordFormats
     private final int generation;
     private final Capability[] capabilities;
     private final String storeVersion;
+    private final String firstNeo4jVersion;
 
-    protected BaseRecordFormats( String storeVersion, int generation, Capability... capabilities )
+    protected BaseRecordFormats( String storeVersion, String firstNeo4jVersion, int generation,
+            Capability... capabilities )
     {
         this.storeVersion = storeVersion;
         this.generation = generation;
         this.capabilities = capabilities;
+        this.firstNeo4jVersion = firstNeo4jVersion;
     }
 
     @Override
     public String storeVersion()
     {
         return storeVersion;
+    }
+
+    @Override
+    public String firstNeo4jVersion()
+    {
+        return firstNeo4jVersion;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
@@ -36,15 +36,15 @@ public abstract class BaseRecordFormats implements RecordFormats
     private final int generation;
     private final Capability[] capabilities;
     private final String storeVersion;
-    private final String firstNeo4jVersion;
+    private final String introductionVersion;
 
-    protected BaseRecordFormats( String storeVersion, String firstNeo4jVersion, int generation,
+    protected BaseRecordFormats( String storeVersion, String introductionVersion, int generation,
             Capability... capabilities )
     {
         this.storeVersion = storeVersion;
         this.generation = generation;
         this.capabilities = capabilities;
-        this.firstNeo4jVersion = firstNeo4jVersion;
+        this.introductionVersion = introductionVersion;
     }
 
     @Override
@@ -54,9 +54,9 @@ public abstract class BaseRecordFormats implements RecordFormats
     }
 
     @Override
-    public String firstNeo4jVersion()
+    public String introductionVersion()
     {
-        return firstNeo4jVersion;
+        return introductionVersion;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
@@ -262,7 +262,8 @@ public class RecordFormatSelector
         }
     }
 
-    private static Iterable<RecordFormats> allFormats()
+    @Nonnull
+    public static Iterable<RecordFormats> allFormats()
     {
         Iterable<RecordFormats.Factory> loadableFormatFactories = Service.load( RecordFormats.Factory.class );
         Iterable<RecordFormats> loadableFormats = map( RecordFormats.Factory::newInstance, loadableFormatFactories );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -52,7 +52,7 @@ public interface RecordFormats
      * @return the neo4j version where this format was introduced. It is almost certainly NOT the only version of
      * neo4j where this format is used.
      */
-    String firstNeo4jVersion();
+    String introductionVersion();
 
     /**
      * Generation of this format, format family local int value which should be incrementing along with

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -52,7 +52,7 @@ public interface RecordFormats
      * @return the neo4j version where this format was introduced. It is almost certainly NOT the only version of
      * neo4j where this format is used.
      */
-    String neo4jVersion();
+    String firstNeo4jVersion();
 
     /**
      * Generation of this format, format family local int value which should be incrementing along with

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -49,6 +49,12 @@ public interface RecordFormats
     String storeVersion();
 
     /**
+     * @return the neo4j version where this format was introduced. It is almost certainly NOT the only version of
+     * neo4j where this format is used.
+     */
+    String neo4jVersion();
+
+    /**
      * Generation of this format, format family local int value which should be incrementing along with
      * releases, e.g. store version, e.g. official versions of the product. Use to determine generation of particular
      * format and to be able to find newest of among them.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
@@ -24,25 +24,32 @@ package org.neo4j.kernel.impl.store.format;
  */
 public enum StoreVersion
 {
-    STANDARD_V2_0( "v0.A.1" ),
-    STANDARD_V2_1( "v0.A.3" ),
-    STANDARD_V2_2( "v0.A.5" ),
-    STANDARD_V2_3( "v0.A.6" ),
-    STANDARD_V3_0( "v0.A.7" ),
+    STANDARD_V2_0( "v0.A.1", "2.0.0" ),
+    STANDARD_V2_1( "v0.A.3", "2.1.0" ),
+    STANDARD_V2_2( "v0.A.5", "2.2.0" ),
+    STANDARD_V2_3( "v0.A.6", "2.3.0" ),
+    STANDARD_V3_0( "v0.A.7", "3.0.0" ),
 
-    HIGH_LIMIT_V3_0_0( "vE.H.0" ),
-    HIGH_LIMIT_V3_0_6( "vE.H.0b" ),
-    HIGH_LIMIT_V3_1_0( "vE.H.2" );
+    HIGH_LIMIT_V3_0_0( "vE.H.0", "3.0.0" ),
+    HIGH_LIMIT_V3_0_6( "vE.H.0b", "3.0.6" ),
+    HIGH_LIMIT_V3_1_0( "vE.H.2", "3.1.0" );
 
     private final String versionString;
+    private final String firstNeo4jVersion;
 
-    StoreVersion( String versionString )
+    StoreVersion( String versionString, String firstNeo4jVersion )
     {
         this.versionString = versionString;
+        this.firstNeo4jVersion = firstNeo4jVersion;
     }
 
     public String versionString()
     {
         return versionString;
+    }
+
+    public String firstNeo4jVersion()
+    {
+        return firstNeo4jVersion;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/StoreVersion.java
@@ -35,12 +35,12 @@ public enum StoreVersion
     HIGH_LIMIT_V3_1_0( "vE.H.2", "3.1.0" );
 
     private final String versionString;
-    private final String firstNeo4jVersion;
+    private final String introductionVersion;
 
-    StoreVersion( String versionString, String firstNeo4jVersion )
+    StoreVersion( String versionString, String introductionVersion )
     {
         this.versionString = versionString;
-        this.firstNeo4jVersion = firstNeo4jVersion;
+        this.introductionVersion = introductionVersion;
     }
 
     public String versionString()
@@ -48,8 +48,8 @@ public enum StoreVersion
         return versionString;
     }
 
-    public String firstNeo4jVersion()
+    public String introductionVersion()
     {
-        return firstNeo4jVersion;
+        return introductionVersion;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
@@ -41,13 +41,8 @@ public class StandardV2_0 extends BaseRecordFormats
 
     public StandardV2_0()
     {
-        super( STORE_VERSION, 2, Capability.SCHEMA, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "2.0.0";
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_0.firstNeo4jVersion(), 2, Capability.SCHEMA, Capability.LUCENE_3,
+                Capability.VERSION_TRAILERS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
@@ -41,7 +41,7 @@ public class StandardV2_0 extends BaseRecordFormats
 
     public StandardV2_0()
     {
-        super( STORE_VERSION, StoreVersion.STANDARD_V2_0.firstNeo4jVersion(), 2, Capability.SCHEMA, Capability.LUCENE_3,
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_0.introductionVersion(), 2, Capability.SCHEMA, Capability.LUCENE_3,
                 Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
@@ -45,6 +45,12 @@ public class StandardV2_0 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "2.0.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormatV2_0();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
@@ -46,6 +46,12 @@ public class StandardV2_1 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "2.1.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormat();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
@@ -41,7 +41,7 @@ public class StandardV2_1 extends BaseRecordFormats
 
     public StandardV2_1()
     {
-        super( STORE_VERSION, StoreVersion.STANDARD_V2_1.firstNeo4jVersion(), 3, Capability.SCHEMA,
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_1.introductionVersion(), 3, Capability.SCHEMA,
                 Capability.DENSE_NODES, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
@@ -41,14 +41,8 @@ public class StandardV2_1 extends BaseRecordFormats
 
     public StandardV2_1()
     {
-        super( STORE_VERSION, 3, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
-                Capability.VERSION_TRAILERS );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "2.1.0";
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_1.firstNeo4jVersion(), 3, Capability.SCHEMA,
+                Capability.DENSE_NODES, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
@@ -41,14 +41,8 @@ public class StandardV2_2 extends BaseRecordFormats
 
     public StandardV2_2()
     {
-        super( STORE_VERSION, 4, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
-                Capability.VERSION_TRAILERS );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "2.2.0";
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_2.firstNeo4jVersion(), 4, Capability.SCHEMA,
+                Capability.DENSE_NODES, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
@@ -46,6 +46,12 @@ public class StandardV2_2 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "2.2.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormat();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
@@ -41,7 +41,7 @@ public class StandardV2_2 extends BaseRecordFormats
 
     public StandardV2_2()
     {
-        super( STORE_VERSION, StoreVersion.STANDARD_V2_2.firstNeo4jVersion(), 4, Capability.SCHEMA,
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_2.introductionVersion(), 4, Capability.SCHEMA,
                 Capability.DENSE_NODES, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -45,6 +45,12 @@ public class StandardV2_3 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "2.3.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormat();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -41,13 +41,8 @@ public class StandardV2_3 extends BaseRecordFormats
 
     public StandardV2_3()
     {
-        super( STORE_VERSION, 5, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3 );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "2.3.0";
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_3.firstNeo4jVersion(), 5, Capability.SCHEMA,
+                Capability.DENSE_NODES, Capability.LUCENE_3 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -41,7 +41,7 @@ public class StandardV2_3 extends BaseRecordFormats
 
     public StandardV2_3()
     {
-        super( STORE_VERSION, StoreVersion.STANDARD_V2_3.firstNeo4jVersion(), 5, Capability.SCHEMA,
+        super( STORE_VERSION, StoreVersion.STANDARD_V2_3.introductionVersion(), 5, Capability.SCHEMA,
                 Capability.DENSE_NODES, Capability.LUCENE_3 );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -46,6 +46,12 @@ public class StandardV3_0 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "3.0.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormat();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -42,13 +42,8 @@ public class StandardV3_0 extends BaseRecordFormats
 
     public StandardV3_0()
     {
-        super( STORE_VERSION, 6, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_5 );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "3.0.0";
+        super( STORE_VERSION, StoreVersion.STANDARD_V3_0.firstNeo4jVersion(), 6, Capability.SCHEMA,
+                Capability.DENSE_NODES, Capability.LUCENE_5 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -42,7 +42,7 @@ public class StandardV3_0 extends BaseRecordFormats
 
     public StandardV3_0()
     {
-        super( STORE_VERSION, StoreVersion.STANDARD_V3_0.firstNeo4jVersion(), 6, Capability.SCHEMA,
+        super( STORE_VERSION, StoreVersion.STANDARD_V3_0.introductionVersion(), 6, Capability.SCHEMA,
                 Capability.DENSE_NODES, Capability.LUCENE_5 );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreVersionCheck.java
@@ -63,21 +63,12 @@ public class StoreVersionCheck
             return new Result( Outcome.missingStoreFile, null, neostoreFile.getName() );
         }
 
-        if ( storeVersion.isPresent() )
-        {
-            if ( expectedVersion.equals( storeVersion.get() ) )
-            {
-                return new Result( Outcome.ok, null, neostoreFile.getName() );
-            }
-            else
-            {
-                return new Result( Outcome.unexpectedStoreVersion, storeVersion.get(), neostoreFile.getName() );
-            }
-        }
-        else
-        {
-            return new Result( Outcome.storeVersionNotFound, null, neostoreFile.getName() );
-        }
+        return storeVersion
+                .map( v ->
+                        expectedVersion.equals( v ) ?
+                        new Result( Outcome.ok, null, neostoreFile.getName() ) :
+                        new Result( Outcome.unexpectedStoreVersion, v, neostoreFile.getName() ) )
+                .orElse( new Result( Outcome.storeVersionNotFound, null, neostoreFile.getName() ) );
     }
 
     public static class Result

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
@@ -54,6 +54,12 @@ public class ForcedSecondaryUnitRecordFormats implements RecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return actual.neo4jVersion();
+    }
+
+    @Override
     public int generation()
     {
         return actual.generation();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
@@ -54,9 +54,9 @@ public class ForcedSecondaryUnitRecordFormats implements RecordFormats
     }
 
     @Override
-    public String firstNeo4jVersion()
+    public String introductionVersion()
     {
-        return actual.firstNeo4jVersion();
+        return actual.introductionVersion();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
@@ -54,9 +54,9 @@ public class ForcedSecondaryUnitRecordFormats implements RecordFormats
     }
 
     @Override
-    public String neo4jVersion()
+    public String firstNeo4jVersion()
     {
-        return actual.neo4jVersion();
+        return actual.firstNeo4jVersion();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -104,7 +104,7 @@ public class RecordFormatPropertyConfiguratorTest
         }
 
         @Override
-        public String neo4jVersion()
+        public String firstNeo4jVersion()
         {
             return null;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -104,6 +104,12 @@ public class RecordFormatPropertyConfiguratorTest
         }
 
         @Override
+        public String neo4jVersion()
+        {
+            return null;
+        }
+
+        @Override
         public int generation()
         {
             return 0;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -104,7 +104,7 @@ public class RecordFormatPropertyConfiguratorTest
         }
 
         @Override
-        public String firstNeo4jVersion()
+        public String introductionVersion()
         {
             return null;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -69,9 +69,9 @@ public class PrepareTrackingRecordFormats implements RecordFormats
     }
 
     @Override
-    public String neo4jVersion()
+    public String firstNeo4jVersion()
     {
-        return actual.neo4jVersion();
+        return actual.firstNeo4jVersion();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -69,9 +69,9 @@ public class PrepareTrackingRecordFormats implements RecordFormats
     }
 
     @Override
-    public String firstNeo4jVersion()
+    public String introductionVersion()
     {
-        return actual.firstNeo4jVersion();
+        return actual.introductionVersion();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -69,6 +69,12 @@ public class PrepareTrackingRecordFormats implements RecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return actual.neo4jVersion();
+    }
+
+    @Override
     public PrepareTrackingRecordFormat<NodeRecord> node()
     {
         return new PrepareTrackingRecordFormat<>( actual.node(), nodePrepare );

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -56,14 +56,8 @@ public class HighLimit extends BaseRecordFormats
 
     public HighLimit()
     {
-        super( STORE_VERSION, 3, Capability.DENSE_NODES, Capability.RELATIONSHIP_TYPE_3BYTES, Capability.SCHEMA,
-                Capability.LUCENE_5 );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "3.1.0";
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_1_0.firstNeo4jVersion(), 3, Capability.DENSE_NODES,
+                Capability.RELATIONSHIP_TYPE_3BYTES, Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -56,7 +56,7 @@ public class HighLimit extends BaseRecordFormats
 
     public HighLimit()
     {
-        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_1_0.firstNeo4jVersion(), 3, Capability.DENSE_NODES,
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_1_0.introductionVersion(), 3, Capability.DENSE_NODES,
                 Capability.RELATIONSHIP_TYPE_3BYTES, Capability.SCHEMA, Capability.LUCENE_5 );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -61,6 +61,12 @@ public class HighLimit extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "3.1.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormat();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
@@ -64,7 +64,7 @@ public class HighLimitV3_0_0 extends BaseRecordFormats
 
     public HighLimitV3_0_0()
     {
-        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_0.firstNeo4jVersion(), 1, Capability.DENSE_NODES,
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_0.introductionVersion(), 1, Capability.DENSE_NODES,
                 Capability.SCHEMA, Capability.LUCENE_5 );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
@@ -68,6 +68,12 @@ public class HighLimitV3_0_0 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "3.0.0";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormatV3_0_0();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitV3_0_0.java
@@ -64,13 +64,8 @@ public class HighLimitV3_0_0 extends BaseRecordFormats
 
     public HighLimitV3_0_0()
     {
-        super( STORE_VERSION, 1, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "3.0.0";
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_0.firstNeo4jVersion(), 1, Capability.DENSE_NODES,
+                Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
@@ -58,7 +58,7 @@ public class HighLimitV3_0_6 extends BaseRecordFormats
 
     public HighLimitV3_0_6()
     {
-        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_6.firstNeo4jVersion(), 2, Capability.DENSE_NODES,
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_6.introductionVersion(), 2, Capability.DENSE_NODES,
                 Capability.SCHEMA, Capability.LUCENE_5 );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
@@ -62,6 +62,12 @@ public class HighLimitV3_0_6 extends BaseRecordFormats
     }
 
     @Override
+    public String neo4jVersion()
+    {
+        return "3.0.6";
+    }
+
+    @Override
     public RecordFormat<NodeRecord> node()
     {
         return new NodeRecordFormatV3_0_6();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitV3_0_6.java
@@ -58,13 +58,8 @@ public class HighLimitV3_0_6 extends BaseRecordFormats
 
     public HighLimitV3_0_6()
     {
-        super( STORE_VERSION, 2, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
-    }
-
-    @Override
-    public String neo4jVersion()
-    {
-        return "3.0.6";
+        super( STORE_VERSION, StoreVersion.HIGH_LIMIT_V3_0_6.firstNeo4jVersion(), 2, Capability.DENSE_NODES,
+                Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/VersionCommandEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/VersionCommandEnterpriseTest.java
@@ -34,6 +34,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.format.highlimit.v300.HighLimitV3_0_0;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -78,13 +79,14 @@ public class VersionCommandEnterpriseTest
 
         execute( databaseDirectory.toString() );
 
-        verify( out, times( 3 ) ).accept( outCaptor.capture() );
+        verify( out, times( 4 ) ).accept( outCaptor.capture() );
 
         assertEquals(
                 Arrays.asList(
-                        "Store version:      vE.H.0",
-                        "Introduced in:      3.0.0",
-                        "Superseded in:      3.0.6" ),
+                        "Store format version:    vE.H.0",
+                        "Introduced in version:   3.0.0",
+                        "Superseded in version:   3.0.6",
+                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
                 outCaptor.getAllValues() );
     }
 

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/VersionCommandEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/VersionCommandEnterpriseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.highlimit.v300.HighLimitV3_0_0;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.STORE_VERSION;
+
+public class VersionCommandEnterpriseTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    private Path databaseDirectory;
+    private ByteArrayOutputStream baos;
+    private VersionCommand command;
+    private DefaultFileSystemAbstraction fs;
+    private PageCache pageCache;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        fs = new DefaultFileSystemAbstraction();
+        pageCache = StandalonePageCacheFactory.createPageCache( fs );
+        Path homeDir = testDirectory.directory( "home-dir" ).toPath();
+        databaseDirectory = homeDir.resolve( "data/databases/foo.db" );
+        Files.createDirectories( databaseDirectory );
+        baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream( baos );
+        command = new VersionCommand( printStream::println );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        baos.close();
+        pageCache.close();
+    }
+
+    @Test
+    public void readsEnterpriseStoreVersionCorrectly() throws Exception
+    {
+        prepareNeoStoreFile( HighLimitV3_0_0.RECORD_FORMATS.storeVersion() );
+
+        execute( databaseDirectory.toString() );
+
+        assertEquals(
+                String.format( "Store version:      vE.H.0%n" +
+                        "Introduced in:      3.0.0%n" +
+                        "Superceded in:      3.0.6%n" ),
+                baos.toString() );
+    }
+
+    private void execute( String storePath ) throws Exception
+    {
+        command.execute( new String[]{"--store=" + storePath} );
+    }
+
+    private void prepareNeoStoreFile( String storeVersion ) throws IOException
+    {
+        File neoStoreFile = createNeoStoreFile();
+        long value = MetaDataStore.versionStringToLong( storeVersion );
+        MetaDataStore.setRecord( pageCache, neoStoreFile, STORE_VERSION, value );
+    }
+
+    private File createNeoStoreFile() throws IOException
+    {
+        fs.mkdir( databaseDirectory.toFile() );
+        File neoStoreFile = new File( databaseDirectory.toFile(), MetaDataStore.DEFAULT_NAME );
+        fs.create( neoStoreFile ).close();
+        return neoStoreFile;
+    }
+}


### PR DESCRIPTION
Help text is as follows:

```
usage: neo4j-admin version --store=<path-to-dir>

Checks the version of a Neo4j database store. Note that this command expects a
path to a store directory, for example --store=data/databases/graph.db.

options:
  --store=<path-to-dir>   Path to database store to check version of.
```

changelog [tools] `neo4j-admin`: added `version` command

This command can be pointed against a store and reports information
about its version. 

```
usage: neo4j-admin version --store=<path-to-dir>
```

Two example outputs are

- If store matches latest known version to the tool:

```
Store format version:    v0.A.7
Introduced in version:   3.0.0
Current version:         3.0.5
```

- If store is older than latest known version to the tool:

```
Store format version:    v0.A.5
Introduced in version:   2.2.0
Superseded in version:   2.3.0
Current version:         3.0.5
```