### PR TITLE
Reordered InternalFlatFileRealm.deleteUser to avoid risk of native auth inconsistency

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -570,23 +570,16 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     @Override
     public boolean deleteUser( String username ) throws IOException, InvalidArgumentsException
     {
-        boolean result = false;
         synchronized ( this )
         {
-            User user = getUser( username );
-            if ( userRepository.delete( user ) )
-            {
-                removeUserFromAllRoles( username );
-                result = true;
-            }
-            else
-            {
-                // We should not get here, but if we do the assert will fail and give a nice error msg
-                getUser( username );
-            }
+            User user = getUser( username );    // throws if user does not exists
+            removeUserFromAllRoles( username ); // performed first to always maintain auth-roles repo consistency
+            userRepository.delete( user );      // this will not fail as we know the user exists in this lock
+                                                // assuming no one messes with the user and role repositories
+                                                // outside this instance
         }
         clearCacheForUser( username );
-        return result;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
By removing the user from all roles before deleting, the role and auth files
should not go through an inconsistent intermediate state

This change is isolated to a reordering of operations inside a lock, and should not imply any changes for the running server. The only reason for this change in to remove the minuscle risk of getting inconsistent auth and roles files on backup, which could theoretically happen if the backup was taken simultaneously as a user was deleted.