### PR TITLE
Freeze security context before acquiring transaction

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -215,8 +215,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
      * Reset this transaction to a vanilla state, turning it into a logically new transaction.
      */
     public KernelTransactionImplementation initialize(
-            long lastCommittedTx, long lastTimeStamp, StatementLocks statementLocks, Type type, SecurityContext securityContext,
-            long transactionTimeout )
+            long lastCommittedTx, long lastTimeStamp, StatementLocks statementLocks, Type type,
+            SecurityContext frozenSecurityContext, long transactionTimeout )
     {
         this.type = type;
         this.statementLocks = statementLocks;
@@ -229,7 +229,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.lastTransactionTimestampWhenStarted = lastTimeStamp;
         this.transactionEvent = tracer.beginTransaction();
         assert transactionEvent != null : "transactionEvent was null!";
-        this.securityContext = securityContext.freeze();
+        this.securityContext = frozenSecurityContext;
         this.transactionId = NOT_COMMITTED_TRANSACTION_ID;
         this.commitTime = NOT_COMMITTED_TRANSACTION_COMMIT_TIME;
         this.currentTransactionOperations = timeoutMillis > 0 ? operationContainer.guardedParts() : operationContainer.nonGuarderParts();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -157,6 +157,7 @@ public class KernelTransactions extends LifecycleAdapter
     public KernelTransaction newInstance( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
     {
         assertCurrentThreadIsNotBlockingNewTransactions();
+        SecurityContext frozenSecurityContext = securityContext.freeze();
         newTransactionsLock.readLock().lock();
         try
         {
@@ -165,7 +166,7 @@ public class KernelTransactions extends LifecycleAdapter
             KernelTransactionImplementation tx = localTxPool.acquire();
             StatementLocks statementLocks = statementLocksFactory.newInstance();
             tx.initialize( lastCommittedTransaction.transactionId(),
-                    lastCommittedTransaction.commitTimestamp(), statementLocks, type, securityContext, timeout );
+                    lastCommittedTransaction.commitTimestamp(), statementLocks, type, frozenSecurityContext, timeout );
             return tx;
         }
         finally
@@ -297,5 +298,4 @@ public class KernelTransactions extends LifecycleAdapter
                     "Thread that is blocking new transactions from starting can't start new transaction" );
         }
     }
-
 }


### PR DESCRIPTION
Freeze security context before acquiring transaction, to avoid transaction leakage if the freezing failes.

changelog [security] Fixed transaction leakage with expired LDAP authorization by freezing security context before acquiring the transaction