### PR TITLE
More cache friendly traversal iterators

### DIFF
--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
@@ -120,7 +120,7 @@ public class TestAStar extends Neo4jAlgoTestCase
         graph.makeEdge( "c", "end", "length", 4L );
         graph.makeEdge( "start", "d", "length", (short)2 );
         graph.makeEdge( "d", "e", "length", (byte)3 );
-        graph.makeEdge( "e", "end", "length", (int)2 );
+        graph.makeEdge( "e", "end", "length", 2 );
 
         // WHEN
         WeightedPath path = finder.findSinglePath( start, end );
@@ -222,7 +222,7 @@ public class TestAStar extends Neo4jAlgoTestCase
         WeightedPath path = traversalFinder.findSinglePath( nodeA, nodeC );
         assertEquals( (Double) 5.0D, (Double) path.weight() );
         assertPathDef( path, "A", "B", "C" );
-        assertEquals( MapUtil.<Node,Double>genericMap( nodeA, 0D, nodeB, 2D, nodeC, 5D ), seenBranchStates );
+        assertEquals( MapUtil.<Node,Double>genericMap( nodeA, 0D, nodeB, 2D ), seenBranchStates );
     }
 
     @Test

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIterator.java
@@ -27,11 +27,12 @@ import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.storageengine.api.RelationshipItem;
 
 /**
- * Convert a {@link RelationshipItem} cursor into a {@link RelationshipIterator} that implements {@link Resource).
+ * Convert a {@link RelationshipItem} cursor into a {@link RelationshipIterator} that implements {@link Resource}.
  */
 public class CursorRelationshipIterator implements RelationshipIterator, Resource
 {
     private Cursor<RelationshipItem> cursor;
+    private boolean hasDeterminedNext;
     private boolean hasNext;
 
     private long id;
@@ -42,7 +43,6 @@ public class CursorRelationshipIterator implements RelationshipIterator, Resourc
     public CursorRelationshipIterator( Cursor<RelationshipItem> resourceCursor )
     {
         cursor = resourceCursor;
-        hasNext = nextCursor();
     }
 
     private boolean nextCursor()
@@ -62,6 +62,11 @@ public class CursorRelationshipIterator implements RelationshipIterator, Resourc
     @Override
     public boolean hasNext()
     {
+        if ( !hasDeterminedNext )
+        {
+            hasNext = nextCursor();
+            hasDeterminedNext = true;
+        }
         return hasNext;
     }
 
@@ -83,7 +88,7 @@ public class CursorRelationshipIterator implements RelationshipIterator, Resourc
             }
             finally
             {
-                hasNext = nextCursor();
+                hasDeterminedNext = false;
             }
         }
         throw new NoSuchElementException();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
@@ -125,14 +125,19 @@ class TraversalBranchImpl implements TraversalBranch
         setEvaluation( context.evaluate( this, null ) );
     }
 
+    @Override
     public void initialize( final PathExpander expander, TraversalContext metadata )
     {
         evaluate( metadata );
-        expandRelationships( expander );
     }
 
+    @Override
     public TraversalBranch next( PathExpander expander, TraversalContext context )
     {
+        if ( relationships == null )
+        {
+            expandRelationships( expander );
+        }
         while ( relationships.hasNext() )
         {
             Relationship relationship = relationships.next();
@@ -172,16 +177,19 @@ class TraversalBranchImpl implements TraversalBranch
         relationships = PRUNED_ITERATOR;
     }
 
+    @Override
     public int length()
     {
         return depthAndEvaluationBits&0x3FFFFFFF;
     }
 
+    @Override
     public TraversalBranch parent()
     {
         return this.parent;
     }
 
+    @Override
     public int expanded()
     {
         return expandedCount;
@@ -205,6 +213,7 @@ class TraversalBranchImpl implements TraversalBranch
         setEvaluation( Evaluation.of( includes() & eval.includes(), continues() & eval.continues() ) );
     }
 
+    @Override
     public Node startNode()
     {
         return findStartBranch().endNode();
@@ -220,16 +229,19 @@ class TraversalBranchImpl implements TraversalBranch
         return branch;
     }
 
+    @Override
     public Node endNode()
     {
         return source;
     }
 
+    @Override
     public Relationship lastRelationship()
     {
         return howIGotHere;
     }
 
+    @Override
     public Iterable<Relationship> relationships()
     {
         LinkedList<Relationship> relationships = new LinkedList<Relationship>();
@@ -271,6 +283,7 @@ class TraversalBranchImpl implements TraversalBranch
         };
     }
 
