### PR TITLE
Fixes importer issue which could hang shutdown during panic

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/EntityDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/EntityDataGenerator.java
@@ -84,7 +84,7 @@ public class EntityDataGenerator<T> extends InputIterator.Adapter<T>
     public void close()
     {
         super.close();
-        processing.shutdown( 0 );
+        processing.shutdown();
     }
 
     @Override

--- a/community/import-tool/src/test/java/org/neo4j/tooling/EntityDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/EntityDataGenerator.java
@@ -84,7 +84,7 @@ public class EntityDataGenerator<T> extends InputIterator.Adapter<T>
     public void close()
     {
         super.close();
-        processing.shutdown( false );
+        processing.shutdown( 0 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/FutureAdapter.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -159,7 +160,12 @@ public abstract class FutureAdapter<V> implements Future<V>
 
     public static <T> Future<T> future( final Callable<T> task )
     {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        return future( task, Executors.defaultThreadFactory() );
+    }
+
+    public static <T> Future<T> future( final Callable<T> task, ThreadFactory factory )
+    {
+        ExecutorService executor = Executors.newSingleThreadExecutor( factory );
         Future<T> future = executor.submit( task );
         executor.shutdown();
         return future;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -168,6 +168,12 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
     {
         if ( shutDown )
         {
+            // We're already shut down, although take the ABORT_QUEUED flag seriously as to abort all
+            // processors still working on tasks. This looks like a panic.
+            if ( (flags & TaskExecutor.SF_ABORT_QUEUED) != 0 )
+            {
+                this.abortQueued = true;
+            }
             return;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
@@ -58,7 +58,8 @@ public interface TaskExecutor<LOCAL> extends Parallelizable
     void panic( Throwable panic );
 
     /**
-     * @return {@code true} if {@link #shutdown()} has been called, otherwise {@code false}.
+     * @return {@code true} if {@link #shutdown()} or {@link #panic(Throwable)} has been called,
+     * otherwise {@code false}.
      */
     boolean isShutdown();
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
@@ -32,9 +32,6 @@ import org.neo4j.unsafe.impl.batchimport.Parallelizable;
  */
 public interface TaskExecutor<LOCAL> extends Parallelizable
 {
-    int SF_AWAIT_ALL_COMPLETED = 0x1;
-    int SF_ABORT_QUEUED = 0x2;
-
     /**
      * Submits a task to be executed by one of the processors in this {@link TaskExecutor}. Tasks will be
      * executed in the order of which they arrive.
@@ -46,14 +43,22 @@ public interface TaskExecutor<LOCAL> extends Parallelizable
     /**
      * Shuts down this {@link TaskExecutor}, disallowing new tasks to be {@link #submit(Task) submitted}.
      *
-     * @param flags {@link #SF_AWAIT_ALL_COMPLETED} will wait for all queued or already executing tasks to be
-     * executed and completed, before returning from this method. {@link #SF_ABORT_QUEUED} will have
-     * submitted tasks which haven't started executing yet cancelled, never to be executed.
+     * submitted tasks will be processed before returning from this method.
      */
-    void shutdown( int flags );
+    void shutdown();
 
     /**
-     * @return {@code true} if {@link #shutdown(int)} has been called, otherwise {@code false}.
+     * Puts this executor into panic mode. Call to {@link #shutdown()} has no effect after a panic.
+     * Call to {@link #assertHealthy()} will communicate the panic as well.
+     * This semantically includes something like a shutdown, but submitted tasks which haven't started
+     * being processed will be aborted and currently processing tasks will not be awaited for completion.
+     *
+     * @param panic cause of panic.
+     */
+    void panic( Throwable panic );
+
+    /**
+     * @return {@code true} if {@link #shutdown()} has been called, otherwise {@code false}.
      */
     boolean isShutdown();
 
@@ -61,8 +66,8 @@ public interface TaskExecutor<LOCAL> extends Parallelizable
      * Asserts that this {@link TaskExecutor} is healthy. Useful to call when deciding to wait on a condition
      * this executor is expected to fulfill.
      *
-     * @throws RuntimeException of some sort if this executor is in a bad stage, the original error that
-     * made this executor fail.
+     * @throws RuntimeException of some sort if this executor is in a bad state, containing the original error,
+     * if any, that made this executor fail.
      */
     void assertHealthy();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -46,7 +46,6 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.Deser
 import org.neo4j.unsafe.impl.batchimport.staging.TicketedProcessing;
 
 import static org.neo4j.csv.reader.Source.singleChunk;
-import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.kernel.impl.util.Validators.emptyValidator;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.noDecorator;
 
@@ -263,7 +262,14 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
     @Override
     public void close()
     {
-        processing.shutdown();
+        if ( processingCompletion.isDone() )
+        {
+            processing.shutdown();
+        }
+        else
+        {
+            processing.panic( new IllegalStateException( "Processing not completed when closing, indicating panic" ) );
+        }
         try
         {
             source.close();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializer.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.impl.util.Validator;
 import org.neo4j.kernel.impl.util.collection.ContinuableArrayCursor;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
-import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntity;
 import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
@@ -47,6 +46,7 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.InputGroupsDeserializer.Deser
 import org.neo4j.unsafe.impl.batchimport.staging.TicketedProcessing;
 
 import static org.neo4j.csv.reader.Source.singleChunk;
+import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.kernel.impl.util.Validators.emptyValidator;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.noDecorator;
 
@@ -263,11 +263,7 @@ public class ParallelInputEntityDeserializer<ENTITY extends InputEntity> extends
     @Override
     public void close()
     {
-        // At this point normally the "slurp" above will have called shutdown and so calling close
-        // before that has completed signals some sort of panic. Encode this knowledge in flags passed
-        // to shutdown
-        int flags = processingCompletion.isDone() ? 0 : TaskExecutor.SF_ABORT_QUEUED;
-        processing.shutdown( flags );
+        processing.shutdown();
         try
         {
             source.close();

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
@@ -33,7 +33,6 @@ import org.neo4j.test.Race;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.test.RepeatRule.Repeat;
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy.Park;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -41,9 +40,6 @@ import static org.junit.Assert.fail;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor.SF_ABORT_QUEUED;
-import static org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor.SF_AWAIT_ALL_COMPLETED;
 
 public class DynamicTaskExecutorTest
 {
@@ -72,7 +68,7 @@ public class DynamicTaskExecutorTest
         while ( task1.executed == 0 )
         {   // Busy loop
         }
-        executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+        executor.shutdown();
 
         // THEN
         assertEquals( 1, task1.executed );
@@ -100,7 +96,7 @@ public class DynamicTaskExecutorTest
         while ( task1.executed == 0 )
         {   // Busy loop
         }
-        executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+        executor.shutdown();
 
         // THEN
         assertEquals( 1, task1.executed );
@@ -132,7 +128,7 @@ public class DynamicTaskExecutorTest
         Thread.sleep( 200 ); // gosh, a Thread.sleep...
         assertEquals( 0, task4.executed );
         task3.latch.finish();
-        executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+        executor.shutdown();
 
         // THEN
         assertEquals( 1, task1.executed );
@@ -154,7 +150,7 @@ public class DynamicTaskExecutorTest
         {
             executor.submit( tasks[i] = new ExpensiveTask( 10 ) );
         }
-        executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+        executor.shutdown();
 
         // THEN
         for ( ExpensiveTask task : tasks )
@@ -208,7 +204,6 @@ public class DynamicTaskExecutorTest
 
         // THEN
         assertExceptionOnSubmit( executor, exception );
-        executor.shutdown( SF_ABORT_QUEUED ); // call would block if the shutdown as part of failure doesn't complete properly
     }
 
     @Test
@@ -264,7 +259,7 @@ public class DynamicTaskExecutorTest
                 @Override
                 public Void doWork( Void state ) throws Exception
                 {
-                    executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+                    executor.shutdown();
                     return null;
                 }
             } );
@@ -301,7 +296,7 @@ public class DynamicTaskExecutorTest
         assertEquals( 1, executor.processors( -2 ) );
         assertEquals( 1, executor.processors( -2 ) );
         assertEquals( 1, executor.processors( 0 ) );
-        executor.shutdown( SF_AWAIT_ALL_COMPLETED );
+        executor.shutdown();
     }
 
     @Repeat( times = 100 )
@@ -311,7 +306,7 @@ public class DynamicTaskExecutorTest
         // GIVEN
         TaskExecutor<Void> executor = new DynamicTaskExecutor<>( 1, 2, 2, PARK, "test" );
         Race race = new Race( true );
-        race.addContestant( () -> executor.shutdown( SF_AWAIT_ALL_COMPLETED ) );
+        race.addContestant( () -> executor.shutdown() );
         race.addContestant( () -> executor.processors( 1 ) );
 
         // WHEN

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -25,9 +25,11 @@ import org.junit.Test;
 import java.io.StringReader;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+
 import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.test.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators;
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DeserializerFactories.defaultNodeDeserializer;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.IdType.ACTUAL;
 
 public class ParallelInputEntityDeserializerTest
@@ -100,6 +103,54 @@ public class ParallelInputEntityDeserializerTest
             }
             assertFalse( deserializer.hasNext() );
             assertEquals( threads, observedProcessingThreads.size() );
+        }
+    }
+
+    // Timeout is so that if this bug strikes again it will only cause this test to run for a limited time
+    // before failing. Normally this test is really quick
+    @Test( timeout = 10_000 )
+    public void shouldTreatExternalCloseAsPanic() throws Exception
+    {
+        // GIVEN enough data to fill up queues
+        int entities = 500;
+        Data<InputNode> data = testData( entities );
+        Configuration config = new Configuration.Overridden( COMMAS )
+        {
+            @Override
+            public int bufferSize()
+            {
+                return 100;
+            }
+        };
+        IdType idType = ACTUAL;
+        Collector badCollector = mock( Collector.class );
+        Groups groups = new Groups();
+
+        // WHEN closing before having consumed all results
+        DeserializerFactory<InputNode> deserializerFactory =
+                defaultNodeDeserializer( groups, config, idType, badCollector );
+        try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,
+                defaultFormatNodeFileHeader(), config, idType, 3, 3, deserializerFactory,
+                Validators.<InputNode>emptyValidator(), InputNode.class ) )
+        {
+            deserializer.hasNext();
+            deserializer.close();
+
+            // Why pull some items after it has been closed? The above close() symbolizes a panic from
+            // somewhere, anywhere in the importer. At that point there are still batches that have been
+            // processed and are there for the taking. One of the components in the hang scenario that we want
+            // to test comes from a processor in TicketedProcessing forever trying to offer its processed
+            // result to the result queue (where the loop didn't care if it had been forcefully shut down.
+            // To get one of the processing threads into doing that we need to pull some of the already
+            // processed items so that it wants to go ahead and offer its result.
+            for ( int i = 0; i < 100 && deserializer.hasNext(); i++ )
+            {
+                deserializer.next();
+            }
+        }
+        catch ( TaskExecutionPanicException e )
+        {
+            // THEN it should be able to exit (this exception comes as a side effect)
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.test.RandomRule;
-import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators;
@@ -148,7 +147,7 @@ public class ParallelInputEntityDeserializerTest
                 deserializer.next();
             }
         }
-        catch ( TaskExecutionPanicException e )
+        catch ( IllegalStateException e )
         {
             // THEN it should be able to exit (this exception comes as a side effect)
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -139,7 +139,7 @@ public class ParallelInputEntityDeserializerTest
             // somewhere, anywhere in the importer. At that point there are still batches that have been
             // processed and are there for the taking. One of the components in the hang scenario that we want
             // to test comes from a processor in TicketedProcessing forever trying to offer its processed
-            // result to the result queue (where the loop didn't care if it had been forcefully shut down.
+            // result to the result queue, where the loop didn't care if it had been forcefully shut down.
             // To get one of the processing threads into doing that we need to pull some of the already
             // processed items so that it wants to go ahead and offer its result.
             for ( int i = 0; i < 100 && deserializer.hasNext(); i++ )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
@@ -89,10 +89,10 @@ public class TicketedProcessingTest
             processing.submit( i );
         }
         processing.endOfSubmissions();
-        processing.shutdown();
 
         // THEN
         assertions.get();
+        processing.shutdown();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
@@ -32,8 +32,6 @@ import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
 import org.neo4j.test.OtherThreadRule;
-import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -90,7 +88,8 @@ public class TicketedProcessingTest
         {
             processing.submit( i );
         }
-        processing.shutdown( TaskExecutor.SF_AWAIT_ALL_COMPLETED );
+        processing.endOfSubmissions();
+        processing.shutdown();
 
         // THEN
         assertions.get();
@@ -133,7 +132,7 @@ public class TicketedProcessingTest
         assertEquals( 3, processing.next().intValue() );
 
         // THEN
-        processing.shutdown( TaskExecutor.SF_AWAIT_ALL_COMPLETED );
+        processing.shutdown();
     }
 
     @Test( timeout = 10_000 )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
@@ -30,6 +30,7 @@ import java.util.function.BiFunction;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
 import org.neo4j.test.OtherThreadRule;
+import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -83,7 +84,7 @@ public class TicketedProcessingTest
         {
             processing.submit( i );
         }
-        processing.shutdown( true );
+        processing.shutdown( TaskExecutor.SF_AWAIT_ALL_COMPLETED );
 
         // THEN
         assertions.get();
@@ -126,7 +127,7 @@ public class TicketedProcessingTest
         assertEquals( 3, processing.next().intValue() );
 
         // THEN
-        processing.shutdown( true );
+        processing.shutdown( TaskExecutor.SF_AWAIT_ALL_COMPLETED );
     }
 
     private static class StringJob

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedProcessingTest.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.staging;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
@@ -29,12 +30,17 @@ import java.util.function.BiFunction;
 
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
+import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutionPanicException;
 import org.neo4j.test.OtherThreadRule;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import static java.lang.Integer.parseInt;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -128,6 +134,38 @@ public class TicketedProcessingTest
 
         // THEN
         processing.shutdown( TaskExecutor.SF_AWAIT_ALL_COMPLETED );
