### PR TITLE
Use label scan store by default if possible for schema index population

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreView.java
@@ -44,7 +44,7 @@ public class DynamicIndexStoreView extends NeoStoreIndexStoreView
     private static final int VISIT_ALL_NODES_THRESHOLD_PERCENTAGE =
             FeatureToggles.getInteger( DynamicIndexStoreView.class, "all.nodes.visit.percentage.threshold", 10 );
     protected static boolean USE_LABEL_INDEX_FOR_SCHEMA_INDEX_POPULATION = FeatureToggles.flag(
-            DynamicIndexStoreView.class, "use.label.index", false );
+            DynamicIndexStoreView.class, "use.label.index", true );
 
     private final LabelScanStore labelScanStore;
     private final CountsTracker counts;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewIdIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewIdIterator.java
@@ -39,7 +39,7 @@ class LabelScanViewIdIterator implements PrimitiveLongResourceIterator
     private PrimitiveLongIterator idIterator;
     private LabelScanStore labelScanStore;
     private int[] labelIds;
-    private long currentId = 0;
+    private long currentId = -1;
 
     LabelScanViewIdIterator( LabelScanViewNodeStoreScan labelScanViewNodeStoreScan,
             LabelScanStore labelScanStore, int[] labelIds )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.state.storeview;
 
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -63,18 +61,6 @@ public class DynamicIndexStoreViewTest
     private Visitor<NodeLabelUpdate,Exception> labelUpdateVisitor = mock( Visitor.class );
     private IntPredicate propertyKeyIdFilter = mock( IntPredicate.class );
     private AllEntriesLabelScanReader nodeLabelRanges = mock( AllEntriesLabelScanReader.class );
-
-    @BeforeClass
-    public static void init()
-    {
-        DynamicIndexStoreView.USE_LABEL_INDEX_FOR_SCHEMA_INDEX_POPULATION = true;
-    }
-
-    @AfterClass
-    public static void cleanup()
-    {
-        DynamicIndexStoreView.USE_LABEL_INDEX_FOR_SCHEMA_INDEX_POPULATION = false;
-    }
 
     @Before
     public void setUp()

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -387,10 +387,8 @@ public class MultiIndexPopulationConcurrentUpdatesIT
                 Visitor<NodePropertyUpdates,FAILURE> propertyUpdatesVisitor,
                 Visitor<NodeLabelUpdate,FAILURE> labelUpdateVisitor )
         {
-            DynamicIndexStoreViewWrapper.USE_LABEL_INDEX_FOR_SCHEMA_INDEX_POPULATION = true;
             StoreScan<FAILURE> storeScan =
                     super.visitNodes( labelIds, propertyKeyIdFilter, propertyUpdatesVisitor, labelUpdateVisitor );
-            DynamicIndexStoreViewWrapper.USE_LABEL_INDEX_FOR_SCHEMA_INDEX_POPULATION = false;
             return new LabelScanViewNodeStoreWrapper( nodeStore, locks, propertyStore, getLabelScanStore(),
                     element -> false, propertyUpdatesVisitor, labelIds, propertyKeyIdFilter,
                     (LabelScanViewNodeStoreScan) storeScan, updates);


### PR DESCRIPTION
Switch toggle to allow usage of label scan store by default as a source during index population