### PR TITLE
NumberArrayFactory catches all errors in Auto

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -26,6 +26,7 @@ import org.neo4j.helpers.Exceptions;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
+import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
 
@@ -212,60 +213,60 @@ public interface NumberArrayFactory
         @Override
         public LongArray newLongArray( long length, long defaultValue, long base )
         {
-            OutOfMemoryError error = null;
+            Throwable error = null;
             for ( NumberArrayFactory candidate : candidates )
             {
                 try
                 {
                     return candidate.newLongArray( length, defaultValue, base );
                 }
-                catch ( OutOfMemoryError e )
+                catch ( Throwable e )
                 {   // Allright let's try the next one
                     error = e;
                 }
             }
-            throw error( length, 8, error );
+            throw launderedException( error( length, 8, error ) );
         }
 
         @Override
         public IntArray newIntArray( long length, int defaultValue, long base )
         {
-            OutOfMemoryError error = null;
+            Throwable error = null;
             for ( NumberArrayFactory candidate : candidates )
             {
                 try
                 {
                     return candidate.newIntArray( length, defaultValue, base );
                 }
-                catch ( OutOfMemoryError e )
+                catch ( Throwable e )
                 {   // Allright let's try the next one
                     error = e;
                 }
             }
-            throw error( length, 4, error );
+            throw launderedException( error( length, 4, error ) );
         }
 
         @Override
         public ByteArray newByteArray( long length, byte[] defaultValue, long base )
         {
-            OutOfMemoryError error = null;
+            Throwable error = null;
             for ( NumberArrayFactory candidate : candidates )
             {
                 try
                 {
                     return candidate.newByteArray( length, defaultValue, base );
                 }
-                catch ( OutOfMemoryError e )
+                catch ( Throwable e )
                 {   // Allright let's try the next one
                     error = e;
                 }
             }
-            throw error( length, defaultValue.length, error );
+            throw launderedException( error( length, defaultValue.length, error ) );
         }
 
-        private OutOfMemoryError error( long length, int itemSize, OutOfMemoryError error )
+        private Throwable error( long length, int itemSize, Throwable error )
         {
-            throw Exceptions.withMessage( error, format( "%s: Not enough memory available for allocating %s, tried %s",
+            return Exceptions.withMessage( error, format( "%s: Not enough memory available for allocating %s, tried %s",
                     error.getMessage(), bytes( length*itemSize ), Arrays.toString( candidates ) ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
@@ -24,8 +24,10 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -120,5 +122,24 @@ public class NumberArrayFactoryTest
         verify( lowMemoryFactory, times( 1 ) ).newIntArray( 1*KILO, -1, 0 );
         assertTrue( array instanceof HeapIntArray );
         assertEquals( 12345, array.get( 1*KILO-10 ) );
+    }
+
+    @Test
+    public void shouldEvenCatchOtherExceptionsAndTryNext() throws Exception
+    {
+        // GIVEN
+        NumberArrayFactory throwingMemoryFactory = mock( NumberArrayFactory.class );
+        doThrow( ArithmeticException.class ).when( throwingMemoryFactory )
+                .newByteArray( anyLong(), any( byte[].class ), anyInt() );
+        NumberArrayFactory factory = new NumberArrayFactory.Auto( throwingMemoryFactory, NumberArrayFactory.HEAP );
+
+        // WHEN
+        ByteArray array = factory.newByteArray( 1*KILO, new byte[4], 0 );
+        array.setInt( 1*KILO-10, 0, 12345 );
+
+        // THEN
+        verify( throwingMemoryFactory, times( 1 ) ).newByteArray( eq( 1*KILO ), any( byte[].class ), eq( 0L ) );
+        assertTrue( array instanceof HeapByteArray );
+        assertEquals( 12345, array.getInt( 1*KILO-10, 0 ) );
     }
 }


### PR DESCRIPTION
so that errors like ArithmeticException due to trying to allocate a HEAP
array which is bigger than 2^32-1 will be caught and the next factory
attempted instead.