### PR TITLE
Solve bug when combining pattern comprehension and map projections

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -265,4 +265,16 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
 
     executeWithCostPlannerOnly(query).toList //does not throw
   }
+
+  test("pattern comprehension play nice with map projections") {
+    val movie = createLabeledNode(Map("title" -> "The Shining"), "Movie")
+    val actor1 = createNode("name" -> "Actor1")
+    val actor2 = createNode("name" -> "Actor2")
+    relate(actor1, movie, "ACTED_IN")
+    relate(actor2, movie, "ACTED_IN")
+    val query = """match (m:Movie) return m { .title, cast: [(m)<-[:ACTED_IN]-(p) | p.name] }"""
+
+    executeWithCostPlannerOnly(query).toList //does not throw
+  }
+
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/desugarMapProjection.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/desugarMapProjection.scala
@@ -37,12 +37,10 @@ case class desugarMapProjection(state: SemanticState) extends Rewriter {
   def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
 
   private val instance: Rewriter = Rewriter.lift {
-    case e@MapProjection(id, items) =>
+    case e@MapProjection(id, items, scope) =>
 
       def propertySelect(propertyPosition: InputPosition, name: String): LiteralEntry = {
         val key = PropertyKeyName(name)(propertyPosition)
-
-        val scope = state.recordedScopes(e)
         val idPos = scope.symbolTable(id.name).definition.position
         val newIdentifier = Variable(id.name)(idPos)
         val value = Property(newIdentifier, key)(propertyPosition)

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/recordScopes.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/recordScopes.scala
@@ -24,12 +24,12 @@ import org.neo4j.cypher.internal.frontend.v3_1.{Rewriter, SemanticState, topDown
 
 case class recordScopes(semanticState: SemanticState) extends Rewriter {
 
-  def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
+  def apply(that: AnyRef): AnyRef = instance.apply(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = topDown(Rewriter.lift {
     case x: PatternComprehension =>
       x.withOuterScope(semanticState.recordedScopes(x).symbolDefinitions.map(_.asVariable))
     case x: MapProjection =>
       x.withOuterScope(semanticState.recordedScopes(x))
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/recordScopes.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/recordScopes.scala
@@ -19,15 +19,17 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_1.ast.rewriters
 
-import org.neo4j.cypher.internal.frontend.v3_1.ast.PatternComprehension
-import org.neo4j.cypher.internal.frontend.v3_1.{Rewriter, SemanticState, bottomUp}
+import org.neo4j.cypher.internal.frontend.v3_1.ast.{MapProjection, PatternComprehension}
+import org.neo4j.cypher.internal.frontend.v3_1.{Rewriter, SemanticState, topDown}
 
 case class recordScopes(semanticState: SemanticState) extends Rewriter {
 
-  def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+  def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
 
   private val instance: Rewriter = Rewriter.lift {
     case x: PatternComprehension =>
       x.withOuterScope(semanticState.recordedScopes(x).symbolDefinitions.map(_.asVariable))
+    case x: MapProjection =>
+      x.withOuterScope(semanticState.recordedScopes(x))
   }
 }

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/DesugarDesugaredMapProjectionTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/DesugarDesugaredMapProjectionTest.scala
@@ -75,9 +75,10 @@ class DesugarDesugaredMapProjectionTest extends CypherFunSuite {
         val mkException = new SyntaxExceptionCreator(originalQuery, InputPosition.NONE)
         val sequence: Rewriter = inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException))
         val originalAst = parser.parse(q).endoRewrite(sequence)
-        val semanticCheckResult: SemanticCheckResult = originalAst.semanticCheck(SemanticState.clean)
+        val semanticCheckResult = originalAst.semanticCheck(SemanticState.clean)
+        val withScopes = originalAst.endoRewrite(recordScopes(semanticCheckResult.state))
 
-        originalAst.endoRewrite(desugarMapProjection(semanticCheckResult.state))
+        withScopes.endoRewrite(desugarMapProjection(semanticCheckResult.state))
       }
 
       val rewrittenOriginal = rewrite(originalQuery)

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/MapProjection.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/MapProjection.scala
@@ -19,11 +19,12 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_1.ast
 
-import org.neo4j.cypher.internal.frontend.v3_1.ast.Expression.{SemanticContext, _}
+import org.neo4j.cypher.internal.frontend.v3_1.ast.Expression._
 import org.neo4j.cypher.internal.frontend.v3_1.symbols._
 import org.neo4j.cypher.internal.frontend.v3_1.{InputPosition, _}
 
-case class MapProjection(name: Variable, items: Seq[MapProjectionElement])(val position: InputPosition)
+case class MapProjection(name: Variable, items: Seq[MapProjectionElement], outerScope: Scope = Scope.empty)
+                        (val position: InputPosition)
   extends Expression with SimpleTyping {
   protected def possibleTypes = CTMap
 
@@ -31,6 +32,9 @@ case class MapProjection(name: Variable, items: Seq[MapProjectionElement])(val p
     items.semanticCheck(ctx) chain
     super.semanticCheck(ctx) ifOkChain // We need to remember the scope to later rewrite this ASTNode
     recordCurrentScope
+
+  def withOuterScope(outerScope: Scope) =
+    copy(outerScope = outerScope)(position)
 }
 
 sealed trait MapProjectionElement extends SemanticCheckableWithContext with ASTNode


### PR DESCRIPTION
MapProjection needs the current scope, so it's been recorded in the semantic state.
But since MapProjections can contain other AST elements that get rewritten, it's important to
put this information in a rewrite-safe format and not keep it in the SemanticState, where any
rewrite will make the information hard to get at.

This commit puts the scope information into the MapProjection AST-object.