### PR TITLE
Make tests safe to run on different OSs

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
-import org.neo4j.cypher.{NewPlannerTestSupport, QueryStatisticsTestSupport, ExecutionEngineFunSuite}
-import org.scalatest.matchers.{MatchResult, Matcher}
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.WindowsStringSafe
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
 
 class QueryPlanCompactionAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport
   with NewPlannerTestSupport with QueryPlanTestSupport {
+
+  implicit val windowsSafe = WindowsStringSafe
 
   test("Compact very long query containing consecutive update operations") {
     val query =

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/InlineProjectionsTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/InlineProjectionsTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters
 
 import org.apache.commons.lang3.SystemUtils
+import org.neo4j.cypher.internal
 import org.neo4j.cypher.internal.compiler.v3_0.SyntaxExceptionCreator
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{AstRewritingTestSupport, CantHandleQueryException}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -365,22 +366,23 @@ class InlineProjectionsTest extends CypherFunSuite with AstRewritingTestSupport 
   }
 
   test("match (n) where id(n) IN [0,1,2,3] with n.division AS `n.division`, max(n.age) AS `max(n.age)` with `n.division` AS `n.division`, `max(n.age)` AS `max(n.age)` RETURN `n.division` AS `n.division`, `max(n.age)` AS `max(n.age)` order by `max(n.age)`") {
+    import internal.frontend.v3_0.helpers.StringHelper._
+
     val result = projectionInlinedAst(
       """match (n) where id(n) IN [0,1,2,3]
         |with n.division AS `n.division`, max(n.age) AS `max(n.age)`
         |with `n.division` AS `n.division`, `max(n.age)` AS `max(n.age)`
         |RETURN `n.division` AS `n.division`, `max(n.age)` AS `max(n.age)` order by `max(n.age)`
-      """.stripMargin)
+      """.stripMargin.fixNewLines)
 
-    // TODO: this is a temporary solution we should rethink how to generated fresh ids on windows
-    val freshIdName = if (SystemUtils.IS_OS_WINDOWS) "`  FRESHID199`" else "`  FRESHID196`"
+    val freshIdName = "`  FRESHID196`"
     result should equal(ast(
       s"""match (n) where id(n) IN [0,1,2,3]
         |with n.division AS `n.division`, max(n.age) AS `max(n.age)`
         |with `n.division` AS `n.division`, `max(n.age)` AS `max(n.age)`
         |with `n.division` AS `n.division`, `max(n.age)` AS $freshIdName order by $freshIdName
         |RETURN `n.division` AS `n.division`, $freshIdName AS `max(n.age)`
-      """.stripMargin))
+      """.stripMargin.fixNewLines))
   }
 
   test("should not inline expressions used many times: WITH 1 as a MATCH (a) WHERE a.prop = x OR a.bar > x RETURN a, x => WITH 1 as a MATCH (a) WHERE a.prop = x OR a.bar > x RETURN a, x") {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipeTest.scala
@@ -22,11 +22,11 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{ListLiteral, Expression, Variable, Literal}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expression, ListLiteral, Literal, Variable}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.{ManyQueryExpression, QueryExpression, RangeQueryExpression, SingleQueryExpression}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
-import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InternalException, LabelId, PropertyKeyId}
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.index.IndexDescriptor
@@ -34,6 +34,7 @@ import org.neo4j.kernel.api.index.IndexDescriptor
 class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
   implicit val monitor = mock[PipeMonitor]
+  implicit val windowsSafe = WindowsStringSafe
 
   val label = LabelToken(LabelName("LabelName") _, LabelId(11))
   val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName") _, PropertyKeyId(10))

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/RenderTreeTableTest.scala
@@ -21,16 +21,17 @@ package org.neo4j.cypher.internal.compiler.v3_0.planDescription
 
 import java.util.Locale
 
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Property, LengthFunction, Variable}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{LengthFunction, Property, Variable}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{Equals, HasLabel, Not, PropertyExists}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
-import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.scalatest.BeforeAndAfterAll
 
 class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
