### PR TITLE
Fix join failures

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -195,6 +195,7 @@ public class MultiPaxosServerFactory
                         internal( SnapshotMessage.join ) )
 
                 .rule( ClusterState.discovery, ClusterMessage.configurationResponse, ClusterState.joining,
+                        internal( ProposerMessage.join ),
                         internal( AcceptorMessage.join ),
                         internal( LearnerMessage.join ),
                         internal( AtomicBroadcastMessage.join ) )


### PR DESCRIPTION
A rare occurrence of events could cause a conflict in proposals
and because of a missing join event to the ProperState it wouldn't
retry.