### PR TITLE
Fix shutdown race issue with store copy

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -126,6 +126,7 @@ public class CoreServerModule
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config,
                 platformModule.kernelExtensions.listFactories(), platformModule.pageCache );
+        life.add( copiedStoreRecovery );
 
         LifeSupport servicesToStopOnStoreCopy = new LifeSupport();
         CoreStateDownloader downloader =

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -203,6 +203,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config,
                 platformModule.kernelExtensions.listFactories(), platformModule.pageCache );
+        txPulling.add( copiedStoreRecovery );
 
         TxPollingClient txPuller =
                 new TxPollingClient( logProvider, fileSystem, localDatabase, storeFetcher, catchUpClient,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class CopiedStoreRecoveryTest
+{
+    @Test
+    public void shouldThrowIfAlreadyShutdown()
+    {
+        // Given
+        CopiedStoreRecovery copiedStoreRecovery =
+                new CopiedStoreRecovery( Config.defaults(), Iterables.empty(), mock( PageCache.class ) );
+        copiedStoreRecovery.shutdown();
+
+        try
+        {
+            // when
+            copiedStoreRecovery.recoverCopiedStore( new File( "nowhere" ) );
+            fail( "should have thrown" );
+        }
+        catch ( StoreCopyFailedException ex )
+        {
+            // then
+            assertEquals( "Abort store-copied store recovery due to database shutdown", ex.getMessage() );
+        }
+    }
+}


### PR DESCRIPTION
When recovering a temporary database copied from another machine, we
borrow the pagecache from the current database.  If the database is
shutdown before the recovery completes the page cache shutdown fails
due to file still mapped from the temporary database. This change
fixes it by abortint recovery if the database is already shutdown, or
the shutdown waits for the recovery to complete in order to cleanly
shutdown the page cache.