### PR TITLE
Clarify usage of dbms.security.auth_cache_ttl

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -254,7 +254,9 @@ public class SecuritySettings
     //=========================================================================
 
     @Description( "The time to live (TTL) for cached authentication and authorization info when using " +
-                  "external auth providers (LDAP or plugin). Setting the TTL to 0 will disable auth caching." )
+                  "external auth providers (LDAP or plugin). Setting the TTL to 0 will disable auth caching. " +
+                  "Disabling caching while using the LDAP auth provider requires the use of an LDAP system account " +
+                  "for resolving authorization information." )
     public static final Setting<Long> auth_cache_ttl =
             setting( "dbms.security.auth_cache_ttl", DURATION, "10m" );
 


### PR DESCRIPTION
Clarified that disabling the auth cache while using the LDAP auth provider and not using the LDAP system account is not supported.