+  implicit val windowsSafe = WindowsStringSafe
 
   private val defaultLocale = Locale.getDefault
   override def beforeAll() {
@@ -771,25 +772,25 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
 
   test("Variable line compaction with no variables") {
     val line = Line("NODE", Map.empty, Set.empty)
-    val compacted = new CompactedLine(line, Set.empty)
+    val compacted = CompactedLine(line, Set.empty)
     compacted.formattedVariables should be("")
   }
 
   test("Variable line compaction with only new variables") {
     val line = Line("NODE", Map.empty, Set("a", "b"))
-    val compacted = new CompactedLine(line, Set.empty)
+    val compacted = CompactedLine(line, Set.empty)
     compacted.formattedVariables should be("a, b")
   }
 
   test("Variable line compaction with only old variables") {
     val line = Line("NODE", Map.empty, Set("a", "b"))
-    val compacted = new CompactedLine(line, Set("a", "b"))
+    val compacted = CompactedLine(line, Set("a", "b"))
     compacted.formattedVariables should be("a, b")
   }
 
   test("Variable line compaction with old and new variables") {
     val line = Line("NODE", Map.empty, Set("a", "b", "c", "d"))
-    val compacted = new CompactedLine(line, Set("a", "b"))
+    val compacted = CompactedLine(line, Set("a", "b"))
     compacted.formattedVariables should be("c, d -- a, b")
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/WithPlanningIntegrationTest.scala
@@ -20,10 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{DoNotIncludeTies, AllNodesScan, Limit, Projection}
-import org.neo4j.cypher.internal.compiler.v3_0.test_helpers.WindowsStringSafe
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{AllNodesScan, DoNotIncludeTies, Limit, Projection}
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, SignedDecimalIntegerLiteral}
-import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, WindowsStringSafe}
 
 class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
   implicit val windowsSafe = WindowsStringSafe

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DumpToStringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DumpToStringAcceptanceTest.scala
@@ -19,7 +19,11 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.WindowsStringSafe
+
 class DumpToStringAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  implicit val windowsSafe = WindowsStringSafe
 
   test("format node") {
     createNode(Map("prop1" -> "A", "prop2" -> 2))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -449,6 +449,8 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
   }
 
   private def executeQuery(query: String) {
-    execute(query.replaceAll("\n\r", "\n")).toList
+    import internal.frontend.v3_0.helpers.StringHelper._
+
+    execute(query.fixNewLines).toList
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -19,11 +19,9 @@
  */
 package org.neo4j.cypher
 
-import org.apache.commons.lang3.SystemUtils
 import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.neo4j.cypher.internal.compiler.v3_0.CypherSerializer
-import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper
 
 class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
 
@@ -439,26 +437,18 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
       "Expected exactly one statement per query but got: 2")
   }
 
-  def expectError(query: String, expectedError: String) {
-    import StringHelper._
+  private def expectError(query: String, expectedError: String) {
     val error = intercept[CypherException](executeQuery(query))
-    assertThat(error.getMessage, containsString(expectedError.fixPosition))
+    assertThat(error.getMessage, containsString(expectedError))
   }
 
   private def expectSyntaxError(query: String, expectedError: String, expectedOffset: Int) {
-    import StringHelper._
     val error = intercept[SyntaxException](executeQuery(query))
-    assertThat(error.getMessage(), containsString(expectedError.fixPosition))
-    assertThat(error.offset, equalTo(Some(fixPosition(query, expectedOffset)): Option[Int]))
+    assertThat(error.getMessage(), containsString(expectedError))
+    assertThat(error.offset, equalTo(Some(expectedOffset): Option[Int]))
   }
 
-  private def fixPosition(q: String, originalOffset: Int): Int = if (SystemUtils.IS_OS_WINDOWS) {
-    val subString = q.replaceAll("\n\r", "\n").substring(0, originalOffset)
-    val numberOfNewLines = subString.filter(_ == '\n').length
-    originalOffset + numberOfNewLines
-  } else originalOffset
-
-  def executeQuery(query: String) {
-    execute(query).toList
+  private def executeQuery(query: String) {
+    execute(query.replaceAll("\n\r", "\n")).toList
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -697,12 +697,13 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   private def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
 
     import scala.collection.JavaConverters._
+    import internal.frontend.v3_0.helpers.StringHelper._
 
     try {
       val jParams = new util.HashMap[String, Object]()
       params.foreach(kv => jParams.put(kv._1, kv._2.asInstanceOf[AnyRef]))
 
-      graph.execute(query.replaceAll("\n\r", "\n"), jParams).asScala.size
+      graph.execute(query.fixNewLines, jParams).asScala.size
       fail(s"Did not get the expected syntax error, expected: $expected")
     } catch {
       case x: QueryExecutionException =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -694,22 +694,20 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
                             "coordinates e.g. {latitude: 12.78, longitude: 56.7, crs: 'WGS-84'}. (line 1, column 14 (offset: 13))")
   }
 
-  def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
-    import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper._
+  private def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
 
     import scala.collection.JavaConverters._
 
-    val fixedExpected = expected.fixPosition
     try {
       val jParams = new util.HashMap[String, Object]()
       params.foreach(kv => jParams.put(kv._1, kv._2.asInstanceOf[AnyRef]))
 
-      graph.execute(query, jParams).asScala.size
-      fail(s"Did not get the expected syntax error, expected: $fixedExpected")
+      graph.execute(query.replaceAll("\n\r", "\n"), jParams).asScala.size
+      fail(s"Did not get the expected syntax error, expected: $expected")
     } catch {
       case x: QueryExecutionException =>
         val actual = x.getMessage.lines.next().trim
-        actual should equal(fixedExpected)
+        actual should equal(expected)
     }
   }
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/StringHelper.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/StringHelper.scala
@@ -31,6 +31,8 @@ object StringHelper {
     def cypherEscape: String =
       text.replace("\\", "\\\\")
 
+    def fixNewLines: String = text.replaceAll("\r\n", "\n")
+
     // (line 1, column 8 (offset: 7))
     def fixPosition: String = if (SystemUtils.IS_OS_WINDOWS) {
       positionPattern.replaceAllIn(text, (matcher) => {

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/test_helpers/WindowsStringSafe.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/test_helpers/WindowsStringSafe.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.test_helpers
+package org.neo4j.cypher.internal.frontend.v3_0.test_helpers
 
 import org.scalactic.Equality
 


### PR DESCRIPTION
Before this commit, our tests were safe to run on the same OS as they were built on. 
With this change, you can create the artefacts on one OS, and then run the tests on a different one, something that was not supported earlier.