### PR TITLE
Introduce PruningVarExpand operator

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -28,14 +28,6 @@ import scala.collection.JavaConverters._
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
-  test("should fail if columnAs refers to unknown column") {
-    val n1 = createNode()
-    val n2 = createNode()
-    val r = relate(n1, n2)
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n)-[r]->() RETURN n, r")
-    a[NotFoundException] should be thrownBy result.columnAs("m")
-  }
-
   // Not TCK material -- only one integer type
   test("comparing numbers should work nicely") {
     val n1 = createNode(Map("x" -> 50))
@@ -66,7 +58,6 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   }
 
   // Not TCK material -- shortestPath(), allShortestPaths()
-
   test("should return shortest path") {
     createNodes("A", "B")
     val r1 = relate("A" -> "KNOWS" -> "B")
@@ -242,7 +233,7 @@ return p""")
 
     val result = executeWithAllPlannersAndCompatibilityMode(query, "0" -> node1.getId, "1" -> node2.getId)
     graph.inTx(
-      result.toSet should equal(Set(Map("paths" -> new PathImpl(node1, r, node2)), Map("paths" -> new PathImpl(node2, r, node1))))
+      result.toSet should equal(Set(Map("paths" -> PathImpl(node1, r, node2)), Map("paths" -> PathImpl(node2, r, node1))))
     )
   }
 
@@ -429,7 +420,7 @@ return p""")
     val result = executeWithCostPlannerOnly("MATCH (n:User) WHERE exists(n.email) RETURN n")
 
     // then
-    result.toList should equal(List(Map("n" -> nodes(0)), Map("n" -> nodes(1))))
+    result.toList should equal(List(Map("n" -> nodes.head), Map("n" -> nodes(1))))
     result.executionPlanDescription().toString should include("NodeIndexScan")
   }
 
