### PR TITLE
Produce a warning when dbms.pagecache.memory.size is not configured

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -37,7 +37,6 @@ import org.neo4j.kernel.configuration.Migrator;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.impl.cache.MonitorGc;
-import org.neo4j.kernel.impl.util.OsBeanUtil;
 import org.neo4j.logging.Level;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.BoltConnector.EncryptionLevel.OPTIONAL;
@@ -375,47 +374,7 @@ public abstract class GraphDatabaseSettings
                   "the page cache. The default page cache memory assumes the machine is dedicated to running " +
                   "Neo4j, and is heuristically set to 50% of RAM minus the max Java heap size." )
     public static final Setting<Long> pagecache_memory =
-            setting( "dbms.memory.pagecache.size", BYTES, defaultPageCacheMemory(), min( 8192 * 30L ) );
-
-    private static String defaultPageCacheMemory()
-    {
-        // First check if we have a default override...
-        String defaultMemoryOverride = System.getProperty( "dbms.pagecache.memory.default.override" );
-        if ( defaultMemoryOverride != null )
-        {
-            return defaultMemoryOverride;
-        }
-
-        double ratioOfFreeMem = 0.50;
-        String defaultMemoryRatioOverride = System.getProperty( "dbms.pagecache.memory.ratio.default.override" );
-        if ( defaultMemoryRatioOverride != null )
-        {
-            ratioOfFreeMem = Double.parseDouble( defaultMemoryRatioOverride );
-        }
-
-        // Try to compute (RAM - maxheap) * 0.50 if we can get reliable numbers...
-        long maxHeapMemory = Runtime.getRuntime().maxMemory();
-        if ( 0 < maxHeapMemory && maxHeapMemory < Long.MAX_VALUE )
-        {
-            try
-            {
-                long physicalMemory = OsBeanUtil.getTotalPhysicalMemory();
-                if ( 0 < physicalMemory && physicalMemory < Long.MAX_VALUE && maxHeapMemory < physicalMemory )
-                {
-                    long heuristic = (long) ((physicalMemory - maxHeapMemory) * ratioOfFreeMem);
-                    long min = ByteUnit.mebiBytes( 32 ); // We'd like at least 32 MiBs.
-                    long max = ByteUnit.tebiBytes( 1 ); // Don't heuristically take more than 1 TiB.
-                    long memory = Math.min( max, Math.max( min, heuristic ) );
-                    return String.valueOf( memory );
-                }
-            }
-            catch ( Exception ignore )
-            {
-            }
-        }
-        // ... otherwise we just go with 2 GiBs.
-        return "2g";
-    }
+            setting( "dbms.memory.pagecache.size", BYTES, null, min( 8192 * 30L ) );
 
     @Description( "Specify which page swapper to use for doing paged IO. " +
                   "This is only used when integrating with proprietary storage technology." )

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -371,8 +371,8 @@ public abstract class GraphDatabaseSettings
                   "suffix, megabytes with 'm' and gigabytes with 'g'). If Neo4j is running on a dedicated server, " +
                   "then it is generally recommended to leave about 2-4 gigabytes for the operating system, give the " +
                   "JVM enough heap to hold all your transaction state and query context, and then leave the rest for " +
-                  "the page cache. The default page cache memory assumes the machine is dedicated to running " +
-                  "Neo4j, and is heuristically set to 50% of RAM minus the max Java heap size." )
+                  "the page cache. If no page cache memory is configured, then a heuristic setting is computed based " +
+                  "on available system resources." )
     public static final Setting<Long> pagecache_memory =
             setting( "dbms.memory.pagecache.size", BYTES, null, min( 8192 * 30L ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -122,21 +122,20 @@ public class ConfiguringPageCacheFactory
         {
             return pageCacheMemorySetting;
         }
-        String heuristic = defaultHeuristicPageCacheMemory();
+        long heuristic = defaultHeuristicPageCacheMemory();
         log.warn( "The " + pagecache_memory.name() + " setting has not been configured. It is recommended that this " +
                   "setting is always explicitly configured, to ensure the system has a balanced configuration. " +
-                  "Until then, a computed heuristic value of '" + heuristic + "' will be used " +
-                  "instead. " );
-        return BYTES.apply( heuristic );
+                  "Until then, a computed heuristic value of " + heuristic + " bytes will be used instead. " );
+        return heuristic;
     }
 
-    public static String defaultHeuristicPageCacheMemory()
+    public static long defaultHeuristicPageCacheMemory()
     {
         // First check if we have a default override...
         String defaultMemoryOverride = System.getProperty( "dbms.pagecache.memory.default.override" );
         if ( defaultMemoryOverride != null )
         {
-            return defaultMemoryOverride;
+            return BYTES.apply( defaultMemoryOverride );
         }
 
         double ratioOfFreeMem = 0.50;
@@ -166,7 +165,7 @@ public class ConfiguringPageCacheFactory
                     // of the system. This means that we won't heuristically try to create a page cache that is too
                     // large to fit on the heap.
                     long memory = Math.min( max, Math.max( min, heuristic ) );
-                    return String.valueOf( memory );
+                    return memory;
                 }
             }
             catch ( Exception ignore )
