### PR TITLE
Restore removed batch inserters public API

### DIFF
--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -80,6 +80,7 @@ import static java.util.Arrays.asList;
 public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
 {
     private final Clock clock;
+    private volatile boolean closed = false;
 
     interface Positionable
     {
@@ -141,6 +142,12 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     {
         closeFiles();
         closeFileSystems();
+        closed = true;
+    }
+
+    public boolean isClosed()
+    {
+        return closed;
     }
 
     private void closeFileSystems() throws IOException

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstractionTest.java
@@ -250,6 +250,7 @@ public class EphemeralFileSystemAbstractionTest
             fileSystemAbstraction.close();
 
             assertTrue( closeTrackingFileSystem.isClosed() );
+            assertTrue( fileSystemAbstraction.isClosed() );
             assertFalse( fileSystemAbstraction.fileExists( testFile ) );
             assertFalse( fileSystemAbstraction.fileExists( testFile ) );
         }

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -162,6 +162,7 @@ the relevant Commercial Agreement.
           <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
           <includes>
             <include>org/neo4j/graphdb/**</include>
+            <include>org/neo4j/unsafe/batchinsert/**</include>
           </includes>
           <excludeMessageCodes>
             <param>6006</param><!-- Field was made final. -->

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.schema.ConstraintCreator;
+import org.neo4j.graphdb.schema.IndexCreator;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+import org.neo4j.unsafe.batchinsert.BatchRelationship;
+
+public class FileSystemClosingBatchInserter implements BatchInserter
+{
+    private final BatchInserter delegate;
+    private final FileSystemAbstraction fileSystem;
+
+    public FileSystemClosingBatchInserter( BatchInserter delegate, FileSystemAbstraction fileSystem )
+    {
+        this.delegate = delegate;
+        this.fileSystem = fileSystem;
+    }
+
+    @Override
+    public long createNode( Map<String,Object> properties, Label... labels )
+    {
+        return delegate.createNode( properties, labels );
+    }
+
+    @Override
+    public void createNode( long id, Map<String,Object> properties, Label... labels )
+    {
+        delegate.createNode( id, properties, labels );
+    }
+
+    @Override
+    public boolean nodeExists( long nodeId )
+    {
+        return delegate.nodeExists( nodeId );
+    }
+
+    @Override
+    public void setNodeProperties( long node, Map<String,Object> properties )
+    {
+        delegate.setNodeProperties( node, properties );
+    }
+
+    @Override
+    public boolean nodeHasProperty( long node, String propertyName )
+    {
+        return delegate.nodeHasProperty( node, propertyName );
+    }
+
+    @Override
+    public void setNodeLabels( long node, Label... labels )
+    {
+        delegate.setNodeLabels( node, labels );
+    }
+
+    @Override
+    public Iterable<Label> getNodeLabels( long node )
+    {
+        return delegate.getNodeLabels( node );
+    }
+
+    @Override
+    public boolean nodeHasLabel( long node, Label label )
+    {
+        return delegate.nodeHasLabel( node, label );
+    }
+
+    @Override
+    public boolean relationshipHasProperty( long relationship, String propertyName )
+    {
+        return delegate.relationshipHasProperty( relationship, propertyName );
+    }
+
+    @Override
+    public void setNodeProperty( long node, String propertyName, Object propertyValue )
+    {
+        delegate.setNodeProperty( node, propertyName, propertyValue );
+    }
+
+    @Override
+    public void setRelationshipProperty( long relationship, String propertyName, Object propertyValue )
+    {
+        delegate.setRelationshipProperty( relationship, propertyName, propertyValue );
+    }
+
+    @Override
+    public Map<String,Object> getNodeProperties( long nodeId )
+    {
+        return delegate.getNodeProperties( nodeId );
+    }
+
+    @Override
+    public Iterable<Long> getRelationshipIds( long nodeId )
+    {
+        return delegate.getRelationshipIds( nodeId );
+    }
+
+    @Override
+    public Iterable<BatchRelationship> getRelationships( long nodeId )
+    {
+        return delegate.getRelationships( nodeId );
+    }
+
+    @Override
+    public long createRelationship( long node1, long node2, RelationshipType type, Map<String,Object> properties )
+    {
+        return delegate.createRelationship( node1, node2, type, properties );
+    }
+
+    @Override
+    public BatchRelationship getRelationshipById( long relId )
+    {
+        return delegate.getRelationshipById( relId );
+    }
+
+    @Override
+    public void setRelationshipProperties( long rel, Map<String,Object> properties )
+    {
+        delegate.setRelationshipProperties( rel, properties );
+    }
+
+    @Override
+    public Map<String,Object> getRelationshipProperties( long relId )
+    {
+        return delegate.getRelationshipProperties( relId );
+    }
+
+    @Override
+    public void removeNodeProperty( long node, String property )
+    {
+        delegate.removeNodeProperty( node, property );
+    }
+
+    @Override
+    public void removeRelationshipProperty( long relationship, String property )
+    {
+        delegate.removeRelationshipProperty( relationship, property );
+    }
+
+    @Override
+    public IndexCreator createDeferredSchemaIndex( Label label )
+    {
+        return delegate.createDeferredSchemaIndex( label );
+    }
+
+    @Override
+    public ConstraintCreator createDeferredConstraint( Label label )
+    {
+        return delegate.createDeferredConstraint( label );
+    }
+
+    @Override
+    public void shutdown()
+    {
+        delegate.shutdown();
+        closeFileSystem();
+    }
+
+    @Override
+    public String getStoreDir()
+    {
+        return delegate.getStoreDir();
+    }
+
+    public FileSystemAbstraction getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    private void closeFileSystem()
+    {
+        try
+        {
+            fileSystem.close();
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertersTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
+import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.unsafe.batchinsert.internal.FileSystemClosingBatchInserter;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.unsafe.batchinsert.BatchInserters.inserter;
+
+public class BatchInsertersTest
+{
+
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
+
+    @Test
+    public void automaticallyCloseCreatedFileSystemOnShutdown() throws Exception
+    {
+        verifyInserterFileSystemClose( inserter( getStoreDir() ) );
+        verifyInserterFileSystemClose( inserter( getStoreDir(), getConfig() ) );
+        verifyInserterFileSystemClose( inserter( getStoreDir(), getConfig(), getKernelExtensions() ) );
+    }
+
+    @Test
+    public void providedFileSystemNotClosedAfterShutdown() throws IOException
+    {
+        EphemeralFileSystemAbstraction fs = fileSystemRule.get();
+        vefiryProvidedFileSystemOpenAfterShutdown( inserter( getStoreDir(), fs ), fs );
+        vefiryProvidedFileSystemOpenAfterShutdown( inserter( getStoreDir(), fs, getConfig() ), fs );
+        vefiryProvidedFileSystemOpenAfterShutdown( inserter( getStoreDir(), fs, getConfig(), getKernelExtensions() ),
+                fs );
+    }
+
+    private Iterable<KernelExtensionFactory<?>> getKernelExtensions()
+    {
+        return Iterables.asIterable( new InMemoryIndexProviderFactory(), new InMemoryLabelScanStoreExtension() );
+    }
+
+    private Map<String,String> getConfig()
+    {
+        return MapUtil.stringMap();
+    }
+
+    private void vefiryProvidedFileSystemOpenAfterShutdown( BatchInserter inserter,
+            EphemeralFileSystemAbstraction fileSystemAbstraction )
+    {
+        inserter.shutdown();
+        assertFalse( fileSystemAbstraction.isClosed() );
+    }
+
+    private File getStoreDir()
+    {
+        return testDirectory.graphDbDir();
+    }
+
+    private void verifyInserterFileSystemClose( BatchInserter inserter )
+    {
+        assertThat( "Expect specific implementation that will do required cleanups.", inserter,
+                is( instanceOf( FileSystemClosingBatchInserter.class ) ) );
+        inserter.shutdown();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert.internal;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+public class FileSystemClosingBatchInserterTest
+{
+
+    @Test
+    public void closeFileSystemOnShutdown() throws Exception
+    {
+        BatchInserter batchInserter = mock( BatchInserter.class );
+        FileSystemAbstraction fileSystem = mock( FileSystemAbstraction.class );
+        FileSystemClosingBatchInserter inserter =
+                new FileSystemClosingBatchInserter( batchInserter, fileSystem );
+
+        inserter.shutdown();
+
+        InOrder verificationOrder = inOrder( batchInserter, fileSystem );
+        verificationOrder.verify( batchInserter ).shutdown();
+        verificationOrder.verify( fileSystem ).close();
+    }
+}


### PR DESCRIPTION
Add batch inserters package to clirr for automatic detection of future API changes.
Restored removed and updated API methods, add tests that verify that we properly close or not close batch inserter file system.