### PR TITLE
Fix return * with order by leaking internal variable names

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -429,4 +429,25 @@ order by a.age""").toList)
 
     result.toList should equal(List(Map("count" -> 1)))
   }
+
+  test("returning * and additional aliased columns should not give duplicate returned columns") {
+    val result = executeWithAllPlanners("WITH 1337 as foo RETURN *, 42 as bar ORDER BY bar")
+
+    result.toList should equal(List(Map("foo" -> 1337, "bar" -> 42)))
+  }
+
+  test("returning * and additional unaliased columns should not give duplicate returned columns") {
+    val result = executeWithAllPlanners("WITH 1337 as foo RETURN *, 42 ORDER BY foo")
+
+    result.toList should equal(List(Map("foo" -> 1337, "42" -> 42)))
+  }
+
+  test("returning * and additional unaliased columns should not give duplicate returned columns 2") {
+    val n = createNode(Map("foo" -> 42))
+
+    val result = executeWithAllPlanners("MATCH (n) RETURN *, n.foo ORDER BY n.foo SKIP 0 LIMIT 5 ")
+    println(result.executionPlanDescription())
+
+    result.toList should equal(List(Map("n"-> n, "n.foo" -> 42)))
+  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/ClauseConverters.scala
@@ -79,7 +79,7 @@ object ClauseConverters {
 
   implicit class ReturnConverter(val clause: Return) extends AnyVal {
     def addReturnToLogicalPlanInput(acc: PlannerQueryBuilder): PlannerQueryBuilder = clause match {
-      case Return(distinct, ri, optOrderBy, skip, limit) if !ri.includeExisting =>
+      case Return(distinct, ri, optOrderBy, skip, limit, _) if !ri.includeExisting =>
 
         val shuffle = optOrderBy.asQueryShuffle.
           withSkip(skip).

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/Namespacer.scala
@@ -48,7 +48,7 @@ object Namespacer {
     statement.treeFold(Set.empty[Ref[Identifier]]) {
 
       // ignore identifier in StartItem that represents index names and key names
-      case Return(_, ReturnItems(_, items), _, _, _) =>
+      case Return(_, ReturnItems(_, items), _, _, _, _) =>
         val identifiers = items.map(_.alias.map(Ref[Identifier]).get)
         (acc, children) => children(acc ++ identifiers)
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/expandStar.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/expandStar.scala
@@ -40,8 +40,8 @@ case class expandStar(state: SemanticState) extends Rewriter {
         case clause: PragmaWithout =>
           With(distinct = false, returnItems = returnItems(clause, Seq.empty, clause.excludedNames), orderBy = None, skip = None, limit = None, where = None)(clause.position)
 
-        case clause@Return(_, ri, _, _, _) if ri.includeExisting =>
-          clause.copy(returnItems = returnItems(clause, ri.items))(clause.position)
+        case clause@Return(_, ri, _, _, _, excludedNames) if ri.includeExisting =>
+          clause.copy(returnItems = returnItems(clause, ri.items, excludedNames))(clause.position)
 
         case expandedAstNode =>
           expandedAstNode

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/expandStar.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/expandStar.scala
@@ -19,9 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
 
-import org.neo4j.cypher.internal.frontend.v2_3.SemanticState
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
-import org.neo4j.cypher.internal.frontend.v2_3.{Rewriter, replace}
+import org.neo4j.cypher.internal.frontend.v2_3.{Rewriter, SemanticState, replace}
 import org.neo4j.helpers.ThisShouldNotHappenError
 
 case class expandStar(state: SemanticState) extends Rewriter {
@@ -41,7 +40,7 @@ case class expandStar(state: SemanticState) extends Rewriter {
           With(distinct = false, returnItems = returnItems(clause, Seq.empty, clause.excludedNames), orderBy = None, skip = None, limit = None, where = None)(clause.position)
 
         case clause@Return(_, ri, _, _, _, excludedNames) if ri.includeExisting =>
-          clause.copy(returnItems = returnItems(clause, ri.items, excludedNames))(clause.position)
+          clause.copy(returnItems = returnItems(clause, ri.items, excludedNames), excludedNames = Set.empty)(clause.position)
 
         case expandedAstNode =>
           expandedAstNode

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeReturnClauses.scala
@@ -43,7 +43,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
   def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
 
   private val clauseRewriter: (Clause => Seq[Clause]) = {
-    case clause @ Return(_, ri, None, _, _) =>
+    case clause @ Return(_, ri, None, _, _, _) =>
       val aliasedItems = ri.items.map({
         case i: AliasedReturnItem =>
           i
@@ -55,7 +55,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
         clause.copy(returnItems = ri.copy(items = aliasedItems)(ri.position))(clause.position)
       )
 
-    case clause @ Return(distinct, ri, orderBy, skip, limit) =>
+    case clause @ Return(distinct, ri, orderBy, skip, limit, _) =>
       clause.verifyOrderByAggregationUse((s,i) => throw mkException(s,i))
       var rewrites = Map[Expression, Identifier]()
 
@@ -78,9 +78,13 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
         case exp: Expression if rewrites.contains(exp) => rewrites(exp).copyId
       }))
 
+      val introducedVariables = aliasProjection.map(_.identifier.name).toSet
+
       Seq(
-        With(distinct = distinct, returnItems = ri.copy(items = aliasProjection)(ri.position), orderBy = newOrderBy, skip = skip, limit = limit, where = None)(clause.position),
-        Return(distinct = false, returnItems = ri.copy(items = finalProjection)(ri.position), orderBy = None, skip = None, limit = None)(clause.position)
+        With(distinct = distinct, returnItems = ri.copy(items = aliasProjection)(ri.position),
+          orderBy = newOrderBy, skip = skip, limit = limit, where = None)(clause.position),
+        Return(distinct = false, returnItems = ri.copy(items = finalProjection)(ri.position),
+          orderBy = None, skip = None, limit = None, excludedNames = introducedVariables)(clause.position)
       )
 
     case clause =>

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeReturnClauses.scala
@@ -78,7 +78,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
         case exp: Expression if rewrites.contains(exp) => rewrites(exp).copyId
       }))
 
-      val introducedVariables = aliasProjection.map(_.identifier.name).toSet
+      val introducedVariables = if (ri.includeExisting) aliasProjection.map(_.identifier.name).toSet else Set.empty[String]
 
       Seq(
         With(distinct = distinct, returnItems = ri.copy(items = aliasProjection)(ri.position),

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -56,15 +56,6 @@ class NormalizeReturnClausesTest extends CypherFunSuite with RewriteTest with As
         |RETURN *""".stripMargin)
   }
 
