### PR TITLE
Fixed that shortest path did not enforce relationship uniqueness.

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.internal.RewindableExecutionResult
+import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor3_0
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.kernel.api.KernelTransaction
+import org.neo4j.kernel.api.security.AccessMode
+
+class ShortestPathRelationshipUniquenessAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("should not find shortest path due to relationship uniquess") {
+    val p0 = createLabeledNode(Map("id" -> "2228"), "Model")
+    val p1 = createLabeledNode(Map("id" -> "2246"), "Model")
+    val p2 = createLabeledNode(Map("id" -> "2248"), "Model")
+    val p3 = createLabeledNode(Map("id" -> "32"), "Model")
+    val p4 = createLabeledNode(Map("id" -> "2640"), "Model")
+    val p5 = createLabeledNode(Map("id" -> "2638"), "Model")
+
+    relate(p0, p1, "2633")
+    relate(p1, p2, "2636")
+    relate(p2, p3, "2644")
+    relate(p2, p4, "2644")
+    relate(p4, p5, "2640")
+    val query =
+      """MATCH p=shortestpath((a:Model)-[r*]-(b:Model))
+    WHERE a.id="2228" AND b.id="2638" AND ANY ( n IN nodes(p)[1..-1] WHERE (n.id = "32") )
+    RETURN nodes(p) as nodes"""
+        .stripMargin
+    val result = executeUsingCostPlannerOnly(query).columnAs("nodes").toList
+    result should be(List.empty)
+  }
+
+  test("should find the longer short path") {
+    val p0 = createLabeledNode(Map("id" -> "2228"), "Model")
+    val p1 = createLabeledNode(Map("id" -> "2246"), "Model")
+    val p2 = createLabeledNode(Map("id" -> "2248"), "Model")
+    val p3 = createLabeledNode(Map("id" -> "32"), "Model")
+    val p4 = createLabeledNode(Map("id" -> "2640"), "Model")
+    val p5 = createLabeledNode(Map("id" -> "2638"), "Model")
+
+    val pLongPath0 = createLabeledNode(Map("id" -> "1"), "Model")
+    val pLongPath1 = createLabeledNode(Map("id" -> "2"), "Model")
+    val pLongPath2 = createLabeledNode(Map("id" -> "3"), "Model")
+    val pLongPath3 = createLabeledNode(Map("id" -> "4"), "Model")
+    val pLongPath4 = createLabeledNode(Map("id" -> "5"), "Model")
+    val pLongPath5 = createLabeledNode(Map("id" -> "6"), "Model")
+
+
+    relate(p0, pLongPath0, "10")
+    relate(pLongPath0, pLongPath1, "20")
+    relate(pLongPath1, pLongPath2, "30")
+    relate(pLongPath2, pLongPath3, "40")
+    relate(pLongPath3, pLongPath4, "50")
+    relate(pLongPath4, pLongPath5, "60")
+    relate(pLongPath5, p3, "70")
+
+    relate(p0, p1, "2633")
+    relate(p1, p2, "2636")
+    relate(p2, p3, "2644")
+    relate(p2, p4, "2644")
+    relate(p4, p5, "2640")
+    val query =
+      """MATCH p=shortestpath((a:Model)-[r*]-(b:Model))
+    WHERE a.id="2228" AND b.id="2638" AND ANY ( n IN nodes(p)[1..-1] WHERE (n.id = "32") )
+    RETURN nodes(p) as nodes"""
+        .stripMargin
+    println(query)
+    val result = executeUsingCostPlannerOnly(query).columnAs("nodes").toList
+    result should be(List(List(p0, pLongPath0, pLongPath1, pLongPath2, pLongPath3, pLongPath4, pLongPath5, p3, p2, p4, p5)))
+  }
+
+  def executeUsingCostPlannerOnly(query: String) =
+    eengine.execute(s"CYPHER planner=COST $query", Map.empty[String, Any], graph.session()) match {
+      case e: ExecutionResultWrapperFor3_0 => RewindableExecutionResult(e)
+    }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ShortestPathExpression.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.{PathExtractor, Pattern, ShortestPath, SingleNode, _}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsAllNodes, ReadsAllRelationships}
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.RelationshipSupport
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.SyntaxException
@@ -30,9 +31,11 @@ import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
 
