### PR TITLE
Fixing store copy to use netty chunking

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -95,7 +95,7 @@ public class CatchUpClient extends LifecycleAdapter
         String operation = String.format( "Timed out executing operation %s on %s (%s)",
                 request, target, catchUpAddress.get() );
 
-        return waitForCompletion( future, operation, channel::millisSinceLastResponse, inactivityTimeoutMillis );
+        return waitForCompletion( future, operation, channel::millisSinceLastResponse, inactivityTimeoutMillis, log );
     }
 
     private class CatchUpChannel implements CatchUpChannelPool.Channel

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -30,6 +30,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.stream.ChunkedWriteHandler;
 
 import java.net.BindException;
 import java.util.concurrent.TimeUnit;
@@ -166,8 +167,9 @@ public class CatchupServer extends LifecycleAdapter
                                 new TxPullRequestHandler( protocol, storeIdSupplier, dataSourceAvailabilitySupplier,
                                         transactionIdStoreSupplier, logicalTransactionStoreSupplier, txPullBatchSize,
                                         monitors, logProvider ) );
+                        pipeline.addLast( new ChunkedWriteHandler() );
                         pipeline.addLast( new GetStoreRequestHandler( protocol, dataSourceSupplier,
-                                checkPointerSupplier, fs ) );
+                                checkPointerSupplier, fs, logProvider ) );
                         pipeline.addLast( new GetStoreIdRequestHandler( protocol, storeIdSupplier ) );
                         pipeline.addLast( new CoreSnapshotRequestHandler( protocol, coreState ) );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TimeoutLoop.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TimeoutLoop.java
@@ -25,10 +25,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+import org.neo4j.logging.Log;
+
 class TimeoutLoop
 {
     static <T> T waitForCompletion( Future<T> future, String operation, Supplier<Long> millisSinceLastResponseSupplier,
-            long inactivityTimeoutMillis ) throws CatchUpClientException
+                                    long inactivityTimeoutMillis, Log log ) throws CatchUpClientException
     {
         long remainingTimeoutMillis = inactivityTimeoutMillis;
         while ( true )
@@ -49,6 +51,7 @@ class TimeoutLoop
             catch ( TimeoutException e )
             {
                 long millisSinceLastResponse = millisSinceLastResponseSupplier.get();
+                log.info( "Request timed out. Time since last response: " + millisSinceLastResponse );
                 if ( millisSinceLastResponse < inactivityTimeoutMillis )
                 {
                     remainingTimeoutMillis = inactivityTimeoutMillis - millisSinceLastResponse;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
@@ -71,7 +71,8 @@ class TrackingResponseHandler implements CatchUpResponseHandler
             recordLastResponse();
             return delegate.onFileContent( requestOutcomeSignal, fileChunk );
         }
-        return false;
+        // true means stop
+        return true;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
 import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
 import org.neo4j.causalclustering.messaging.EndOfStreamException;
 import org.neo4j.causalclustering.messaging.marshalling.ChannelMarshal;
@@ -55,6 +58,11 @@ public class FileChunk
     public byte[] bytes()
     {
         return bytes;
+    }
+
+    public int length()
+    {
+        return encodedLength;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
@@ -21,7 +21,11 @@ package org.neo4j.causalclustering.catchup.storecopy;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.stream.ChunkedNioStream;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.channels.FileChannel;
 import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
@@ -32,6 +36,8 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
 import org.neo4j.storageengine.api.StoreFileMetadata;
 
 import static org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
@@ -43,14 +49,17 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
     private final Supplier<NeoStoreDataSource> dataSource;
     private final Supplier<CheckPointer> checkPointerSupplier;
     private final FileSystemAbstraction fs;
+    private final Log log;
 
     public GetStoreRequestHandler( CatchupServerProtocol protocol, Supplier<NeoStoreDataSource> dataSource,
-            Supplier<CheckPointer> checkPointerSupplier, FileSystemAbstraction fs )
+                                   Supplier<CheckPointer> checkPointerSupplier, FileSystemAbstraction fs,
+                                   LogProvider logProvider )
     {
         this.protocol = protocol;
         this.dataSource = dataSource;
         this.checkPointerSupplier = checkPointerSupplier;
         this.fs = fs;
+        this.log = logProvider.getLog( getClass() );
     }
 
     @Override
@@ -63,12 +72,16 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
         else
         {
             long lastCheckPointedTx = checkPointerSupplier.get().tryCheckPoint( new SimpleTriggerInfo( "Store copy" ) );
-            FileSender fileSender = new FileSender( fs, ctx );
             try ( ResourceIterator<StoreFileMetadata> files = dataSource.get().listStoreFiles( false ) )
             {
                 while ( files.hasNext() )
                 {
-                    fileSender.sendFile( files.next().file() );
+                    File file = files.next().file();
+                    log.debug( "Sending file " + file );
+
+                    ctx.writeAndFlush( ResponseMessageType.FILE );
+                    ctx.writeAndFlush( new FileHeader( file.getName() ) );
+                    ctx.writeAndFlush( new FileSender( fs.open( file, "r" ) ) );
                 }
             }
             endStoreCopy( SUCCESS, ctx, lastCheckPointedTx );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -28,14 +28,18 @@ import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
 
 public class StoreCopyClient
 {
     private final CatchUpClient catchUpClient;
+    private final Log log;
 
-    public StoreCopyClient( CatchUpClient catchUpClient )
+    public StoreCopyClient( CatchUpClient catchUpClient, LogProvider logProvider )
     {
         this.catchUpClient = catchUpClient;
+        log = logProvider.getLog( getClass() );
     }
 
     long copyStoreFiles( MemberId from, StoreId expectedStoreId, StoreFileStreams storeFileStreams ) throws StoreCopyFailedException
@@ -68,6 +72,7 @@ public class StoreCopyClient
                         public void onFileStreamingComplete( CompletableFuture<Long> signal,
                                                              StoreCopyFinishedResponse response )
                         {
+                            log.info( "Finished streaming %s", destination );
                             signal.complete( response.lastCommittedTxBeforeStoreCopy() );
                         }
                     } );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/EntryRecord.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/EntryRecord.java
@@ -64,7 +64,7 @@ public class EntryRecord
         }
         catch ( ReadPastEndException e )
         {
-            throw EndOfStreamException.INSTANCE;
+            throw new EndOfStreamException( e );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -117,7 +117,7 @@ public class CoreServerModule
                 Clocks.systemClock(), inactivityTimeoutMillis, monitors ) );
 
         StoreFetcher storeFetcher = new StoreFetcher( logProvider, fileSystem, platformModule.pageCache,
-                new StoreCopyClient( catchUpClient ), new TxPullClient( catchUpClient, platformModule.monitors ),
+                new StoreCopyClient( catchUpClient, logProvider ), new TxPullClient( catchUpClient, platformModule.monitors ),
                 new TransactionLogCatchUpFactory() );
 
         CoreStateApplier coreStateApplier = new CoreStateApplier( logProvider );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeChannelMarshal.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/storage/SafeChannelMarshal.java
