### PR TITLE
Fix temp-copy settings

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -97,11 +97,11 @@ public class CopiedStoreRecovery extends LifecycleAdapter
                 .setKernelExtensions( kernelExtensions )
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore )
+                .setConfig( "dbms.backup.enabled", Settings.FALSE )
+                .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade,
                         config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
-                .setConfig( GraphDatabaseSettings.record_format,
-                        config.get( GraphDatabaseSettings.record_format ) )
                 .newGraphDatabase();
     }
 }


### PR DESCRIPTION
Disable backup and make sure logging files are stored inside the temp folder so they can be deleted.
Moreover remove unnecessary settings for record format since it is autodetected now.