### PR TITLE
Make sure all expressions are shown in plan descriptions

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LegacySortPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LegacySortPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.SortItem
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpression
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpressions
 
 import scala.math.signum
 
@@ -37,8 +37,13 @@ case class LegacySortPipe(source: Pipe, sortDescription: List[SortItem])
       sortWith((a, b) => compareBy(a, b, sortDescription)(state)).iterator
   }
 
-  def planDescription =
-    source.planDescription.andThen(this.id, "Sort", variables, sortDescription.map(item => LegacyExpression(item.expression)):_*)
+  def planDescription = {
+    val sorting = sortDescription.zipWithIndex.map {
+      case (sortItem, idx) => s"o$idx" -> sortItem.expression
+    }
+
+    source.planDescription.andThen(this.id, "Sort", variables, LegacyExpressions(sorting.toMap))
+  }
 
   override def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProjectionPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProjectionPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.Effects._
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpression
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpressions
 
 /*
 Projection evaluates expressions and stores their values into new slots in the execution context.
@@ -55,7 +55,7 @@ case class ProjectionPipe(source: Pipe, expressions: Map[String, Expression])(va
 
   def planDescriptionWithoutCardinality =
     source.planDescription
-      .andThen(this.id, "Projection", variables, expressions.values.toSeq.map(LegacyExpression):_*)
+      .andThen(this.id, "Projection", variables, LegacyExpressions(expressions))
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.ShortestPath
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsAllNodes, ReadsAllRelationships}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.{CastSupport, ListSupport}
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpression
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpressions
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.graphdb.Path
 
@@ -66,10 +66,8 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
   }
 
   override def planDescriptionWithoutCardinality = {
-    val args = predicates.map { p =>
-      LegacyExpression(p)
-    }
-    source.planDescription.andThen(this.id, "ShortestPath", variables, args:_*)
+    val args = predicates.zipWithIndex.map { case (p, idx) => s"p$idx" -> p }
+    source.planDescription.andThen(this.id, "ShortestPath", variables, LegacyExpressions(args.toMap))
   }
 
   def dup(sources: List[Pipe]): Pipe = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ValueHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ValueHashJoinPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.Effects
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.LegacyExpressions
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{InternalPlanDescription, PlanDescriptionImpl, TwoChildren}
 
 import scala.collection.mutable
@@ -61,7 +61,7 @@ case class ValueHashJoinPipe(lhsExpression: Expression, rhsExpression: Expressio
       id = id,
       name = "ValueHashJoin",
       children = TwoChildren(left.planDescription, right.planDescription),
-      arguments = Seq(Arguments.LegacyExpression(lhsExpression), Arguments.LegacyExpression(rhsExpression)),
+      arguments = Seq(LegacyExpressions(Map("lhs" -> lhsExpression, "rhs" -> rhsExpression))),
       variables
     )
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/InternalPlanDescription.scala
@@ -82,6 +82,9 @@ object InternalPlanDescription {
     case class ColumnsLeft(value: Seq[String]) extends Argument
     case class Expression(value: ast.Expression) extends Argument
     case class LegacyExpression(value: commands.expressions.Expression) extends Argument
+    case class LegacyExpressions(expressions: Map[String, commands.expressions.Expression]) extends Argument {
+      override def name = "LegacyExpression"
+    }
     case class UpdateActionName(value: String) extends Argument
     case class MergePattern(startPoint: String) extends Argument
     case class LegacyIndex(value: String) extends Argument

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -34,6 +34,7 @@ object PlanDescriptionArgumentSerializer {
     arg match {
       case ColumnsLeft(columns) => s"keep columns ${columns.mkString(SEPARATOR)}"
       case LegacyExpression(expr) => removeGeneratedNames(expr.toString)
+      case LegacyExpressions(expressions) => expressions.map({ case (k, v) => s"$k : $v" }).mkString("{", ", ", "}")
       case Expression(expr) => removeGeneratedNames(expr.toString)
       case UpdateActionName(action) => action
       case MergePattern(startPoint) => s"MergePattern($startPoint)"

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -20,13 +20,14 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planDescription
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.ProjectedPath.{nilProjector, singleNodeProjector}
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{NestedPipeExpression, ProjectedPath}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Literal, NestedPipeExpression, ProjectedPath}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ArgumentPipe, PipeMonitor}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.PlanDescriptionArgumentSerializer.serialize
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
 class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
 
   test("serialization should leave numeric arguments as numbers") {
@@ -55,5 +56,10 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
     ))
 
     serialize(LegacyExpression(nested)) should equal("NestedExpression(Argument)")
+  }
+
+  test("projection should show multiple expressions") {
+    serialize(LegacyExpressions(Map("1" -> Literal(42), "2" -> Literal(56)))) should equal(
+      "{1 : Literal(42), 2 : Literal(56)}")
   }
 }


### PR DESCRIPTION
The plan descriptions before and after this commit, for the following query:

```
MATCH(user:Person{name:'Dana'}) 
RETURN SIZE(()-[:FOLLOWS]->(user)) as follows,user
```

![plan descriptions](https://cloud.githubusercontent.com/assets/402248/20564248/a56eecd8-b18c-11e6-9639-d9f70808fe91.png)