### PR TITLE
Respects aligned memory access constraint

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -98,28 +98,54 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     @Override
     public short getShort( long index, int offset )
     {
-        return UnsafeUtil.getShort( address( index, offset ) );
+        return putShort( address( index, offset ) );
+    }
+
+    private short putShort( long p )
+    {
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            return UnsafeUtil.getShort( p );
+        }
+
+        return UnsafeUtil.getShortByteWise( p );
     }
 
     @Override
     public int getInt( long index, int offset )
     {
-        return UnsafeUtil.getInt( address( index, offset ) );
+        return getInt( address( index, offset ) );
+    }
+
+    private int getInt( long p )
+    {
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            return UnsafeUtil.getInt( p );
+        }
+
+        return UnsafeUtil.getIntByteWise( p );
     }
 
     @Override
     public long get6ByteLong( long index, int offset )
     {
         long address = address( index, offset );
-        long low4b = (UnsafeUtil.getInt( address )) & 0xFFFFFFFFL;
-        long high2b = UnsafeUtil.getShort( address + Integer.BYTES );
+        long low4b = getInt( address ) & 0xFFFFFFFFL;
+        long high2b = putShort( address + Integer.BYTES );
         return low4b | (high2b << 32);
     }
 
     @Override
     public long getLong( long index, int offset )
     {
-        return UnsafeUtil.getLong( address( index, offset ) );
+        long p = address( index, offset );
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            return UnsafeUtil.getLong( p );
+        }
+
+        return UnsafeUtil.getLongByteWise( p );
     }
 
     @Override
@@ -141,27 +167,59 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     @Override
     public void setShort( long index, int offset, short value )
     {
-        UnsafeUtil.putShort( address( index, offset ), value );
+        putShort( address( index, offset ), value );
+    }
+
+    private void putShort( long p, short value )
+    {
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            UnsafeUtil.putShort( p, value );
+        }
+        else
+        {
+            UnsafeUtil.putShortByteWise( p, value );
+        }
     }
 
     @Override
     public void setInt( long index, int offset, int value )
     {
-        UnsafeUtil.putInt( address( index, offset ), value );
+        putInt( address( index, offset ), value );
+    }
+
+    private void putInt( long p, int value )
+    {
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            UnsafeUtil.putInt( p, value );
+        }
+        else
+        {
+            UnsafeUtil.putIntByteWise( p, value );
+        }
     }
 
     @Override
     public void set6ByteLong( long index, int offset, long value )
     {
         long address = address( index, offset );
-        UnsafeUtil.putInt( address, (int) value );
-        UnsafeUtil.putShort( address + Integer.BYTES, (short) (value >>> 32) );
+        putInt( address, (int) value );
+        putShort( address + Integer.BYTES, (short) (value >>> 32) );
     }
 
     @Override
     public void setLong( long index, int offset, long value )
     {
-        UnsafeUtil.putLong( address( index, offset ), value );
+        long p = address( index, offset );
+        if ( UnsafeUtil.allowUnalignedMemoryAccess )
+        {
+            UnsafeUtil.putLong( p, value );
+        }
+        else
+        {
+            UnsafeUtil.putLongByteWise( p, value );
+        }
     }
 
     private long address( long index, int offset )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -98,17 +98,17 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     @Override
     public short getShort( long index, int offset )
     {
-        return putShort( address( index, offset ) );
+        return getShort( address( index, offset ) );
     }
 
-    private short putShort( long p )
+    private short getShort( long p )
     {
         if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             return UnsafeUtil.getShort( p );
         }
 
-        return UnsafeUtil.getShortByteWise( p );
+        return UnsafeUtil.getShortByteWiseLittleEndian( p );
     }
 
     @Override
@@ -124,7 +124,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
             return UnsafeUtil.getInt( p );
         }
 
-        return UnsafeUtil.getIntByteWise( p );
+        return UnsafeUtil.getIntByteWiseLittleEndian( p );
     }
 
     @Override
