### PR TITLE
Dump complete file path on shutdown failures

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FileMapping.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/FileMapping.java
@@ -37,6 +37,6 @@ final class FileMapping
     public String toString()
     {
         return String.format( "FileMapping[fname = %s, refCount = %s] :: %s",
-                file.getName(), pagedFile.getRefCount(), next );
+                file, pagedFile.getRefCount(), next );
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -602,7 +602,7 @@ public class MuninnPageCache implements PageCache
             {
                 int refCount = files.pagedFile.getRefCount();
                 msg.append( "\n\t" );
-                msg.append( files.file.getName() );
+                msg.append( files.file );
                 msg.append( " (" ).append( refCount );
                 msg.append( refCount == 1? " mapping)" : " mappings)" );
                 files = files.next;


### PR DESCRIPTION
This helps debugging shutdown failures on the page cache