+import scala.collection.JavaConverters._
 import scala.collection.Map
 
-case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates: Seq[Predicate] = Seq.empty) extends Expression with PathExtractor {
+case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
+                                  withFallBack: Boolean = false) extends Expression with PathExtractor {
   val pathPattern: Seq[Pattern] = Seq(shortestPathPattern)
   val pathVariables = Set(shortestPathPattern.pathName, shortestPathPattern.relIterator.getOrElse(""))
 
@@ -74,7 +77,8 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
           incomingCtx += shortestPathPattern.pathName -> path
           incomingCtx += shortestPathPattern.relIterator.get -> path.relationships()
           predicate.isTrue(incomingCtx)
-      }.getOrElse(true)
+      }.getOrElse(true) &&
+        (!withFallBack || RelationshipSupport.areRelationshipsUnique(path.relationships.asScala.toList))
     }
 
   private def getEndPoint(m: Map[String, Any], start: SingleNode): Node = m.getOrElse(start.name,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RelationshipSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RelationshipSupport.scala
@@ -17,18 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
+package org.neo4j.cypher.internal.compiler.v3_0.helpers
 
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
+import org.neo4j.graphdb.Relationship
+import scala.annotation.tailrec
 
-case class FindShortestPaths(left: LogicalPlan, shortestPath: ShortestPathPattern,
-                             predicates: Seq[Expression] = Seq.empty, withFallBack: Boolean = false)
-                            (val solved: PlannerQuery with CardinalityEstimation)
-  extends LogicalPlan with LazyLogicalPlan {
-
-  val lhs = Some(left)
-  def rhs = None
-
-  def availableSymbols = left.availableSymbols ++ shortestPath.availableSymbols
+object RelationshipSupport {
+  @tailrec
+  def areRelationshipsUnique(relationships: List[Relationship]): Boolean = relationships match {
+    case List() => true
+    case head :: Nil => true
+    case head :: tail => !tail.contains(head) && areRelationshipsUnique(tail)
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
@@ -33,11 +33,12 @@ import scala.collection.JavaConverters._
 /**
  * Shortest pipe inserts a single shortest path between two already found nodes
  */
-case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty)
+case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
+                            withFallBack: Boolean = false)
                            (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with ListSupport with RonjaPipe {
   private def pathName = shortestPathCommand.pathName
-  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates)
+  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates, withFallBack)
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState) =
     input.flatMap(ctx => {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -305,9 +305,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         Eagerly.immutableMapValues[String, ast.Expression, AggregationExpression](aggregatingExpressions, buildExpression(_).asInstanceOf[AggregationExpression])
       )()
 
-    case FindShortestPaths(_, shortestPathPattern, predicates) =>
+    case FindShortestPaths(_, shortestPathPattern, predicates, withFallBack) =>
       val legacyShortestPath = shortestPathPattern.expr.asLegacyPatterns(shortestPathPattern.name.map(_.name)).head
-      new ShortestPathPipe(source, legacyShortestPath, predicates.map(toCommandPredicate))()
+      new ShortestPathPipe(source, legacyShortestPath, predicates.map(toCommandPredicate), withFallBack)()
 
     case UnwindCollection(_, variable, collection) =>
       UnwindPipe(source, toCommandExpression(collection), variable.name)()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -440,10 +440,11 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
     Sort(inner, descriptions)(solved)
   }
 
-  def planShortestPath(inner: LogicalPlan, shortestPaths: ShortestPathPattern, predicates: Seq[Expression])
+  def planShortestPath(inner: LogicalPlan, shortestPaths: ShortestPathPattern, predicates: Seq[Expression],
+                       withFallBack: Boolean)
                       (implicit context: LogicalPlanningContext) = {
     val solved = inner.solved.amendQueryGraph(_.addShortestPath(shortestPaths).addPredicates(predicates: _*))
-    FindShortestPaths(inner, shortestPaths, predicates)(solved)
+    FindShortestPaths(inner, shortestPaths, predicates, withFallBack)(solved)
   }
 
   def planEndpointProjection(inner: LogicalPlan, start: IdName, startInScope: Boolean, end: IdName, endInScope: Boolean, patternRel: PatternRelationship)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
@@ -57,7 +57,7 @@ case object planShortestPaths {
       planShortestPathsWithFallback(inner, shortestPaths, predicates, safePredicates, needFallbackPredicates, queryGraph)
     }
     else {
-      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates)
+      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates, false)
     }
   }
 
