### PR TITLE
Fix bug on close in NeoStores

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -19,19 +19,14 @@
  */
 package org.neo4j.helpers;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.Thread.State;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.Predicate;
 
 import org.neo4j.function.Predicates;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Exceptions
 {
@@ -269,6 +264,17 @@ public class Exceptions
     {
         setMessage( cause, message );
         return cause;
+    }
+
+    public static <T extends Throwable> T chain( T initial, T current )
+    {
+        if ( initial == null )
+        {
+            return current;
+        }
+
+        initial.addSuppressed( current );
+        return initial;
     }
 
 }


### PR DESCRIPTION
If any store does not close cleanly but throws an exception, the
subsequents stores in store array are not gonna be closed.  This will
make the page cache to fail when shutdown due to still store files
mapped in it.  This change will make sure we attempt to close all the
stores even if exceptions are thrown.