### PR TITLE
Allow CC record distribution to handle incorrect references.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
@@ -35,7 +35,7 @@ public interface QueueDistribution
     /**
      * Distributes records into {@link RecordConsumer}.
      */
-    public interface QueueDistributor<RECORD>
+    interface QueueDistributor<RECORD>
     {
         void distribute( RECORD record, RecordConsumer<RECORD> consumer ) throws InterruptedException;
     }
@@ -43,7 +43,7 @@ public interface QueueDistribution
     /**
      * Distributes records round-robin style to all queues.
      */
-    public static final QueueDistribution ROUND_ROBIN = new QueueDistribution()
+    QueueDistribution ROUND_ROBIN = new QueueDistribution()
     {
         @Override
         public <RECORD> QueueDistributor<RECORD> distributor( long recordsPerCpu, int numberOfThreads )
@@ -55,21 +55,21 @@ public interface QueueDistribution
     /**
      * Distributes {@link RelationshipRecord} depending on the start/end node ids.
      */
-    public static final QueueDistribution RELATIONSHIPS = new QueueDistribution()
+    QueueDistribution RELATIONSHIPS = new QueueDistribution()
     {
         @Override
         public QueueDistributor<RelationshipRecord> distributor( long recordsPerCpu, int numberOfThreads )
         {
-            return new RelationshipNodesQueueDistributor( recordsPerCpu );
+            return new RelationshipNodesQueueDistributor( recordsPerCpu, numberOfThreads );
         }
     };
 
-    static class RoundRobinQueueDistributor<RECORD> implements QueueDistributor<RECORD>
+    class RoundRobinQueueDistributor<RECORD> implements QueueDistributor<RECORD>
     {
         private final int numberOfThreads;
-        private int nextQIndex;
+        private int nextQIndex = 0;
 
-        public RoundRobinQueueDistributor( int numberOfThreads )
+        RoundRobinQueueDistributor( int numberOfThreads )
         {
             this.numberOfThreads = numberOfThreads;
         }
@@ -88,21 +88,25 @@ public interface QueueDistribution
         }
     }
 
-    static class RelationshipNodesQueueDistributor implements QueueDistributor<RelationshipRecord>
+    class RelationshipNodesQueueDistributor implements QueueDistributor<RelationshipRecord>
     {
         private final long recordsPerCpu;
+        private final int maxAvailableThread;
+        private final int numberOfThreads;
 
-        public RelationshipNodesQueueDistributor( long recordsPerCpu )
+        RelationshipNodesQueueDistributor( long recordsPerCpu, int numberOfThreads )
         {
             this.recordsPerCpu = recordsPerCpu;
+            this.numberOfThreads = numberOfThreads;
+            this.maxAvailableThread = numberOfThreads - 1;
         }
 
         @Override
         public void distribute( RelationshipRecord relationship, RecordConsumer<RelationshipRecord> consumer )
                 throws InterruptedException
         {
-            int qIndex1 = (int) (relationship.getFirstNode() / recordsPerCpu);
-            int qIndex2 = (int) (relationship.getSecondNode() / recordsPerCpu);
+            int qIndex1 = (int) Math.min( maxAvailableThread, (Math.abs( relationship.getFirstNode() ) / recordsPerCpu) );
+            int qIndex2 = (int) Math.min( maxAvailableThread, (Math.abs( relationship.getSecondNode() ) / recordsPerCpu) );
             try
             {
                 consumer.accept( relationship, qIndex1 );
@@ -114,7 +118,8 @@ public interface QueueDistribution
             catch ( ArrayIndexOutOfBoundsException e )
             {
                 throw Exceptions.withMessage( e, e.getMessage() + ", recordsPerCPU:" + recordsPerCpu +
-                        ", relationship:" + relationship );
+                        ", relationship:" + relationship +
+                        ", number of threads: " + numberOfThreads );
             }
         }
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/QueueDistributionTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/QueueDistributionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.checking.full;
+
+import org.junit.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class QueueDistributionTest
+{
+
+    private static final int MAX_NUMBER_OF_THREADS = 1_000_000;
+    private static final int NUMBER_OF_DISTRIBUTION_ITERATIONS = 1000;
+
+    @Test
+    public void roundRobinRecordDistribution() throws Exception
+    {
+        testRecordDistribution( QueueDistribution.ROUND_ROBIN );
+    }
+
+    @Test
+    public void relationshipNodesDistribution() throws InterruptedException
+    {
+        testRecordDistribution( QueueDistribution.RELATIONSHIPS );
+    }
+
+    private void testRecordDistribution( QueueDistribution queueDistribution ) throws InterruptedException
+    {
+        ThreadLocalRandom randomGenerator = ThreadLocalRandom.current();
+        int numberOfThreads = randomGenerator.nextInt( MAX_NUMBER_OF_THREADS );
+        int recordsPerCpu = randomGenerator.nextInt( Integer.MAX_VALUE );
+        QueueDistribution.QueueDistributor<RelationshipRecord> distributor =
+                queueDistribution.distributor( recordsPerCpu, numberOfThreads );
+        for ( int iteration = 0; iteration <= NUMBER_OF_DISTRIBUTION_ITERATIONS; iteration++ )
+        {
+            RelationshipRecord relationshipRecord = new RelationshipRecord( 1 );
+            relationshipRecord.setFirstNode( nextLong( randomGenerator ) );
+            relationshipRecord.setSecondNode( nextLong( randomGenerator ) );
+            distributor.distribute( relationshipRecord, ( record, qIndex ) ->
+            {
+                assertThat( "Distribution index for record " + record + " should be within a range of available " +
+                                "executors, while expected records per cpu is: " + recordsPerCpu, qIndex,
+                        allOf( greaterThanOrEqualTo( 0 ), lessThan( numberOfThreads ) ) );
+            } );
+        }
+    }
+
+    private long nextLong( ThreadLocalRandom randomGenerator )
+    {
+        return randomGenerator.nextLong();
+    }
+}

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordDistributorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/RecordDistributorTest.java
@@ -36,7 +36,7 @@ public class RecordDistributorTest
     public void shouldDistributeRelationshipRecordsByNodeId() throws Exception
     {
         // GIVEN
-        QueueDistributor<RelationshipRecord> distributor = new RelationshipNodesQueueDistributor( 5 );
+        QueueDistributor<RelationshipRecord> distributor = new RelationshipNodesQueueDistributor( 5, 100 );
         RecordConsumer<RelationshipRecord> consumer = mock( RecordConsumer.class );
 
         // WHEN/THEN


### PR DESCRIPTION
Update record distribution mechanics to handle cases when references in records that we scan are incorrect (negative, too big, etc.).
This PR fixes a bug when index evaluated based on incorrect reference causing CC failure.