+    }
+
+    @Test( timeout = 10_000 )
+    public void shouldShutdownWithAbortOnSlurpFailure() throws Exception
+    {
+        // GIVEN
+        TicketedProcessing<StringJob,Void,Integer> processing = new TicketedProcessing<>( "Slurper", 2,
+                (job,state) ->
+                {
+                    return parseInt( job.string );
+                }, () -> null );
+        @SuppressWarnings( "unchecked" )
+        Iterator<StringJob> jobs = mock( Iterator.class );
+        when( jobs.hasNext() ).thenReturn( true );
+        RuntimeException runtimeException = new RuntimeException( "Slurp failure" );
+        when( jobs.next() ).thenReturn( new StringJob( "1" ) ).thenThrow( runtimeException );
+        processing.slurp( jobs, true );
+
+        // WHEN
+        assertEquals( 1, processing.next().intValue() );
+
+        // THEN
+        try
+        {
+            processing.next();
+            fail( "Should have failed with the provided exception" );
+        }
+        catch ( TaskExecutionPanicException e )
+        {
+            // Good
+            assertEquals( runtimeException.getMessage(), e.getCause().getMessage() );
+        }
     }
 
     private static class StringJob


### PR DESCRIPTION
this would prevent import tool from shutting down, but more importantly
it would prevent the error to be shown.

This fix treats a call to close() before all processing is done in
ParallelInputEntityDeserializer as a panic and delegates that flag to
its executor so that all processors can now abort their processing accordingly.