@@ -174,7 +173,7 @@ public class ConfiguringPageCacheFactory
             }
         }
         // ... otherwise we just go with 2 GiBs.
-        return "2g";
+        return ByteUnit.gibiBytes( 2 );
     }
 
     public int calculatePageSize( Config config, PageSwapperFactory swapperFactory )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -34,6 +34,7 @@ import org.neo4j.logging.Log;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_page_size;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_swapper;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
 
 public class ConfiguringPageCacheFactory
 {
@@ -102,7 +103,8 @@ public class ConfiguringPageCacheFactory
 
     public int calculateMaxPages( Config config, int cachePageSize )
     {
-        long pageCacheMemory = config.get( pagecache_memory );
+        Long pageCacheMemorySetting = config.get( pagecache_memory );
+        long pageCacheMemory = interpretMemorySetting( pageCacheMemorySetting );
         long maxHeap = Runtime.getRuntime().maxMemory();
         if ( pageCacheMemory / maxHeap > 100 )
         {
@@ -112,6 +114,63 @@ public class ConfiguringPageCacheFactory
         }
         long pageCount = pageCacheMemory / cachePageSize;
         return (int) Math.min( Integer.MAX_VALUE - 2000, pageCount );
+    }
+
+    private long interpretMemorySetting( Long pageCacheMemorySetting )
+    {
+        if ( pageCacheMemorySetting != null )
+        {
+            return pageCacheMemorySetting;
+        }
+        String heuristic = defaultHeuristicPageCacheMemory();
+        log.warn( "The " + pagecache_memory.name() + " setting has not been configured. It is recommended that this " +
+                  "setting is always explicitly configured, to ensure the system has a balanced configuration. " +
+                  "Until then, a computed heuristic value of '" + heuristic + "' will be used " +
+                  "instead. " );
+        return BYTES.apply( heuristic );
+    }
+
+    public static String defaultHeuristicPageCacheMemory()
+    {
+        // First check if we have a default override...
+        String defaultMemoryOverride = System.getProperty( "dbms.pagecache.memory.default.override" );
+        if ( defaultMemoryOverride != null )
+        {
+            return defaultMemoryOverride;
+        }
+
+        double ratioOfFreeMem = 0.50;
+        String defaultMemoryRatioOverride = System.getProperty( "dbms.pagecache.memory.ratio.default.override" );
+        if ( defaultMemoryRatioOverride != null )
+        {
+            ratioOfFreeMem = Double.parseDouble( defaultMemoryRatioOverride );
+        }
+
+        // Try to compute (RAM - maxheap) * 0.50 if we can get reliable numbers...
+        long maxHeapMemory = Runtime.getRuntime().maxMemory();
+        if ( 0 < maxHeapMemory && maxHeapMemory < Long.MAX_VALUE )
+        {
+            try
+            {
+                long physicalMemory = OsBeanUtil.getTotalPhysicalMemory();
+                if ( 0 < physicalMemory && physicalMemory < Long.MAX_VALUE && maxHeapMemory < physicalMemory )
+                {
+                    long heuristic = (long) ((physicalMemory - maxHeapMemory) * ratioOfFreeMem);
+                    long min = ByteUnit.mebiBytes( 32 ); // We'd like at least 32 MiBs.
+                    long max = ByteUnit.gibiBytes( 20 ); // Don't heuristically take more than 20 GiBs.
+                    // 20 GiBs of page cache memory is ~2.6 million 8 KiB pages. If each page has an overhead of
+                    // 72 bytes, then this will take up ~175 MiBs of heap memory. We should be able to tolerate that
+                    // in most environments.
+                    long memory = Math.min( max, Math.max( min, heuristic ) );
+                    return String.valueOf( memory );
+                }
+            }
+            catch ( Exception ignore )
+            {
+            }
+        }
+        // ... otherwise we just go with 2 GiBs.
+        return "2g";
     }
 
     public int calculatePageSize( Config config, PageSwapperFactory swapperFactory )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -157,10 +157,14 @@ public class ConfiguringPageCacheFactory
                 {
                     long heuristic = (long) ((physicalMemory - maxHeapMemory) * ratioOfFreeMem);
                     long min = ByteUnit.mebiBytes( 32 ); // We'd like at least 32 MiBs.
-                    long max = ByteUnit.gibiBytes( 20 ); // Don't heuristically take more than 20 GiBs.
+                    long max = Math.min( maxHeapMemory * 70, ByteUnit.gibiBytes( 20 ) );
+                    // Don't heuristically take more than 20 GiBs, and don't take more than 70 times our max heap.
                     // 20 GiBs of page cache memory is ~2.6 million 8 KiB pages. If each page has an overhead of
                     // 72 bytes, then this will take up ~175 MiBs of heap memory. We should be able to tolerate that
-                    // in most environments.
+                    // in most environments. The "no more than 70 times heap" heuristic is based on the page size over
+                    // the per page overhead, 8192 / 72 ~= 114, plus leaving some extra room on the heap for the rest
+                    // of the system. This means that we won't heuristically try to create a page cache that is too
+                    // large to fit on the heap.
                     long memory = Math.min( max, Math.max( min, heuristic ) );
                     return String.valueOf( memory );
                 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 
 import static java.lang.Math.min;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
@@ -126,8 +127,13 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         @Override
         public long pageCacheMemory()
         {
-            String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
-            return min( MAX_PAGE_CACHE_MEMORY, BYTES.apply( defaultPageCacheMemory ) );
+            Long pageCacheMemory = config.get( pagecache_memory );
+            if ( pageCacheMemory == null )
+            {
+                String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
+                pageCacheMemory = BYTES.apply( defaultPageCacheMemory );
+            }
+            return min( MAX_PAGE_CACHE_MEMORY, pageCacheMemory );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -20,12 +20,13 @@
 package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 
 import static java.lang.Math.min;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
 
 /**
  * User controlled configuration for a {@link BatchImporter}.
@@ -64,7 +65,8 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         {
             // Get the upper bound of what we can get from the default config calculation
             // We even want to limit amount of memory a bit more since we don't need very much during import
-            return min( MAX_PAGE_CACHE_MEMORY, Config.defaults().get( pagecache_memory ) );
+            String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
+            return min( MAX_PAGE_CACHE_MEMORY, BYTES.apply( defaultPageCacheMemory ) );
         }
 
         @Override
@@ -124,7 +126,8 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         @Override
         public long pageCacheMemory()
         {
-            return min( MAX_PAGE_CACHE_MEMORY, config.get( pagecache_memory ) );
+            String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
+            return min( MAX_PAGE_CACHE_MEMORY, BYTES.apply( defaultPageCacheMemory ) );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -27,7 +27,6 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_thresho
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
-import static org.neo4j.kernel.configuration.Settings.BYTES;
 
 /**
  * User controlled configuration for a {@link BatchImporter}.
@@ -66,8 +65,8 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         {
             // Get the upper bound of what we can get from the default config calculation
             // We even want to limit amount of memory a bit more since we don't need very much during import
-            String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
-            return min( MAX_PAGE_CACHE_MEMORY, BYTES.apply( defaultPageCacheMemory ) );
+            long defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
+            return min( MAX_PAGE_CACHE_MEMORY, defaultPageCacheMemory );
         }
 
         @Override
@@ -130,8 +129,7 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
             Long pageCacheMemory = config.get( pagecache_memory );
             if ( pageCacheMemory == null )
             {
-                String defaultPageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
-                pageCacheMemory = BYTES.apply( defaultPageCacheMemory );
+                pageCacheMemory = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
             }
             return min( MAX_PAGE_CACHE_MEMORY, pageCacheMemory );
         }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -34,9 +34,8 @@ import org.neo4j.io.ByteUnit;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -46,11 +45,10 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class GraphDatabaseSettingsTest
 {
     @Test
-    public void mustHaveReasonableDefaultPageCacheMemorySizeInBytes() throws Exception
+    public void mustHaveNullDefaultPageCacheMemorySizeInBytes() throws Exception
     {
-        long bytes = Config.defaults().get( GraphDatabaseSettings.pagecache_memory );
-        assertThat( bytes, greaterThanOrEqualTo( ByteUnit.mebiBytes( 32 ) ) );
-        assertThat( bytes, lessThanOrEqualTo( ByteUnit.tebiBytes( 1 ) ) );
+        Long bytes = Config.defaults().get( GraphDatabaseSettings.pagecache_memory );
+        assertThat( bytes, is( nullValue() ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
@@ -33,7 +33,6 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
-import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.parseLongWithUnit;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.MAX_PAGE_CACHE_MEMORY;
 
@@ -78,7 +77,7 @@ public class ConfigurationTest
         long memory = config.pageCacheMemory();
 
         // THEN
-        long heuristic = BYTES.apply( ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory() );
+        long heuristic = ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory();
         assertTrue( within( memory, heuristic, MAX_PAGE_CACHE_MEMORY ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport;
 import org.junit.Test;
 
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -32,6 +33,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.parseLongWithUnit;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.MAX_PAGE_CACHE_MEMORY;
 
@@ -76,7 +78,8 @@ public class ConfigurationTest
         long memory = config.pageCacheMemory();
 
         // THEN
-        assertTrue( within( memory, Config.defaults().get( pagecache_memory ), MAX_PAGE_CACHE_MEMORY ) );
+        long heuristic = BYTES.apply( ConfiguringPageCacheFactory.defaultHeuristicPageCacheMemory() );
+        assertTrue( within( memory, heuristic, MAX_PAGE_CACHE_MEMORY ) );
     }
 
     @Test


### PR DESCRIPTION
changelog The default heuristic value for the `dbms.pagecache.memory.size` setting has been changed to work better in deployments where the configured available heap memory is very small, relative to the available system memory. A warning is now written to the log, when the page cache memory has not been explicitly configured. In embedded deployments, the result of `config.get( GraphDatabaseSettings.pagecache_memory )` will now be `null` instead a the computed heuristic, in order to indicate when the setting has not been explicitly configured.