### PR TITLE
Ensure idempotent append

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/RaftMembershipState.java
@@ -70,7 +70,7 @@ public class RaftMembershipState extends LifecycleAdapter
 {
     private MembershipEntry committed;
     private MembershipEntry appended;
-    long ordinal; // persistence ordinal must be increased each time we change committed or appended
+    private long ordinal; // persistence ordinal must be increased each time we change committed or appended
 
     public RaftMembershipState()
     {
@@ -86,6 +86,8 @@ public class RaftMembershipState extends LifecycleAdapter
 
     public boolean append( long logIndex, Set<MemberId> members )
     {
+        if ( appended != null && logIndex <= appended.logIndex() ) { return false; }
+
         if ( committed != null && logIndex <= committed.logIndex() )
         {
             return false;
@@ -140,8 +142,9 @@ public class RaftMembershipState extends LifecycleAdapter
         return appended != null;
     }
 
-    public Set<MemberId> getLatest()
+    Set<MemberId> getLatest()
     {
+
         return appended != null ? appended.members() :
                committed != null ? committed.members() : new HashSet<>();
     }
@@ -183,6 +186,11 @@ public class RaftMembershipState extends LifecycleAdapter
     public MembershipEntry committed()
     {
         return committed;
+    }
+
+    public long getOrdinal()
+    {
+        return ordinal;
     }
 
     public static class Marshal extends SafeStateMarshal<RaftMembershipState>

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -99,9 +99,7 @@ public class CoreServerModule
 
         final Supplier<DatabaseHealth> databaseHealthSupplier = dependencies.provideDependency( DatabaseHealth.class );
 
-        StateStorage<Long> lastFlushedStorage;
-
-        lastFlushedStorage = life.add(
+        StateStorage<Long> lastFlushedStorage = life.add(
                 new DurableStateStorage<>( fileSystem, clusterStateDirectory, LAST_FLUSHED_NAME,
                         new LongIndexMarshal(), config.get( CausalClusteringSettings.last_flushed_state_size ),
                         logProvider ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
@@ -46,7 +46,7 @@ public class RaftMachineLogTest
     RaftMachineBuilder.CommitListener commitListener;
 
     private MemberId myself = member( 0 );
-    private ReplicatedContent content = ReplicatedInteger.valueOf( 1 );
+    private ReplicatedContent content = valueOf( 1 );
     private RaftLog testEntryLog;
 
     private RaftMachine raft;
@@ -93,9 +93,9 @@ public class RaftMachineLogTest
     @Test
     public void shouldRemoveLaterEntryFromLogConflictingWithNewEntry() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 7 ) ) ); /* conflicting entry */
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 4 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 7 ) ) ); /* conflicting entry */
 
         // when
         ReplicatedInteger newData = valueOf( 11 );
@@ -110,17 +110,17 @@ public class RaftMachineLogTest
     @Test
     public void shouldNotTouchTheLogIfWeDoMatchEverywhere() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) ); // 0
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) ); // 1
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) ); // 5
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) ); // 10
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) ); // 0
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) ); // 1
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) ); // 5
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) ); // 10
 
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );
@@ -142,17 +142,17 @@ public class RaftMachineLogTest
     @Test
     public void shouldNotTouchTheLogIfWeDoNotMatchAnywhere() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
 
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );
@@ -174,17 +174,17 @@ public class RaftMachineLogTest
     @Test
     public void shouldTruncateOnFirstMismatchAndThenAppendOtherEntries() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
 
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );
@@ -219,17 +219,17 @@ public class RaftMachineLogTest
     @Test
     public void shouldNotTruncateLogIfHistoryDoesNotMatch() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
 
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );
@@ -249,17 +249,17 @@ public class RaftMachineLogTest
     @Test
     public void shouldTruncateLogIfFirstEntryMatchesAndSecondEntryMismatchesOnTerm() throws Exception
     {
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
-        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, valueOf( 99 ) ) );
 
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );


### PR DESCRIPTION
Reject any append for an entry that has already been appended.
This is in response to an infrequent soak testing issue where a single
member in the cluster would panic on recovery leading to operator
intervention.