### PR TITLE
allow for clean shutdown in case of an OOM earlier

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -538,8 +538,14 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
 
     public void close()
     {
-        array.close();
-        relGroupCache.close();
+        if ( array != null )
+        {
+            array.close();
+        }
+        if ( relGroupCache != null )
+        {
+            relGroupCache.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
that left array and relGroupCache being null during the `setHighNodeId` call