### PR TITLE
Setting dbms.tracer=null will no longer prevent the database from starting when metrics are enabled

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LogRotationMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LogRotationMonitor.java
@@ -24,4 +24,19 @@ public interface LogRotationMonitor
     long numberOfLogRotationEvents();
 
     long logRotationAccumulatedTotalTimeMillis();
+
+    LogRotationMonitor NULL = new LogRotationMonitor()
+    {
+        @Override
+        public long numberOfLogRotationEvents()
+        {
+            return 0;
+        }
+
+        @Override
+        public long logRotationAccumulatedTotalTimeMillis()
+        {
+            return 0;
+        }
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerMonitor.java
@@ -24,4 +24,19 @@ public interface CheckPointerMonitor
     long numberOfCheckPointEvents();
 
     long checkPointAccumulatedTotalTimeMillis();
+
+    CheckPointerMonitor NULL = new CheckPointerMonitor()
+    {
+        @Override
+        public long numberOfCheckPointEvents()
+        {
+            return 0;
+        }
+
+        @Override
+        public long checkPointAccumulatedTotalTimeMillis()
+        {
+            return 0;
+        }
+    };
 }


### PR DESCRIPTION
Some default tracer implementations were implementing additional interfaces
that were looked after via the dependency resolver. This made the metrics
kernel extension fail to start when `dbms.tracer=null` was configured - a
setting that effectively turns all tracers off.

The `PlatformModule` now detects this, and publishes null-variants of the
alternative monitor interfaces when the configured tracer does not implement
them.