### PR TITLE
Add a close() method to the PageSwapperFactory interface

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -117,7 +117,7 @@ public class ConsistencyCheckService
             {
                 pageCache.close();
             }
-            catch ( IOException e )
+            catch ( Exception e )
             {
                 log.error( "Failure during shutdown of the page cache", e );
             }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -89,9 +89,15 @@ public interface PageCache extends AutoCloseable
     void flushAndForce( IOLimiter limiter ) throws IOException;
 
     /**
-     * Flush all dirty pages and close the page cache.
+     * Close the page cache to prevent any future mapping of files.
+     * This also releases any internal resources, including the {@link PageSwapperFactory} through its
+     * {@link PageSwapperFactory#close() close} method.
+     * @throws IllegalStateException if not all files have been unmapped, with {@link PagedFile#close()}, prior to
+     * closing the page cache. In this case, the page cache <em>WILL NOT</em> be considered to be successfully closed.
+     * @throws RuntimeException if the {@link PageSwapperFactory#close()} method throws. In this case the page cache
+     * <em>WILL BE</em> considered to have been closed successfully.
      **/
-    void close() throws IOException;
+    void close() throws IllegalStateException;
 
     /**
      * The size in bytes of the pages managed by this cache.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -129,4 +129,6 @@ public interface PageSwapperFactory
      * @throws IOException If an I/O error occurs, possibly with the canonicalisation of the paths.
      */
     Stream<FileHandle> streamFilesRecursive( File directory ) throws IOException;
+
+    void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapperFactory.java
@@ -130,5 +130,12 @@ public interface PageSwapperFactory
      */
     Stream<FileHandle> streamFilesRecursive( File directory ) throws IOException;
 
+    /**
+     * Close and release any resources associated with this PageSwapperFactory, that it may have opened or acquired
+     * during its construction or use.
+     * <p>
+     * This method cannot be called before all of the opened {@link PageSwapper PageSwappers} have been closed,
+     * and it is guaranteed that no new page swappers will be created after this method has been called.
+     */
     void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -83,6 +83,12 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
         return streamFilesRecursive( directory.getCanonicalFile(), fs );
     }
 
