### PR TITLE
start/stop catchup server last/first

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -195,11 +195,14 @@ public class CoreServerModule
 
         servicesToStopOnStoreCopy.add( catchupServer );
 
-        life.add( raftServer );
-        life.add( catchupServer );
+        // batches messages from raft server -> core state
+        // core state will drop messages if not ready
         life.add( batchingMessageHandler );
         life.add( new ContinuousJob( jobScheduler, new JobScheduler.Group( "raft-batch-handler", NEW_THREAD ),
                 batchingMessageHandler, logProvider ) );
+
+        life.add( raftServer ); // must start before core state so that it can trigger snapshot downloads when necessary
         life.add( coreState );
+        life.add( catchupServer ); // must start last and stop first, since it handles external requests
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreState.java
@@ -195,6 +195,7 @@ public class CoreState implements MessageHandler<RaftMessages.ClusterIdAwareMess
     {
         applicationProcess.stop();
         localDatabase.stop();
+        allowMessageHandling = false;
     }
 
     @Override


### PR DESCRIPTION
Since this server handles external requests it is important
that it is shutdown and quiet before starting to shutdown
other internal components. Similary, it is important to
not start it up until all other components are fully
up and running.