@@ -132,7 +132,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     {
         long address = address( index, offset );
         long low4b = getInt( address ) & 0xFFFFFFFFL;
-        long high2b = putShort( address + Integer.BYTES );
+        long high2b = getShort( address + Integer.BYTES );
         return low4b | (high2b << 32);
     }
 
@@ -145,7 +145,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
             return UnsafeUtil.getLong( p );
         }
 
-        return UnsafeUtil.getLongByteWise( p );
+        return UnsafeUtil.getLongByteWiseLittleEndian( p );
     }
 
     @Override
@@ -178,7 +178,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
         }
         else
         {
-            UnsafeUtil.putShortByteWise( p, value );
+            UnsafeUtil.putShortByteWiseLittleEndian( p, value );
         }
     }
 
@@ -196,7 +196,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
         }
         else
         {
-            UnsafeUtil.putIntByteWise( p, value );
+            UnsafeUtil.putIntByteWiseLittleEndian( p, value );
         }
     }
 
@@ -218,7 +218,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
         }
         else
         {
-            UnsafeUtil.putLongByteWise( p, value );
+            UnsafeUtil.putLongByteWiseLittleEndian( p, value );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
@@ -23,6 +23,7 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseNumberArray<N>
 {
+    private final long allocatedAddress;
     protected final long address;
     protected final long length;
     private boolean closed;
@@ -32,7 +33,23 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
         super( itemSize, base );
         UnsafeUtil.assertHasUnsafe();
         this.length = length;
-        this.address = UnsafeUtil.allocateMemory( length * itemSize );
+
+        long dataSize = length * itemSize;
+        boolean itemSizeIsPowerOfTwo = Integer.bitCount( itemSize ) == 1;
+        if ( UnsafeUtil.allowUnalignedMemoryAccess || !itemSizeIsPowerOfTwo )
+        {
+            // we can end up here even if we require aligned memory access. Reason is that item size
+            // isn't power of two anyway and so we have to fallback to safer means of accessing the memory,
+            // i.e. byte for byte.
+            this.allocatedAddress = this.address = UnsafeUtil.allocateMemory( dataSize );
+        }
+        else
+        {
+            // the item size is a power of two and we're required to access memory aligned
+            // so we can allocate a bit more to ensure we can get an aligned memory address to start from.
+            this.allocatedAddress = UnsafeUtil.allocateMemory( dataSize + itemSize - 1 );
+            this.address = UnsafeUtil.alignedMemory( allocatedAddress, itemSize );
+        }
     }
 
     @Override
@@ -55,7 +72,7 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
             if ( length > 0 )
             {
                 // Allocating 0 bytes actually returns address 0
-                UnsafeUtil.free( address );
+                UnsafeUtil.free( allocatedAddress );
             }
             closed = true;
         }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