+    @Override
+    public void close()
+    {
+        // We have nothing to close
+    }
+
     /**
      * Static implementation of {@link SingleFilePageSwapperFactory#streamFilesRecursive(File)} that does not require
      * any external state, other than what is presented through the given {@link FileSystemAbstraction}.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -473,7 +473,7 @@ public class MuninnPageCache implements PageCache
             {
                 close();
             }
-            catch ( IOException closeException )
+            catch ( Exception closeException )
             {
                 exception.addSuppressed( closeException );
             }
@@ -586,7 +586,7 @@ public class MuninnPageCache implements PageCache
     }
 
     @Override
-    public synchronized void close() throws IOException
+    public synchronized void close()
     {
         if ( closed )
         {
@@ -619,6 +619,9 @@ public class MuninnPageCache implements PageCache
 
         interrupt( evictionThread );
         evictionThread = null;
+
+        // Close the page swapper factory last. If this fails then we will still consider ourselves closed.
+        swapperFactory.close();
     }
 
     private void interrupt( Thread thread )

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -98,9 +98,8 @@ public class AdversarialPageCache implements PageCache
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
-        adversary.injectFailure( FileNotFoundException.class, IOException.class, SecurityException.class );
         delegate.close();
     }
 

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -100,6 +100,7 @@ public class AdversarialPageCache implements PageCache
     @Override
     public void close()
     {
+        adversary.injectFailure( IllegalStateException.class );
         delegate.close();
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -50,7 +50,7 @@ public class DelegatingPageCache implements PageCache
         return delegate.pageSize();
     }
 
-    public void close() throws IOException
+    public void close()
     {
         delegate.close();
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperTest.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -112,14 +112,14 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     }
 
     @Test
-    public void swappingInMustFillPageWithData() throws IOException
+    public void swappingInMustFillPageWithData() throws Exception
     {
         byte[] bytes = new byte[] { 1, 2, 3, 4 };
         StoreChannel channel = getFs().create( getFile() );
         channel.writeAll( wrap( bytes ) );
         channel.close();
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         PageSwapper swapper = createSwapper( factory, getFile(), 4, null, false );
         ByteBuffer target = ByteBuffer.allocateDirect( 4 );
         ByteBufferPage page = new ByteBufferPage( target );
@@ -129,7 +129,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     }
 
     @Test
-    public void mustZeroFillPageBeyondEndOfFile() throws IOException
+    public void mustZeroFillPageBeyondEndOfFile() throws Exception
     {
         byte[] bytes = new byte[] {
                 // --- page 0:
@@ -141,7 +141,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         channel.writeAll( wrap( bytes ) );
         channel.close();
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         PageSwapper swapper = createSwapper( factory, getFile(), 4, null, false );
         ByteBuffer target = ByteBuffer.allocateDirect( 4 );
         ByteBufferPage page = new ByteBufferPage( target );
@@ -151,14 +151,14 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     }
 
     @Test
-    public void swappingOutMustWritePageToFile() throws IOException
+    public void swappingOutMustWritePageToFile() throws Exception
     {
         getFs().create( getFile() ).close();
 
         byte[] expected = new byte[] { 1, 2, 3, 4 };
         ByteBufferPage page = new ByteBufferPage( wrap( expected ) );
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         PageSwapper swapper = createSwapper( factory, getFile(), 4, null, false );
         swapper.write( 0, page );
 
@@ -170,7 +170,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     }
 
     @Test
-    public void swappingOutMustNotOverwriteDataBeyondPage() throws IOException
+    public void swappingOutMustNotOverwriteDataBeyondPage() throws Exception
     {
         byte[] initialData = new byte[] {
                 // --- page 0:
@@ -195,7 +195,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         byte[] change = new byte[] { 8, 7, 6, 5 };
         ByteBufferPage page = new ByteBufferPage( wrap( change ) );
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         PageSwapper swapper = createSwapper( factory, getFile(), 4, null, false );
         swapper.write( 1, page );
 
@@ -214,7 +214,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     {
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS );
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( fs );
         File file = testDir.file( "file" );
@@ -239,7 +239,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     {
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS ); // no file locking on Windows.
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( fs );
         File file = testDir.file( "file" );
@@ -259,7 +259,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     {
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS ); // no file locking on Windows.
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( fs );
         File file = testDir.file( "file" );
@@ -294,7 +294,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     {
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS ); // no file locking on Windows.
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( fs );
         File file = testDir.file( "file" );
@@ -314,7 +314,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
     {
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS ); // no file locking on Windows.
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( fs );
         File file = testDir.file( "file" );
@@ -344,7 +344,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         assumeFalse( "No file locking on Windows", SystemUtils.IS_OS_WINDOWS ); // no file locking on Windows.
 
         final AtomicInteger openFilesCounter = new AtomicInteger();
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         factory.setFileSystemAbstraction( new DelegatingFileSystemAbstraction( fs )
         {
@@ -365,7 +365,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         } );
         File file = testDir.file( "file" );
         try ( StoreChannel ch = fs.create( file );
-              FileLock lock = ch.tryLock() )
+              FileLock ignore = ch.tryLock() )
         {
             createSwapper( factory, file, 4, NO_CALLBACK, false ).close();
             fail( "Creating a page swapper for a locked channel should have thrown" );
@@ -406,7 +406,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         byte[] data = new byte[bytesTotal];
         ThreadLocalRandom.current().nextBytes( data );
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         factory.setFileSystemAbstraction( getFs() );
         File file = getFile();
         PageSwapper swapper = createSwapper( factory, file, bytesTotal, NO_CALLBACK, true );
@@ -450,7 +450,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         clear( zeroPage );
 
         File file = getFile();
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         RandomAdversary adversary = new RandomAdversary( 0.5, 0.0, 0.0 );
         factory.setFileSystemAbstraction( new AdversarialFileSystemAbstraction( adversary, getFs() ) );
         PageSwapper swapper = createSwapper( factory, file, bytesTotal, NO_CALLBACK, true );
@@ -487,7 +487,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         byte[] data = new byte[bytesTotal];
         ThreadLocalRandom.current().nextBytes( data );
 
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         factory.setFileSystemAbstraction( getFs() );
         File file = getFile();
         PageSwapper swapper = createSwapper( factory, file, bytesTotal, NO_CALLBACK, true );
@@ -545,7 +545,7 @@ public class SingleFilePageSwapperTest extends PageSwapperTest
         clear( zeroPage );
 
         File file = getFile();
-        PageSwapperFactory factory = swapperFactory();
+        PageSwapperFactory factory = createSwapperFactory();
         RandomAdversary adversary = new RandomAdversary( 0.5, 0.0, 0.0 );
         factory.setFileSystemAbstraction( new AdversarialFileSystemAbstraction( adversary, getFs() ) );
         PageSwapper swapper = createSwapper( factory, file, bytesPerPage, NO_CALLBACK, true );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurablePageSwapperFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurablePageSwapperFactory.java
@@ -24,14 +24,15 @@ import org.neo4j.kernel.configuration.Config;
 
 /**
  * A PageSwapperFactory that can take additional configurations.
- *
- * The configuration options should be name-spaced under <code>dbms.memory.pagecache.swapper.{implementationName}</code>.
+ * <p>
+ * The configuration options should be name-spaced under
+ * <code>dbms.memory.pagecache.swapper.{implementationName}</code>.
  */
 public interface ConfigurablePageSwapperFactory extends PageSwapperFactory
 {
     /**
      * Apply the given configuration to this PageSwapperFactory.
-     *
+     * <p>
      * This must be called before the factory creates its first PageSwapper.
      */
     void configure( Config config );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -128,7 +128,7 @@ public class BatchingNeoStores implements AutoCloseable
             {
                 pageCache.close();
             }
-            catch ( IOException e )
+            catch ( Exception e )
             {
                 // Oddly enough we can't close the page cache, how to communicate this? Here we add as suppressed
                 ise.addSuppressed( e );

--- a/community/kernel/src/test/java/org/neo4j/test/rule/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/PageCacheRule.java
@@ -69,7 +69,7 @@ public class PageCacheRule extends ExternalResource
             {
                 pageCache.close();
             }
-            catch ( IOException e )
+            catch ( Exception e )
             {
                 throw new AssertionError(
                         "Failed to stop existing PageCache prior to creating a new one", e );
@@ -94,7 +94,7 @@ public class PageCacheRule extends ExternalResource
             {
                 pageCache.close();
             }
-            catch ( IOException e )
+            catch ( Exception e )
             {
                 throw new AssertionError( "Failed to stop PageCache after test", e );
             }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -53,13 +53,13 @@ public class ExternallyManagedPageCache implements PageCache
 {
     private final PageCache delegate;
 
-    public ExternallyManagedPageCache( PageCache delegate )
+    private ExternallyManagedPageCache( PageCache delegate )
     {
         this.delegate = delegate;
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
         // Don't close the delegate, because we are not in charge of its life cycle.
     }
@@ -118,7 +118,7 @@ public class ExternallyManagedPageCache implements PageCache
     {
         private final PageCache delegatePageCache;
 
-        public GraphDatabaseFactoryWithPageCacheFactory( PageCache delegatePageCache )
+        GraphDatabaseFactoryWithPageCacheFactory( PageCache delegatePageCache )
         {
             this.delegatePageCache = delegatePageCache;
         }

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -130,7 +130,7 @@ public class StoreMigration
             long duration = System.currentTimeMillis() - startTime;
             log.info( format( "Migration completed in %d s%n", duration / 1000 ) );
         }
-        catch ( IOException e )
+        catch ( Exception e )
         {
             throw new StoreUpgrader.UnableToUpgradeException( "Failure during upgrade", e );
         }


### PR DESCRIPTION
This allows the page swapper factories to initialise internal resources in
`configure`, and release them in `close`.

This is useful for our block device integration.