@@ -441,7 +432,7 @@ return p""")
     val result = executeWithCostPlannerOnly("MATCH (n:User) WHERE exists(n.email) AND n.email = 'me@mine' RETURN n")
 
     // then
-    result.toList should equal(List(Map("n" -> nodes(0))))
+    result.toList should equal(List(Map("n" -> nodes.head)))
     result.executionPlanDescription().toString should include("NodeIndexSeek")
     result.executionPlanDescription().toString should not include "NodeIndexScan"
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.pipes
+
+import org.neo4j.collection.primitive.{Primitive, PrimitiveLongObjectMap}
+import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
+import org.neo4j.cypher.internal.frontend.v3_2.{InternalException, SemanticDirection}
+import org.neo4j.graphdb.{Node, Relationship}
+
+case class PruningVarLengthExpandPipe(source: Pipe,
+                                      fromName: String,
+                                      toName: String,
+                                      types: LazyTypes,
+                                      dir: SemanticDirection,
+                                      min: Int,
+                                      max: Int,
+                                      filteringStep: VarLengthPredicate = VarLengthPredicate.NONE)
+                                     (val id: Id = new Id)
+                                     (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with Pipe {
+  self =>
+
+  assert(min <= max)
+
+  /*
+  This algorithm has been implemented using a state machine. This Cypher statement shows the static connections between the states.
+
+  create (ln:State  {name: "LoadNext", loads: "The start node of the expansion.", checksRelationshipUniqueness: false}),
+         (pre:State {name: "PrePruning", loads: "The relationship iterator of the nodes before min length has been reached.", checksRelationshipUniqueness: true}),
+         (pru:State {name: "Pruning", loads: "The relationship iterator of the nodes after min length has been reached.", checksRelationshipUniqueness: true}),
+         (nil:State {name: "Empty", signals: "End of the line. No more expansions to be done."}),
+         (ln)-[:GOES_TO {if: "Input iterator is not empty, load next input row and the start node from it"}]->(pre),
+         (ln)-[:GOES_TO {if: "Input iterator is not empty"}]->(nil),
+         (nil)-[:GOES_TO]->(nil),
+         (pre)-[:GOES_TO {if: "Next step is still less than min"}]->(pre),
+         (pre)-[:GOES_TO {if: "Next step is min or greater"}]->(pru),
+         (pru)-[:GOES_TO {if: "Next step is still less than max"}]->(pru)
+
+   Missing from this picture are the dynamic connections between the states - both `pre` and `pru` have a `whenEmptied`
+   field that is followed once the loaded iterator has been emptied.
+ */
+
+  object Constants {
+    val VERY_BIG_VALUE = 1000001
+  }
+
+  sealed trait State {
+    // Note that the ExecutionContext part here can be null.
+    // This code is used in a hot spot, and avoiding object creation is important.
+    def next(): (State, ExecutionContext)
+  }
+
+  case object Empty extends State {
+    override def next() = (this, null)
+  }
+
+  /**
+    * Performs regular DFS for traversal of the var-length paths up to length (min-1), mapping to one node of the path.
+    *
+    * @param whenEmptied The state to return to when this node is done
+    * @param node        The current node
+    * @param path        The path so far. Only the first pathLength elements are valid.
+    * @param pathLength  Length of the path so far
+    * @param state       The QueryState
+    * @param row         The current row we are adding reachable nodes to
+    * @param expandMap   maps NodeID -> FullExpandDepths
+    */
+  class PrePruningDFS(whenEmptied: State,
+                      node: Node,
+                      val path: Array[Long],
+                      val pathLength: Int,
+                      val state: QueryState,
+                      row: ExecutionContext,
+                      expandMap: PrimitiveLongObjectMap[FullExpandDepths]
+                     ) extends State with Expandable with CheckPath {
+
+    private var rels: Iterator[Relationship] = _
+
+    /*
+    Loads the relationship iterator of the nodes before min length has been reached.
+     */
+    override def next(): (State, ExecutionContext) = {
+
+      if (rels == null)
+        rels = expand(row, node)
+
+      while (rels.hasNext) {
+        val r = rels.next()
+        val relId = r.getId
+
+        if (!seenRelationshipInPath(relId)) {
+          val nextState: State = traverseRelationship(r, relId)
+
+          return nextState.next()
+        }
+      }
+
+      if (pathLength >= self.min)
+        (whenEmptied, row.newWith(self.toName -> node))
+      else
+        whenEmptied.next()
+    }
+
+    /**
+      * Creates the appropriate state for following a relationship to the next node.
+      */
+    private def traverseRelationship(r: Relationship, relId: Long): State = {
+      val nextNode = r.getOtherNode(node)
+      path(pathLength) = relId
+      val nextPathLength = pathLength + 1
+      if (nextPathLength >= self.min)
+        new PruningDFS(whenEmptied = this,
+          node = nextNode,
+          path = path,
+          pathLength = nextPathLength,
+          state = state,
+          row = row,
+          expandMap = expandMap,
+          updateMinFullExpandDepth = _ => {})
+      else
+        new PrePruningDFS(whenEmptied = this,
+          node = nextNode,
+          path = path,
+          pathLength = nextPathLength,
+          state = state,
+          row = row,
+          expandMap = expandMap)
+    }
+  }
+
+
+  /**
+    * Performs DFS travelsal, but omits traversing relationships that have been completely traversed (to the
+    * remaining depth) before.
+    *
+    * Pruning and full expand depths
+    * The full expand depth is an integer that denotes how deep a relationship has previously been explored. For
+    * example, a full expand depth of 2 would mean that all nodes that can be reached by following this relationship
+    * and maximally one more permitted relationship have already been visited. A relationship is permitted if is
+    * conforms to the var-length predicates (which is controlled at expand time), and the relationship is not already
+    * part of the current path.
+    *
+    * Before emitting a node (after relationship traversals), the PruningDFS updates the full expand depth of the
+    * incoming relationship on the previous node in the path. The full expand depth is computed as
+    * 1                 if the max path length is reached
+    * A_VERY_BIG_VALUE  if the node has no relationships except the incoming one
+    * d+1               otherwise, where d is the minimum outgoing full expand depth
+    *
+    * @param whenEmptied              The state to return to when this node is done
+    * @param node                     The current node
+    * @param path                     The path so far. Only the first pathLength elements are valid.
+    * @param pathLength               Length of the path so far
+    * @param state                    The QueryState
+    * @param row                      The current row we are adding reachable nodes to
+    * @param expandMap                maps NodeID -> FullExpandDepths
+    * @param updateMinFullExpandDepth Method that is called on node completion. Updates the FullExpandDepth for
+    *                                 incoming relationship in the previous node.
+    *
+    *                                 For this algorithm the incoming relationship is the one traversed to reach this
+    *                                 node, while outgoing relationships are all other relationships connected to this
+    *                                 node.
+    **/
+  class PruningDFS(whenEmptied: State,
+                   node: Node,
+                   val path: Array[Long],
+                   val pathLength: Int,
+                   val state: QueryState,
+                   row: ExecutionContext,
+                   expandMap: PrimitiveLongObjectMap[FullExpandDepths],
+                   updateMinFullExpandDepth: Int => Unit) extends State with Expandable with CheckPath {
+
+    import FullExpandDepths.UNINITIALIZED
+
+    var idx = 0
+    var fullExpandDepths: FullExpandDepths = UNINITIALIZED
+
+    override def next(): (State, ExecutionContext) = {
+
+      if (pathLength < self.max) {
+        if (fullExpandDepths == UNINITIALIZED)
+          initiateRecursion()
+
+        while (hasRelationships) {
+          val currentRelIdx = nextRelationship()
+          if (!haveFullyExploredTheRemainingDepthBefore(currentRelIdx)) {
+            val rel = fullExpandDepths.rels(currentRelIdx)
+            val relId = rel.getId
+            if (!seenRelationshipInPath(relId)) {
+              val nextNode = rel.getOtherNode(node)
+              path(pathLength) = relId
+              val nextState = new PruningDFS(whenEmptied = this,
+                node = nextNode,
+                path = path,
+                pathLength = pathLength + 1,
+                state = state,
+                row = row,
+                expandMap = expandMap,
+                updateMinFullExpandDepth = fullExpandDepths.depths(currentRelIdx) = _)
+              return nextState.next()
+            }
+          }
+        }
+
+        expandMap.put(node.getId, fullExpandDepths)
+      }
+
+      updateMinFullExpandDepth(currentFullExpandDepth)
+
+      (whenEmptied, row.newWith(self.toName -> node))
+    }
+
+    private def hasRelationships = idx < fullExpandDepths.rels.length
+
+    private def nextRelationship() = {
+      val i = idx
+      idx += 1
+      i
+    }
+
+    private def depthLeft = self.max - pathLength
+
+    private def haveFullyExploredTheRemainingDepthBefore(i: Int) = fullExpandDepths.depths(i) >= depthLeft
+
+    private def currentFullExpandDepth: Int =
+      if (pathLength == self.max) 1
+      else {
+        // The maximum amount of steps that have been fully explored is the minimum full expand depth of the
+        // next relationships. The incoming relationship is not included, as that is the relationship that will be
+        // updated.
+        val incomingRelationship = path(pathLength - 1)
+        fullExpandDepths.minOutgoingDepth(incomingRelationship) + 1
+      }
+
+    private def initiateRecursion() = {
+      fullExpandDepths = expandMap.get(node.getId)
+      if (fullExpandDepths == null) {
+        val relIter = expand(row, node)
+        fullExpandDepths = FullExpandDepths(relIter.toArray)
+      }
+    }
+  }
+
+  class LoadNext(private val input: Iterator[ExecutionContext], val state: QueryState) extends State with Expandable {
+
+    override def next(): (State, ExecutionContext) =
+      if (input.isEmpty) {
+        (Empty, null)
+      } else {
+        val row = input.next()
+        val nextState = new PrePruningDFS(whenEmptied = this,
+                                          node = getNodeFromRow(row),
+                                          path = new Array[Long](max),
+                                          pathLength = 0,
+                                          state = state,
+                                          row = row,
+                                          expandMap = Primitive.longObjectMap[FullExpandDepths]())
+        nextState.next()
+      }
+
+    private def getNodeFromRow(row: ExecutionContext): Node =
+      row.getOrElse(fromName, throw new InternalException(s"Expected a node on `$fromName`")).asInstanceOf[Node]
+  }
+
+  trait CheckPath {
+    def pathLength: Int
+
+    val path: Array[Long]
+
+    def seenRelationshipInPath(r: Long): Boolean = {
+      if (pathLength == 0) return false
+      var idx = 0
+      while (idx < pathLength) {
+        if (path(idx) == r) return true
+        idx += 1
+      }
+      false
+    }
+  }
+
+  trait Expandable {
+    def state: QueryState
+
+    /**
+      * List all relationships of a node, given the predicates of this pipe.
+      */
+    def expand(row: ExecutionContext, node: Node) = {
+      val relationships = state.query.getRelationshipsForIds(node, dir, types.types(state.query))
+      relationships.filter(r => {
+        filteringStep.filterRelationship(row, state)(r) &&
+          filteringStep.filterNode(row, state)(r.getOtherNode(node))
+      })
+    }
+  }
+
+  object FullExpandDepths {
+    def apply(rels: Array[Relationship]) = new FullExpandDepths(rels)
+
+    val UNINITIALIZED: FullExpandDepths = null
+  }
+
+  class FullExpandDepths(// all relationships that connect to this node, filtered by the var-length predicates
+                         val rels: Array[Relationship]) {
+    // The fully expanded depth for each relationship in rels
+    val depths = new Array[Int](rels.length)
+
+    /**
+      * Computes the minimum outgoing full expanded depth.
+      *
+      * @param incomingRelId id of the incoming relationship, which is omitted from this computation
+      * @return the full expand depth
+      */
+    def minOutgoingDepth(incomingRelId: Long): Int = {
+      var min = Constants.VERY_BIG_VALUE
+      var i = 0
+      while (i < rels.length) {
+        if (rels(i).getId != incomingRelId)
+          min = math.min(depths(i), min)
+        i += 1
+      }
+      min
+    }
+  }
+
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    state.decorator.registerParentPipe(this)
+
+    new Iterator[ExecutionContext] {
+
+      var (stateMachine, current) = new LoadNext(input, state).next()
+
+      override def hasNext = current != null
+
+      override def next() = {
+        if (current == null) {
+          // fail
+          Iterator.empty.next()
+        }
+        val temp = current
+        val (nextState, nextCurrent) = stateMachine.next()
+        stateMachine = nextState
+        current = nextCurrent
+        temp
+      }
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
@@ -26,14 +26,14 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.collection.mutable
 
-trait VarLenghtPredicate {
+trait VarLengthPredicate {
   def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean
   def filterRelationship(row: ExecutionContext, state:QueryState)(rel: Relationship): Boolean
 }
 
-object VarLenghtPredicate {
+object VarLengthPredicate {
 
-  val NONE = new VarLenghtPredicate {
+  val NONE = new VarLengthPredicate {
 
     override def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean = true
 
@@ -50,7 +50,7 @@ case class VarLengthExpandPipe(source: Pipe,
                                min: Int,
                                max: Option[Int],
                                nodeInScope: Boolean,
-                               filteringStep: VarLenghtPredicate = VarLenghtPredicate.NONE)
+                               filteringStep: VarLengthPredicate= VarLengthPredicate.NONE)
                               (val id: Id = new Id)
                               (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
   private def varLengthExpand(node: Node, state: QueryState, maxDepth: Option[Int],

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
@@ -26,14 +26,14 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.collection.mutable
 
-trait VarlenghtPredicate {
+trait VarLenghtPredicate {
   def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean
   def filterRelationship(row: ExecutionContext, state:QueryState)(rel: Relationship): Boolean
 }
 
-object VarlenghtPredicate {
+object VarLenghtPredicate {
 
-  val NONE = new VarlenghtPredicate {
+  val NONE = new VarLenghtPredicate {
 
     override def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean = true
 
@@ -50,10 +50,9 @@ case class VarLengthExpandPipe(source: Pipe,
                                min: Int,
                                max: Option[Int],
                                nodeInScope: Boolean,
-                               filteringStep: VarlenghtPredicate = VarlenghtPredicate.NONE)
+                               filteringStep: VarLenghtPredicate = VarLenghtPredicate.NONE)
                               (val id: Id = new Id)
                               (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
-
   private def varLengthExpand(node: Node, state: QueryState, maxDepth: Option[Int],
                               row: ExecutionContext): Iterator[(Node, Seq[Relationship])] = {
     val stack = new mutable.Stack[(Node, Seq[Relationship])]

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -426,7 +426,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     val nodeCommand = asCommand(nodePreds)
     val relCommand = asCommand(relPreds)
 
-    new VarlenghtPredicate {
+    new VarLenghtPredicate {
       override def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean = nodeCommand(row, state, node)
 
       override def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean = relCommand(row, state, rel)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -273,6 +273,10 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       case Optional(inner, protectedSymbols) =>
         OptionalPipe((inner.availableSymbols -- protectedSymbols).map(_.name), source)(id = id)
 
+      case PruningVarExpand(_, IdName(from), dir, types, IdName(toName), minLength, maxLength, predicates) =>
+        val predicate = varLengthPredicate(predicates)
+        PruningVarLengthExpandPipe(source, from, toName, LazyTypes(types), dir, minLength, maxLength, predicate)()
+
       case Sort(_, sortItems) =>
         SortPipe(source, sortItems.map(translateSortDescription))(id = id)
 
@@ -426,7 +430,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     val nodeCommand = asCommand(nodePreds)
     val relCommand = asCommand(relPreds)
 
-    new VarLenghtPredicate {
+    new VarLengthPredicate {
       override def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean = nodeCommand(row, state, node)
 
       override def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean = relCommand(row, state, rel)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -213,6 +213,10 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
       case ProjectEndpoints(_, IdName(relName), IdName(start), _, IdName(end), _, _, _, _) =>
         PlanDescriptionImpl(id, "ProjectEndpoints", children, Seq(KeyNames(Seq(relName, start, end))), variables)
 
+      case PruningVarExpand(_, IdName(fromName), dir, types, IdName(toName), min, max, predicates) =>
+        val expandSpec = ExpandExpression(fromName, "", types.map(_.name), toName, dir, minLength = min, maxLength = Some(max))
+        PlanDescriptionImpl(id, s"VarLengthExpand(Pruning)", children, Seq(expandSpec), variables)
+
       case _: RemoveLabels =>
         PlanDescriptionImpl(id, "RemoveLabels", children, Seq.empty, variables)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
@@ -61,6 +61,22 @@ case class VarExpand(left: LogicalPlan,
   override def availableSymbols = left.availableSymbols + relName + to
 }
 
+case class PruningVarExpand(left: LogicalPlan,
+                            from: IdName,
+                            dir: SemanticDirection,
+                            types: Seq[RelTypeName],
+                            to: IdName,
+                            minLength: Int,
+                            maxLength: Int,
+                            predicates: Seq[(Variable, Expression)] = Seq.empty)
+                           (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
+
+  override val lhs = Some(left)
+  override def rhs = None
+
+  override def availableSymbols = left.availableSymbols + to
+}
+
 sealed trait ExpansionMode
 case object ExpandAll extends ExpansionMode
 case object ExpandInto extends ExpansionMode

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
@@ -24,10 +24,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, RelTypeName, Variable}
 import org.neo4j.cypher.internal.ir.v3_2.{IdName, VarPatternLength}
 
-sealed trait ExpansionMode
-case object ExpandAll extends ExpansionMode
-case object ExpandInto extends ExpansionMode
-
 case class Expand(left: LogicalPlan,
                   from: IdName,
                   dir: SemanticDirection,
@@ -35,23 +31,18 @@ case class Expand(left: LogicalPlan,
                   to: IdName, relName: IdName,
                   mode: ExpansionMode = ExpandAll)(val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LazyLogicalPlan {
-
-  val lhs = Some(left)
-  def rhs = None
-
-  def availableSymbols: Set[IdName] = left.availableSymbols + relName + to
+  override val lhs = Some(left)
+  override def rhs = None
+  override def availableSymbols: Set[IdName] = left.availableSymbols + relName + to
 }
 
 case class OptionalExpand(left: LogicalPlan, from: IdName, dir: SemanticDirection, types: Seq[RelTypeName], to: IdName, relName: IdName, mode: ExpansionMode = ExpandAll, predicates: Seq[Expression] = Seq.empty)
                          (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
-  val lhs = Some(left)
-  def rhs = None
-
-  def availableSymbols: Set[IdName] = left.availableSymbols + relName + to
+  override val lhs = Some(left)
+  override def rhs = None
+  override def availableSymbols = left.availableSymbols + relName + to
 }
 
-// TODO: Support proper var length handling in Ronja again
-// TODO: Fix cost and cardinality calculation for this
 case class VarExpand(left: LogicalPlan,
                      from: IdName,
                      dir: SemanticDirection,
@@ -64,8 +55,12 @@ case class VarExpand(left: LogicalPlan,
                      predicates: Seq[(Variable, Expression)] = Seq.empty)
                     (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
 
-  val lhs = Some(left)
-  def rhs = None
+  override val lhs = Some(left)
+  override def rhs = None
 
-  def availableSymbols: Set[IdName] = left.availableSymbols + relName + to
+  override def availableSymbols = left.availableSymbols + relName + to
 }
+
+sealed trait ExpansionMode
+case object ExpandAll extends ExpansionMode
+case object ExpandInto extends ExpansionMode

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -36,7 +36,8 @@ case class LogicalPlanRewriter(rewriterSequencer: String => RewriterStepSequence
     simplifyEquality,
     unnestOptional,
     predicateRemovalThroughJoins,
-    removeIdenticalPlans
+    removeIdenticalPlans,
+    pruningVarExpander
   ).rewriter)
 
   def apply(that: AnyRef) = instance(that)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
+import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, FunctionInvocation}
+import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, topDown}
+
+import scala.collection.mutable
+
+case object pruningVarExpander extends Rewriter {
+
+  private def findDistinctSet(plan: LogicalPlan): Set[LogicalPlan] = {
+
+    def collectDistinctSet(plan: LogicalPlan,
+                           distinctBy: Option[Set[String]],
+                           distinctSet: mutable.Set[VarExpand]): Unit = {
+      val lowerDistinctLand: Option[Set[String]] = plan match {
+        case Aggregation(left, groupExpr, aggrExpr) if aggrExpr.values.forall(isDistinct) =>
+          val variablesInTheDistinctSet = groupExpr.values.flatMap(_.dependencies.map(_.name)).toSet
+          Some(variablesInTheDistinctSet)
+
+        case expand: VarExpand
+          if distinctBy.nonEmpty && !distinctNeedsRelsFromExpand(distinctBy, expand) && expand.length.max.nonEmpty =>
+          distinctSet += expand
+          distinctBy
+
+        case _: Selection |
+             _: Expand |
+             _: VarExpand |
+             _: Apply |
+             _: Optional |
+             _: Projection =>
+          distinctBy
+
+        case _ =>
+          None
+      }
+
+      plan.lhs.foreach(collectDistinctSet(_, lowerDistinctLand, distinctSet))
+      plan.rhs.foreach(collectDistinctSet(_, lowerDistinctLand, distinctSet))
+    }
+
+    val distinctSet = mutable.Set[VarExpand]()
+    collectDistinctSet(plan, distinctBy = None, distinctSet)
+    distinctSet.toSet
+  }
+
+  // When the distinct horizon needs the path that includes the var length relationship,
+  // we can't use DistinctVarExpand - we need all the paths
+  def distinctNeedsRelsFromExpand(inDistinctLand: Option[Set[String]], expand: VarExpand): Boolean =
+  inDistinctLand.forall(vars => vars(expand.relName.name))
+
+  private def isDistinct(e: Expression) = e match {
+    case f: FunctionInvocation => f.distinct
+    case _ => false
+  }
+
+  override def apply(input: AnyRef) = {
+    input match {
+      case plan: LogicalPlan =>
+        val distinctSet = findDistinctSet(plan)
+
+        val innerRewriter = topDown(Rewriter.lift {
+          case expand@VarExpand(lhs, fromId, dir, projectedDir, relTypes, toId, relId, length, _, predicates) if distinctSet(expand) =>
+            PruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
+        })
+        plan.endoRewrite(innerRewriter)
+
+      case _ => input
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
@@ -689,7 +689,7 @@ class VarLengthExpandPipeTest extends CypherFunSuite {
     val left = newMockedPipe(SymbolTable(Map("a" -> CTNode)))
     when(left.createResults(queryState)).thenReturn(Iterator(row("a" -> firstNode)))
 
-    val filteringStep = new VarlenghtPredicate {
+    val filteringStep = new VarLenghtPredicate {
 
       override def filterNode(row: ExecutionContext,
                               state: QueryState)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
@@ -689,7 +689,7 @@ class VarLengthExpandPipeTest extends CypherFunSuite {
     val left = newMockedPipe(SymbolTable(Map("a" -> CTNode)))
     when(left.createResults(queryState)).thenReturn(Iterator(row("a" -> firstNode)))
 
-    val filteringStep = new VarLenghtPredicate {
+    val filteringStep = new VarLengthPredicate {
 
       override def filterNode(row: ExecutionContext,
                               state: QueryState)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.v3_2.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.ir.v3_2.{IdName, VarPatternLength}
+
+class PruningVarExpanderTest extends CypherFunSuite with LogicalPlanningTestSupport {
+  test("simples possible query that can use DistinctVarExpand") {
+    // Simplest query:
+    // match (a)-[*1..3]->(b) return distinct b
+
+    val fromId = IdName("from")
+    val allNodes = AllNodesScan(fromId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val toId = IdName("to")
+    val relId = IdName("r")
+    val originalExpand = VarExpand(allNodes, fromId, dir, dir, Seq.empty, toId, relId, length)(solved)
+    val input = Aggregation(originalExpand, Map("to" -> Variable("to")(pos)), Map.empty)(solved)
+
+    val rewrittenExpand = PruningVarExpand(allNodes, fromId, dir, Seq.empty, toId, 1, 3)(solved)
+    val expectedOutput = Aggregation(rewrittenExpand, Map("to" -> Variable("to")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(expectedOutput)
+  }
+
+  test("query with distinct aggregation") {
+    // Simplest query:
+    // match (from)-[*1..3]->(to) return count(distinct to)
+
+    val fromId = IdName("from")
+    val allNodes = AllNodesScan(fromId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val toId = IdName("to")
+    val relId = IdName("r")
+    val originalExpand = VarExpand(allNodes, fromId, dir, dir, Seq.empty, toId, relId, length)(solved)
+    val aggregatingExpression = FunctionInvocation(functionName = FunctionName("count")(pos), distinct = true, args = IndexedSeq(Variable("to")(pos)))(pos)
+    val input = Aggregation(originalExpand, Map.empty, Map("x" -> aggregatingExpression))(solved)
+
+    val rewrittenExpand = PruningVarExpand(allNodes, fromId, dir, Seq.empty, toId, 1, 3)(solved)
+    val expectedOutput = Aggregation(rewrittenExpand, Map.empty, Map("x" -> aggregatingExpression))(solved)
+
+    rewrite(input) should equal(expectedOutput)
+  }
+
+  test("Simple query that filters between expand and distinct") {
+    // Simplest query:
+    // match (a)-[*1..3]->(b:X) return distinct b
+
+    val fromId = IdName("from")
+    val allNodes = AllNodesScan(fromId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val toId = IdName("to")
+    val relId = IdName("r")
+    val originalExpand = VarExpand(allNodes, fromId, dir, dir, Seq.empty, toId, relId, length)(solved)
+    val predicate = HasLabels(Variable("to")(pos), Seq(LabelName("X")(pos)))(pos)
+    val filter = Selection(Seq(predicate), originalExpand)(solved)
+    val input = Aggregation(filter, Map("to" -> Variable("to")(pos)), Map.empty)(solved)
+
+    val rewrittenExpand = PruningVarExpand(allNodes, fromId, dir, Seq.empty, toId, 1, 3)(solved)
+    val filterAfterRewrite = Selection(Seq(predicate), rewrittenExpand)(solved)
+    val expectedOutput = Aggregation(filterAfterRewrite, Map("to" -> Variable("to")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(expectedOutput)
+  }
+
+  test("Query that aggregates before making the result DISTINCT") {
+    // Simplest query:
+    // match (a)-[:R*1..3]->(b) with count(*) as count return distinct count
+
+    val fromId = IdName("from")
+    val allNodes = AllNodesScan(fromId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val toId = IdName("to")
+    val relId = IdName("r")
+    val originalExpand = VarExpand(allNodes, fromId, dir, dir, Seq.empty, toId, relId, length)(solved)
+    val aggregate = Aggregation(originalExpand, Map.empty, Map("count" -> CountStar()(pos)))(solved)
+    val input = Aggregation(aggregate, Map("to" -> Variable("to")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(input)
+  }
+
+  test("Double var expand with distinct result") {
+    // Simplest query:
+    // match (a)-[:R*1..3]->(b)-[:T*1..3]->(c) return distinct c
+
+    val aId = IdName("a")
+    val relRId = IdName("r")
+    val bId = IdName("b")
+    val relTId = IdName("t")
+    val cId = IdName("c")
+    val allNodes = AllNodesScan(aId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val originalExpand = VarExpand(allNodes, aId, dir, dir, Seq(RelTypeName("R")(pos)), bId, relRId, length)(solved)
+    val originalExpand2 = VarExpand(originalExpand, bId, dir, dir, Seq(RelTypeName("T")(pos)), cId, relTId, length)(solved)
+    val input = Aggregation(originalExpand2, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    val rewrittenExpand = PruningVarExpand(allNodes, aId, dir, Seq(RelTypeName("R")(pos)), bId, 1, 3)(solved)
+    val rewrittenExpand2 = PruningVarExpand(rewrittenExpand, bId, dir, Seq(RelTypeName("T")(pos)), cId, 1, 3)(solved)
+    val expectedOutput = Aggregation(rewrittenExpand2, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(expectedOutput)
+  }
+
+  test("var expand followed by normal expand") {
+    // Simplest query:
+    // match (a)-[:R*1..3]->(b)-[:T]->(c) return distinct c
+
+    val aId = IdName("a")
+    val relRId = IdName("r")
+    val bId = IdName("b")
+    val relTId = IdName("t")
+    val cId = IdName("c")
+    val allNodes = AllNodesScan(aId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val originalExpand = VarExpand(allNodes, aId, dir, dir, Seq(RelTypeName("R")(pos)), bId, relRId, length)(solved)
+    val originalExpand2 = Expand(originalExpand, bId, dir, Seq(RelTypeName("T")(pos)), cId, relTId)(solved)
+    val input = Aggregation(originalExpand2, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    val rewrittenExpand = PruningVarExpand(allNodes, aId, dir, Seq(RelTypeName("R")(pos)), bId, 1, 3)(solved)
+    val rewrittenExpand2 = Expand(rewrittenExpand, bId, dir, Seq(RelTypeName("T")(pos)), cId, relTId)(solved)
+    val expectedOutput = Aggregation(rewrittenExpand2, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(expectedOutput)
+  }
+
+  test("optional match can be solved with DistinctVarExpand") {
+    /* Simplest query:
+       match (a) optional match (a)-[:R*1..3]->(b)-[:T]->(c) return distinct c
+       in logical plans:
+
+              distinct1                            distinct2
+                 |                                    |
+               apply1                               apply2
+               /   \                                /   \
+       all-nodes   optional1      ===>       all-nodes  optional2
+                     \                                    \
+                     var-length-expand                   distinct-var-expand
+                       \                                    \
+                       argument                            argument
+    */
+
+    val aId = IdName("a")
+    val relRId = IdName("r")
+    val bId = IdName("b")
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+
+    val allNodes = AllNodesScan(aId, Set.empty)(solved)
+    val argument = Argument(Set(aId))(solved)()
+    val originalExpand = VarExpand(argument, aId, dir, dir, Seq(RelTypeName("R")(pos)), bId, relRId, length)(solved)
+    val optional1 = Optional(originalExpand, Set(aId))(solved)
+    val apply1 = Apply(allNodes, optional1)(solved)
+    val distinct1 = Aggregation(apply1, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    val rewrittenExpand = PruningVarExpand(argument, aId, dir, Seq(RelTypeName("R")(pos)), bId, 1, 3)(solved)
+    val optional2 = Optional(rewrittenExpand, Set(aId))(solved)
+    val apply2 = Apply(allNodes, optional2)(solved)
+    val distinct2 = Aggregation(apply2, Map("c" -> Variable("c")(pos)), Map.empty)(solved)
+
+    rewrite(distinct1) should equal(distinct2)
+  }
+
+  test("should not rewrite when doing non-distinct aggregation") {
+    // Should not be rewritten since it's asking for a count of all paths leading to a node
+    // match (a)-[*1..3]->(b) return b, count(*)
+
+    val fromId = IdName("from")
+    val allNodes = AllNodesScan(fromId, Set.empty)(solved)
+    val dir = SemanticDirection.BOTH
+    val length = VarPatternLength(1, Some(3))
+    val toId = IdName("to")
+    val relId = IdName("r")
+    val originalExpand = VarExpand(allNodes, fromId, dir, dir, Seq.empty, toId, relId, length)(solved)
+    val input = Aggregation(originalExpand, Map("r" -> Variable("r")(pos)), Map.empty)(solved)
+
+    rewrite(input) should equal(input)
+  }
+
+  private def rewrite(p: LogicalPlan): LogicalPlan =
+    p.endoRewrite(pruningVarExpander)
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipeTest.scala
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.pipes
+
+import org.neo4j.cypher.GraphDatabaseFunSuite
+import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_2.QueryStateHelper.queryStateFrom
+import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{Literal, Property, Variable}
+import org.neo4j.cypher.internal.compiler.v3_2.commands.predicates.{Equals, Predicate, True}
+import org.neo4j.cypher.internal.compiler.v3_2.commands.values.UnresolvedProperty
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.kernel.api.KernelTransaction.Type
+import org.neo4j.kernel.api.security.SecurityContext
+
+import scala.collection.immutable.IndexedSeq
+import scala.util.Random
+
+class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
+  val types = LazyTypes(Seq.empty[String])
+  implicit val pipeMonitor = mock[PipeMonitor]
+
+  test("node without any relationships produces empty result") {
+    val n1 = createNode()
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState) shouldBe empty
+    }
+  }
+
+  test("node with a single relationships produces a single output node") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2)
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList shouldBe List(Map("from" -> n1, "to" -> n2))
+    }
+  }
+
+  test("node with a single relationships produces a two output nodes if minLength is zero") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2)
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 0, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList shouldBe List(
+        Map("from" -> n1, "to" -> n2),
+        Map("from" -> n1, "to" -> n1)
+      )
+    }
+  }
+
+  test("long path, take the middle of it") {
+
+    val nodes = (0 to 10) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes.head)))
+    val min = 3
+    val max = 5
+    val pipeUnderTest = createPipe(src, min, max, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).map(_.apply("to")).toSet should equal(
+        nodes.slice(min, max + 1).toSet // Slice is excluding the end, whereas ()-[*3..5]->() is including
+      )
+    }
+  }
+
+  test("self-loop in path is OK") {
+    /*
+    The only path in the graph starting from n1 that is two relationships long includes a self loop.
+    (n1)-[0]->(n1)-[1]->(n2) or (n1)-[1]->(n2)-[1]->(n1)
+     */
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n1)
+    relate(n1, n2)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 2, 2, SemanticDirection.BOTH)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("var-length with relationship predicate") {
+    /*
+    (n1)-[0 {k:1}]->(n2)-[1]->(n3)
+    MATCH (n1)-[r*1..2 {k:1}]-(n) RETURN DISTINCT n
+     */
+
+    val n1 = createNode()
+    val n2 = createNode()
+    val n3 = createNode()
+    relate(n1, n2, "k" -> 1)
+    relate(n2, n3, "k" -> 2)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val predicate = Equals(Property(Variable("r"), UnresolvedProperty("k")), Literal(1))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, predicate, True())
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("var-length with node predicate") {
+    /*
+    (n1)-[0]->(n2 {k:1})-[1]->(n3)
+    MATCH p = (n1)-[r*1..2]-(n) WHERE all(n IN nodes(p) | n.k=1) RETURN DISTINCT n
+     */
+
+    val n1 = createNode()
+    val n2 = createNode("k" -> 1)
+    val n3 = createNode()
+    relate(n1, n2)
+    relate(n2, n3)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val predicate = Equals(Property(Variable("to"), UnresolvedProperty("k")), Literal(1))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, True(), predicate)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("two ways to get to the same node - one inside and one outside the max") {
+    /*
+    (x)-[1]->()-[2]->()-[3]->()-[4]->(y)-[4]->(z)
+      \                              ^
+       \----------------------------/
+
+     */
+    val nodes = (0 to 5) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val n1 = nodes.head
+    val n4 = nodes(4)
+    val n5 = nodes(5)
+    relate(n1, n4)
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes.head)))
+    val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(nodes.tail.map(n => Map("from" -> n1, "to" -> n)).toSet)
+    }
+  }
+
+  test("multiple start nodes") {
+    val nodes = (0 to 10) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes(1)), Map("from" -> nodes(5))))
+    val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(Set(
+        Map("from" -> nodes(1), "to" -> nodes(2)),
+        Map("from" -> nodes(1), "to" -> nodes(3)),
+        Map("from" -> nodes(1), "to" -> nodes(4)),
+        Map("from" -> nodes(1), "to" -> nodes(5)),
+        Map("from" -> nodes(5), "to" -> nodes(6)),
+        Map("from" -> nodes(5), "to" -> nodes(7)),
+        Map("from" -> nodes(5), "to" -> nodes(8)),
+        Map("from" -> nodes(5), "to" -> nodes(9))
+      ))
+    }
+  }
+
+  private def setUpGraph(seed: Long, POPULATION: Int, friendCount: Int = 50): IndexedSeq[Node] = {
+    val r = new Random(seed)
+
+    var tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+    var count = 0
+
+    def checkAndSwitch() = {
+      count += 1
+      if (count == 1000) {
+        tx.success()
+        tx.close()
+        tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+        count = 0
+      }
+    }
+
+    val nodes = (0 to POPULATION) map { _ =>
+      checkAndSwitch()
+      createNode()
+    }
+
+    for {
+      n1 <- nodes
+      friends = r.nextInt(friendCount)
+      friendIdx <- 0 to friends
+      n2 = nodes(r.nextInt(POPULATION))
+    } {
+      checkAndSwitch()
+      relate(n1, n2)
+    }
+
+    tx.success()
+    tx.close()
+
+    nodes
+  }
+
+  private def testNode(startNode: Node, r: Random) = {
+    val min = r.nextInt(3)
+    val max = min + 1 + r.nextInt(3)
+    val sourcePipe = new FakePipe(Iterator(Map("from" -> startNode)))
+    val sourcePipe2 = new FakePipe(Iterator(Map("from" -> startNode)))
+    val pipeUnderTest = createPipe(sourcePipe, min, max, SemanticDirection.BOTH)
+    val pipe = VarLengthExpandPipe(sourcePipe2, "from", "r", "to", SemanticDirection.BOTH, SemanticDirection.BOTH, types, min, Some(max), nodeInScope = false)()
+    val comparison = DistinctPipe(pipe, Map("from" -> Variable("from"), "to" -> Variable("to")))()
+
+    val distinctExpand = graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList
+    }
+
+    val distinctAfterVarLengthExpand = graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      comparison.createResults(queryState).toList
+    }
+
+    val oldThing = distinctAfterVarLengthExpand.toSet
+    val newThing = distinctExpand.toSet
+    if (oldThing != newThing) {
+      val missingFromNew = oldThing -- newThing
+      val shouldNotBeInNew = newThing -- oldThing
+      var message =
+        s"""startNode: $startNode
+            |size of old result ${oldThing.size}
+            |size of new result ${newThing.size}
+            |min $min
+            |max $max
+            |""".stripMargin
+      if(missingFromNew.nonEmpty) {
+        message += s"missing from new result: ${missingFromNew.mkString(",")}\n"
+      }
+      if(shouldNotBeInNew.nonEmpty) {
+        message += s"should not be in new result: ${shouldNotBeInNew.mkString(",")}\n"
+      }
+
+      fail(message)
+    }
+  }
+
+  test("random and compare") {
+    // runs DistinctVarExpand and VarExpand side-by-side and checks that the reachable nodes are the same
+    val POPULATION: Int = 1 * 1000
+    val seed = System.currentTimeMillis()
+    val nodes = setUpGraph(seed, POPULATION, 20)
+    val r = new Random
+
+    val start = System.currentTimeMillis()
+
+    while(System.currentTimeMillis() - start < 10000) {
+      withClue("seed used: " + seed) {
+        testNode(nodes(r.nextInt(POPULATION)), r)
+      }
+    }
+  }
+
+  private def createPipe(src: FakePipe, min: Int, max: Int, outgoing: SemanticDirection) = {
+    PruningVarLengthExpandPipe(src, "from", "to", types, outgoing, min, max)()
+  }
+
+  private def createPipe(src: FakePipe,
+                         min: Int,
+                         max: Int,
+                         outgoing: SemanticDirection,
+                         relationshipPredicate: Predicate,
+                         nodePredicate: Predicate) = {
+    PruningVarLengthExpandPipe(src, "from", "to", types, outgoing, min, max, new VarLengthPredicate {
+      override def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean = {
+        row("to") = node
+        val result = nodePredicate.isTrue(row)(state)
+        row.remove("to")
+        result
+      }
+
+      override def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean = {
+        row("r") = rel
+        val result = relationshipPredicate.isTrue(row)(state)
+        row.remove("r")
+        result
+      }
+    })()
+  }
+}


### PR DESCRIPTION
This new operator can be used to solve queries where only the distinct end-nodes of a variable length path is needed, such as in this query:

```
MATCH (:Person {id: 42})-[*1..5]->(contact)
RETURN DISTINCT contact
```
