### PR TITLE
CodeGen clean up

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -46,50 +46,50 @@ public abstract class Expression extends ExpressionTemplate
         }
     };
 
-    public static Expression gt( final Expression lhs, final Expression rhs, TypeReference argType )
+    public static Expression gt( final Expression lhs, final Expression rhs )
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.gt( lhs, rhs, argType );
+                visitor.gt( lhs, rhs );
             }
         };
     }
 
-    public static Expression gte( final Expression lhs, final Expression rhs, TypeReference argType )
+    public static Expression gte( final Expression lhs, final Expression rhs )
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.gte( lhs, rhs, argType );
+                visitor.gte( lhs, rhs );
             }
         };
     }
 
-    public static Expression lt( final Expression lhs, final Expression rhs, TypeReference argType )
+    public static Expression lt( final Expression lhs, final Expression rhs)
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.lt( lhs, rhs, argType );
+                visitor.lt( lhs, rhs);
             }
         };
     }
 
-    public static Expression lte( final Expression lhs, final Expression rhs, TypeReference argType )
+    public static Expression lte( final Expression lhs, final Expression rhs )
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.lte( lhs, rhs, argType );
+                visitor.lte( lhs, rhs );
             }
         };
     }
@@ -118,14 +118,14 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
-    public static Expression equal( final Expression lhs, final Expression rhs, TypeReference argType )
+    public static Expression equal( final Expression lhs, final Expression rhs )
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.equal( lhs, rhs, argType );
+                visitor.equal( lhs, rhs );
             }
         };
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -36,7 +36,6 @@ public abstract class Expression extends ExpressionTemplate
 
     public abstract void accept( ExpressionVisitor visitor );
 
-
     static final Expression SUPER = new Expression( OBJECT )
     {
         @Override
@@ -147,7 +146,7 @@ public abstract class Expression extends ExpressionTemplate
         if ( !lhs.type.equals( rhs.type ) )
         {
             throw new IllegalArgumentException(
-                    String.format( "Cannot add variable with different types. LHS %s, RHS %s", lhs.type.simpleName(),
+                    String.format( "Cannot add variables with different types. LHS %s, RHS %s", lhs.type.simpleName(),
                             rhs.type.simpleName() ));
         }
 
@@ -166,7 +165,7 @@ public abstract class Expression extends ExpressionTemplate
         if ( !lhs.type.equals( rhs.type ) )
         {
             throw new IllegalArgumentException(
-                    String.format( "Cannot subtract variable with different types. LHS %s, RHS %s", lhs.type.simpleName(),
+                    String.format( "Cannot subtract variables with different types. LHS %s, RHS %s", lhs.type.simpleName(),
                             rhs.type.simpleName() ));
         }
         return new Expression( lhs.type )
@@ -179,26 +178,20 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
-    public static Expression multiplyLongs( final Expression lhs, final Expression rhs )
+    public static Expression multiply( final Expression lhs, final Expression rhs )
     {
-        return new Expression( LONG )
+        if ( !lhs.type.equals( rhs.type ) )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Cannot multiply variables with different types. LHS %s, RHS %s", lhs.type.simpleName(),
+                            rhs.type.simpleName() ));
+        }
+        return new Expression( lhs.type )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.multiplyLongs( lhs, rhs );
-            }
-        };
-    }
-
-    public static Expression multiplyDoubles( final Expression lhs, final Expression rhs )
-    {
-        return new Expression( DOUBLE )
-        {
-            @Override
-            public void accept( ExpressionVisitor visitor )
-            {
-                visitor.multiplyDoubles( lhs, rhs );
+                visitor.multiply( lhs, rhs );
             }
         };
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -161,38 +161,20 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
-    public static Expression subtractInts( final Expression lhs, final Expression rhs )
+    public static Expression subtract( final Expression lhs, final Expression rhs )
     {
-        return new Expression( INT )
+        if ( !lhs.type.equals( rhs.type ) )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Cannot subtract variable with different types. LHS %s, RHS %s", lhs.type.simpleName(),
+                            rhs.type.simpleName() ));
+        }
+        return new Expression( lhs.type )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.subtractInts( lhs, rhs );
-            }
-        };
-    }
-
-    public static Expression subtractLongs( final Expression lhs, final Expression rhs )
-    {
-        return new Expression( LONG )
-        {
-            @Override
-            public void accept( ExpressionVisitor visitor )
-            {
-                visitor.subtractLongs( lhs, rhs );
-            }
-        };
-    }
-
-    public static Expression subtractDoubles( final Expression lhs, final Expression rhs )
-    {
-        return new Expression( DOUBLE )
-        {
-            @Override
-            public void accept( ExpressionVisitor visitor )
-            {
-                visitor.subtractDoubles( lhs, rhs );
+                visitor.subtract( lhs, rhs );
             }
         };
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -70,14 +70,14 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
-    public static Expression lt( final Expression lhs, final Expression rhs)
+    public static Expression lt( final Expression lhs, final Expression rhs )
     {
         return new Expression( BOOLEAN )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.lt( lhs, rhs);
+                visitor.lt( lhs, rhs );
             }
         };
     }
@@ -142,38 +142,21 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
-    public static Expression addInts( final Expression lhs, final Expression rhs )
+    public static Expression add( final Expression lhs, final Expression rhs )
     {
-        return new Expression( INT )
+        if ( !lhs.type.equals( rhs.type ) )
         {
-            @Override
-            public void accept( ExpressionVisitor visitor )
-            {
-                visitor.addInts( lhs, rhs );
-            }
-        };
-    }
+            throw new IllegalArgumentException(
+                    String.format( "Cannot add variable with different types. LHS %s, RHS %s", lhs.type.simpleName(),
+                            rhs.type.simpleName() ));
+        }
 
-    public static Expression addLongs( final Expression lhs, final Expression rhs )
-    {
-        return new Expression( LONG )
+        return new Expression( lhs.type )
         {
             @Override
             public void accept( ExpressionVisitor visitor )
             {
-                visitor.addLongs( lhs, rhs );
-            }
-        };
-    }
-
-    public static Expression addDoubles( final Expression lhs, final Expression rhs )
-    {
-        return new Expression( DOUBLE )
-        {
-            @Override
-            public void accept( ExpressionVisitor visitor )
-            {
-                visitor.addDoubles( lhs, rhs );
+                visitor.add( lhs, rhs );
             }
         };
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
@@ -241,4 +241,9 @@ public abstract class ExpressionTemplate
             }
         };
     }
