### PR TITLE
Test fixes for running on Solaris

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -39,7 +39,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -47,6 +46,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -179,7 +179,7 @@ public class ConsistencyCheckServiceIntegrationTest
     private GraphDatabaseService getGraphDatabaseService()
     {
         GraphDatabaseBuilder builder =
-                new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.absolutePath() );
+                new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.absolutePath() );
         builder.setConfig( settings(  ) );
 
         return builder.newGraphDatabase();
@@ -187,8 +187,7 @@ public class ConsistencyCheckServiceIntegrationTest
 
     protected Map<String,String> settings( String... strings )
     {
-        Map<String, String> defaults = new HashMap<>();
-        defaults.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        Map<String, String> defaults = new HashMap<>( ConfigForTesting.TEST_DEFAULTS.getParams() );
         defaults.put( GraphDatabaseSettings.record_format.name(), getRecordFormatName() );
         return stringMap( defaults, strings );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DetectAllRelationshipInconsistenciesIT.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/DetectAllRelationshipInconsistenciesIT.java
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -54,6 +53,7 @@ import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.RandomRule;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.Label.label;
@@ -158,7 +158,7 @@ public class DetectAllRelationshipInconsistenciesIT
 
     private GraphDatabaseAPI getGraphDatabaseAPI()
     {
-        return (GraphDatabaseAPI) new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( directory.absolutePath() )
+        return (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( directory.absolutePath() )
                 .setConfig( GraphDatabaseSettings.record_format, getRecordFormatName() )
                 .newGraphDatabase();
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
@@ -23,16 +23,12 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.consistency.ConsistencyCheckService;
-import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.NullLogProvider;
-
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 
 public class StoreAssertions
 {
@@ -42,11 +38,9 @@ public class StoreAssertions
 
     public static void assertConsistentStore( File storeDir ) throws ConsistencyCheckIncompleteException, IOException
     {
-        Config configuration = new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ),
-                GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
         AssertableLogProvider logger = new AssertableLogProvider();
         ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(
-                storeDir, configuration, ProgressMonitorFactory.NONE, NullLogProvider.getInstance(), false );
+                storeDir, TEST_DEFAULTS, ProgressMonitorFactory.NONE, NullLogProvider.getInstance(), false );
 
         assertTrue( "Consistency check for " + storeDir + " found inconsistencies:\n\n" + logger.serialize(),
                 result.isSuccessful() );

--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -80,7 +80,7 @@ import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.Iterators.asSet;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.fromInput;
@@ -228,7 +228,7 @@ public class ParallelBatchImporterTest
     {
         ConsistencyCheckService consistencyChecker = new ConsistencyCheckService();
         Result result = consistencyChecker.runFullConsistencyCheck( storeDir,
-                new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) ),
+                TEST_DEFAULTS,
                 ProgressMonitorFactory.NONE,
                 NullLogProvider.getInstance(), false );
         assertTrue( "Database contains inconsistencies, there should be a report in " + storeDir,

--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -208,8 +208,7 @@ public class HostnamePortTest
     public void testMatchesKnownHostWithIP() throws Exception
     {
     	// Given
-    	
-    	String hostname1 = InetAddress.getLocalHost().getHostName();
+        String hostname1 = InetAddress.getLocalHost().getHostName().replace( '.', '-' );
     	String host1 = InetAddress.getLocalHost().getHostAddress();
     	// Building fake IP for host2
     	StringBuilder host2 = new StringBuilder();
@@ -256,7 +255,7 @@ public class HostnamePortTest
     {
     	// Given 
     	
-    	String hostname1 = InetAddress.getLocalHost().getHostName();
+        String hostname1 = InetAddress.getLocalHost().getHostName();
     	String host1 = InetAddress.getLocalHost().getHostAddress();
     	String hostname2 = "neo4j.org";
     	
@@ -338,7 +337,7 @@ public class HostnamePortTest
     {
     	// Given
     	
-    	String host1 = InetAddress.getLocalHost().getHostName();
+        String host1 = InetAddress.getLocalHost().getHostName().replace( '.', '-' );
     	// any other hostname?
     	String host2 = "neo4j.org";
     	

--- a/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
@@ -27,7 +27,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
@@ -41,6 +40,7 @@ import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -78,7 +78,7 @@ public class GraphDatabaseFacadeFactoryTest
         try
         {
             // When
-            db.newFacade( dir.graphDbDir(), Collections.<String,String>emptyMap(), deps, mockFacade );
+            db.newFacade( dir.graphDbDir(), ConfigForTesting.TEST_DEFAULTS.getParams(), deps, mockFacade );
             fail( "Should have thrown " + RuntimeException.class );
         }
         catch ( RuntimeException exception )
@@ -100,7 +100,7 @@ public class GraphDatabaseFacadeFactoryTest
         try
         {
             // When
-            db.newFacade( dir.graphDbDir(), Collections.<String,String>emptyMap(), deps, mockFacade );
+            db.newFacade( dir.graphDbDir(), ConfigForTesting.TEST_DEFAULTS.getParams(), deps, mockFacade );
             fail( "Should have thrown " + RuntimeException.class );
         }
         catch ( RuntimeException exception )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 
@@ -62,8 +63,7 @@ public class CommonAbstractStoreBehaviourTest
      * Note that tests MUST use the non-modifying {@link Config#with(Map, Class[])} method, to make alternate copies
      * of this settings class.
      */
-    private static final Config CONFIG = Config.empty().augment( stringMap(
-            GraphDatabaseSettings.pagecache_memory.name(), "8M" ) );
+    private static final Config CONFIG = ConfigForTesting.TEST_DEFAULTS;
 
     private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
     private final PageCacheRule pageCacheRule = new PageCacheRule();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
@@ -27,12 +27,12 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -48,7 +48,7 @@ public class RelationshipGroupStoreIT
     @Test
     public void shouldCreateAllTheseRelationshipTypes() throws Exception
     {
-        GraphDatabaseService db = new GraphDatabaseFactory()
+        GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
                 .setConfig( GraphDatabaseSettings.dense_node_threshold, "1" )
                 .newGraphDatabase();
@@ -86,5 +86,4 @@ public class RelationshipGroupStoreIT
     {
         return RelationshipType.withName( "TYPE_" + i );
     }
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTests.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTests.java
@@ -38,8 +38,9 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.test.TargetDirectory;
 
-import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 
 public class CommitContentionTests
 {
@@ -183,7 +184,7 @@ public class CommitContentionTests
                     }
                 };
             }
-        }.newFacade( storeLocation.graphDbDir(), emptyMap(), state.databaseDependencies() );
+        }.newFacade( storeLocation.graphDbDir(), TEST_DEFAULTS.getParams(), state.databaseDependencies() );
     }
 
     private void waitForFirstTransactionToStartPushing() throws InterruptedException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -36,7 +36,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
@@ -49,6 +48,7 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -77,7 +77,7 @@ public class PartialTransactionFailureIT
         adversary.disable();
 
         File storeDir = dir.graphDbDir();
-        final Map<String,String> params = stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        final Map<String,String> params = stringMap( ConfigForTesting.TEST_DEFAULTS.getParams() );
         final EmbeddedGraphDatabase db = new TestEmbeddedGraphDatabase( storeDir, params )
         {
             @Override

--- a/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.qa.tooling;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,6 +45,8 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
+
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class DumpProcessInformationTest
@@ -52,6 +55,25 @@ public class DumpProcessInformationTest
 
     @Rule
     public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    @Before
+    public void checkEnvironment()
+    {
+        assumeTrue( commandExists( "jps" ) );
+        assumeTrue( commandExists( "jstack -h" ) );
+    }
+
+    private boolean commandExists( String command )
+    {
+        try
+        {
+            return Runtime.getRuntime().exec( command ).waitFor() == 0;
+        }
+        catch ( Throwable e )
+        {
+            return false;
+        }
+    }
 
     @Test
     public void shouldDumpProcessInformation() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
@@ -46,7 +46,7 @@ public class AdversarialPageCacheGraphDatabaseFactory
 
     public static GraphDatabaseFactory create( FileSystemAbstraction fs, Adversary adversary )
     {
-        return new GraphDatabaseFactory()
+        return new TestGraphDatabaseFactory()
         {
             @Override
             protected GraphDatabaseService newDatabase( File dir, Map<String,String> config, Dependencies dependencies )

--- a/community/kernel/src/test/java/org/neo4j/test/ConfigForTesting.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ConfigForTesting.java
@@ -17,13 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.server;
+package org.neo4j.test;
 
-public class CommunityBootstrapperTest extends BaseBootstrapperTest
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class ConfigForTesting
 {
-    @Override
-    protected ServerBootstrapper newBootstrapper()
-    {
-        return new CommunityBootstrapper();
-    }
+    public static final Config TEST_DEFAULTS = Config.defaults().augment( stringMap(
+            GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
 }

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
@@ -20,6 +20,7 @@
 package org.neo4j.test;
 
 import java.io.File;
+import java.util.Map;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -68,7 +69,8 @@ public class NeoStoresRule extends ExternalResource
     public NeoStores open( RecordFormats format, String... config )
     {
         efs = new EphemeralFileSystemAbstraction();
-        Config conf = new Config( stringMap( config ) );
+        Map<String,String> defaults = ConfigForTesting.TEST_DEFAULTS.getParams();
+        Config conf = new Config( stringMap( defaults, config ) );
         pageCache = getOrCreatePageCache( conf, efs );
         return open( efs, pageCache, format, config );
     }

--- a/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/PageCacheRule.java
@@ -20,14 +20,11 @@
 package org.neo4j.test;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.adversaries.Adversary;
 import org.neo4j.adversaries.pagecache.AdversarialPageCache;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
@@ -51,9 +48,7 @@ public class PageCacheRule extends ExternalResource
 
     public PageCache getPageCache( FileSystemAbstraction fs )
     {
-        Map<String,String> settings = new HashMap<>();
-        settings.put( GraphDatabaseSettings.pagecache_memory.name(), "8M" );
-        return getPageCache( fs, new Config( settings ) );
+        return getPageCache( fs, ConfigForTesting.TEST_DEFAULTS );
     }
 
     public PageCache getPageCache( FileSystemAbstraction fs, Config config )

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseBuilder.java
@@ -19,14 +19,18 @@
  */
 package org.neo4j.test;
 
+import java.util.Map;
+
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
 public class TestGraphDatabaseBuilder extends GraphDatabaseBuilder
 {
     public TestGraphDatabaseBuilder( DatabaseCreator creator )
     {
         super( creator );
-        super.config.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        for ( Map.Entry<String,String> testDefault : ConfigForTesting.TEST_DEFAULTS.getParams().entrySet() )
+        {
+            super.config.put( testDefault.getKey(), testDefault.getValue() );
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -85,7 +85,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
     {
         super.configure( builder );
         // Reduce the default page cache memory size to 8 mega-bytes for test databases.
-        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
+        builder.setConfig( ConfigForTesting.TEST_DEFAULTS.getParams() );
         builder.setConfig( GraphDatabaseSettings.auth_store, tempFile( "auth" ).toString() );
     }
 
@@ -112,6 +112,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
         return this;
     }
 
+    @Override
     public TestGraphDatabaseFactory setMonitors( Monitors monitors )
     {
         getCurrentState().setMonitors( monitors );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/Inserter.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/Inserter.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class Inserter
 {
     public static void main( String[] args ) throws IOException
     {
         File path = new File( args[0] );
-        final GraphDatabaseService db = new GraphDatabaseFactory()
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( path )
                 .newGraphDatabase();
         final Index<Node> index = getIndex( db );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JUnitRuleTest.java
@@ -29,13 +29,13 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
 import org.neo4j.harness.junit.Neo4jRule;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -111,7 +111,7 @@ public class JUnitRuleTest
     {
         // given
 
-        GraphDatabaseService db = new GraphDatabaseFactory()
+        GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( testDirectory.directory() )
                 .newGraphDatabase();
         try {

--- a/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
+++ b/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
@@ -35,15 +35,16 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 
 public class ConcurrentChangesOnEntitiesTest
 {
@@ -56,7 +57,7 @@ public class ConcurrentChangesOnEntitiesTest
     @Before
     public void setup()
     {
-        db = new GraphDatabaseFactory()
+        db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
                 .newGraphDatabase();
     }
@@ -200,7 +201,7 @@ public class ConcurrentChangesOnEntitiesTest
         try
         {
             ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(
-                    testDirectory.graphDbDir(), Config.defaults(), ProgressMonitorFactory.textual( System.err ),
+                    testDirectory.graphDbDir(), TEST_DEFAULTS, ProgressMonitorFactory.textual( System.err ),
                     logProvider, false );
             assertTrue( result.isSuccessful() );
         }

--- a/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
@@ -40,7 +40,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.helpers.collection.Iterables;
@@ -48,6 +47,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.Boolean.getBoolean;
 
@@ -292,7 +292,7 @@ public class UniquenessRecoveryTest
 
     private static GraphDatabaseService graphdb( File path )
     {
-        return new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( path ).newGraphDatabase();
+        return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( path ).newGraphDatabase();
     }
 
     private static void flushPageCache( GraphDatabaseService db )

--- a/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
+++ b/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
@@ -35,18 +35,19 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 
 public class DynamicIndexStoreViewIT
 {
 
-    private SuppressOutput suppressOutput = SuppressOutput.suppressAll();
-    private TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
+    private final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
 
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule( testDirectory ).around( suppressOutput );
@@ -55,7 +56,7 @@ public class DynamicIndexStoreViewIT
     public void populateDbWithConcurrentUpdates() throws Exception
     {
         GraphDatabaseService database =
-                new GraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir() );
+                new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir() );
         try
         {
             int counter = 1;
@@ -99,7 +100,7 @@ public class DynamicIndexStoreViewIT
         {
             database.shutdown();
             ConsistencyCheckService consistencyCheckService = new ConsistencyCheckService();
-            consistencyCheckService.runFullConsistencyCheck( testDirectory.graphDbDir(), Config.empty(),
+            consistencyCheckService.runFullConsistencyCheck( testDirectory.graphDbDir(), TEST_DEFAULTS,
                     ProgressMonitorFactory.NONE, FormattedLogProvider.toOutputStream( System.out ), false );
         }
     }
@@ -107,8 +108,8 @@ public class DynamicIndexStoreViewIT
     private class Populator extends Thread
     {
 
-        private GraphDatabaseService databaseService;
-        private long totalNodes;
+        private final GraphDatabaseService databaseService;
+        private final long totalNodes;
         private volatile boolean terminate;
 
         Populator( GraphDatabaseService databaseService, long totalNodes )

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -39,7 +39,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.TimeUtil;
@@ -58,6 +57,7 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
@@ -78,8 +78,8 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.helpers.progress.ProgressMonitorFactory.NONE;
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
 
@@ -167,17 +167,15 @@ public class MultipleIndexPopulationStressIT
         populateDbAndIndexes( nodeCount, multiThreaded );
         ConsistencyCheckService cc = new ConsistencyCheckService();
         Result result = cc.runFullConsistencyCheck( directory.graphDbDir(),
-                new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) ),
-                NONE, NullLogProvider.getInstance(), false );
+                TEST_DEFAULTS, NONE, NullLogProvider.getInstance(), false );
         assertTrue( result.isSuccessful() );
         dropIndexes();
     }
 
     private void populateDbAndIndexes( int nodeCount, boolean multiThreaded ) throws InterruptedException
     {
-        final GraphDatabaseService db = new GraphDatabaseFactory()
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.pagecache_memory, "8m" )
                 .setConfig( GraphDatabaseSettings.multi_threaded_schema_index_population_enabled, multiThreaded + "" )
                 .newGraphDatabase();
         try
@@ -212,9 +210,8 @@ public class MultipleIndexPopulationStressIT
 
     private void dropIndexes()
     {
-        GraphDatabaseService db = new GraphDatabaseFactory()
+        GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.pagecache_memory, "8m" )
                 .newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -63,6 +62,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -233,7 +233,7 @@ public class StoreUpgraderInterruptionTestIT
 
     private void startStopDatabase( File workingDirectory )
     {
-        GraphDatabaseService databaseService = new GraphDatabaseFactory().newEmbeddedDatabase( workingDirectory );
+        GraphDatabaseService databaseService = new TestGraphDatabaseFactory().newEmbeddedDatabase( workingDirectory );
         databaseService.shutdown();
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -34,7 +34,9 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -74,6 +76,7 @@ import org.neo4j.kernel.impl.storemigration.participant.AbstractStoreMigrationPa
 import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
@@ -98,6 +101,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allLegacyStoreFilesHaveVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allStoreFilesHaveNoTrailer;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.changeVersionNumber;
@@ -108,6 +112,7 @@ import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.removeChec
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.truncateAllFiles;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.truncateFile;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.verifyFilesHaveSameContent;
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 
 @RunWith(Parameterized.class)
 public class StoreUpgraderTest
@@ -536,7 +541,8 @@ public class StoreUpgraderTest
 
     private Config getTuningConfig()
     {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), getRecordFormatsName() ) );
+        return new Config( stringMap( TEST_DEFAULTS.getParams(), GraphDatabaseSettings.record_format.name(),
+                getRecordFormatsName() ) );
     }
 
     protected RecordFormats getRecordFormats()

--- a/community/neo4j/src/test/java/upgrade/TestMigrateToDenseNodeSupport.java
+++ b/community/neo4j/src/test/java/upgrade/TestMigrateToDenseNodeSupport.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.KernelAPI;
@@ -129,7 +128,7 @@ public class TestMigrateToDenseNodeSupport
     @Ignore( "Used for creating the dataset, using the previous store version" )
     public void createDb()
     {
-        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
         try
         {
             try ( Transaction tx = db.beginTx() )

--- a/community/shell/src/main/java/org/neo4j/shell/StartClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/StartClient.java
@@ -126,7 +126,12 @@ public class StartClient
     // Visible for testing
     StartClient( PrintStream out, PrintStream err )
     {
-        this.factory = loadEditionDatabaseFactory();
+        this( out, err, loadEditionDatabaseFactory() );
+    }
+
+    StartClient( PrintStream out, PrintStream err, GraphDatabaseFactory factory )
+    {
+        this.factory = factory;
         this.out = out;
         this.err = err;
     }

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
@@ -36,13 +36,13 @@ import org.junit.Test;
 import org.neo4j.bolt.v1.runtime.Sessions;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.shell.impl.AbstractClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.SuppressOutput;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -99,7 +99,7 @@ public class StartClientTest
     }
 
     @Test
-    public void givenShellClientWhenReadFromStdinThenExecutePipedCommands() throws IOException
+    public void givenShellClientWhenReadFromStdinThenExecutePipedCommands()
     {
         // Given
         // an empty database
@@ -162,7 +162,7 @@ public class StartClientTest
                 .thenReturn( new Welcome( StringUtils.EMPTY, 1, StringUtils.EMPTY ) );
         when( databaseShellServer.interpretLine( any( Serializable.class ), any( String.class ), any( Output.class ) ) )
                 .thenReturn( new Response( StringUtils.EMPTY, Continuation.INPUT_COMPLETE ) );
-        StartClient startClient = new StartClient( out, err )
+        StartClient startClient = new StartClient( out, err, new TestGraphDatabaseFactory() )
         {
             @Override
             protected GraphDatabaseShellServer getGraphDatabaseShellServer( File path, boolean readOnly, String configFile ) throws RemoteException
@@ -187,7 +187,7 @@ public class StartClientTest
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         CtrlCHandler ctrlCHandler = mock( CtrlCHandler.class );
         StartClient client = new StartClient(
-                new PrintStream( out ), new PrintStream( err ) );
+                new PrintStream( out ), new PrintStream( err ), new TestGraphDatabaseFactory() );
 
         // when
         client.start( new String[]{"-path", db.getGraphDatabaseAPI().getStoreDir(),
@@ -218,20 +218,20 @@ public class StartClientTest
     }
 
     @Test
-    public void shouldNotStartBolt() throws IOException
+    public void shouldNotStartBolt()
     {
         // Given
         AssertableLogProvider log = new AssertableLogProvider();
 
         // When
-        new StartClient( System.out, System.err )
+        new StartClient( System.out, System.err, new TestGraphDatabaseFactory() )
         {
             @Override
             protected GraphDatabaseShellServer getGraphDatabaseShellServer( File path, boolean readOnly, String
                     configFile ) throws RemoteException
             {
                 return new GraphDatabaseShellServer(
-                        new GraphDatabaseFactory().setUserLogProvider( log ), path, readOnly, configFile );
+                        new TestGraphDatabaseFactory().setUserLogProvider( log ), path, readOnly, configFile );
             }
         }.start( new String[]{
                         "-c", "RETURN 1;",

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -48,6 +48,7 @@ import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.SuppressOutput;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
@@ -1303,7 +1304,7 @@ public class TestApps extends AbstractShellTest
 
     private StartClient getStartClient()
     {
-        return new StartClient( System.out, System.err )
+        return new StartClient( System.out, System.err, new TestGraphDatabaseFactory() )
         {
             @Override
             protected GraphDatabaseShellServer getGraphDatabaseShellServer( File path, boolean readOnly,
@@ -1319,7 +1320,7 @@ public class TestApps extends AbstractShellTest
         return db.getDependencyResolver().resolveDependency( TransactionIdStore.class ).getLastCommittedTransactionId();
     }
 
-    private String createCsvFile( long size ) throws IOException, InterruptedException
+    private String createCsvFile( long size ) throws IOException
     {
         File tmpFile = File.createTempFile( "data", ".csv", null );
         tmpFile.deleteOnExit();

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -42,7 +42,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.helpers.collection.Iterables;
@@ -90,6 +89,7 @@ import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -452,7 +452,7 @@ public class BackupServiceIT
 
         // it should be possible to at this point to start db based on our backup and create couple of properties
         // their ids should not clash with already existing
-        GraphDatabaseService backupBasedDatabase = new GraphDatabaseFactory()
+        GraphDatabaseService backupBasedDatabase = new TestGraphDatabaseFactory()
                 .newEmbeddedDatabase( backupDir.getAbsoluteFile() );
         try
         {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
@@ -23,28 +23,28 @@ import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class EmbeddedServer implements ServerInterface
 {
-    private GraphDatabaseService db;
+    private final GraphDatabaseService db;
 
     public EmbeddedServer( File storeDir, String serverAddress )
     {
-        GraphDatabaseBuilder graphDatabaseBuilder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir );
+        GraphDatabaseBuilder graphDatabaseBuilder = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir );
         graphDatabaseBuilder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
         graphDatabaseBuilder.setConfig( OnlineBackupSettings.online_backup_server, serverAddress );
-        graphDatabaseBuilder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         this.db = graphDatabaseBuilder.newGraphDatabase();
     }
 
+    @Override
     public void shutdown()
     {
         db.shutdown();
     }
 
+    @Override
     public void awaitStarted()
     {
     }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/ServerProcess.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/ServerProcess.java
@@ -22,8 +22,8 @@ package org.neo4j.backup;
 import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.Pair;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.subprocess.SubProcess;
 
 public class ServerProcess extends SubProcess<ServerInterface, Pair<File, String>> implements ServerInterface
@@ -37,12 +37,13 @@ public class ServerProcess extends SubProcess<ServerInterface, Pair<File, String
         String backupConfigValue = config.other();
         if ( backupConfigValue == null )
         {
-            this.db = new GraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+            this.db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
         }
         else
         {
             // TODO This is using the old config style - is this class even used anywhere!?
-            this.db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir ).setConfig( "enable_online_backup", backupConfigValue ).newGraphDatabase();
+            this.db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                    .setConfig( "enable_online_backup", backupConfigValue ).newGraphDatabase();
         }
     }
 

--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -185,6 +185,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-enterprise-kernel</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/enterprise/ha/src/test/java/org/neo4j/ha/CreateEmptyDb.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/CreateEmptyDb.java
@@ -23,7 +23,7 @@ import org.junit.Ignore;
 
 import java.io.File;
 
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 @Ignore("Not a test")
 public class CreateEmptyDb
@@ -35,6 +35,6 @@ public class CreateEmptyDb
 
     public static void at( File storeDir )
     {
-        new GraphDatabaseFactory().newEmbeddedDatabase( storeDir ).shutdown();
+        new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir ).shutdown();
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
@@ -28,9 +28,9 @@ import java.io.File;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -145,7 +145,7 @@ public class ForeignStoreIdIT
 
     private File createAnotherStore( File directory, int transactions )
     {
-        GraphDatabaseService db = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( directory );
+        GraphDatabaseService db = new TestEnterpriseGraphDatabaseFactory().newEmbeddedDatabase( directory );
         createNodes( db, transactions, "node" );
         db.shutdown();
         return directory;

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProofDatabase.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProofDatabase.java
@@ -29,9 +29,9 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.neo4j.graphdb.Label.label;
 
@@ -44,7 +44,7 @@ public class ProofDatabase
     {
         File dbDir = new File( location );
         cleanDbDir( dbDir );
-        this.gds = new GraphDatabaseFactory().newEmbeddedDatabase( dbDir );
+        this.gds = new TestGraphDatabaseFactory().newEmbeddedDatabase( dbDir );
     }
 
     public Node newState( ClusterState state )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -92,13 +92,13 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.test.ConfigForTesting;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 import static org.neo4j.helpers.ArrayUtil.contains;
 import static org.neo4j.helpers.collection.Iterables.count;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.fs.FileUtils.copyRecursively;
 
 /**
@@ -135,8 +135,8 @@ public class ClusterManager
     }
 
     public static final long DEFAULT_TIMEOUT_SECONDS = 60L;
-    public static final Map<String,String> CONFIG_FOR_SINGLE_JVM_CLUSTER = unmodifiableMap( stringMap(
-            GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
+    public static final Map<String,String> CONFIG_FOR_SINGLE_JVM_CLUSTER = unmodifiableMap(
+            ConfigForTesting.TEST_DEFAULTS.getParams() );
 
     public interface StoreDirInitializer
     {

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -22,11 +22,11 @@ package org.neo4j.graphdb;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class StartupConstraintSemanticsTest
     public void shouldNotAllowOpeningADatabaseWithPECInCommunityEdition() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
+        GraphDatabaseService graphDb = new TestEnterpriseGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
         try
         {
             graphDb.execute( "CREATE CONSTRAINT ON (n:Draconian) ASSERT exists(n.required)" );
@@ -57,7 +57,7 @@ public class StartupConstraintSemanticsTest
         // when
         try
         {
-            graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
+            graphDb = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
             fail( "should have failed to start!" );
         }
         // then

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/factory/EnterpriseDatabaseRule.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/factory/EnterpriseDatabaseRule.java
@@ -20,12 +20,13 @@
 package org.neo4j.graphdb.factory;
 
 import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 public class EnterpriseDatabaseRule extends EmbeddedDatabaseRule
 {
     @Override
     protected GraphDatabaseFactory newFactory()
     {
-        return new EnterpriseGraphDatabaseFactory();
+        return new TestEnterpriseGraphDatabaseFactory();
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -38,15 +37,15 @@ import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck.Result;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.logging.NullLog;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.pagecache.tracing.PageCacheTracer.NULL;
 import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
 import static org.neo4j.kernel.impl.storemigration.StoreFile.NEO_STORE;
@@ -62,13 +61,13 @@ public class StoreMigratorTest
     {
         // GIVEN a store in vE.H.0 format
         File storeDir = directory.directory();
-        new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+        new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 // The format should be vE.H.0, HighLimit.NAME may point to a different version in future versions
                 .setConfig( GraphDatabaseSettings.record_format, HighLimitV3_0_0.NAME )
                 .newGraphDatabase()
                 .shutdown();
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
-        Config config = new Config( stringMap( pagecache_memory.name(), "8m" ) );
+        Config config = ConfigForTesting.TEST_DEFAULTS;
 
         try ( PageCache pageCache = new ConfiguringPageCacheFactory( fs, config,
                 NULL, NullLog.getInstance() ).getOrCreatePageCache() )

--- a/enterprise/kernel/src/test/java/org/neo4j/test/TestEnterpriseGraphDatabaseFactory.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/test/TestEnterpriseGraphDatabaseFactory.java
@@ -28,6 +28,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.impl.enterprise.EnterpriseFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.logging.AbstractLogService;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -100,5 +101,12 @@ public class TestEnterpriseGraphDatabaseFactory extends TestGraphDatabaseFactory
                         GraphDatabaseDependencies.newDependencies( state.databaseDependencies() ) );
             }
         };
+    }
+
+    @Override
+    protected GraphDatabaseService newDatabase( File storeDir, Map<String,String> config,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
+    {
+        return new EnterpriseFacadeFactory().newFacade( storeDir, config, dependencies );
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
@@ -41,7 +41,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -51,6 +50,8 @@ import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.test.ConfigForTesting.TEST_DEFAULTS;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
 
 @RunWith( Parameterized.class )
@@ -118,7 +119,7 @@ public class ConsistencyCheckServiceRecordFormatIT
         ConsistencyCheckService service = new ConsistencyCheckService();
 
         File storeDir = new File( db.getStoreDir() );
-        ConsistencyCheckService.Result result = service.runFullConsistencyCheck( storeDir, Config.empty(),
+        ConsistencyCheckService.Result result = service.runFullConsistencyCheck( storeDir, TEST_DEFAULTS,
                 ProgressMonitorFactory.textual( System.out ), FormattedLogProvider.toOutputStream( System.out ), true );
 
         assertTrue( "Store is inconsistent", result.isSuccessful() );

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
@@ -37,13 +37,13 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.single;
@@ -94,7 +94,7 @@ public class BatchInsertEnterpriseTest
         }
 
         // THEN
-        GraphDatabaseService db = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( directory.directory() );
+        GraphDatabaseService db = new TestEnterpriseGraphDatabaseFactory().newEmbeddedDatabase( directory.directory() );
         try ( Transaction tx = db.beginTx() )
         {
             Node node1 = db.getNodeById( node1Id );
@@ -183,7 +183,7 @@ public class BatchInsertEnterpriseTest
 
     private GraphDatabaseService newDb( File storeDir, String recordFormat )
     {
-        return new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+        return new TestEnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.record_format, recordFormat )
                 .newGraphDatabase();
     }

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/RecordFormatsMigrationIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/RecordFormatsMigrationIT.java
@@ -29,7 +29,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -44,14 +43,15 @@ import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnexpectedUpgradingStoreFormatException;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
 
 public class RecordFormatsMigrationIT
@@ -124,7 +124,7 @@ public class RecordFormatsMigrationIT
 
     private GraphDatabaseService startDb( String recordFormatName )
     {
-        return new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
+        return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.record_format, recordFormatName )
                 .newGraphDatabase();
@@ -142,7 +142,7 @@ public class RecordFormatsMigrationIT
 
     private void assertStoreFormat( RecordFormats expected ) throws IOException
     {
-        Config config = new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
+        Config config = ConfigForTesting.TEST_DEFAULTS;
         try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs, config ) )
         {
             RecordFormats actual = RecordFormatSelector.selectForStoreOrConfig( config, testDir.graphDbDir(), fs,

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
@@ -36,7 +36,6 @@ import java.util.List;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -69,6 +68,7 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -140,7 +140,7 @@ public class StoreMigratorFrom20IT
         assertTrue( monitor.isStarted() );
         assertTrue( monitor.isFinished() );
 
-        GraphDatabaseService database = new EnterpriseGraphDatabaseFactory()
+        GraphDatabaseService database = new TestEnterpriseGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( storeDir.absolutePath() )
                 .newGraphDatabase();
         try

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom21IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom21IT.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.helpers.collection.Pair;
@@ -44,11 +43,12 @@ import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AccessMode;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.ConfigForTesting;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -97,14 +97,14 @@ public class StoreMigratorFrom21IT
 
         File dir = MigrationTestUtils.find21FormatStoreDirectoryWithDuplicateProperties( storeDir.directory() );
 
-        GraphDatabaseBuilder builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( dir )
+        GraphDatabaseBuilder builder = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( dir )
                         .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
         GraphDatabaseService database = builder.newGraphDatabase();
         database.shutdown();
         ConsistencyCheckService service = new ConsistencyCheckService();
 
         ConsistencyCheckService.Result result = service.runFullConsistencyCheck( dir.getAbsoluteFile(),
-                Config.empty(), ProgressMonitorFactory.NONE, NullLogProvider.getInstance(), false );
+                ConfigForTesting.TEST_DEFAULTS, ProgressMonitorFactory.NONE, NullLogProvider.getInstance(), false );
         assertTrue( result.isSuccessful() );
 
         database = builder.newGraphDatabase();

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -66,18 +66,6 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
         return new EnterpriseBootstrapper();
     }
 
-    @Override
-    protected void start(String[] args)
-    {
-        EnterpriseEntryPoint.start( args );
-    }
-
-    @Override
-    protected void stop(String[] args)
-    {
-        EnterpriseEntryPoint.stop( args );
-    }
-
     @Test
     public void shouldBeAbleToStartInSingleMode() throws Exception
     {

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -32,11 +32,11 @@ import java.nio.file.Files;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.storemigration.LogFiles;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.ha.ClusterRule;
 
 import static org.junit.Assert.assertNotNull;
@@ -162,7 +162,7 @@ public class HAClusterStartupIT
             GraphDatabaseService db = null;
             try
             {
-                db = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( seedDir );
+                db = new TestEnterpriseGraphDatabaseFactory().newEmbeddedDatabase( seedDir );
                 createSomeData( db );
             }
             finally

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/LegacyIndexesUpgradeTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/LegacyIndexesUpgradeTest.java
@@ -125,13 +125,12 @@ public class LegacyIndexesUpgradeTest
         GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
         GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( testDir.graphDbDir() );
         builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, Boolean.toString( allowUpgread ));
-        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         return builder.newGraphDatabase();
     }
 
     private void checkIndexData()
     {
-        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
         try
         {
             IntFunction<String> keyFactory = basicKeyFactory();

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -187,7 +187,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
@@ -249,7 +248,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
@@ -321,7 +319,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             try
             {
                 builder.newGraphDatabase();

--- a/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
+++ b/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
@@ -34,13 +34,13 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -195,7 +195,7 @@ public class DatabaseRebuildToolTest
 
     private void databaseWithSomeTransactions( File dir )
     {
-        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( dir );
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir );
         Node[] nodes = new Node[10];
         for ( int i = 0; i < nodes.length; i++ )
         {


### PR DESCRIPTION
Many tests had problems running a database with default config since JRE on Solaris seems to lack capability to figure out amount of free memory and so defaulted to page cache size unsuitable for smaller machines. This made many tests fail with GC overhead / heap problems.

Some other tests were made more robust due to exposed issues not necessarily tied to Solaris, but differences in environment.