### PR TITLE
Fix recovery issue in the code finding the latest check point

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -62,7 +62,7 @@ public class LatestCheckPointFinder
             LogVersionedStoreChannel channel = PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem, version );
             if ( channel == null )
             {
-                return new LatestCheckPoint( null, false, oldestVersionFound );
+                break;
             }
 
             oldestVersionFound = version;

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
@@ -19,14 +19,17 @@
  */
 package org.neo4j.kernel.recovery;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -42,50 +45,41 @@ import org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.encodeLogVersion;
 
+@RunWith( Parameterized.class )
 public class LatestCheckPointFinderTest
 {
     private final PhysicalLogFiles logFiles = mock( PhysicalLogFiles.class );
     private final FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
     @SuppressWarnings( "unchecked" )
     private final LogEntryReader<ReadableLogChannel> reader = mock( LogEntryReader.class );
-    private final int olderLogVersion = 0;
-    private final int logVersion = 1;
 
-    @Before
-    public void setup() throws IOException
+    private final int startLogVersion;
+    private final int endLogVersion;
+
+    public LatestCheckPointFinderTest( Integer startLogVersion, Integer endLogVersion )
     {
-        for ( int i = 0; i <= logVersion; i++ )
-        {
-            File file = mock( File.class );
-            when( logFiles.getLogFileForVersion( i ) ).thenReturn( file );
-            StoreChannel channel = mock( StoreChannel.class );
-            when( fs.open( file, "rw" ) ).thenReturn( channel );
-            final int version = i;
-            when( channel.read( any( ByteBuffer.class ) ) ).thenAnswer( new Answer<Integer>()
-            {
-                @Override
-                public Integer answer( InvocationOnMock invocationOnMock ) throws Throwable
-                {
-                    ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
-                    buffer.putLong( encodeLogVersion( version ) );
-                    buffer.putLong( 33 );
-                    return LOG_HEADER_SIZE;
-                }
-            } );
-        }
-        when( fs.fileExists( any( File.class ) ) ).thenReturn( true );
+        this.startLogVersion = startLogVersion;
+        this.endLogVersion = endLogVersion;
+    }
+
+    @Parameterized.Parameters( name="{0},{1}")
+    public static Collection<Object[]> params()
+    {
+        return Arrays.asList( new Object[]{0, 1}, new Object[]{42, 43}  );
     }
 
     @Test
     public void noLogFilesFound() throws Throwable
     {
-        // given
-        // override the setup...
+        // given no files
+        int logVersion = startLogVersion;
         when( logFiles.getLogFileForVersion( logVersion ) ).thenReturn( mock( File.class ) );
         when( fs.fileExists( any( File.class ) ) ).thenReturn( false );
 
@@ -95,7 +89,6 @@ public class LatestCheckPointFinderTest
         LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-
         assertEquals( new LatestCheckPoint( null, false, -1 ), latestCheckPoint );
     }
 
@@ -103,166 +96,179 @@ public class LatestCheckPointFinderTest
     public void oneLogFileNoCheckPoints() throws Throwable
     {
         // given
+        int logVersion = startLogVersion;
+        setupLogFiles( logVersion, logVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( olderLogVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, false, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( null, false, logVersion ), latestCheckPoint );
     }
 
     @Test
     public void oneLogFileNoCheckPointsOneStart() throws Throwable
     {
         // given
+        int logVersion = startLogVersion;
+        setupLogFiles( logVersion, logVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( start, null );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 16 ) );
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, (LogEntry) null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( olderLogVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, true, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( null, true, logVersion ), latestCheckPoint );
     }
 
     @Test
     public void twoLogFilesNoCheckPoints() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, false, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( null, false, startLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void twoLogFilesNoCheckPointsOneStart() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( start, null );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, true, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( null, true, startLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointOnly() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 33 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( checkPoint, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointAndAStartBefore() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 33 ) );
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointAndAStartAfter() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 16 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 33 ) );
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 16 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 33 ) );
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointAndAStartAtSamePosition() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 16 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 16 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingMultipleCheckPointsOneStartInBetween() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 33 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 22 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 mock( CheckPoint.class ), start, checkPoint, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingMultipleCheckPointsOneStartAfterBoth() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( logVersion, 22 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 33 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 22 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 33 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 mock( CheckPoint.class ), checkPoint, start, null );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingACheckPointAndNewerFileContainingAStart() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start1 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( logVersion, 22 ) );
-        LogEntryStart start2 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( olderLogVersion, 33 ) );
+        LogEntryStart start1 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 22 ) );
+        LogEntryStart start2 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 16 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 33 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 start1, null, // first file
@@ -270,19 +276,20 @@ public class LatestCheckPointFinderTest
         );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, startLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingACheckPointAndNewerFileIsEmpty() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( olderLogVersion, 33 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 16 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 33 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 null, // first file
@@ -290,19 +297,20 @@ public class LatestCheckPointFinderTest
         );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, false, startLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingAStartAndNewerFileContainingACheckPointPointingToAPreviousPositionThanStart() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( olderLogVersion, 16 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 22 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 16 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 checkPoint, // first file
@@ -310,19 +318,20 @@ public class LatestCheckPointFinderTest
         );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingAStartAndNewerFileContainingACheckPointPointingToALaterPositionThanStart() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( olderLogVersion, 25 ) );