@@ -43,7 +43,7 @@ public abstract class SafeChannelMarshal<STATE> implements ChannelMarshal<STATE>
         }
         catch ( ReadPastEndException e )
         {
-            throw EndOfStreamException.INSTANCE;
+            throw new EndOfStreamException( e );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/EndOfStreamException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/EndOfStreamException.java
@@ -26,11 +26,8 @@ package org.neo4j.causalclustering.messaging;
  */
 public class EndOfStreamException extends Exception
 {
-    @SuppressWarnings( "ThrowableInstanceNeverThrown" )
-    public static final EndOfStreamException INSTANCE = new EndOfStreamException();
-
-    private EndOfStreamException()
+    public EndOfStreamException(Throwable e)
     {
-        // consider using the INSTANCE
+        this.initCause( e );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -203,7 +203,8 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         StoreFetcher storeFetcher = new StoreFetcher( platformModule.logging.getInternalLogProvider(),
                 fileSystem, platformModule.pageCache,
-                new StoreCopyClient( catchUpClient ), new TxPullClient( catchUpClient, platformModule.monitors ),
+                new StoreCopyClient( catchUpClient, logProvider ),
+                new TxPullClient( catchUpClient, platformModule.monitors ),
                 new TransactionLogCatchUpFactory() );
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TimeoutLoopTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/TimeoutLoopTest.java
@@ -26,6 +26,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+import org.neo4j.logging.NullLog;
+import org.neo4j.logging.NullLogProvider;
+
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -45,7 +48,7 @@ public class TimeoutLoopTest
         Supplier<Long> lastResponseSupplier = () -> 1L;
 
         // when
-        long value = TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 2 );
+        long value = TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 2, NullLog.getInstance() );
 
         // then
         assertEquals( 12L, value );
@@ -64,7 +67,7 @@ public class TimeoutLoopTest
         try
         {
             // when
-            TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 1 );
+            TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 1, NullLog.getInstance() );
             fail( "Should have timed out" );
         }
         catch ( CatchUpClientException e )
@@ -86,7 +89,7 @@ public class TimeoutLoopTest
         Supplier<Long> lastResponseSupplier = () -> 1L;
 
         // when
-        long value = TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 2 );
+        long value = TimeoutLoop.<Long>waitForCompletion( future, "", lastResponseSupplier, 2, NullLog.getInstance() );
 
         // then
         assertEquals( 12L, value );
@@ -102,7 +105,7 @@ public class TimeoutLoopTest
         // when
         try
         {
-            TimeoutLoop.<Long>waitForCompletion( future, "", () -> 1L, 2 );
+            TimeoutLoop.<Long>waitForCompletion( future, "", () -> 1L, 2, NullLog.getInstance() );
             fail( "Should have thrown exception" );
         }
         catch ( CatchUpClientException e )


### PR DESCRIPTION
We're now wiring our chunking into ChunkedInput so
it does chunking at multiple levels. We were previously
having a problem where we probably flooded Netty on the
server side and then nothing would be sent for 5 minutes.

With this change we let Netty handle the flow control.