### PR TITLE
Story copy now uses relative paths.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
@@ -19,14 +19,11 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
+import java.io.File;
+import java.util.function.Supplier;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.stream.ChunkedNioStream;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.channels.FileChannel;
-import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
 import org.neo4j.causalclustering.catchup.ResponseMessageType;
@@ -42,6 +39,7 @@ import org.neo4j.storageengine.api.StoreFileMetadata;
 
 import static org.neo4j.causalclustering.catchup.CatchupServerProtocol.State;
 import static org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponse.Status.SUCCESS;
+import static org.neo4j.io.fs.FileUtils.relativePath;
 
 public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStoreRequest>
 {
@@ -80,7 +78,7 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
                     log.debug( "Sending file " + file );
 
                     ctx.writeAndFlush( ResponseMessageType.FILE );
-                    ctx.writeAndFlush( new FileHeader( file.getName() ) );
+                    ctx.writeAndFlush( new FileHeader( relativePath( dataSource.get().getStoreDir(), file ) ) );
                     ctx.writeAndFlush( new FileSender( fs.open( file, "r" ) ) );
                 }
             }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/FileCopyMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/FileCopyMonitor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.tx;
+
+import java.io.File;
+
+public interface FileCopyMonitor
+{
+    void copyFile( File file );
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -118,7 +118,7 @@ public class CoreServerModule
 
         StoreFetcher storeFetcher = new StoreFetcher( logProvider, fileSystem, platformModule.pageCache,
                 new StoreCopyClient( catchUpClient, logProvider ), new TxPullClient( catchUpClient, platformModule.monitors ),
-                new TransactionLogCatchUpFactory() );
+                new TransactionLogCatchUpFactory(), platformModule.monitors );
 
         CoreStateApplier coreStateApplier = new CoreStateApplier( logProvider );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -205,7 +205,8 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
                 fileSystem, platformModule.pageCache,
                 new StoreCopyClient( catchUpClient, logProvider ),
                 new TxPullClient( catchUpClient, platformModule.monitors ),
-                new TransactionLogCatchUpFactory() );
+                new TransactionLogCatchUpFactory(),
+                platformModule.monitors );
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config,
                 platformModule.kernelExtensions.listFactories(), platformModule.pageCache );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFetcherTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFetcherTest.java
@@ -34,6 +34,7 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
@@ -59,7 +60,7 @@ public class StoreFetcherTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ) );
+                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         MemberId localhost = new MemberId( UUID.randomUUID() );
@@ -89,7 +90,7 @@ public class StoreFetcherTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ) );
+                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         fetcher.copyStore( localhost, wantedStoreId, new File( "destination" ) );
@@ -109,7 +110,7 @@ public class StoreFetcherTest
 
         StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
                 null,
-                storeCopyClient, txPullClient, factory( writer ) );
+                storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         doThrow( StoreCopyFailedException.class ).when( txPullClient )
                 .pullTransactions( any( MemberId.class ), eq( storeId ), anyLong(), any( TransactionLogCatchUpWriter.class ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -56,6 +56,7 @@ import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.internal.DatabaseHealth;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.test.DbRepresentation;
 
@@ -167,6 +168,15 @@ public class Cluster
     public ReadReplica addReadReplicaWithId( int memberId )
     {
         return addReadReplicaWithIdAndRecordFormat( memberId, StandardV3_0.NAME );
+    }
+
+    public ReadReplica addReadReplicaWithIdAndMonitors( int memberId, Monitors monitors )
+    {
+        List<AdvertisedSocketAddress> hazelcastAddresses = buildAddresses( coreMembers.keySet() );
+        ReadReplica member = new ReadReplica( parentDir, memberId, discoveryServiceFactory,
+                hazelcastAddresses, stringMap(), emptyMap(), StandardV3_0.NAME, monitors );
+        readReplicas.put( memberId, member );
+        return member;
     }
 
     public void shutdown() throws ExecutionException, InterruptedException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -26,13 +26,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.core.consensus.log.segmented.FileNames;
@@ -53,6 +56,7 @@ import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
 import org.neo4j.kernel.impl.store.MetaDataStore;
@@ -62,27 +66,32 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.causalclustering.ClusterRule;
 
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import static org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.com.storecopy.StoreUtil.TEMP_COPY_DIRECTORY_NAME;
 import static org.neo4j.function.Predicates.awaitEx;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -141,6 +150,12 @@ public class ReadReplicaReplicationIT
         Cluster cluster = clusterRule.withNumberOfReadReplicas( 0 ).startCluster();
         int nodesBeforeReadReplicaStarts = 1;
 
+        cluster.coreTx( ( db, tx ) ->
+        {
+            db.schema().constraintFor( Label.label( "Foo" ) ).assertPropertyIsUnique( "foobar" ).create();
+            tx.success();
+        } );
+
         // when
         for ( int i = 0; i < 100; i++ )
         {
@@ -151,7 +166,21 @@ public class ReadReplicaReplicationIT
             } );
         }
 
-        cluster.addReadReplicaWithId( 0 ).start();
+        AtomicBoolean labelScanStoreCorrectlyPlaced = new AtomicBoolean( false );
+        Monitors monitors = new Monitors();
+        ReadReplica rr = cluster.addReadReplicaWithIdAndMonitors( 0, monitors );
+
+        File labelScanStore = LabelScanStoreProvider.getStoreDirectory( new File( rr.storeDir(), TEMP_COPY_DIRECTORY_NAME ) );
+
+        monitors.addMonitorListener( (FileCopyMonitor) file ->
+        {
+            if ( file.getParent().contains( labelScanStore.getPath() ) )
+            {
+                labelScanStoreCorrectlyPlaced.set( true );
+            }
+        } );
+
+        rr.start();
 
         for ( int i = 0; i < 100; i++ )
         {
@@ -173,12 +202,14 @@ public class ReadReplicaReplicationIT
 
                 for ( Node node : readReplica.getAllNodes() )
                 {
-                    assertEquals( "baz_bat", node.getProperty( "foobar" ) );
+                    assertThat( node.getProperty( "foobar" ).toString(), startsWith( "baz_bat" ) );
                 }
 
                 tx.success();
             }
         }
+
+        assertTrue( labelScanStoreCorrectlyPlaced.get() );
     }
 
     @Test
@@ -507,16 +538,16 @@ public class ReadReplicaReplicationIT
     {
         for ( int i = 0; i < amount; i++ )
         {
-            Node node = db.createNode();
-            node.setProperty( "foobar", "baz_bat" );
-            node.setProperty( "foobar1", "baz_bat" );
-            node.setProperty( "foobar2", "baz_bat" );
-            node.setProperty( "foobar3", "baz_bat" );
-            node.setProperty( "foobar4", "baz_bat" );
-            node.setProperty( "foobar5", "baz_bat" );
-            node.setProperty( "foobar6", "baz_bat" );
-            node.setProperty( "foobar7", "baz_bat" );
-            node.setProperty( "foobar8", "baz_bat" );
+            Node node = db.createNode(Label.label( "Foo" ));
+            node.setProperty( "foobar", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar1", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar2", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar3", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar4", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar5", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar6", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar7", format( "baz_bat%s", UUID.randomUUID() ) );
+            node.setProperty( "foobar8", format( "baz_bat%s", UUID.randomUUID() ) );
         }
     }
 }


### PR DESCRIPTION
Previously it was copying all the files into the storeDir
which meant that we were unnecessarily creating indexes
after a store copy.

changelog: Store copies from a Read Replica could result in index files appearing in the top level database directory. This no longer is the case and index files are always placed in the correct subdirectory.