### PR TITLE
Make all test databases - impermanent and embedded alike - use 8 MiB page cache memory by default

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
@@ -48,7 +48,7 @@ public class AdversarialPageCacheGraphDatabaseFactory
 
     public static GraphDatabaseFactory create( FileSystemAbstraction fs, Adversary adversary )
     {
-        return new GraphDatabaseFactory()
+        return new TestGraphDatabaseFactory()
         {
             @Override
             protected GraphDatabaseService newDatabase( File dir, Map<String,String> config, Dependencies dependencies )

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -85,14 +85,19 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
         return newImpermanentDatabaseBuilder( ImpermanentGraphDatabase.PATH );
     }
 
-    private void configure( GraphDatabaseBuilder builder, File storeDir )
+    @Override
+    protected void configure( GraphDatabaseBuilder builder )
     {
-        super.configure( builder );
         // Reduce the default page cache memory size to 8 mega-bytes for test databases.
         builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-        builder.setConfig( GraphDatabaseSettings.logs_directory, new File( storeDir, "logs" ).getAbsolutePath() );
         builder.setConfig( boltConnector("bolt").type, BOLT.name() );
         builder.setConfig( boltConnector("bolt").enabled, "false" );
+    }
+
+    private void configure( GraphDatabaseBuilder builder, File storeDir )
+    {
+        configure( builder );
+        builder.setConfig( GraphDatabaseSettings.logs_directory, new File( storeDir, "logs" ).getAbsolutePath() );
     }
 
     @Override


### PR DESCRIPTION
Databases created with the TestGraphDatabaseFactory now all use 8 MiB of page cache memory by default, unless explicitly configured otherwise.
This setting previously only applied to impermanent databases.
Now it applies to embedded databases as well.