@@ -82,7 +82,7 @@ case object planShortestPaths {
     // Plan FindShortestPaths within an Apply with an Optional so we get null rows when
     // the graph algorithm does not find anything (left-hand-side)
     val lhsArgument = lpp.planArgumentRowFrom(inner)
-    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates)
+    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, true)
     val lhsOption = lpp.planOptional(lhsSp, Set.empty)
     val lhs = lpp.planApply(inner, lhsOption)
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RelationshipSupportTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RelationshipSupportTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.helpers
+
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.Relationship
+import org.neo4j.kernel.impl.core.RelationshipProxy
+import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions
+
+class RelationshipSupportTest extends CypherFunSuite {
+
+  test("Should handle empty list") {
+    RelationshipSupport.areRelationshipsUnique(List.empty) should be(true)
+  }
+
+  test("Should handle lists of one") {
+    RelationshipSupport.areRelationshipsUnique(List(mock[Relationship])) should be(true)
+  }
+
+  test("Should handle lists of length two") {
+    val actions = mock[RelationshipActions]
+    val a = new RelationshipProxy(actions, 1)
+    val b = new RelationshipProxy(actions, 2)
+    val a1 = new RelationshipProxy(actions, 1)
+
+    RelationshipSupport.areRelationshipsUnique(List(a, b)) should be(true)
+    RelationshipSupport.areRelationshipsUnique(List(a, a)) should be(false)
+    RelationshipSupport.areRelationshipsUnique(List(a, a1)) should be(false)
+  }
+
+  test("Should handle lists of length three") {
+    val actions = mock[RelationshipActions]
+    val a = new RelationshipProxy(actions, 1)
+    val b = new RelationshipProxy(actions, 2)
+    val c = new RelationshipProxy(actions, 3)
+
+    RelationshipSupport.areRelationshipsUnique(List(a, b, c)) should be(true)
+    RelationshipSupport.areRelationshipsUnique(List(a, a, b)) should be(false)
+    RelationshipSupport.areRelationshipsUnique(List(a, b, b)) should be(false)
+    RelationshipSupport.areRelationshipsUnique(List(a, b, a)) should be(false)
+  }
+
+  test("Should handle long lists") {
+    val actions = mock[RelationshipActions]
+    val a = new RelationshipProxy(actions, 1)
+    val b = new RelationshipProxy(actions, 2)
+    val c = new RelationshipProxy(actions, 3)
+    val d = new RelationshipProxy(actions, 4)
+    val e = new RelationshipProxy(actions, 5)
+    val f = new RelationshipProxy(actions, 6)
+    val g = new RelationshipProxy(actions, 7)
+    val h = new RelationshipProxy(actions, 8)
+    val i = new RelationshipProxy(actions, 9)
+
+    val l0 = List(a, b, c, d, e, f, g, h, i)
+    RelationshipSupport.areRelationshipsUnique(l0) should be(true)
+    val l1 = List(a, a, c, d, e, f, g, h, i)
+    RelationshipSupport.areRelationshipsUnique(l1) should be(false)
+    val l2 = List(a, b, c, d, d, f, g, h, i)
+    RelationshipSupport.areRelationshipsUnique(l2) should be(false)
+    val l3 = List(a, b, c, d, e, f, g, h, h)
+    RelationshipSupport.areRelationshipsUnique(l3) should be(false)
+    val l4 = List(a, b, c, d, e, f, g, h, a)
+    RelationshipSupport.areRelationshipsUnique(l4) should be(false)
+  }
+}


### PR DESCRIPTION
changelog: Ensures that shortest path enforces relationship uniqueness when using the exhaustive fallback plan. This only applies to cases where a predicate require the exhaustive fallback plan.