+        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 22 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 25 ) );
 
         when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
                 checkPoint, // first file
@@ -330,30 +339,63 @@ public class LatestCheckPointFinderTest
         );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, logVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
     }
 
     @Test
     public void latestLogEmptyStartEntryBeforeAndAfterCheckPointInTheLastButOneLog() throws Throwable
     {
         // given
+        setupLogFiles( startLogVersion, endLogVersion );
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntry firstStart = new LogEntryStart(  0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 20 ) );
-        LogEntry secondStart = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 27 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( olderLogVersion, 25 ) );
+        LogEntry firstStart = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 20 ) );
+        LogEntry secondStart = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 27 ) );
+        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 25 ) );
 
-        when( reader.readLogEntry( any( ReadableVersionableLogChannel.class ) ) ).thenReturn(
+        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
                 null, // first file
                 firstStart, checkPoint, secondStart, null // second file
         );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, olderLogVersion ), latestCheckPoint );
+        assertEquals( new LatestCheckPoint( checkPoint, true, startLogVersion ), latestCheckPoint );
+    }
+
+    private void setupLogFiles( int startLogVersion, int endLogVersion ) throws IOException
+    {
+        when( fs.fileExists( any( File.class ) ) ).thenReturn( false );
+        for ( int i = startLogVersion; i <= endLogVersion; i++ )
+        {
+            File file = mock( File.class );
+            when( fs.fileExists( file ) ).thenReturn( true );
+            when( logFiles.getLogFileForVersion( i ) ).thenReturn( file );
+            StoreChannel channel = mock( StoreChannel.class );
+            when( fs.open( eq( file ), anyString() ) ).thenReturn( channel );
+            final int version = i;
+            when( channel.read( any( ByteBuffer.class ) ) ).thenAnswer( new Answer<Object>()
+            {
+                @Override
+                public Object answer( InvocationOnMock invocationOnMock ) throws Throwable
+                {
+                    ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+                    buffer.putLong( encodeLogVersion( version ) );
+                    buffer.putLong( 33 );
+                    return LOG_HEADER_SIZE;
+                }
+            } );
+        }
+
+        // to make sure we have a mocked file for the file before startLogVersion to avoid NPE...
+        if ( startLogVersion > 0 )
+        {
+            File file = mock( File.class );
+            when( logFiles.getLogFileForVersion( startLogVersion - 1 ) ).thenReturn( file );
+        }
     }
 }


### PR DESCRIPTION
In the case there are only log files with versions greater than zero
and no checkpoints in any of those, we mistakenly report that no
recovery is needed.

changelog: Fix a bug that could prevent recovery from finding the latest check point record in the logs, preventing adequate recovery of the store.