### PR TITLE
Handle explicit multiline description strings

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/Arguments.java
@@ -19,17 +19,18 @@
  */
 package org.neo4j.commandline.arguments;
 
-import org.apache.commons.lang3.text.WordUtils;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.text.WordUtils;
 
 import org.neo4j.commandline.arguments.common.Database;
 import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
@@ -113,7 +114,7 @@ public class Arguments
 
     public String description( String text )
     {
-        String wrappedText = WordUtils.wrap( text, LINE_LENGTH );
+        String wrappedText = wrapText( text, LINE_LENGTH );
         if ( namedArgs.isEmpty() )
         {
             return wrappedText;
@@ -130,6 +131,22 @@ public class Arguments
                 namedArgs.values().stream()
                         .map( c -> formatArgumentDescription( alignLength, c ) )
                         .collect( Collectors.joining( NEWLINE ) ) );
+    }
+
+    /**
+     * Original line-endings in the text are respected.
+     *
+     * @param text to wrap
+     * @param lineLength no line will exceed this length
+     * @return the text where no line exceeds the specified length
+     */
+    public static String wrapText( final String text, final int lineLength )
+    {
+        List<String> lines = Arrays.asList( text.split( "\r?\n" ) );
+
+        return lines.stream()
+                .map( l -> WordUtils.wrap( l, lineLength ) )
+                .collect( Collectors.joining( NEWLINE ) );
     }
 
     public String formatArgumentDescription( final int longestAlignmentLength, final NamedArgument argument )
@@ -160,7 +177,7 @@ public class Arguments
             rightWidth = LINE_LENGTH - newLineIndent;
         }
 
-        final String[] rightLines = WordUtils.wrap( rightText, rightWidth ).split( NEWLINE );
+        final String[] rightLines = wrapText( rightText, rightWidth ).split( NEWLINE );
 
         final String fmt = "%-" + (startOnNewLine ? newLineIndent : rightAlignIndex) + "s%s";
         String firstLine = String.format( fmt, leftText, startOnNewLine ? "" : rightLines[0] );

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
@@ -96,4 +96,35 @@ public class ArgumentsTest
                                         "names.") )
                         .description( "How to use" ) );
     }
+
+    @Test
+    public void descriptionShouldHandleExistingNewlines() throws Exception
+    {
+        assertEquals( String.format( "This is the first line%n" +
+                        "And this is the second line%n" +
+                        "The third line is so long that it requires some wrapping by the code itself%n" +
+                        "because as you can see it just keeps going ang going and going and going and%n" +
+                        "going and going." ),
+                builder.description( String.format(
+                        "This is the first line%n" + "And this is the second line%n" +
+                                "The third line is so long that it requires some wrapping by the code itself because " +
+                                "as you " +
+                                "can see it just keeps going ang going and going and going and going and going." ) ) );
+    }
+
+    @Test
+    public void wrappingHandlesBothKindsOfLineEndingsAndOutputsPlatformDependentOnes() throws Exception
+    {
+        assertEquals( String.format( "One with Linux%n" +
+                        "One with Windows%n" +
+                        "And one which is%n" +
+                        "just long and should%n" +
+                        "be wrapped by the%n" +
+                        "function" ),
+                Arguments.wrapText(
+                        "One with Linux\n" +
+                                "One with Windows\r\n" +
+                                "And one which is just long and should be wrapped by the function",
+                        20 ) );
+    }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -84,10 +84,10 @@ public class ImportCommand implements AdminCommand
                             "Note that file groups must be enclosed in quotation marks." ) )
             .withArgument( new OptionalNamedArg( "id-type", new String[]{"STRING", "INTEGER", "ACTUAL"},
                     "STRING", "Each node must provide a unique id. This is used to find the correct " +
-                    "nodes when creating relationships. Possible values are " +
-                    "STRING: arbitrary strings for identifying nodes, " +
-                    "INTEGER: arbitrary integer values for identifying nodes, " +
-                    "ACTUAL: (advanced) actual node ids. " +
+                    "nodes when creating relationships. Possible values are\n" +
+                    "  STRING: arbitrary strings for identifying nodes,\n" +
+                    "  INTEGER: arbitrary integer values for identifying nodes,\n" +
+                    "  ACTUAL: (advanced) actual node ids.\n" +
                     "For more information on id handling, please see the Neo4j Manual: " +
                     "http://neo4j.com/docs/operations-manual/current/deployment/#import-tool" ) )
             .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",
@@ -115,10 +115,10 @@ public class ImportCommand implements AdminCommand
                             "Note that file groups must be enclosed in quotation marks." ) )
             .withArgument( new OptionalNamedArg( "id-type", new String[]{"STRING", "INTEGER", "ACTUAL"},
                     "STRING", "Each node must provide a unique id. This is used to find the correct " +
-                    "nodes when creating relationships. Possible values are " +
-                    "STRING: arbitrary strings for identifying nodes, " +
-                    "INTEGER: arbitrary integer values for identifying nodes, " +
-                    "ACTUAL: (advanced) actual node ids. " +
+                    "nodes when creating relationships. Possible values are:\n" +
+                    "  STRING: arbitrary strings for identifying nodes,\n" +
+                    "  INTEGER: arbitrary integer values for identifying nodes,\n" +
+                    "  ACTUAL: (advanced) actual node ids.\n" +
                     "For more information on id handling, please see the Neo4j Manual: " +
                     "http://neo4j.com/docs/operations-manual/current/deployment/#import-tool" ) )
             .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -186,10 +186,11 @@ public class ImportCommandTest
                             "      groups must be enclosed in quotation marks. [default:]%n" +
                             "  --id-type=<STRING|INTEGER|ACTUAL>%n" +
                             "      Each node must provide a unique id. This is used to find the correct nodes%n" +
-                            "      when creating relationships. Possible values are STRING: arbitrary strings%n" +
-                            "      for identifying nodes, INTEGER: arbitrary integer values for identifying%n" +
-                            "      nodes, ACTUAL: (advanced) actual node ids. For more information on id%n" +
-                            "      handling, please see the Neo4j Manual:%n" +
+                            "      when creating relationships. Possible values are:%n" +
+                            "        STRING: arbitrary strings for identifying nodes,%n" +
+                            "        INTEGER: arbitrary integer values for identifying nodes,%n" +
+                            "        ACTUAL: (advanced) actual node ids.%n" +
+                            "      For more information on id handling, please see the Neo4j Manual:%n" +
                             "      http://neo4j.com/docs/operations-manual/current/deployment/#import-tool%n" +
                             "      [default:STRING]%n" +
                             "  --input-encoding=<character-set>%n" +


### PR DESCRIPTION
This also restores the previous formatting in the ImportCommand help text.