-import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
-
 public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
 {
     public LongKeyLongValueUnsafeTable( int capacity )
@@ -31,21 +29,21 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     @Override
     protected long internalKey( long keyAddress )
     {
-        return UnsafeUtil.getLong( keyAddress );
+        return alignmentSafeGetLongAsTwoInts( keyAddress );
     }
 
     @Override
     protected void internalPut( long keyAddress, long key, long[] value )
     {
-        UnsafeUtil.putLong( keyAddress, key );
-        UnsafeUtil.putLong( keyAddress+8, value[0] );
+        alignmentSafePutLongAsTwoInts( keyAddress, key );
+        alignmentSafePutLongAsTwoInts( keyAddress + 8, value[0] );
     }
 
     @Override
     protected long[] internalRemove( long keyAddress )
     {
-        valueMarker[0] = UnsafeUtil.getLong( keyAddress+8 );
-        UnsafeUtil.putLong( keyAddress, -1 );
+        valueMarker[0] = alignmentSafeGetLongAsTwoInts( keyAddress+8 );
+        alignmentSafePutLongAsTwoInts( keyAddress, -1 );
         return valueMarker;
     }
 
@@ -53,8 +51,8 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     public long[] putValue( int index, long[] value )
     {
         long valueAddress = valueAddress( index );
-        long oldValue = UnsafeUtil.getLong( valueAddress );
-        UnsafeUtil.putLong( valueAddress, value[0] );
+        long oldValue = alignmentSafeGetLongAsTwoInts( valueAddress );
+        alignmentSafePutLongAsTwoInts( valueAddress, value[0] );
         return pack( oldValue );
     }
 
@@ -72,7 +70,7 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     @Override
     public long[] value( int index )
     {
-        long value = UnsafeUtil.getLong( valueAddress( index ) );
+        long value = alignmentSafeGetLongAsTwoInts( valueAddress( index ) );
         return pack( value );
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyUnsafeTable.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
-import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
-
 public class LongKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
 {
     public LongKeyUnsafeTable( int capacity, VALUE valueMarker )
@@ -31,13 +29,13 @@ public class LongKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
     @Override
     protected long internalKey( long keyAddress )
     {
-        return UnsafeUtil.getLong( keyAddress );
+        return alignmentSafeGetLongAsTwoInts( keyAddress );
     }
 
     @Override
     protected void internalPut( long keyAddress, long key, VALUE value )
     {
-        UnsafeUtil.putLong( keyAddress, key );
+        alignmentSafePutLongAsTwoInts( keyAddress, key );
     }
 
     @Override

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
@@ -25,17 +25,24 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Random;
 
 import org.neo4j.collection.primitive.Primitive;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
+
+import static java.lang.System.currentTimeMillis;
+
 import static org.neo4j.collection.primitive.Primitive.VALUE_MARKER;
 
 @RunWith( Parameterized.class )
 public class BasicTableTest
 {
     private final TableFactory factory;
+
+    private static final long seed = currentTimeMillis();
+    private static final Random random = new Random( seed );
 
     @Parameterized.Parameters
     public static Collection<Object[]> data()
@@ -138,7 +145,7 @@ public class BasicTableTest
             @Override
             public Object sampleValue()
             {
-                return new int[] {4};
+                return new int[] {random.nextInt( Integer.MAX_VALUE )};
             }
         } } );
         result.add( new Object[] { new TableFactory()
@@ -158,7 +165,7 @@ public class BasicTableTest
             @Override
             public Object sampleValue()
             {
-                return new long[] {1458489572354L};
+                return new long[] {Math.abs( random.nextLong() )};
             }
         } } );
         result.add( new Object[] { new TableFactory()
@@ -178,7 +185,7 @@ public class BasicTableTest
             @Override
             public Object sampleValue()
             {
-                return new long[] {1458489572354L};
+                return new long[] {Math.abs( random.nextLong() )};
             }
         } } );
         return result;

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -333,6 +333,31 @@ public final class UnsafeUtil
     }
 
     /**
+     * Returns address pointer equal to or slightly after the given {@code pointer}.
+     * The returned pointer as aligned with {@code alignBy} such that {@code pointer % alignBy == 0}.
+     * The given pointer should be allocated with at least the requested size + {@code alignBy - 1},
+     * where the additional bytes will serve as padding for the worst case where the start of the usable
+     * area of the allocated memory will need to be shifted at most {@code alignBy - 1} bytes to the right.
+     *
+     * 0   4   8   12  16  20        ; 4-byte alignments
+     * |---|---|---|---|---|         ; memory
+     *        --------===            ; allocated memory (-required, =padding)
+     *         ^------^              ; used memory
+     *
+     * @param pointer pointer to allocated memory from {@link #allocateMemory(long)}.
+     * @param alignBy power-of-two size to align to, e.g. 4 or 8.
+     * @return pointer to place inside the allocated memory to consider the effective start of the
+     * memory, which from that point is aligned by {@code alignBy}.
+     */
+    public static long alignedMemory( long pointer, int alignBy )
+    {
+        assert Integer.bitCount( alignBy ) == 1 : "Requires alignment to be power of 2, but was " + alignBy;
+
+        long misalignment = pointer % alignBy;
+        return misalignment == 0 ? pointer : pointer + (alignBy - misalignment);
+    }
+
+    /**
      * Free the memory that was allocated with {@link #allocateMemory}.
      */
     public static void free( long pointer )