-  test("introduce WITH clause for ORDER BY where returning all IDs and additional columns") {
-    assertRewrite(
-      """MATCH n
-        |RETURN *, n.foo AS bar ORDER BY n.foo SKIP 2 LIMIT 5""".stripMargin,
-      """MATCH n
-        |WITH *, n.foo AS `  FRESHID20` ORDER BY `  FRESHID20` SKIP 2 LIMIT 5
-        |RETURN *, `  FRESHID20` AS bar""".stripMargin)
-  }
-
   test("match n return n, count(*) as c order by c") {
     assertRewrite(
       "match n return n, count(*) as c order by c",

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ProjectNamedPathsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/ProjectNamedPathsTest.scala
@@ -39,7 +39,7 @@ class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport 
 
   private def parseReturnedExpr(queryText: String) =
     projectionInlinedAst(queryText) match {
-      case Query(_, SingleQuery(Seq(_, Return(_, ReturnItems(_, Seq(AliasedReturnItem(expr, Identifier("p")))), _, _, _)))) => expr
+      case Query(_, SingleQuery(Seq(_, Return(_, ReturnItems(_, Seq(AliasedReturnItem(expr, Identifier("p")))), _, _, _, _)))) => expr
     }
 
   test("MATCH p = (a) RETURN p" ) {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/SimpleTokenResolverTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/SimpleTokenResolverTest.scala
@@ -48,7 +48,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
             Seq(),
             Some(Where(Equals(Property(Identifier("n"), pkToken), StringLiteral("Resolved"))))
           ),
-          Return(false, ReturnItems(true, Seq()), None, None, None)
+          Return(false, ReturnItems(true, Seq()), None, None, None, _)
         ))) =>
             pkToken.name should equal("name")
             pkToken.id should equal(Some(PropertyKeyId(12)))
@@ -71,7 +71,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
             Seq(),
             Some(Where(Equals(Property(Identifier("n"), pkToken), StringLiteral("Unresolved"))))
           ),
-          Return(false, ReturnItems(true, Seq()), None, None, None)
+          Return(false, ReturnItems(true, Seq()), None, None, None, _)
         ))) =>
             pkToken.name should equal("name")
             pkToken.id should equal(None)
@@ -94,7 +94,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           Some(Where(HasLabels(Identifier("n"), Seq(labelToken))))
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         labelToken.name should equal("Resolved")
         labelToken.id should equal(Some(LabelId(12)))
@@ -117,7 +117,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           Some(Where(HasLabels(Identifier("n"), Seq(labelToken))))
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         labelToken.name should equal("Unresolved")
         labelToken.id should equal(None)
@@ -144,7 +144,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           None
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         relTypeToken.name should equal("RESOLVED")
         relTypeToken.id should equal(Some(RelTypeId(12)))
@@ -171,7 +171,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           None
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         relTypeToken.name should equal("UNRESOLVED")
         relTypeToken.id should equal(None)

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Clause.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Clause.scala
@@ -368,7 +368,8 @@ case class Return(
     returnItems: ReturnItems,
     orderBy: Option[OrderBy],
     skip: Option[Skip],
-    limit: Option[Limit])(val position: InputPosition) extends ProjectionClause {
+    limit: Option[Limit],
+    excludedNames: Set[String] = Set.empty)(val position: InputPosition) extends ProjectionClause {
 
   def name = "RETURN"
 


### PR DESCRIPTION
changelog: `RETURN *` with `ORDER BY` should not leak internal variable names in the final result due to AST rewriting.