+    @Override
     public Iterable<Node> nodes()
     {
         LinkedList<Node> nodes = new LinkedList<Node>();
@@ -313,6 +326,7 @@ class TraversalBranchImpl implements TraversalBranch
         };
     }
 
+    @Override
     public Iterator<PropertyContainer> iterator()
     {
         LinkedList<PropertyContainer> entities = new LinkedList<PropertyContainer>();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CursorRelationshipIteratorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.impl.util.collection.ContinuableArrayCursor;
+import org.neo4j.storageengine.api.RelationshipItem;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class CursorRelationshipIteratorTest
+{
+    @Test
+    public void shouldLazilyGoToNext() throws Exception
+    {
+        // GIVEN
+        Cursor<RelationshipItem> cursor = spy( new ContinuableArrayCursor<>( new Supplier<RelationshipItem[]>()
+        {
+            private boolean first = true;
+
+            @Override
+            public RelationshipItem[] get()
+            {
+                if ( first )
+                {
+                    first = false;
+                    return new RelationshipItem[] {mock( RelationshipItem.class ), mock( RelationshipItem.class )};
+                }
+                return null;
+            }
+        } ) );
+
+        try ( CursorRelationshipIterator iterator = new CursorRelationshipIterator( cursor ) )
+        {
+            verifyZeroInteractions( cursor );
+
+            // WHEN/THEN
+            assertTrue( iterator.hasNext() );
+            verify( cursor, times( 1 ) ).next();
+            iterator.next();
+            verify( cursor, times( 1 ) ).next();
+
+            assertTrue( iterator.hasNext() );
+            verify( cursor, times( 2 ) ).next();
+            iterator.next();
+            verify( cursor, times( 2 ) ).next();
+
+            assertFalse( iterator.hasNext() );
+            verify( cursor, times( 3 ) ).next();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.traversal;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.traversal.BranchState;
+import org.neo4j.graphdb.traversal.TraversalBranch;
+import org.neo4j.graphdb.traversal.TraversalContext;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
+
+public class TraversalBranchImplTest
+{
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldExpandOnFirstAccess() throws Exception
+    {
+        // GIVEN
+        TraversalBranch parent = mock( TraversalBranch.class );
+        Node source = mock( Node.class );
+        TraversalBranchImpl branch = new TraversalBranchImpl( parent, source );
+        @SuppressWarnings( "rawtypes" )
+        PathExpander expander = mock( PathExpander.class );
+        when( expander.expand( eq( branch ), any( BranchState.class ) ) ).thenReturn( Collections.emptySet() );
+        TraversalContext context = mock( TraversalContext.class );
+        when( context.evaluate( eq( branch ), any( BranchState.class ) ) ).thenReturn( INCLUDE_AND_CONTINUE );
+
+        // WHEN initializing
+        branch.initialize( expander, context );
+
+        // THEN the branch should not be expanded
+        verifyZeroInteractions( source );
+
+        // and WHEN actually traversing from it
+        branch.next( expander, context );
+
+        // THEN we should expand it
+        verify( expander ).expand( any( Path.class ), any( BranchState.class ) );
+    }
+}


### PR DESCRIPTION
By changing two things:
- No eager relationship cursor initialization. Previously a CursorRelationshipIterator was always
  one step ahead, i.e. when constructing it the first item was read, when going to the first item
  the second item was read, a.s.o. In a traversal scenario this would mean that many of the
  eagerly read relationships would be read in vain because the paths would never even be explored.
- No eager expansion of traversal branches. Previously a TraversalBranch would be expanded when
  initializing it, i.e. when simply discovering it. Decision about when to actually traverse to it
  would be made by a BranchOrderingPolicy. To immediately expand a discovered path would only be  benefitial if that branch would be selected as the immediate next branch, otherwise it would
  - (a) be potentially an unnecessary read (of one node, but also its first relationship given the
    previously eager relationship cursor as explained above
  - (b) remove some of the benefits of physically co-located relationships, again depending on
    branch ordering, but would remove the benefits in all scenarios

All in all this change results in less node/relationship records read and opportunity to read
relationship chains more consecutively without interleaved "other" records, during a traversal.
Effects of these optimizations depend on the dataset and traversal, but worst case is the same or
slightly better and best case is much better.

As an example in a breadth-first outgoing traversal with outgoing relationships physically co-located,
as can be after e.g. an import, performance was increased by 30%.