@@ -895,5 +920,114 @@ public final class UnsafeUtil
         boolean previousSetting = nativeAccessCheckEnabled;
         nativeAccessCheckEnabled = newSetting;
         return previousSetting;
+    }
+
+    /**
+     * Gets a {@code short} at memory address {@code p} by reading byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
+     * previously put using {@link #putShortByteWise(long, short)}.
+     *
+     * @param p address pointer to start reading at.
+     * @return the read value, which was read byte for byte.
+     */
+    public static short getShortByteWise( long p )
+    {
+        short a = (short) (UnsafeUtil.getByte( p     ) & 0xFF);
+        short b = (short) (UnsafeUtil.getByte( p + 1 ) & 0xFF);
+        return (short) ((b << 8) | a);
+    }
+
+    /**
+     * Gets a {@code int} at memory address {@code p} by reading byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
+     * previously put using {@link #putIntByteWise(long, int)}.
+     *
+     * @param p address pointer to start reading at.
+     * @return the read value, which was read byte for byte.
+     */
+    public static int getIntByteWise( long p )
+    {
+        int a = UnsafeUtil.getByte( p     ) & 0xFF;
+        int b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
+        int c = UnsafeUtil.getByte( p + 2 ) & 0xFF;
+        int d = UnsafeUtil.getByte( p + 3 ) & 0xFF;
+        return (d << 24) | (c << 16) | (b << 8) | a;
+    }
+
+    /**
+     * Gets a {@code long} at memory address {@code p} by reading byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
+     * previously put using {@link #putLongByteWise(long, long)}.
+     *
+     * @param p address pointer to start reading at.
+     * @return the read value, which was read byte for byte.
+     */
+    public static long getLongByteWise( long p )
+    {
+        long a = UnsafeUtil.getByte( p     ) & 0xFF;
+        long b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
+        long c = UnsafeUtil.getByte( p + 2 ) & 0xFF;
+        long d = UnsafeUtil.getByte( p + 3 ) & 0xFF;
+        long e = UnsafeUtil.getByte( p + 4 ) & 0xFF;
+        long f = UnsafeUtil.getByte( p + 5 ) & 0xFF;
+        long g = UnsafeUtil.getByte( p + 6 ) & 0xFF;
+        long h = UnsafeUtil.getByte( p + 7 ) & 0xFF;
+        return (h << 56) | (g << 48) | (f << 40) | (e << 32) | (d << 24) | (c << 16) | (b << 8) | a;
+    }
+
+    /**
+     * Puts a {@code short} at memory address {@code p} by writing byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
+     * read using {@link #getShortByteWise(long)}.
+     *
+     * @param p address pointer to start writing at.
+     * @param value value to write byte for byte.
+     */
+    public static void putShortByteWise( long p, short value )
+    {
+        UnsafeUtil.putByte( p    , (byte)( value      ) );
+        UnsafeUtil.putByte( p + 1, (byte)( value >> 8 ) );
+    }
+
+    /**
+     * Puts a {@code int} at memory address {@code p} by writing byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
+     * read using {@link #getIntByteWise(long)}.
+     *
+     * @param p address pointer to start writing at.
+     * @param value value to write byte for byte.
+     */
+    public static void putIntByteWise( long p, int value )
+    {
+        UnsafeUtil.putByte( p    , (byte)( value       ) );
+        UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );
+        UnsafeUtil.putByte( p + 2, (byte)( value >> 16 ) );
+        UnsafeUtil.putByte( p + 3, (byte)( value >> 24 ) );
+    }
+
+    /**
+     * Puts a {@code long} at memory address {@code p} by writing byte for byte, instead of the whole value
+     * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
+     * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
+     * read using {@link #getShortByteWise(long)}.
+     *
+     * @param p address pointer to start writing at.
+     * @param value value to write byte for byte.
+     */
+    public static void putLongByteWise( long p, long value )
+    {
+        UnsafeUtil.putByte( p    , (byte)( value       ) );
+        UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );
+        UnsafeUtil.putByte( p + 2, (byte)( value >> 16 ) );
+        UnsafeUtil.putByte( p + 3, (byte)( value >> 24 ) );
+        UnsafeUtil.putByte( p + 4, (byte)( value >> 32 ) );
+        UnsafeUtil.putByte( p + 5, (byte)( value >> 40 ) );
+        UnsafeUtil.putByte( p + 6, (byte)( value >> 48 ) );
+        UnsafeUtil.putByte( p + 7, (byte)( value >> 56 ) );
     }
 }

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -339,10 +339,12 @@ public final class UnsafeUtil
      * where the additional bytes will serve as padding for the worst case where the start of the usable
      * area of the allocated memory will need to be shifted at most {@code alignBy - 1} bytes to the right.
      *