+
+    public TypeReference type()
+    {
+        return type;
+    }
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -63,7 +63,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void load(  LocalVariable variable)
+    public void load( LocalVariable variable )
     {
         result.append( "load{type=" );
         if ( variable.type() == null )
@@ -125,9 +125,9 @@ class ExpressionToString implements ExpressionVisitor
     {
         result.append( "ternary{test=" );
         test.accept( this );
-        result.append(", onTrue=");
+        result.append( ", onTrue=" );
         onTrue.accept( this );
-        result.append(", onFalse=");
+        result.append( ", onFalse=" );
         onFalse.accept( this );
         result.append( "}" );
     }
@@ -135,7 +135,7 @@ class ExpressionToString implements ExpressionVisitor
     @Override
     public void ternaryOnNull( Expression test, Expression onTrue, Expression onFalse )
     {
-        ternary( Expression.equal( test, Expression.constant( null ), TypeReference.OBJECT ),
+        ternary( Expression.equal( test, Expression.constant( null ) ),
                 onTrue, onFalse );
     }
 
@@ -143,12 +143,12 @@ class ExpressionToString implements ExpressionVisitor
     public void ternaryOnNonNull( Expression test, Expression onTrue, Expression onFalse )
     {
         ternary( Expression.not(
-                Expression.equal( test, Expression.constant( null ), TypeReference.OBJECT )),
+                Expression.equal( test, Expression.constant( null ) ) ),
                 onTrue, onFalse );
     }
 
     @Override
-    public void equal( Expression lhs, Expression rhs, TypeReference ignored )
+    public void equal( Expression lhs, Expression rhs )
     {
         result.append( "equal(" );
         lhs.accept( this );
@@ -180,19 +180,19 @@ class ExpressionToString implements ExpressionVisitor
     @Override
     public void addInts( Expression lhs, Expression rhs )
     {
-        add(lhs, rhs);
+        add( lhs, rhs );
     }
 
     @Override
     public void addLongs( Expression lhs, Expression rhs )
     {
-        add(lhs, rhs);
+        add( lhs, rhs );
     }
 
     @Override
     public void addDoubles( Expression lhs, Expression rhs )
     {
-        add(lhs, rhs);
+        add( lhs, rhs );
     }
 
     private void add( Expression lhs, Expression rhs )
@@ -205,7 +205,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void gt( Expression lhs, Expression rhs, TypeReference ignored )
+    public void gt( Expression lhs, Expression rhs )
     {
         result.append( "gt(" );
         lhs.accept( this );
@@ -215,7 +215,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void gte( Expression lhs, Expression rhs, TypeReference ignored )
+    public void gte( Expression lhs, Expression rhs )
     {
         result.append( "gt(" );
         lhs.accept( this );
@@ -225,7 +225,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void lt( Expression lhs, Expression rhs, TypeReference ignored )
+    public void lt( Expression lhs, Expression rhs )
     {
         result.append( "lt(" );
         lhs.accept( this );
@@ -235,7 +235,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void lte( Expression lhs, Expression rhs, TypeReference ignored )
+    public void lte( Expression lhs, Expression rhs )
     {
         result.append( "gt(" );
         lhs.accept( this );
@@ -247,19 +247,19 @@ class ExpressionToString implements ExpressionVisitor
     @Override
     public void subtractInts( Expression lhs, Expression rhs )
     {
-        sub( lhs, rhs);
+        sub( lhs, rhs );
     }
 
     @Override
     public void subtractLongs( Expression lhs, Expression rhs )
     {
-        sub( lhs, rhs);
+        sub( lhs, rhs );
     }
 
     @Override
     public void subtractDoubles( Expression lhs, Expression rhs )
     {
-        sub( lhs, rhs);
+        sub( lhs, rhs );
     }
 
     private void sub( Expression lhs, Expression rhs )
@@ -274,13 +274,13 @@ class ExpressionToString implements ExpressionVisitor
     @Override
     public void multiplyLongs( Expression lhs, Expression rhs )
     {
-        mul( lhs, rhs);
+        mul( lhs, rhs );
     }
 
     @Override
     public void multiplyDoubles( Expression lhs, Expression rhs )
     {
-        mul( lhs, rhs);
+        mul( lhs, rhs );
     }
 
     private void mul( Expression lhs, Expression rhs )

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -178,24 +178,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void addInts( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    @Override
-    public void addLongs( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    @Override
-    public void addDoubles( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    private void add( Expression lhs, Expression rhs )
+    public void add( Expression lhs, Expression rhs )
     {
         result.append( "add(" );
         lhs.accept( this );

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -238,18 +238,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void multiplyLongs( Expression lhs, Expression rhs )
-    {
-        mul( lhs, rhs );
-    }
-
-    @Override
-    public void multiplyDoubles( Expression lhs, Expression rhs )
-    {
-        mul( lhs, rhs );
-    }
-
-    private void mul( Expression lhs, Expression rhs )
+    public void multiply( Expression lhs, Expression rhs )
     {
         result.append( "mul(" );
         lhs.accept( this );

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -228,24 +228,7 @@ class ExpressionToString implements ExpressionVisitor
     }
 
     @Override
-    public void subtractInts( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs );
-    }
-
-    @Override
-    public void subtractLongs( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs );
-    }
-
-    @Override
-    public void subtractDoubles( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs );
-    }
-
-    private void sub( Expression lhs, Expression rhs )
+    public void subtract( Expression lhs, Expression rhs )
     {
         result.append( "sub(" );
         lhs.accept( this );

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -61,11 +61,7 @@ public interface ExpressionVisitor
 
     void lte( Expression lhs, Expression rhs );
 
-    void subtractInts( Expression lhs, Expression rhs );
-
-    void subtractLongs( Expression lhs, Expression rhs );
-
-    void subtractDoubles( Expression lhs, Expression rhs );
+    void subtract( Expression lhs, Expression rhs );
 
     void multiplyLongs( Expression lhs, Expression rhs );
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -25,7 +25,7 @@ public interface ExpressionVisitor
 
     void invoke( MethodReference method, Expression[] arguments );
 
-    void load( LocalVariable variable);
+    void load( LocalVariable variable );
 
     void getField( Expression target, FieldReference field );
 
@@ -45,7 +45,7 @@ public interface ExpressionVisitor
 
     void ternaryOnNonNull( Expression test, Expression onTrue, Expression onFalse );
 
-    void equal( Expression lhs, Expression rhs, TypeReference type );
+    void equal( Expression lhs, Expression rhs);
 
     void or( Expression lhs, Expression rhs );
 
@@ -57,13 +57,13 @@ public interface ExpressionVisitor
 
     void addDoubles( Expression lhs, Expression rhs );
 
-    void gt( Expression lhs, Expression rhs, TypeReference type );
+    void gt( Expression lhs, Expression rhs );
 
-    void gte( Expression lhs, Expression rhs, TypeReference type );
+    void gte( Expression lhs, Expression rhs );
 
-    void lt( Expression lhs, Expression rhs, TypeReference type );
+    void lt( Expression lhs, Expression rhs );
 
-    void lte( Expression lhs, Expression rhs, TypeReference type );
+    void lte( Expression lhs, Expression rhs );
 
     void subtractInts( Expression lhs, Expression rhs );
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -51,11 +51,7 @@ public interface ExpressionVisitor
 
     void and( Expression lhs, Expression rhs );
 
-    void addInts( Expression lhs, Expression rhs );
-
-    void addLongs( Expression lhs, Expression rhs );
-
-    void addDoubles( Expression lhs, Expression rhs );
+    void add( Expression lhs, Expression rhs );
 
     void gt( Expression lhs, Expression rhs );
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -63,9 +63,7 @@ public interface ExpressionVisitor
 
     void subtract( Expression lhs, Expression rhs );
 
-    void multiplyLongs( Expression lhs, Expression rhs );
-
-    void multiplyDoubles( Expression lhs, Expression rhs );
+    void multiply( Expression lhs, Expression rhs );
 
     void cast( TypeReference type, Expression expression );
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/LocalVariable.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/LocalVariable.java
@@ -27,6 +27,7 @@ public class LocalVariable extends Expression
 
     LocalVariable( TypeReference type, String name, int index )
     {
+        super( type );
         this.type = type;
         this.name = name;
         this.index = index;

--- a/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/TypeReference.java
@@ -94,6 +94,11 @@ public class TypeReference
         return new TypeReference( "", name, false, false, true, "", Modifier.PUBLIC );
     }
 
+    public static TypeReference arrayOf( TypeReference type )
+    {
+        return new TypeReference( type.packageName, type.simpleName + "[]", false, true, false, type.declaringClassName, type.modifiers );
+    }
+
     public static TypeReference parameterizedType( Class<?> base, Class<?>... parameters )
     {
         return parameterizedType( typeReference( base ), typeReferences( parameters ) );
@@ -141,8 +146,12 @@ public class TypeReference
     private final String declaringClassName;
     private final int modifiers;
 
-    public static final TypeReference VOID = new TypeReference( "", "void", true, false, false, "", void.class.getModifiers() ),
-            OBJECT = new TypeReference( "java.lang", "Object", false, false, false, "", Object.class.getModifiers() );
+    public static final TypeReference VOID = new TypeReference( "", "void", true, false, false, "", void.class.getModifiers() );
+    public static final TypeReference OBJECT = new TypeReference( "java.lang", "Object", false, false, false, "", Object.class.getModifiers() );
+    public static final TypeReference BOOLEAN = new TypeReference( "", "boolean", true, false, false, "", boolean.class.getModifiers() );
+    public static final TypeReference INT = new TypeReference( "", "int", true, false, false, "", int.class.getModifiers() );
+    public static final TypeReference LONG = new TypeReference( "", "long", true, false, false, "", long.class.getModifiers() );
+    public static final TypeReference DOUBLE = new TypeReference( "", "double", true, false, false, "", double.class.getModifiers() );
     static final TypeReference[] NO_TYPES = new TypeReference[0];
 
     TypeReference( String packageName, String simpleName, boolean isPrimitive, boolean isArray,
@@ -222,25 +231,43 @@ public class TypeReference
     public boolean equals( Object o )
     {
         if ( this == o )
-        {
-            return true;
-        }
-        if ( !(o instanceof TypeReference) )
-        {
-            return false;
-        }
-        TypeReference that = (TypeReference) o;
-        return simpleName.equals( that.simpleName ) &&
-               packageName.equals( that.packageName ) &&
-               Arrays.equals( parameters, that.parameters );
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        TypeReference reference = (TypeReference) o;
+
+        if ( isPrimitive != reference.isPrimitive )
+        { return false; }
+        if ( isArray != reference.isArray )
+        { return false; }
+        if ( isTypeParameter != reference.isTypeParameter )
+        { return false; }
+        if ( modifiers != reference.modifiers )
+        { return false; }
+        if ( packageName != null ? !packageName.equals( reference.packageName ) : reference.packageName != null )
+        { return false; }
+        if ( simpleName != null ? !simpleName.equals( reference.simpleName ) : reference.simpleName != null )
+        { return false; }
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if ( !Arrays.equals( parameters, reference.parameters ) )
+        { return false; }
+        return declaringClassName != null ? declaringClassName.equals( reference.declaringClassName )
+                                          : reference.declaringClassName == null;
+
     }
 
     @Override
     public int hashCode()
     {
-        int result = packageName.hashCode();
-        result = 31 * result + simpleName.hashCode();
+        int result = packageName != null ? packageName.hashCode() : 0;
+        result = 31 * result + (simpleName != null ? simpleName.hashCode() : 0);
         result = 31 * result + Arrays.hashCode( parameters );
+        result = 31 * result + (isPrimitive ? 1 : 0);
+        result = 31 * result + (isArray ? 1 : 0);
+        result = 31 * result + (isTypeParameter ? 1 : 0);
+        result = 31 * result + (declaringClassName != null ? declaringClassName.hashCode() : 0);
+        result = 31 * result + modifiers;
         return result;
     }
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -55,6 +55,7 @@ import static org.objectweb.asm.Opcodes.FASTORE;
 import static org.objectweb.asm.Opcodes.FCMPG;
 import static org.objectweb.asm.Opcodes.FCMPL;
 import static org.objectweb.asm.Opcodes.FLOAD;
+import static org.objectweb.asm.Opcodes.FSUB;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.GOTO;
@@ -424,7 +425,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     }
 
     @Override
-    public void lte( Expression lhs, Expression rhs)
+    public void lte( Expression lhs, Expression rhs )
     {
         assertSameType( lhs, rhs, "compare" );
         numberOperation( lhs.type(),
@@ -436,27 +437,15 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     }
 
     @Override
-    public void subtractInts( Expression lhs, Expression rhs )
+    public void subtract( Expression lhs, Expression rhs )
     {
         lhs.accept( this );
         rhs.accept( this );
-        methodVisitor.visitInsn( ISUB );
-    }
-
-    @Override
-    public void subtractLongs( Expression lhs, Expression rhs )
-    {
-        lhs.accept( this );
-        rhs.accept( this );
-        methodVisitor.visitInsn( LSUB );
-    }
-
-    @Override
-    public void subtractDoubles( Expression lhs, Expression rhs )
-    {
-        lhs.accept( this );
-        rhs.accept( this );
-        methodVisitor.visitInsn( DSUB );
+        numberOperation( lhs.type(),
+                () -> methodVisitor.visitInsn( ISUB ),
+                () -> methodVisitor.visitInsn( LSUB ),
+                () -> methodVisitor.visitInsn( FSUB ),
+                () -> methodVisitor.visitInsn( DSUB ) );
     }
 
     @Override
@@ -680,7 +669,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     {
         if ( !lhs.type().equals( rhs.type() ) )
         {
-            throw new IllegalArgumentException( String.format( "Can only %s values of the same type", operation ));
+            throw new IllegalArgumentException( String.format( "Can only %s values of the same type", operation ) );
         }
     }
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -50,6 +50,7 @@ import static org.objectweb.asm.Opcodes.DLOAD;
 import static org.objectweb.asm.Opcodes.DMUL;
 import static org.objectweb.asm.Opcodes.DSUB;
 import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.FADD;
 import static org.objectweb.asm.Opcodes.FASTORE;
 import static org.objectweb.asm.Opcodes.FCMPG;
 import static org.objectweb.asm.Opcodes.FCMPL;
@@ -283,7 +284,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     @Override
     public void equal( Expression lhs, Expression rhs )
     {
-        assertSameType( lhs, rhs );
+        assertSameType( lhs, rhs, "compare" );
         switch ( lhs.type().simpleName() )
         {
         case "int":
@@ -373,33 +374,23 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     }
 
     @Override
-    public void addInts( Expression lhs, Expression rhs )
+    public void add( Expression lhs, Expression rhs )
     {
+        assertSameType( lhs, rhs, "add" );
         lhs.accept( this );
         rhs.accept( this );
-        methodVisitor.visitInsn( IADD );
-    }
 
-    @Override
-    public void addLongs( Expression lhs, Expression rhs )
-    {
-        lhs.accept( this );
-        rhs.accept( this );
-        methodVisitor.visitInsn( LADD );
-    }
-
-    @Override
-    public void addDoubles( Expression lhs, Expression rhs )
-    {
-        lhs.accept( this );
-        rhs.accept( this );
-        methodVisitor.visitInsn( DADD );
+        numberOperation( lhs.type(),
+                () -> methodVisitor.visitInsn( IADD ),
+                () -> methodVisitor.visitInsn( LADD ),
+                () -> methodVisitor.visitInsn( FADD ),
+                () -> methodVisitor.visitInsn( DADD ) );
     }
 
     @Override
     public void gt( Expression lhs, Expression rhs )
     {
-        assertSameType( lhs, rhs );
+        assertSameType( lhs, rhs, "compare" );
         numberOperation( lhs.type(),
                 () -> compareIntOrReferenceType( lhs, rhs, IF_ICMPLE ),
                 () -> compareLongOrFloatType( lhs, rhs, LCMP, IFLE ),
@@ -411,7 +402,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     @Override
     public void gte( Expression lhs, Expression rhs )
     {
-        assertSameType( lhs, rhs );
+        assertSameType( lhs, rhs, "compare" );
         numberOperation( lhs.type(),
                 () -> compareIntOrReferenceType( lhs, rhs, IF_ICMPLT ),
                 () -> compareLongOrFloatType( lhs, rhs, LCMP, IFLT ),
@@ -423,7 +414,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     @Override
     public void lt( Expression lhs, Expression rhs )
     {
-        assertSameType( lhs, rhs );
+        assertSameType( lhs, rhs, "compare" );
         numberOperation( lhs.type(),
                 () -> compareIntOrReferenceType( lhs, rhs, IF_ICMPGE ),
                 () -> compareLongOrFloatType( lhs, rhs, LCMP, IFGE ),
@@ -435,7 +426,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     @Override
     public void lte( Expression lhs, Expression rhs)
     {
-        assertSameType( lhs, rhs );
+        assertSameType( lhs, rhs, "compare" );
         numberOperation( lhs.type(),
                 () -> compareIntOrReferenceType( lhs, rhs, IF_ICMPGT ),
                 () -> compareLongOrFloatType( lhs, rhs, LCMP, IFGT ),
@@ -685,11 +676,11 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
         }
     }
 
-    private void assertSameType( Expression lhs, Expression rhs )
+    private void assertSameType( Expression lhs, Expression rhs, String operation )
     {
         if ( !lhs.type().equals( rhs.type() ) )
         {
-            throw new IllegalArgumentException( "Can only compare values of the same type" );
+            throw new IllegalArgumentException( String.format( "Can only %s values of the same type", operation ));
         }
     }
 

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -55,6 +55,7 @@ import static org.objectweb.asm.Opcodes.FASTORE;
 import static org.objectweb.asm.Opcodes.FCMPG;
 import static org.objectweb.asm.Opcodes.FCMPL;
 import static org.objectweb.asm.Opcodes.FLOAD;
+import static org.objectweb.asm.Opcodes.FMUL;
 import static org.objectweb.asm.Opcodes.FSUB;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
@@ -78,6 +79,7 @@ import static org.objectweb.asm.Opcodes.IF_ICMPLE;
 import static org.objectweb.asm.Opcodes.IF_ICMPLT;
 import static org.objectweb.asm.Opcodes.IF_ICMPNE;
 import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.IMUL;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
@@ -439,6 +441,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     @Override
     public void subtract( Expression lhs, Expression rhs )
     {
+        assertSameType( lhs, rhs, "subtract" );
         lhs.accept( this );
         rhs.accept( this );
         numberOperation( lhs.type(),
@@ -449,19 +452,16 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
     }
 
     @Override
-    public void multiplyDoubles( Expression lhs, Expression rhs )
+    public void multiply( Expression lhs, Expression rhs )
     {
+        assertSameType( lhs, rhs, "multiply" );
         lhs.accept( this );
         rhs.accept( this );
-        methodVisitor.visitInsn( DMUL );
-    }
-
-    @Override
-    public void multiplyLongs( Expression lhs, Expression rhs )
-    {
-        lhs.accept( this );
-        rhs.accept( this );
-        methodVisitor.visitInsn( LMUL );
+        numberOperation( lhs.type(),
+                () -> methodVisitor.visitInsn( IMUL ),
+                () -> methodVisitor.visitInsn( LMUL ),
+                () -> methodVisitor.visitInsn( FMUL ),
+                () -> methodVisitor.visitInsn( DMUL ) );
     }
 
     @Override

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -388,24 +388,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     }
 
     @Override
-    public void addInts( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    @Override
-    public void addLongs( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    @Override
-    public void addDoubles( Expression lhs, Expression rhs )
-    {
-        add( lhs, rhs );
-    }
-
-    private void add( Expression lhs, Expression rhs )
+    public void add( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " + " );
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -181,7 +181,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
         Expression[] nulls = new Expression[tests.length];
         for ( int i = 0; i < tests.length; i++ )
         {
-            nulls[i] = Expression.equal(tests[i], Expression.constant( null ), TypeReference.OBJECT);
+            nulls[i] = Expression.equal(tests[i], Expression.constant( null ) );
         }
         beginIf(nulls);
     }
@@ -192,7 +192,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
         Expression[] notNulls = new Expression[tests.length];
         for ( int i = 0; i < tests.length; i++ )
         {
-            notNulls[i] = Expression.not(Expression.equal(tests[i], Expression.constant( null ), TypeReference.OBJECT));
+            notNulls[i] = Expression.not(Expression.equal(tests[i], Expression.constant( null ) ));
         }
         beginIf(notNulls);
     }
@@ -356,7 +356,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     @Override
     public void ternaryOnNull( Expression test, Expression onTrue, Expression onFalse )
     {
-        ternary( Expression.equal( test, Expression.constant( null ), TypeReference.OBJECT ),
+        ternary( Expression.equal( test, Expression.constant( null ) ),
                 onTrue, onFalse );
     }
 
@@ -364,12 +364,12 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     public void ternaryOnNonNull( Expression test, Expression onTrue, Expression onFalse )
     {
         ternary( Expression.not(
-                Expression.equal( test, Expression.constant( null ), TypeReference.OBJECT )),
+                Expression.equal( test, Expression.constant( null ) )),
                 onTrue, onFalse );
     }
 
     @Override
-    public void equal( Expression lhs, Expression rhs, TypeReference ignored )
+    public void equal( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " == " );
     }
@@ -411,25 +411,25 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     }
 
     @Override
-    public void gt( Expression lhs, Expression rhs, TypeReference ignored )
+    public void gt( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " > " );
     }
 
     @Override
-    public void gte( Expression lhs, Expression rhs, TypeReference ignored )
+    public void gte( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " >= " );
     }
 
     @Override
-    public void lt( Expression lhs, Expression rhs, TypeReference ignored )
+    public void lt( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " < " );
     }
 
     @Override
-    public void lte( Expression lhs, Expression rhs, TypeReference ignored )
+    public void lte( Expression lhs, Expression rhs )
     {
         binaryOperation( lhs, rhs, " <= " );
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -418,24 +418,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     }
 
     @Override
-    public void subtractInts( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs);
-    }
-
-    @Override
-    public void subtractLongs( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs);
-    }
-
-    @Override
-    public void subtractDoubles( Expression lhs, Expression rhs )
-    {
-        sub( lhs, rhs);
-    }
-
-    private void sub( Expression lhs, Expression rhs )
+    public void subtract( Expression lhs, Expression rhs )
     {
         lhs.accept( this );
         append( " - " );

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -426,18 +426,7 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     }
 
     @Override
-    public void multiplyLongs( Expression lhs, Expression rhs )
-    {
-        mul( lhs, rhs);
-    }
-
-    @Override
-    public void multiplyDoubles( Expression lhs, Expression rhs )
-    {
-        mul( lhs, rhs);
-    }
-
-    private void mul( Expression lhs, Expression rhs )
+    public void multiply( Expression lhs, Expression rhs )
     {
         lhs.accept( this );
         append( " * " );

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -1193,144 +1193,144 @@ public class CodeGenerationTest
     {
         // boolean
         assertTrue( compareForType( boolean.class, true, true,
-                ( a, b ) -> Expression.equal( a, b, typeReference( boolean.class ) ) ) );
+                Expression::equal ) );
         assertTrue( compareForType( boolean.class, false, false,
-                ( a, b ) -> Expression.equal( a, b, typeReference( boolean.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( boolean.class, true, false,
-                ( a, b ) -> Expression.equal( a, b, typeReference( boolean.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( boolean.class, false, true,
-                ( a, b ) -> Expression.equal( a, b, typeReference( boolean.class ) ) ) );
+                Expression::equal ) );
 
         // byte
         assertTrue( compareForType( byte.class, (byte) 42, (byte) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( byte.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( byte.class, (byte) 43, (byte) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( byte.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( byte.class, (byte) 42, (byte) 43,
-                ( a, b ) -> Expression.equal( a, b, typeReference( byte.class ) ) ) );
+                Expression::equal ) );
 
         // short
         assertTrue( compareForType( short.class, (short) 42, (short) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( short.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( short.class, (short) 43, (short) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( short.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( short.class, (short) 42, (short) 43,
-                ( a, b ) -> Expression.equal( a, b, typeReference( short.class ) ) ) );
+                Expression::equal ) );
 
         // char
         assertTrue( compareForType( char.class, (char) 42, (char) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( char.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( char.class, (char) 43, (char) 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( char.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( char.class, (char) 42, (char) 43,
-                ( a, b ) -> Expression.equal( a, b, typeReference( char.class ) ) ) );
+                Expression::equal ) );
 
         //int
         assertTrue( compareForType( int.class, 42, 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( int.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( int.class, 43, 42,
-                ( a, b ) -> Expression.equal( a, b, typeReference( int.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( int.class, 42, 43,
-                ( a, b ) -> Expression.equal( a, b, typeReference( int.class ) ) ) );
+                Expression::equal ) );
 
         //long
         assertTrue( compareForType( long.class, 42L, 42L,
-                ( a, b ) -> Expression.equal( a, b, typeReference( long.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( long.class, 43L, 42L,
-                ( a, b ) -> Expression.equal( a, b, typeReference( long.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( long.class, 42L, 43L,
-                ( a, b ) -> Expression.equal( a, b, typeReference( long.class ) ) ) );
+                Expression::equal ) );
 
         //float
         assertTrue( compareForType( float.class, 42F, 42F,
-                ( a, b ) -> Expression.equal( a, b, typeReference( float.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( float.class, 43F, 42F,
-                ( a, b ) -> Expression.equal( a, b, typeReference( float.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( float.class, 42F, 43F,
-                ( a, b ) -> Expression.equal( a, b, typeReference( float.class ) ) ) );
+                Expression::equal ) );
 
         //double
         assertTrue( compareForType( double.class, 42D, 42D,
-                ( a, b ) -> Expression.equal( a, b, typeReference( double.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( double.class, 43D, 42D,
-                ( a, b ) -> Expression.equal( a, b, typeReference( double.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( double.class, 42D, 43D,
-                ( a, b ) -> Expression.equal( a, b, typeReference( double.class ) ) ) );
+                Expression::equal ) );
 
         //reference
         Object obj1 = new Object();
         Object obj2 = new Object();
         assertTrue( compareForType( Object.class, obj1, obj1,
-                ( a, b ) -> Expression.equal( a, b, typeReference( Object.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( Object.class, obj1, obj2,
-                ( a, b ) -> Expression.equal( a, b, typeReference( Object.class ) ) ) );
+                Expression::equal ) );
         assertFalse( compareForType( Object.class, obj2, obj1,
-                ( a, b ) -> Expression.equal( a, b, typeReference( Object.class ) ) ) );
+                Expression::equal ) );
     }
 
     @Test
     public void shouldHandleGreaterThan() throws Throwable
     {
         assertTrue( compareForType( float.class, 43F, 42F,
-                ( a, b ) -> Expression.gt( a, b, typeReference( float.class ) ) ) );
+                Expression::gt ) );
         assertTrue( compareForType( long.class, 43L, 42L,
-                ( a, b ) -> Expression.gt( a, b, typeReference( long.class ) ) ) );
+                Expression::gt ) );
 
         // byte
         assertTrue( compareForType( byte.class, (byte) 43, (byte) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( byte.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( byte.class, (byte) 42, (byte) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( byte.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( byte.class, (byte) 42, (byte) 43,
-                ( a, b ) -> Expression.gt( a, b, typeReference( byte.class ) ) ) );
+                Expression::gt ) );
 
         // short
         assertTrue( compareForType( short.class, (short) 43, (short) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( short.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( short.class, (short) 42, (short) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( short.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( short.class, (short) 42, (short) 43,
-                ( a, b ) -> Expression.gt( a, b, typeReference( short.class ) ) ) );
+                Expression::gt ) );
 
         // char
         assertTrue( compareForType( char.class, (char) 43, (char) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( char.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( char.class, (char) 42, (char) 42,
-                ( a, b ) -> Expression.gt( a, b, typeReference( char.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( char.class, (char) 42, (char) 43,
-                ( a, b ) -> Expression.gt( a, b, typeReference( char.class ) ) ) );
+                Expression::gt ) );
 
         //int
         assertTrue(
-                compareForType( int.class, 43, 42, ( a, b ) -> Expression.gt( a, b, typeReference( int.class ) ) ) );
+                compareForType( int.class, 43, 42, Expression::gt ) );
         assertFalse(
-                compareForType( int.class, 42, 42, ( a, b ) -> Expression.gt( a, b, typeReference( int.class ) ) ) );
+                compareForType( int.class, 42, 42, Expression::gt ) );
         assertFalse(
-                compareForType( int.class, 42, 43, ( a, b ) -> Expression.gt( a, b, typeReference( int.class ) ) ) );
+                compareForType( int.class, 42, 43, Expression::gt ) );
 
         //long
         assertTrue( compareForType( long.class, 43L, 42L,
-                ( a, b ) -> Expression.gt( a, b, typeReference( long.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( long.class, 42L, 42L,
-                ( a, b ) -> Expression.gt( a, b, typeReference( long.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( long.class, 42L, 43L,
-                ( a, b ) -> Expression.gt( a, b, typeReference( long.class ) ) ) );
+                Expression::gt ) );
 
         //float
         assertTrue( compareForType( float.class, 43F, 42F,
-                ( a, b ) -> Expression.gt( a, b, typeReference( float.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( float.class, 42F, 42F,
-                ( a, b ) -> Expression.gt( a, b, typeReference( float.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( float.class, 42F, 43F,
-                ( a, b ) -> Expression.gt( a, b, typeReference( float.class ) ) ) );
+                Expression::gt ) );
 
         //double
         assertTrue( compareForType( double.class, 43D, 42D,
-                ( a, b ) -> Expression.gt( a, b, typeReference( double.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( double.class, 42D, 42D,
-                ( a, b ) -> Expression.gt( a, b, typeReference( double.class ) ) ) );
+                Expression::gt ) );
         assertFalse( compareForType( double.class, 42D, 43D,
-                ( a, b ) -> Expression.gt( a, b, typeReference( double.class ) ) ) );
+                Expression::gt ) );
     }
 
     @Test

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -56,9 +56,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.neo4j.codegen.Expression.addDoubles;
-import static org.neo4j.codegen.Expression.addInts;
-import static org.neo4j.codegen.Expression.addLongs;
+import static org.neo4j.codegen.Expression.add;
 import static org.neo4j.codegen.Expression.and;
 import static org.neo4j.codegen.Expression.constant;
 import static org.neo4j.codegen.Expression.invoke;
@@ -491,12 +489,12 @@ public class CodeGenerationTest
         try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
         {
             try ( CodeBlock callEach = simple.generateMethod( void.class, "check",
-                    param( boolean.class, "a"), param( boolean.class, "b"), param(Runnable.class, "runner") ) )
+                    param( boolean.class, "a" ), param( boolean.class, "b" ), param( Runnable.class, "runner" ) ) )
             {
-                try ( CodeBlock loop = callEach.whileLoop( callEach.load("a"), callEach.load("b") ))
+                try ( CodeBlock loop = callEach.whileLoop( callEach.load( "a" ), callEach.load( "b" ) ) )
                 {
                     loop.expression( invoke(
-                            loop.load("runner"),
+                            loop.load( "runner" ),
                             methodReference( Runnable.class, void.class, "run" ) ) );
                     loop.returns();
                 }
@@ -510,11 +508,12 @@ public class CodeGenerationTest
         Runnable d = mock( Runnable.class );
 
         // when
-        MethodHandle callEach = instanceMethod( handle.newInstance(), "check", boolean.class, boolean.class, Runnable.class );
-        callEach.invoke( true, true, a);
-        callEach.invoke( true, false, b);
-        callEach.invoke( false, true, c);
-        callEach.invoke( false, false, d);
+        MethodHandle callEach =
+                instanceMethod( handle.newInstance(), "check", boolean.class, boolean.class, Runnable.class );
+        callEach.invoke( true, true, a );
+        callEach.invoke( true, false, b );
+        callEach.invoke( false, true, c );
+        callEach.invoke( false, false, d );
 
         // then
         verify( a ).run();
@@ -647,9 +646,11 @@ public class CodeGenerationTest
         try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
         {
             try ( CodeBlock conditional = simple.generateMethod( void.class, "conditional",
-                    param( boolean.class, "test1" ),  param( boolean.class, "test2" ), param( Runnable.class, "runner" ) ) )
+                    param( boolean.class, "test1" ), param( boolean.class, "test2" ),
+                    param( Runnable.class, "runner" ) ) )
             {
-                try ( CodeBlock doStuff = conditional.ifStatement( conditional.load( "test1" ), conditional.load( "test2" ) ) )
+                try ( CodeBlock doStuff = conditional
+                        .ifStatement( conditional.load( "test1" ), conditional.load( "test2" ) ) )
                 {
                     doStuff.expression(
                             invoke( doStuff.load( "runner" ), RUN ) );
@@ -665,7 +666,8 @@ public class CodeGenerationTest
         Runnable runner4 = mock( Runnable.class );
 
         // when
-        MethodHandle conditional = instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, Runnable.class );
+        MethodHandle conditional =
+                instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, Runnable.class );
         conditional.invoke( true, true, runner1 );
         conditional.invoke( false, true, runner2 );
         conditional.invoke( true, false, runner3 );
@@ -677,6 +679,7 @@ public class CodeGenerationTest
         verifyZeroInteractions( runner3 );
         verifyZeroInteractions( runner4 );
     }
+
     @Test
     public void shouldGenerateIfNotExpressionStatement() throws Throwable
     {
@@ -720,7 +723,7 @@ public class CodeGenerationTest
             try ( CodeBlock conditional = simple.generateMethod( void.class, "conditional",
                     param( boolean.class, "test" ), param( Runnable.class, "runner" ) ) )
             {
-                try ( CodeBlock doStuff = conditional.ifNotStatement( conditional.load( "test" ) )  )
+                try ( CodeBlock doStuff = conditional.ifNotStatement( conditional.load( "test" ) ) )
                 {
                     doStuff.expression(
                             invoke( doStuff.load( "runner" ), RUN ) );
@@ -1359,22 +1362,7 @@ public class CodeGenerationTest
             try ( CodeBlock block = simple.generateMethod( clazz, "add",
                     param( clazz, "a" ), param( clazz, "b" ) ) )
             {
-                if ( clazz == int.class )
-                {
-                    block.returns( addInts( block.load( "a" ), block.load( "b" ) ) );
-                }
-                else if ( clazz == long.class )
-                {
-                    block.returns( addLongs( block.load( "a" ), block.load( "b" ) ) );
-                }
-                else if ( clazz == double.class )
-                {
-                    block.returns( addDoubles( block.load( "a" ), block.load( "b" ) ) );
-                }
-                else
-                {
-                    fail( "adding " + clazz.getSimpleName() + " is not supported" );
-                }
+                block.returns( add( block.load( "a" ), block.load( "b" ) ) );
             }
 
             handle = simple.handle();
@@ -1646,7 +1634,8 @@ public class CodeGenerationTest
             simple.generate( MethodTemplate.constructor( param( String.class, "name" ), param( Object.class, "foo" ) )
                     .invokeSuper( new ExpressionTemplate[]{load( "name", typeReference( String.class ) )},
                             new TypeReference[]{typeReference( String.class )} )
-                    .put( self(simple.handle()), String.class, "foo", cast( String.class, load( "foo", typeReference( Object.class ) ) ) )
+                    .put( self( simple.handle() ), String.class, "foo",
+                            cast( String.class, load( "foo", typeReference( Object.class ) ) ) )
                     .build() );
             handle = simple.handle();
         }
@@ -1750,12 +1739,12 @@ public class CodeGenerationTest
         try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
         {
             FieldReference value = simple.field( clazz, "value" );
-            simple.generate(MethodTemplate.constructor(  param( clazz, "value" ) )
+            simple.generate( MethodTemplate.constructor( param( clazz, "value" ) )
                     .invokeSuper()
-                    .put( self(simple.handle()), value.type(), value.name(), load( "value", value.type() ) )
-                    .build());
+                    .put( self( simple.handle() ), value.type(), value.name(), load( "value", value.type() ) )
+                    .build() );
             simple.generate( MethodTemplate.method( clazz, "value" )
-                    .returns( ExpressionTemplate.get( self(simple.handle()), clazz, "value" ) )
+                    .returns( ExpressionTemplate.get( self( simple.handle() ), clazz, "value" ) )
                     .build() );
             handle = simple.handle();
         }

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -1644,9 +1644,9 @@ public class CodeGenerationTest
         {
             simple.field( String.class, "foo" );
             simple.generate( MethodTemplate.constructor( param( String.class, "name" ), param( Object.class, "foo" ) )
-                    .invokeSuper( new ExpressionTemplate[]{load( "name" )},
+                    .invokeSuper( new ExpressionTemplate[]{load( "name", typeReference( String.class ) )},
                             new TypeReference[]{typeReference( String.class )} )
-                    .put( self(), String.class, "foo", cast( String.class, load( "foo" ) ) )
+                    .put( self(simple.handle()), String.class, "foo", cast( String.class, load( "foo", typeReference( Object.class ) ) ) )
                     .build() );
             handle = simple.handle();
         }
@@ -1752,10 +1752,10 @@ public class CodeGenerationTest
             FieldReference value = simple.field( clazz, "value" );
             simple.generate(MethodTemplate.constructor(  param( clazz, "value" ) )
                     .invokeSuper()
-                    .put( self(), value.type(), value.name(), load( "value" ) )
+                    .put( self(simple.handle()), value.type(), value.name(), load( "value", value.type() ) )
                     .build());
             simple.generate( MethodTemplate.method( clazz, "value" )
-                    .returns( ExpressionTemplate.get( self(), clazz, "value" ) )
+                    .returns( ExpressionTemplate.get( self(simple.handle()), clazz, "value" ) )
                     .build() );
             handle = simple.handle();
         }

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -64,8 +64,7 @@ import static org.neo4j.codegen.Expression.newArray;
 import static org.neo4j.codegen.Expression.newInstance;
 import static org.neo4j.codegen.Expression.not;
 import static org.neo4j.codegen.Expression.or;
-import static org.neo4j.codegen.Expression.subtractDoubles;
-import static org.neo4j.codegen.Expression.subtractLongs;
+import static org.neo4j.codegen.Expression.subtract;
 import static org.neo4j.codegen.Expression.ternary;
 import static org.neo4j.codegen.ExpressionTemplate.cast;
 import static org.neo4j.codegen.ExpressionTemplate.load;
@@ -1387,18 +1386,7 @@ public class CodeGenerationTest
             try ( CodeBlock block = simple.generateMethod( clazz, "sub",
                     param( clazz, "a" ), param( clazz, "b" ) ) )
             {
-                if ( clazz == long.class )
-                {
-                    block.returns( subtractLongs( block.load( "a" ), block.load( "b" ) ) );
-                }
-                else if ( clazz == double.class )
-                {
-                    block.returns( subtractDoubles( block.load( "a" ), block.load( "b" ) ) );
-                }
-                else
-                {
-                    fail( "adding " + clazz.getSimpleName() + " is not supported" );
-                }
+                    block.returns( subtract( block.load( "a" ), block.load( "b" ) ) );
             }
 
             handle = simple.handle();

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -60,6 +60,7 @@ import static org.neo4j.codegen.Expression.add;
 import static org.neo4j.codegen.Expression.and;
 import static org.neo4j.codegen.Expression.constant;
 import static org.neo4j.codegen.Expression.invoke;
+import static org.neo4j.codegen.Expression.multiply;
 import static org.neo4j.codegen.Expression.newArray;
 import static org.neo4j.codegen.Expression.newInstance;
 import static org.neo4j.codegen.Expression.not;
@@ -1346,8 +1347,17 @@ public class CodeGenerationTest
     @Test
     public void shouldHandleSubtraction() throws Throwable
     {
+        assertThat( subtractForType( int.class, 19, 18 ), equalTo( 1 ) );
         assertThat( subtractForType( long.class, 19L, 18L ), equalTo( 1L ) );
         assertThat( subtractForType( double.class, 19D, 18D ), equalTo( 1D ) );
+    }
+
+    @Test
+    public void shouldHandleMultiplication() throws Throwable
+    {
+        assertThat( multiplyForType( int.class, 17, 18 ), equalTo( 306 ) );
+        assertThat( multiplyForType( long.class, 17L, 18L ), equalTo( 306L ) );
+        assertThat( multiplyForType( double.class, 17D, 18D ), equalTo( 306D ) );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -1395,6 +1405,31 @@ public class CodeGenerationTest
         // when
         MethodHandle sub =
                 instanceMethod( handle.newInstance(), "sub", clazz, clazz );
+
+        // then
+        return (T) sub.invoke( lhs, rhs );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private <T> T multiplyForType( Class<T> clazz, T lhs, T rhs ) throws Throwable
+    {
+        // given
+        createGenerator();
+        ClassHandle handle;
+        try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
+        {
+            try ( CodeBlock block = simple.generateMethod( clazz, "multiply",
+                    param( clazz, "a" ), param( clazz, "b" ) ) )
+            {
+                block.returns( multiply( block.load( "a" ), block.load( "b" ) ) );
+            }
+
+            handle = simple.handle();
+        }
+
+        // when
+        MethodHandle sub =
+                instanceMethod( handle.newInstance(), "multiply", clazz, clazz );
 
         // then
         return (T) sub.invoke( lhs, rhs );

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeStructure.scala
@@ -91,11 +91,11 @@ trait MethodStructure[E] {
   def loadVariable(varName: String): E
 
   // arithmetic
-  def add(lhs: E, rhs: E): E
-  def subtract(lhs: E, rhs: E): E
-  def multiply(lhs: E, rhs: E): E
-  def divide(lhs: E, rhs: E): E
-  def modulus(lhs: E, rhs: E): E
+  def addExpression(lhs: E, rhs: E): E
+  def subtractExpression(lhs: E, rhs: E): E
+  def multiplyExpression(lhs: E, rhs: E): E
+  def divideExpression(lhs: E, rhs: E): E
+  def modulusExpression(lhs: E, rhs: E): E
 
   // predicates
   def threeValuedNotExpression(value: E): E

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Addition.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Addition.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class Addition(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExpression with BinaryOperator {
 
-  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.add
+  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.addExpression
 
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Division.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Division.scala
@@ -25,7 +25,7 @@ case class Division(lhs: CodeGenExpression, rhs: CodeGenExpression)
   extends CodeGenExpression with BinaryOperator{
 
   override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.divide
+    structure.divideExpression
 
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Modulo.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Modulo.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class Modulo(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExpression with BinaryOperator {
 
-  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.modulus
+  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.modulusExpression
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 
   override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTFloat, ReferenceType)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Multiplication.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Multiplication.scala
@@ -26,7 +26,7 @@ case class Multiplication(lhs: CodeGenExpression, rhs: CodeGenExpression)
 
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 
-  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.multiply
+  override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.multiplyExpression
 
   override def name: String = "multiply"
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Subtraction.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Subtraction.scala
@@ -25,7 +25,7 @@ case class Subtraction(lhs: CodeGenExpression, rhs: CodeGenExpression)
   extends CodeGenExpression with BinaryOperator {
 
   override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.subtract
+    structure.subtractExpression
 
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
@@ -189,8 +189,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
   override def decreaseCounterAndCheckForZero(name: String): Expression = {
     val local = locals(name)
-    generator.assign(local, subtractInts(local, constant(1)))
-
+    generator.assign(local, subtract(local, constant(1)))
     equal(constant(0), local)
   }
 
@@ -468,8 +467,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
           invoke(generator.load(tableVar), countingTablePut, generator.load(keyVar),
                  ternary(
                    equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL"))),
-                   constant(1),
-                   Expression.add(generator.load(countName), constant(1))))))
+                   constant(1), add(generator.load(countName), constant(1))))))
 
     case LongsToCountTable =>
       val countName = context.namer.newVarName()
@@ -489,7 +487,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                  ternaryOnNull(generator.load(countName),
                                invoke(boxInteger,
                                       constant(1)), invoke(boxInteger,
-                                                           Expression.add(
+                                                           add(
                                                              invoke(generator.load(countName),
                                                                     unboxInteger),
                                                              constant(1)))))))
@@ -504,7 +502,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
       generator.assign(times, invoke(generator.load(tableVar), countingTableGet, generator.load(keyVar)))
       using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
-        body.assign(times, subtractInts(times, constant(1)))
+        body.assign(times, subtract(times, constant(1)))
       }
     case LongsToCountTable =>
       val times = generator.declare(typeRef[Int], context.namer.newVarName())
@@ -524,7 +522,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
       using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
-        body.assign(times, subtractInts(times, constant(1)))
+        body.assign(times, subtract(times, constant(1)))
       }
 
     case tableType@LongToListTable(structure, localVars) =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
@@ -469,7 +469,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                  ternary(
                    equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL"))),
                    constant(1),
-                   addInts(generator.load(countName), constant(1))))))
+                   Expression.add(generator.load(countName), constant(1))))))
 
     case LongsToCountTable =>
       val countName = context.namer.newVarName()
@@ -489,7 +489,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                  ternaryOnNull(generator.load(countName),
                                invoke(boxInteger,
                                       constant(1)), invoke(boxInteger,
-                                                           addInts(
+                                                           Expression.add(
                                                              invoke(generator.load(countName),
                                                                     unboxInteger),
                                                              constant(1)))))))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
@@ -106,7 +106,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
     generator.assign(typeRef[Long], toNodeVar, toGraphDb(direction) match {
       case Direction.INCOMING => start
       case Direction.OUTGOING => end
-      case Direction.BOTH => ternary(equal(start, generator.load(fromNodeVar), typeRef[Long]), end, start)
+      case Direction.BOTH => ternary(equal(start, generator.load(fromNodeVar)), end, start)
     })
     generator.assign(typeRef[Long], relVar, invoke(generator.load(extractor), getRelationship))
   }
@@ -191,12 +191,12 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
     val local = locals(name)
     generator.assign(local, subtractInts(local, constant(1)))
 
-    equal(constant(0), local, typeRef[Int])
+    equal(constant(0), local)
   }
 
   override def counterEqualsZero(name: String): Expression = {
     val local = locals(name)
-    equal(constant(0), local, typeRef[Int])
+    equal(constant(0), local)
   }
 
   override def setInRow(column: String, value: Expression) =
@@ -231,7 +231,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
       ternary(
-        equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType)),
+        equal(nullValue(codeGenType), generator.load(varName)),
         nullValue(codeGenType),
         onSuccess)
     case _ => ternaryOnNull(generator.load(varName), constant(null), onSuccess)
@@ -240,7 +240,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nullableReference(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
       ternary(
-        equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType)),
+        equal(nullValue(codeGenType), generator.load(varName)),
         constant(null),
         onSuccess)
     case _ => ternaryOnNull(generator.load(varName), constant(null), onSuccess)
@@ -296,7 +296,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def threeValuedEqualsExpression(lhs: Expression, rhs: Expression) = invoke(Methods.ternaryEquals, lhs, rhs)
 
   override def equalityExpression(lhs: Expression, rhs: Expression, codeGenType: CodeGenType) =
-    if (codeGenType.isPrimitive) equal(lhs, rhs, lowerType(codeGenType))
+    if (codeGenType.isPrimitive) equal(lhs, rhs)
     else invoke(lhs, Methods.equals, rhs)
 
   override def orExpression(lhs: Expression, rhs: Expression) = or(lhs, rhs)
@@ -308,7 +308,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
 
   override def isNull(varName: String, codeGenType: CodeGenType) =
-    equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType))
+    equal(nullValue(codeGenType), generator.load(varName))
 
   override def notNull(varName: String, codeGenType: CodeGenType) = not(isNull(varName, codeGenType))
 
@@ -467,7 +467,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
         pop(
           invoke(generator.load(tableVar), countingTablePut, generator.load(keyVar),
                  ternary(
-                   equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL")), typeRef[Int]),
+                   equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL"))),
                    constant(1),
                    addInts(generator.load(countName), constant(1))))))
 
@@ -502,7 +502,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
       val keyVar = keyVars.head
       val times = generator.declare(typeRef[Int], context.namer.newVarName())
       generator.assign(times, invoke(generator.load(tableVar), countingTableGet, generator.load(keyVar)))
-      using(generator.whileLoop(gt(times, constant(0), typeRef[Int]))) { body =>
+      using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
         body.assign(times, subtractInts(times, constant(1)))
       }
@@ -522,7 +522,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                          constant(-1),
                          invoke(intermediate, unboxInteger)))
 
-      using(generator.whileLoop(gt(times, constant(0), typeRef[Int]))) { body =>
+      using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
         body.assign(times, subtractInts(times, constant(1)))
       }
@@ -708,7 +708,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nodeIdSeek(nodeIdVar: String, expression: Expression)(block: MethodStructure[Expression] => Unit) = {
     generator.assign(typeRef[Long], nodeIdVar, invoke(Methods.mathCastToLong, expression))
     using(generator.ifStatement(
-      gt(generator.load(nodeIdVar), constant(-1L), typeRef[Long]),
+      gt(generator.load(nodeIdVar), constant(-1L)),
       invoke(readOperations, nodeExists, generator.load(nodeIdVar))
     )) { ifBody =>
       block(copy(generator = ifBody))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedQueryStructure.scala
@@ -94,8 +94,8 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
         tracer = clazz.field(typeRef[QueryExecutionTracer], "tracer"),
         params = clazz.field(typeRef[util.Map[String, Object]], "params"),
         closeable = clazz.field(typeRef[SuccessfulCloseable], "closeable"),
-        success = clazz.generate(Templates.SUCCESS),
-        close = clazz.generate(Templates.CLOSE))
+        success = clazz.generate(Templates.success(clazz.handle())),
+        close = clazz.generate(Templates.close(clazz.handle())))
         // the "COLUMNS" static field
         clazz.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](
         columns.map(key => constant(key))))
@@ -106,10 +106,10 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       }
 
       // simple methods
-      clazz.generate(Templates.CONSTRUCTOR)
-      clazz.generate(Templates.SET_SUCCESSFUL_CLOSEABLE)
-      clazz.generate(Templates.EXECUTION_MODE)
-      clazz.generate(Templates.EXECUTION_PLAN_DESCRIPTION)
+      clazz.generate(Templates.constructor(clazz.handle()))
+      clazz.generate(Templates.setSuccessfulCloseable(clazz.handle()))
+      clazz.generate(Templates.executionMode(clazz.handle()))
+      clazz.generate(Templates.executionPlanDescription(clazz.handle()))
       clazz.generate(Templates.JAVA_COLUMNS)
 
       using(clazz.generate(MethodDeclaration.method(typeRef[Unit], "accept",

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/Templates.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/Templates.scala
@@ -104,7 +104,7 @@ object Templates {
     .invoke(Expression.newInstance(typeRef[RelationshipDataExtractor]),
             MethodReference.constructorReference(typeRef[RelationshipDataExtractor]))
 
-  val CONSTRUCTOR = MethodTemplate.constructor(
+  def constructor(classHandle: ClassHandle) = MethodTemplate.constructor(
     param[TaskCloser]("closer"),
     param[QueryContext]("queryContext"),
     param[ExecutionMode]("executionMode"),
@@ -113,40 +113,45 @@ object Templates {
 
     param[util.Map[String, Object]]("params")).
     invokeSuper().
-    put(self(), typeRef[TaskCloser], "closer", load("closer")).
-    put(self(), typeRef[ReadOperations], "ro",
+    put(self(classHandle), typeRef[TaskCloser], "closer", load("closer", typeRef[TaskCloser])).
+    put(self(classHandle), typeRef[ReadOperations], "ro",
         cast(classOf[ReadOperations], invoke(
-          invoke(load("queryContext"), method[QueryContext, QueryTransactionalContext]("transactionalContext")),
+          invoke(load("queryContext", typeRef[QueryContext]), method[QueryContext, QueryTransactionalContext]("transactionalContext")),
           method[QueryTransactionalContext, Object]("readOperations")))).
-    put(self(), typeRef[ExecutionMode], "executionMode", load("executionMode")).
-    put(self(), typeRef[Provider[InternalPlanDescription]], "description", load("description")).
-    put(self(), typeRef[QueryExecutionTracer], "tracer", load("tracer")).
-    put(self(), typeRef[util.Map[String, Object]], "params", load("params")).
-    put(self(), typeRef[NodeManager], "nodeManager",
+    put(self(classHandle), typeRef[ExecutionMode], "executionMode", load("executionMode", typeRef[ExecutionMode])).
+    put(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description", load("description", typeRef[InternalPlanDescription])).
+    put(self(classHandle), typeRef[QueryExecutionTracer], "tracer", load("tracer", typeRef[QueryExecutionTracer])).
+    put(self(classHandle), typeRef[util.Map[String, Object]], "params", load("params", typeRef[util.Map[String, Object]])).
+    put(self(classHandle), typeRef[NodeManager], "nodeManager",
         cast(typeRef[NodeManager],
-             invoke(load("queryContext"), method[QueryContext, Object]("entityAccessor")))).
+             invoke(load("queryContext", typeRef[QueryContext]), method[QueryContext, Object]("entityAccessor")))).
     build()
 
-  val SET_SUCCESSFUL_CLOSEABLE = MethodTemplate.method(typeRef[Unit], "setSuccessfulCloseable",
-                                                       param[SuccessfulCloseable]("closeable")).
-    put(self(), typeRef[SuccessfulCloseable], "closeable", load("closeable")).
+  def setSuccessfulCloseable(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "setSuccessfulCloseable",
+                                                                               param[SuccessfulCloseable]("closeable")).
+    put(self(classHandle), typeRef[SuccessfulCloseable], "closeable", load("closeable", typeRef[SuccessfulCloseable])).
     build()
-  val SUCCESS = MethodTemplate.method(typeRef[Unit], "success").
+
+  def success(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "success").
     expression(
-      invoke(get(self(), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("success"))).
+      invoke(get(self(classHandle), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("success"))).
     build()
-  val CLOSE = MethodTemplate.method(typeRef[Unit], "close").
+
+  def close(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "close").
     expression(
-      invoke(get(self(), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("close"))).
+      invoke(get(self(classHandle), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("close"))).
     build()
-  val EXECUTION_MODE = MethodTemplate.method(typeRef[ExecutionMode], "executionMode").
-    returns(get(self(), typeRef[ExecutionMode], "executionMode")).
+
+  def executionMode(classHandle: ClassHandle) = MethodTemplate.method(typeRef[ExecutionMode], "executionMode").
+    returns(get(self(classHandle), typeRef[ExecutionMode], "executionMode")).
     build()
-  val EXECUTION_PLAN_DESCRIPTION = MethodTemplate.method(typeRef[InternalPlanDescription], "executionPlanDescription").
+
+  def executionPlanDescription(classHandle: ClassHandle) = MethodTemplate.method(typeRef[InternalPlanDescription], "executionPlanDescription").
     returns(cast( typeRef[InternalPlanDescription],
-      invoke(get(self(), typeRef[Provider[InternalPlanDescription]], "description"),
+      invoke(get(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description"),
                    method[Provider[InternalPlanDescription], Object]("get")))).
     build()
+
   val JAVA_COLUMNS = MethodTemplate.method(typeRef[util.List[String]], "javaColumns").
     returns(get(typeRef[util.List[String]], "COLUMNS")).
     build()

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -189,7 +189,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
   override def decrementCounter(name: String) = {
     val local = locals(name)
-    generator.assign(local, subtractInts(local, constant(1)))
+    generator.assign(local, subtract(local, constant(1)))
   }
 
   override def checkCounter(name: String, comparator: Comparator, value: Int): Expression = {
@@ -374,15 +374,15 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
   override def loadVariable(varName: String) = generator.load(varName)
 
-  override def add(lhs: Expression, rhs: Expression) = math(Methods.mathAdd, lhs, rhs)
+  override def addExpression(lhs: Expression, rhs: Expression) = math(Methods.mathAdd, lhs, rhs)
 
-  override def subtract(lhs: Expression, rhs: Expression) = math(Methods.mathSub, lhs, rhs)
+  override def subtractExpression(lhs: Expression, rhs: Expression) = math(Methods.mathSub, lhs, rhs)
 
-  override def multiply(lhs: Expression, rhs: Expression) = math(Methods.mathMul, lhs, rhs)
+  override def multiplyExpression(lhs: Expression, rhs: Expression) = math(Methods.mathMul, lhs, rhs)
 
-  override def divide(lhs: Expression, rhs: Expression) = math(Methods.mathDiv, lhs, rhs)
+  override def divideExpression(lhs: Expression, rhs: Expression) = math(Methods.mathDiv, lhs, rhs)
 
-  override def modulus(lhs: Expression, rhs: Expression) = math(Methods.mathMod, lhs, rhs)
+  override def modulusExpression(lhs: Expression, rhs: Expression) = math(Methods.mathMod, lhs, rhs)
 
   private def math(method: MethodReference, lhs: Expression, rhs: Expression): Expression =
     invoke(method, lhs, rhs)
@@ -472,8 +472,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
           invoke(generator.load(tableVar), countingTablePut, generator.load(keyVar),
                  ternary(
                    equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL"))),
-                   constant(1),
-                   addInts(generator.load(countName), constant(1))))))
+                   constant(1), add(generator.load(countName), constant(1))))))
 
     case LongsToCountTable =>
       val countName = context.namer.newVarName()
@@ -493,7 +492,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                  ternaryOnNull(generator.load(countName),
                                invoke(boxInteger,
                                       constant(1)), invoke(boxInteger,
-                                                           addInts(
+                                                           add(
                                                              invoke(generator.load(countName),
                                                                     unboxInteger),
                                                              constant(1)))))))
@@ -508,7 +507,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
       generator.assign(times, invoke(generator.load(tableVar), countingTableGet, generator.load(keyVar)))
       using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
-        body.assign(times, subtractInts(times, constant(1)))
+        body.assign(times, subtract(times, constant(1)))
       }
     case LongsToCountTable =>
       val times = generator.declare(typeRef[Int], context.namer.newVarName())
@@ -528,7 +527,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
       using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
-        body.assign(times, subtractInts(times, constant(1)))
+        body.assign(times, subtract(times, constant(1)))
       }
 
     case tableType@LongToListTable(structure, localVars) =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -106,7 +106,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
     generator.assign(typeRef[Long], toNodeVar, toGraphDb(direction) match {
       case Direction.INCOMING => start
       case Direction.OUTGOING => end
-      case Direction.BOTH => ternary(equal(start, generator.load(fromNodeVar), typeRef[Long]), end, start)
+      case Direction.BOTH => ternary(equal(start, generator.load(fromNodeVar)), end, start)
     })
     generator.assign(typeRef[Long], relVar, invoke(generator.load(extractor), getRelationship))
   }
@@ -187,7 +187,6 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
     generator.assign(variable, invoke(mathCastToInt, initialValue))
   }
 
-
   override def decrementCounter(name: String) = {
     val local = locals(name)
     generator.assign(local, subtractInts(local, constant(1)))
@@ -196,11 +195,11 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def checkCounter(name: String, comparator: Comparator, value: Int): Expression = {
     val local = locals(name)
     comparator match {
-      case Equal =>  equal(local, constant(value), typeRef[Int])
-      case LessThan => lt(local, constant(value), typeRef[Int])
-      case LessThanEqual => lte(local, constant(value), typeRef[Int])
-      case GreaterThan  => gt(local, constant(value), typeRef[Int])
-      case GreaterThanEqual  => gte(local, constant(value), typeRef[Int])
+      case Equal =>  equal(local, constant(value))
+      case LessThan => lt(local, constant(value))
+      case LessThanEqual => lte(local, constant(value))
+      case GreaterThan  => gt(local, constant(value))
+      case GreaterThanEqual  => gte(local, constant(value))
     }
   }
 
@@ -236,7 +235,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
       ternary(
-        equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType)),
+        equal(nullValue(codeGenType), generator.load(varName)),
         nullValue(codeGenType),
         onSuccess)
     case _ => ternaryOnNull(generator.load(varName), constant(null), onSuccess)
@@ -245,7 +244,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nullableReference(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
       ternary(
-        equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType)),
+        equal(nullValue(codeGenType), generator.load(varName)),
         constant(null),
         onSuccess)
     case _ => ternaryOnNull(generator.load(varName), constant(null), onSuccess)
@@ -301,7 +300,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def threeValuedEqualsExpression(lhs: Expression, rhs: Expression) = invoke(Methods.ternaryEquals, lhs, rhs)
 
   override def equalityExpression(lhs: Expression, rhs: Expression, codeGenType: CodeGenType) =
-    if (codeGenType.isPrimitive) equal(lhs, rhs, lowerType(codeGenType))
+    if (codeGenType.isPrimitive) equal(lhs, rhs)
     else invoke(lhs, Methods.equals, rhs)
 
   override def orExpression(lhs: Expression, rhs: Expression) = or(lhs, rhs)
@@ -313,7 +312,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
 
 
   override def isNull(varName: String, codeGenType: CodeGenType) =
-    equal(nullValue(codeGenType), generator.load(varName), lowerType(codeGenType))
+    equal(nullValue(codeGenType), generator.load(varName))
 
   override def notNull(varName: String, codeGenType: CodeGenType) = not(isNull(varName, codeGenType))
 
@@ -472,7 +471,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
         pop(
           invoke(generator.load(tableVar), countingTablePut, generator.load(keyVar),
                  ternary(
-                   equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL")), typeRef[Int]),
+                   equal(generator.load(countName), get(staticField[LongKeyIntValueTable, Int]("NULL"))),
                    constant(1),
                    addInts(generator.load(countName), constant(1))))))
 
@@ -507,7 +506,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
       val keyVar = keyVars.head
       val times = generator.declare(typeRef[Int], context.namer.newVarName())
       generator.assign(times, invoke(generator.load(tableVar), countingTableGet, generator.load(keyVar)))
-      using(generator.whileLoop(gt(times, constant(0), typeRef[Int]))) { body =>
+      using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
         body.assign(times, subtractInts(times, constant(1)))
       }
@@ -527,7 +526,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
                          constant(-1),
                          invoke(intermediate, unboxInteger)))
 
-      using(generator.whileLoop(gt(times, constant(0), typeRef[Int]))) { body =>
+      using(generator.whileLoop(gt(times, constant(0)))) { body =>
         block(copy(generator = body))
         body.assign(times, subtractInts(times, constant(1)))
       }
@@ -713,7 +712,7 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
   override def nodeIdSeek(nodeIdVar: String, expression: Expression)(block: MethodStructure[Expression] => Unit) = {
     generator.assign(typeRef[Long], nodeIdVar, invoke(Methods.mathCastToLong, expression))
     using(generator.ifStatement(
-      gt(generator.load(nodeIdVar), constant(-1L), typeRef[Long]),
+      gt(generator.load(nodeIdVar), constant(-1L)),
       invoke(readOperations, nodeExists, generator.load(nodeIdVar))
     )) { ifBody =>
       block(copy(generator = ifBody))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -94,8 +94,8 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
         tracer = clazz.field(typeRef[QueryExecutionTracer], "tracer"),
         params = clazz.field(typeRef[util.Map[String, Object]], "params"),
         closeable = clazz.field(typeRef[SuccessfulCloseable], "closeable"),
-        success = clazz.generate(Templates.SUCCESS),
-        close = clazz.generate(Templates.CLOSE))
+        success = clazz.generate(Templates.success(clazz.handle())),
+        close = clazz.generate(Templates.close(clazz.handle())))
         // the "COLUMNS" static field
         clazz.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](
         columns.map(key => constant(key))))
@@ -106,10 +106,10 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       }
 
       // simple methods
-      clazz.generate(Templates.CONSTRUCTOR)
-      clazz.generate(Templates.SET_SUCCESSFUL_CLOSEABLE)
-      clazz.generate(Templates.EXECUTION_MODE)
-      clazz.generate(Templates.EXECUTION_PLAN_DESCRIPTION)
+      clazz.generate(Templates.constructor(clazz.handle()))
+      clazz.generate(Templates.setSuccessfulCloseable(clazz.handle()))
+      clazz.generate(Templates.executionMode(clazz.handle()))
+      clazz.generate(Templates.executionPlanDescription(clazz.handle()))
       clazz.generate(Templates.JAVA_COLUMNS)
 
       using(clazz.generate(MethodDeclaration.method(typeRef[Unit], "accept",

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
@@ -104,7 +104,7 @@ object Templates {
     .invoke(Expression.newInstance(typeRef[RelationshipDataExtractor]),
             MethodReference.constructorReference(typeRef[RelationshipDataExtractor]))
 
-  val CONSTRUCTOR = MethodTemplate.constructor(
+  def constructor(classHandle: ClassHandle) = MethodTemplate.constructor(
     param[TaskCloser]("closer"),
     param[QueryContext]("queryContext"),
     param[ExecutionMode]("executionMode"),
@@ -113,40 +113,45 @@ object Templates {
 
     param[util.Map[String, Object]]("params")).
     invokeSuper().
-    put(self(), typeRef[TaskCloser], "closer", load("closer")).
-    put(self(), typeRef[ReadOperations], "ro",
+    put(self(classHandle), typeRef[TaskCloser], "closer", load("closer", typeRef[TaskCloser])).
+    put(self(classHandle), typeRef[ReadOperations], "ro",
         cast(classOf[ReadOperations], invoke(
-          invoke(load("queryContext"), method[QueryContext, QueryTransactionalContext]("transactionalContext")),
+          invoke(load("queryContext", typeRef[QueryContext]), method[QueryContext, QueryTransactionalContext]("transactionalContext")),
           method[QueryTransactionalContext, Object]("readOperations")))).
-    put(self(), typeRef[ExecutionMode], "executionMode", load("executionMode")).
-    put(self(), typeRef[Provider[InternalPlanDescription]], "description", load("description")).
-    put(self(), typeRef[QueryExecutionTracer], "tracer", load("tracer")).
-    put(self(), typeRef[util.Map[String, Object]], "params", load("params")).
-    put(self(), typeRef[NodeManager], "nodeManager",
+    put(self(classHandle), typeRef[ExecutionMode], "executionMode", load("executionMode", typeRef[ExecutionMode])).
+    put(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description", load("description", typeRef[InternalPlanDescription])).
+    put(self(classHandle), typeRef[QueryExecutionTracer], "tracer", load("tracer", typeRef[QueryExecutionTracer])).
+    put(self(classHandle), typeRef[util.Map[String, Object]], "params", load("params", typeRef[util.Map[String, Object]])).
+    put(self(classHandle), typeRef[NodeManager], "nodeManager",
         cast(typeRef[NodeManager],
-             invoke(load("queryContext"), method[QueryContext, Object]("entityAccessor")))).
+             invoke(load("queryContext", typeRef[QueryContext]), method[QueryContext, Object]("entityAccessor")))).
     build()
 
-  val SET_SUCCESSFUL_CLOSEABLE = MethodTemplate.method(typeRef[Unit], "setSuccessfulCloseable",
-                                                       param[SuccessfulCloseable]("closeable")).
-    put(self(), typeRef[SuccessfulCloseable], "closeable", load("closeable")).
+  def setSuccessfulCloseable(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "setSuccessfulCloseable",
+                                                                               param[SuccessfulCloseable]("closeable")).
+    put(self(classHandle), typeRef[SuccessfulCloseable], "closeable", load("closeable", typeRef[SuccessfulCloseable])).
     build()
-  val SUCCESS = MethodTemplate.method(typeRef[Unit], "success").
+
+  def success(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "success").
     expression(
-      invoke(get(self(), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("success"))).
+      invoke(get(self(classHandle), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("success"))).
     build()
-  val CLOSE = MethodTemplate.method(typeRef[Unit], "close").
+
+  def close(classHandle: ClassHandle) = MethodTemplate.method(typeRef[Unit], "close").
     expression(
-      invoke(get(self(), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("close"))).
+      invoke(get(self(classHandle), typeRef[SuccessfulCloseable], "closeable"), method[SuccessfulCloseable, Unit]("close"))).
     build()
-  val EXECUTION_MODE = MethodTemplate.method(typeRef[ExecutionMode], "executionMode").
-    returns(get(self(), typeRef[ExecutionMode], "executionMode")).
+
+  def executionMode(classHandle: ClassHandle) = MethodTemplate.method(typeRef[ExecutionMode], "executionMode").
+    returns(get(self(classHandle), typeRef[ExecutionMode], "executionMode")).
     build()
-  val EXECUTION_PLAN_DESCRIPTION = MethodTemplate.method(typeRef[InternalPlanDescription], "executionPlanDescription").
+
+  def executionPlanDescription(classHandle: ClassHandle) = MethodTemplate.method(typeRef[InternalPlanDescription], "executionPlanDescription").
     returns(cast( typeRef[InternalPlanDescription],
-      invoke(get(self(), typeRef[Provider[InternalPlanDescription]], "description"),
+      invoke(get(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description"),
                    method[Provider[InternalPlanDescription], Object]("get")))).
     build()
+
   val JAVA_COLUMNS = MethodTemplate.method(typeRef[util.List[String]], "javaColumns").
     returns(get(typeRef[util.List[String]], "COLUMNS")).
     build()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
@@ -46,7 +46,7 @@ import scala.collection.JavaConverters
 
 class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
-  private val generator = new CodeGenerator(GeneratedQueryStructure, CodeGenConfiguration(mode = SourceCodeMode))
+  private val generator = new CodeGenerator(GeneratedQueryStructure, CodeGenConfiguration(mode = ByteCodeMode))
 
   test("all nodes scan") { // MATCH a RETURN a
     //given

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructureTest.scala
@@ -227,8 +227,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         tracer = body.field(typeRef[QueryExecutionTracer], "tracer"),
         params = body.field(typeRef[util.Map[String, Object]], "params"),
         closeable = body.field(typeRef[SuccessfulCloseable], "closeable"),
-        success = body.generate(Templates.SUCCESS),
-        close = body.generate(Templates.CLOSE))
+        success = body.generate(Templates.success(body.handle())),
+        close = body.generate(Templates.close(body.handle())))
       // the "COLUMNS" static field
       body.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](Seq.empty))
       using(body.generate(MethodDeclaration.method(typeRef[Unit], "foo"))) { methodBody =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
@@ -17,13 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.spi.v3_1
+package org.neo4j.cypher.internal.spi.v3_2
 
 import java.util.Collections
 
-import org.neo4j.cypher.internal.compiler.v3_1.devNullLogger
-import org.neo4j.cypher.internal.compiler.v3_1.planner.logical.Cardinality
-import org.neo4j.cypher.internal.frontend.v3_1.{LabelId, RelTypeId}
+import org.neo4j.cypher.internal.compiler.v3_2.devNullLogger
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Cardinality
+import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, RelTypeId}
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.kernel.api.KernelTransaction.Type._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
@@ -17,16 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.spi.v3_1
+package org.neo4j.cypher.internal.spi.v3_2
 
 import java.net.URL
 import java.util.Collections
 
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v3_1.helpers.DynamicIterable
-import org.neo4j.cypher.internal.frontend.v3_1.SemanticDirection
+import org.neo4j.cypher.internal.compiler.v3_2.helpers.DynamicIterable
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
+import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
@@ -17,19 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.spi.v3_1.codegen
+package org.neo4j.cypher.internal.spi.v3_2.codegen
 
 import java.util
 
 import org.neo4j.codegen.source.{Configuration, SourceCode}
 import org.neo4j.codegen.{CodeGenerationStrategy, CodeGenerator, Expression, MethodDeclaration}
-import org.neo4j.cypher.internal.compiler.v3_1.codegen._
-import org.neo4j.cypher.internal.compiler.v3_1.codegen.ir.expressions.{CodeGenType, ReferenceType}
-import org.neo4j.cypher.internal.compiler.v3_1.executionplan.{Provider, SuccessfulCloseable}
-import org.neo4j.cypher.internal.compiler.v3_1.helpers._
-import org.neo4j.cypher.internal.compiler.v3_1.planDescription.InternalPlanDescription
-import org.neo4j.cypher.internal.compiler.v3_1.{ExecutionMode, TaskCloser}
-import org.neo4j.cypher.internal.frontend.v3_1.{SemanticDirection, SemanticTable, symbols}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen._
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, ReferenceType}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{Provider, SuccessfulCloseable}
+import org.neo4j.cypher.internal.compiler.v3_2.helpers._
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionMode, TaskCloser}
+import org.neo4j.cypher.internal.frontend.v3_2.{SemanticDirection, SemanticTable, symbols}
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator


### PR DESCRIPTION
Refactor so that an Expression knows about its type. This makes it possible to remove explicitly typed methods for addition, subtraction, multiplication and comparison operators which makes for a nicer API.

This is a rebase of https://github.com/neo4j/neo4j/pull/8268