### PR TITLE
Fallback on interpreted runtime on unsupported type

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.functions.functionConverter
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, MethodStructure}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
+import org.neo4j.cypher.internal.frontend.v3_2.ast
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.{CTBoolean, CTNode, CTRelationship}
-import org.neo4j.cypher.internal.frontend.v3_2.{InternalException, ast}
 
 object ExpressionConverter {
 
@@ -96,7 +96,8 @@ object ExpressionConverter {
     variable.codeGenType.ct match {
       case CTNode => NodeProjection(variable)
       case CTRelationship => RelationshipProjection(variable)
-      case _ => throw new InternalException("The compiled runtime only handles variables pointing to rels and nodes at this time")
+      case _ =>
+        throw new CantCompileQueryException("The compiled runtime cannot handle results of type " + variable.codeGenType.ct)
     }
   }
 


### PR DESCRIPTION
If the compiled runtime encounters a result type it cannot handle it should
fallback on the interpreted runtime rather than fail hard