+     * <pre><code>
      * 0   4   8   12  16  20        ; 4-byte alignments
      * |---|---|---|---|---|         ; memory
      *        --------===            ; allocated memory (-required, =padding)
      *         ^------^              ; used memory
+     * </code></pre>
      *
      * @param pointer pointer to allocated memory from {@link #allocateMemory(long)}.
      * @param alignBy power-of-two size to align to, e.g. 4 or 8.
@@ -926,12 +928,12 @@ public final class UnsafeUtil
      * Gets a {@code short} at memory address {@code p} by reading byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
-     * previously put using {@link #putShortByteWise(long, short)}.
+     * previously put using {@link #putShortByteWiseLittleEndian(long, short)}.
      *
      * @param p address pointer to start reading at.
      * @return the read value, which was read byte for byte.
      */
-    public static short getShortByteWise( long p )
+    public static short getShortByteWiseLittleEndian( long p )
     {
         short a = (short) (UnsafeUtil.getByte( p     ) & 0xFF);
         short b = (short) (UnsafeUtil.getByte( p + 1 ) & 0xFF);
@@ -942,12 +944,12 @@ public final class UnsafeUtil
      * Gets a {@code int} at memory address {@code p} by reading byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
-     * previously put using {@link #putIntByteWise(long, int)}.
+     * previously put using {@link #putIntByteWiseLittleEndian(long, int)}.
      *
      * @param p address pointer to start reading at.
      * @return the read value, which was read byte for byte.
      */
-    public static int getIntByteWise( long p )
+    public static int getIntByteWiseLittleEndian( long p )
     {
         int a = UnsafeUtil.getByte( p     ) & 0xFF;
         int b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
@@ -960,12 +962,12 @@ public final class UnsafeUtil
      * Gets a {@code long} at memory address {@code p} by reading byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values read with this method should have been
-     * previously put using {@link #putLongByteWise(long, long)}.
+     * previously put using {@link #putLongByteWiseLittleEndian(long, long)}.
      *
      * @param p address pointer to start reading at.
      * @return the read value, which was read byte for byte.
      */
-    public static long getLongByteWise( long p )
+    public static long getLongByteWiseLittleEndian( long p )
     {
         long a = UnsafeUtil.getByte( p     ) & 0xFF;
         long b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
@@ -982,12 +984,12 @@ public final class UnsafeUtil
      * Puts a {@code short} at memory address {@code p} by writing byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
-     * read using {@link #getShortByteWise(long)}.
+     * read using {@link #getShortByteWiseLittleEndian(long)}.
      *
      * @param p address pointer to start writing at.
      * @param value value to write byte for byte.
      */
-    public static void putShortByteWise( long p, short value )
+    public static void putShortByteWiseLittleEndian( long p, short value )
     {
         UnsafeUtil.putByte( p    , (byte)( value      ) );
         UnsafeUtil.putByte( p + 1, (byte)( value >> 8 ) );
@@ -997,12 +999,12 @@ public final class UnsafeUtil
      * Puts a {@code int} at memory address {@code p} by writing byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
-     * read using {@link #getIntByteWise(long)}.
+     * read using {@link #getIntByteWiseLittleEndian(long)}.
      *
      * @param p address pointer to start writing at.
      * @param value value to write byte for byte.
      */
-    public static void putIntByteWise( long p, int value )
+    public static void putIntByteWiseLittleEndian( long p, int value )
     {
         UnsafeUtil.putByte( p    , (byte)( value       ) );
         UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );
@@ -1014,12 +1016,12 @@ public final class UnsafeUtil
      * Puts a {@code long} at memory address {@code p} by writing byte for byte, instead of the whole value
      * in one go. This can be useful, even necessary in some scenarios where {@link #allowUnalignedMemoryAccess}
      * is {@code false} and {@code p} isn't aligned properly. Values written with this method should be
-     * read using {@link #getShortByteWise(long)}.
+     * read using {@link #getShortByteWiseLittleEndian(long)}.
      *
      * @param p address pointer to start writing at.
      * @param value value to write byte for byte.
      */
-    public static void putLongByteWise( long p, long value )
+    public static void putLongByteWiseLittleEndian( long p, long value )
     {
         UnsafeUtil.putByte( p    , (byte)( value       ) );
         UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );

--- a/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
+++ b/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
@@ -482,15 +482,15 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void shouldPutAndGetByteWiseShort() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianShort() throws Exception
     {
         // GIVEN
         long p = UnsafeUtil.allocateMemory( 2 );
         short value = (short) 0b11001100_10101010;
 
         // WHEN
-        UnsafeUtil.putShortByteWise( p, value );
-        short readValue = UnsafeUtil.getShortByteWise( p );
+        UnsafeUtil.putShortByteWiseLittleEndian( p, value );
+        short readValue = UnsafeUtil.getShortByteWiseLittleEndian( p );
 
         // THEN
         UnsafeUtil.free( p );
@@ -498,15 +498,15 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void shouldPutAndGetByteWiseInt() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianInt() throws Exception
     {
         // GIVEN
         long p = UnsafeUtil.allocateMemory( 4 );
         int value = 0b11001100_10101010_10011001_01100110;
 
         // WHEN
-        UnsafeUtil.putIntByteWise( p, value );
-        int readValue = UnsafeUtil.getIntByteWise( p );
+        UnsafeUtil.putIntByteWiseLittleEndian( p, value );
+        int readValue = UnsafeUtil.getIntByteWiseLittleEndian( p );
 
         // THEN
         UnsafeUtil.free( p );
@@ -514,15 +514,15 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void shouldPutAndGetByteWiseLong() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianLong() throws Exception
     {
         // GIVEN
         long p = UnsafeUtil.allocateMemory( 8 );
         long value = 0b11001100_10101010_10011001_01100110__10001000_01000100_00100010_00010001L;
 
         // WHEN
-        UnsafeUtil.putLongByteWise( p, value );
-        long readValue = UnsafeUtil.getLongByteWise( p );
+        UnsafeUtil.putLongByteWiseLittleEndian( p, value );
+        long readValue = UnsafeUtil.getLongByteWiseLittleEndian( p );
 
         // THEN
         UnsafeUtil.free( p );


### PR DESCRIPTION
specifically in off-heap versions of primitive-collections and NumberArray.
UnsafeUtil provides means of knowing about aligned memory access constraint,
but doesn't automatically conforms access by it. Need for aligned memory access
is hardware dependent.

Currently the muninn page cache has some logic for this. Other users of
UnsafeUtil are the primitive-collections and NumberArray. They have different
constraints themselves than the page cache do and so they have been changed
to conform to alignment constraints, but can get away with doing less adaptations
than the page cache does. This is the primary reason UnsafeUtil doesn't do
these things automatically, because there are different optimizations that
apply to different use cases.

Original issue came up when noticing that using primitive-collections or
NumberArray on Solaris could crash the JVM.