### PR TITLE
Update TCK dependency

### DIFF
--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -28,6 +28,7 @@ LIMIT with an expression that does not depend on variables
 `toInteger()` handling Any type
 `toInteger()` on a list of strings
 `toInteger()` failing on invalid arguments
+`toInteger()` on a complex-typed expression
 
 // missing properties()
 `properties()` on a node
@@ -56,6 +57,8 @@ Failing when performing property access on a non-map 1
 `toFloat()` failing on invalid arguments
 `toString()` should work on Any type
 `toString()` failing on invalid arguments
+`max()` should aggregate strings
+`min()` should aggregate strings
 
 // other
 Combine MATCH, WITH and CREATE
@@ -78,6 +81,10 @@ Fail when returning type of deleted relationships
 `toString()` handling boolean properties
 `toString()` handling inlined boolean
 `toString()` handling boolean literal
+IN should work with nested list subscripting
+IN should work with nested literal list subscripting
+IN should work with list slices
+IN should work with literal list slices
 
 // new parameter syntax $
 Delete node from a list
@@ -128,6 +135,9 @@ Get node degree via size of pattern comprehension that specifies multiple relati
 Introducing new node variable in pattern comprehension
 Introducing new relationship variable in pattern comprehension
 
-// bugged in spec, awaiting update
-SKIP with an expression that depends on variables should fail
-LIMIT with an expression that depends on variables should fail
+// unsupported comparability
+Fail when comparing nodes to parameters
+Fail when comparing parameters to nodes
+Comparing nodes to properties
+Fail when comparing nodes to relationships
+Fail when comparing relationships to nodes

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-30.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-30.txt
@@ -12,6 +12,7 @@ LIMIT with an expression that does not depend on variables
 `toInteger()` handling Any type
 `toInteger()` on a list of strings
 `toInteger()` failing on invalid arguments
+`toInteger()` on a complex-typed expression
 
 // missing toBoolean()
 `toBoolean()` on valid literal string
@@ -69,7 +70,15 @@ Get node degree via size of pattern comprehension that specifies multiple relati
 Introducing new node variable in pattern comprehension
 Introducing new relationship variable in pattern comprehension
 
-// bugged in spec, awaiting update
-SKIP with an expression that depends on variables should fail
-LIMIT with an expression that depends on variables should fail
-Fail when returning type of deleted relationships
+// unsupported comparability
+Fail when comparing nodes to parameters
+Fail when comparing parameters to nodes
+Comparing nodes to properties
+Fail when comparing nodes to relationships
+Fail when comparing relationships to nodes
+
+// bugs, 3.0 dependency not updated
+IN should work with nested list subscripting
+IN should work with nested literal list subscripting
+IN should work with list slices
+IN should work with literal list slices

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -1,7 +1,8 @@
 Many CREATE clauses
 
-// bugged in spec, awaiting update
-SKIP with an expression that depends on variables should fail
-LIMIT with an expression that depends on variables should fail
-Fail when returning type of deleted relationships
-Fail when returning properties of deleted relationships
+// unsupported comparability
+Fail when comparing nodes to parameters
+Fail when comparing parameters to nodes
+Comparing nodes to properties
+Fail when comparing nodes to relationships
+Fail when comparing relationships to nodes

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost.txt
@@ -1,5 +1,6 @@
-// bugged in spec, awaiting update
-SKIP with an expression that depends on variables should fail
-LIMIT with an expression that depends on variables should fail
-Fail when returning type of deleted relationships
-Fail when returning properties of deleted relationships
+// unsupported comparability
+Fail when comparing nodes to parameters
+Fail when comparing parameters to nodes
+Comparing nodes to properties
+Fail when comparing nodes to relationships
+Fail when comparing relationships to nodes

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/rule.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/rule.txt
@@ -8,8 +8,9 @@ Fail when imposing new predicates on a variable that is already bound
 Introducing new node variable in pattern comprehension
 Introducing new relationship variable in pattern comprehension
 
-// bugged in spec, awaiting update
-SKIP with an expression that depends on variables should fail
-LIMIT with an expression that depends on variables should fail
-Fail when returning type of deleted relationships
-Fail when returning properties of deleted relationships
+// unsupported comparability
+Fail when comparing nodes to parameters
+Fail when comparing parameters to nodes
+Comparing nodes to properties
+Fail when comparing nodes to relationships
+Fail when comparing relationships to nodes

--- a/community/cypher/spec-suite-tools/pom.xml
+++ b/community/cypher/spec-suite-tools/pom.xml
@@ -48,7 +48,7 @@
     <version-package>cypher.internal</version-package>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <opencypher.version>1.0.0-M02</opencypher.version>
+    <opencypher.version>1.0.0-M03</opencypher.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This is in preparation for updating to the new TCK milestone. As usual there is
a number of new scenarios that `2.3` and `3.0` have not been updated to
handle.

One scenario is blacklisted for all configurations as it has not yet
been implemented: Comparability.