### PR TITLE
Fix return * with order by leaking internal variable names

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -453,4 +453,25 @@ order by a.age""").toList)
 
     result.toList should equal(List(Map("count" -> 1)))
   }
+
+  test("returning * and additional aliased columns should not give duplicate returned columns") {
+    val result = executeWithAllPlanners("WITH 1337 as foo RETURN *, 42 as bar ORDER BY bar")
+
+    result.toList should equal(List(Map("foo" -> 1337, "bar" -> 42)))
+  }
+
+  test("returning * and additional unaliased columns should not give duplicate returned columns") {
+    val result = executeWithAllPlanners("WITH 1337 as foo RETURN *, 42 ORDER BY foo")
+
+    result.toList should equal(List(Map("foo" -> 1337, "42" -> 42)))
+  }
+
+  test("returning * and additional unaliased columns should not give duplicate returned columns 2") {
+    val n = createNode(Map("foo" -> 42))
+
+    val result = executeWithAllPlanners("MATCH (n) RETURN *, n.foo ORDER BY n.foo SKIP 0 LIMIT 5 ")
+    println(result.executionPlanDescription())
+
+    result.toList should equal(List(Map("n"-> n, "n.foo" -> 42)))
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
@@ -89,7 +89,7 @@ object ClauseConverters {
 
   private def addReturnToLogicalPlanInput(acc: PlannerQueryBuilder,
                                           clause: Return): PlannerQueryBuilder = clause match {
-    case Return(distinct, ri, optOrderBy, skip, limit) if !ri.includeExisting =>
+    case Return(distinct, ri, optOrderBy, skip, limit, _) if !ri.includeExisting =>
 
       val shuffle = asQueryShuffle(optOrderBy).
         withSkip(skip).

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/Namespacer.scala
@@ -48,7 +48,7 @@ object Namespacer {
     statement.treeFold(Set.empty[Ref[Variable]]) {
 
       // ignore variable in StartItem that represents index names and key names
-      case Return(_, ReturnItems(_, items), _, _, _) =>
+      case Return(_, ReturnItems(_, items), _, _, _, _) =>
         val variables = items.map(_.alias.map(Ref[Variable]).get)
         acc => (acc ++ variables, Some(identity))
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/expandStar.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/expandStar.scala
@@ -34,8 +34,8 @@ case class expandStar(state: SemanticState) extends Rewriter {
       With(distinct = false, returnItems = returnItems(clause, Seq.empty, clause.excludedNames),
         orderBy = None, skip = None, limit = None, where = None)(clause.position)
 
-    case clause@Return(_, ri, _, _, _) if ri.includeExisting =>
-      clause.copy(returnItems = returnItems(clause, ri.items))(clause.position)
+    case clause@Return(_, ri, _, _, _, excludedNames) if ri.includeExisting =>
+      clause.copy(returnItems = returnItems(clause, ri.items, excludedNames))(clause.position)
 
     case expandedAstNode =>
       expandedAstNode

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeReturnClauses.scala
@@ -43,7 +43,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
   def apply(that: AnyRef): AnyRef = instance.apply(that)
 
   private val clauseRewriter: (Clause => Seq[Clause]) = {
-    case clause @ Return(_, ri, None, _, _) =>
+    case clause @ Return(_, ri, None, _, _, _) =>
       val aliasedItems = ri.items.map({
         case i: AliasedReturnItem =>
           i
@@ -55,7 +55,7 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
         clause.copy(returnItems = ri.copy(items = aliasedItems)(ri.position))(clause.position)
       )
 
-    case clause @ Return(distinct, ri, orderBy, skip, limit) =>
+    case clause @ Return(distinct, ri, orderBy, skip, limit, _) =>
       clause.verifyOrderByAggregationUse((s,i) => throw mkException(s,i))
       var rewrites = Map[Expression, Variable]()
 
@@ -78,9 +78,13 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
         case exp: Expression if rewrites.contains(exp) => rewrites(exp).copyId
       }))
 
+      val introducedVariables = aliasProjection.map(_.variable.name).toSet
+
       Seq(
-        With(distinct = distinct, returnItems = ri.copy(items = aliasProjection)(ri.position), orderBy = newOrderBy, skip = skip, limit = limit, where = None)(clause.position),
-        Return(distinct = false, returnItems = ri.copy(items = finalProjection)(ri.position), orderBy = None, skip = None, limit = None)(clause.position)
+        With(distinct = distinct, returnItems = ri.copy(items = aliasProjection)(ri.position),
+          orderBy = newOrderBy, skip = skip, limit = limit, where = None)(clause.position),
+        Return(distinct = false, returnItems = ri.copy(items = finalProjection)(ri.position),
+          orderBy = None, skip = None, limit = None, excludedNames = introducedVariables)(clause.position)
       )
 
     case clause =>

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/ProjectNamedPathsTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/ProjectNamedPathsTest.scala
@@ -39,7 +39,7 @@ class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport 
 
   private def parseReturnedExpr(queryText: String) =
     projectionInlinedAst(queryText) match {
-      case Query(_, SingleQuery(Seq(_, Return(_, ReturnItems(_, Seq(AliasedReturnItem(expr, Variable("p")))), _, _, _)))) => expr
+      case Query(_, SingleQuery(Seq(_, Return(_, ReturnItems(_, Seq(AliasedReturnItem(expr, Variable("p")))), _, _, _, _)))) => expr
     }
 
   test("MATCH p = (a) RETURN p" ) {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/SimpleTokenResolverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/SimpleTokenResolverTest.scala
@@ -48,7 +48,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
             Seq(),
             Some(Where(Equals(Property(Variable("n"), pkToken), StringLiteral("Resolved"))))
           ),
-          Return(false, ReturnItems(true, Seq()), None, None, None)
+          Return(false, ReturnItems(true, Seq()), None, None, None, _)
         ))) =>
             pkToken.name should equal("name")
             pkToken.id should equal(Some(PropertyKeyId(12)))
@@ -71,7 +71,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
             Seq(),
             Some(Where(Equals(Property(Variable("n"), pkToken), StringLiteral("Unresolved"))))
           ),
-          Return(false, ReturnItems(true, Seq()), None, None, None)
+          Return(false, ReturnItems(true, Seq()), None, None, None, _)
         ))) =>
             pkToken.name should equal("name")
             pkToken.id should equal(None)
@@ -94,7 +94,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           Some(Where(HasLabels(Variable("n"), Seq(labelToken))))
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         labelToken.name should equal("Resolved")
         labelToken.id should equal(Some(LabelId(12)))
@@ -117,7 +117,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           Some(Where(HasLabels(Variable("n"), Seq(labelToken))))
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         labelToken.name should equal("Unresolved")
         labelToken.id should equal(None)
@@ -144,7 +144,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           None
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         relTypeToken.name should equal("RESOLVED")
         relTypeToken.id should equal(Some(RelTypeId(12)))
@@ -171,7 +171,7 @@ class SimpleTokenResolverTest extends CypherFunSuite {
           Seq(),
           None
         ),
-        Return(false, ReturnItems(true, Seq()), None, None, None)
+        Return(false, ReturnItems(true, Seq()), None, None, None, _)
       ))) =>
         relTypeToken.name should equal("UNRESOLVED")
         relTypeToken.id should equal(None)

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/Clause.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/Clause.scala
@@ -427,7 +427,8 @@ case class Return(
                    returnItems: ReturnItems,
                    orderBy: Option[OrderBy],
                    skip: Option[Skip],
-                   limit: Option[Limit])(val position: InputPosition) extends ProjectionClause {
+                   limit: Option[Limit],
+                   excludedNames: Set[String] = Set.empty)(val position: InputPosition) extends ProjectionClause {
 
   override def name = "RETURN"
 


### PR DESCRIPTION
RETURN * with ORDER BY should not leak internal variable names in the final
result due to AST rewriting.

This is a 3.0-based alternative to the 2.3-based https://github.com/neo4j/neo4j/pull/8389