### PR TITLE
Fix foreach with bound node variable

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
@@ -420,7 +420,7 @@ object ClauseConverters {
     val currentlyAvailableVariables = builder.currentlyAvailableVariables
 
     val setOfNodeVariables =
-      if (builder.semanticTable.isNode(clause.variable))
+      if (builder.semanticTable.isNode(clause.variable.name))
         Set(IdName.fromVariable(clause.variable))
       else Set.empty
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
@@ -136,4 +136,60 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestS
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }
+
+  test("foreach with non-trivially typed collection and create pattern should not create bound node") {
+    // given
+    val query =
+      """CREATE (a),(b)
+        |WITH a, collect(b) as nodes, true as condition
+        |FOREACH (x IN CASE WHEN condition THEN nodes ELSE [] END | CREATE (a)-[:X]->(x) );""".stripMargin
+
+    // when
+    val result = updateWithBothPlannersAndCompatibilityMode(query)
+
+    // then
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
+  }
+
+  test("foreach with non-trivially typed collection and merge pattern should not create bound node") {
+    // given
+    createLabeledNode("Foo")
+    createLabeledNode("Bar")
+
+    val query =
+      """MATCH (n:Foo),(m:Bar)
+        |FOREACH (x IN CASE WHEN true THEN [n] ELSE [] END |
+        |   MERGE (x)-[:FOOBAR]->(m) );""".stripMargin
+
+    // when
+    val result = updateWithBothPlannersAndCompatibilityMode(query)
+
+    // then
+    assertStats(result, relationshipsCreated = 1)
+  }
+
+  test("foreach with mixed type collection should not plan create of bound node and fail at runtime") {
+    // given
+    createLabeledNode("Foo")
+    createLabeledNode("Bar")
+
+    val query =
+      """MATCH (n:Foo),(m:Bar)
+        |WITH n, [m, 42] as mixedTypeCollection
+        |FOREACH (x IN mixedTypeCollection | CREATE (n)-[:FOOBAR]->(x) );""".stripMargin
+
+    // when
+    val explain = executeWithCostPlannerOnly(s"EXPLAIN $query")
+
+    // then
+    explain.executionPlanDescription().toString shouldNot include("CreateNode")
+
+    // when
+    try {
+      val result = executeWithCostPlannerOnly(query)
+    }
+    catch {
+      case e: Exception => e.getMessage should startWith("Expected to find a node at x but")
+    }
+  }
 }


### PR DESCRIPTION
changelog: Fixes a bug whereby previously-bound nodes were created when using `FOREACH` on a mixed-type collection

Foreach on a mixed/Any type collection containing nodes should not
create nodes already bound by the loop variable.

Switches to use SemanticTable.isNode(_:String) which correctly infers node type.