### PR TITLE
Update clirr configuration to cover modules public API based on official javadoc

### DIFF
--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -81,37 +81,12 @@
       <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default</id>
-            <phase>${clirr-check-phase}</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
-          <failOnError>true</failOnError>
-          <logResults>true</logResults>
-          <!-- This is temporarily hard-coded, because the versionsBack attribute seems to not work on OS X, we'll
-           need to fix that.
-           OBS: Set this to one version ahead, i.e. if you'd like it to compare against 1.9.3 then set it to 1.9.4
-            -->
-          <comparisonVersion>1.9.M05</comparisonVersion>
-          <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
           <includes>
             <include>org/neo4j/cypher</include>
           </includes>
 
-          <!-- Allowed breaking changes in Neo4j 2.0 -->
-          <!-- These rules should be looked over and modified appropriately in 2.1 -->
-          <excludeMessageCodes>
-            <param>6006</param><!-- Field was made final. -->
-            <param>7012</param><!-- Method added to interface -->
-          </excludeMessageCodes>
           <excludes>
-            <!-- Ignore known breaking changes introduced in 2.0 and 2.1 -->
-
             <!-- Ignore all Cypher internals -->
             <exclude>org/neo4j/cypher/internal/*</exclude>
           </excludes>

--- a/community/graph-algo/pom.xml
+++ b/community/graph-algo/pom.xml
@@ -51,6 +51,20 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>org/neo4j/graphalgo/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/jmx/pom.xml
+++ b/community/jmx/pom.xml
@@ -53,6 +53,20 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>org/neo4j/jmx/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -142,32 +142,14 @@ the relevant Commercial Agreement.
       <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default</id>
-            <phase>${clirr-check-phase}</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
-          <failOnError>true</failOnError>
-          <logResults>true</logResults>
-          <!-- This is temporarily hard-coded, because the versionsBack attribute seems to not work on OS X, we'll
-           need to fix that.
-           OBS: Set this to one version ahead, i.e. if you'd like it to compare against 1.9.3 then set it to 1.9.4
-            -->
-          <comparisonVersion>3.0.1</comparisonVersion>
-          <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
           <includes>
             <include>org/neo4j/graphdb/**</include>
-            <include>org/neo4j/unsafe/batchinsert/**</include>
+            <include>org/neo4j/unsafe/batchinsert/*</include>
+            <include>org/neo4j/procedure/*</include>
+            <!--<include>org/neo4j/helpers/*</include> broken atm -->
+            <include>org/neo4j/helpers/collection/*</include>
           </includes>
-          <excludeMessageCodes>
-            <param>6006</param><!-- Field was made final. -->
-            <param>7012</param><!-- Method added to interface -->
-          </excludeMessageCodes>
         </configuration>
       </plugin>
     </plugins>

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -140,39 +140,13 @@ the relevant Commercial Agreement.
       <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default</id>
-            <phase>${clirr-check-phase}</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
-          <failOnError>true</failOnError>
-          <logResults>true</logResults>
-          <!-- This is temporarily hard-coded, because the versionsBack attribute seems to not work on OS X, we'll
-           need to fix that.
-           OBS: Set this to one version ahead, i.e. if you'd like it to compare against 1.9.3 then set it to 1.9.4
-            -->
-          <comparisonVersion>1.9.M05</comparisonVersion>
-          <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
           <includes>
-            <include>org/neo4j/index</include>
+            <include>org/neo4j/index/lucene/*</include>
+            <include>org/neo4j/index/lucene/unsafe/batchinsert/*</include>
           </includes>
-
-          <!-- Allowed breaking changes in Neo4j 2.0 -->
-          <!-- These rules should be looked over and modified appropriately in 2.1 -->
-          <excludeMessageCodes>
-            <param>6006</param><!-- Field was made final. -->
-            <param>7012</param><!-- Method added to interface -->
-          </excludeMessageCodes>
           <excludes>
-            <!-- Ignore known breaking changes introduced in 2.0 and 2.1 -->
-
-            <!-- This package is not public API -->
-            <exclude>org/neo4j/index/impl/*</exclude>
+            <exclude>org/neo4j/index/lucene/LuceneLabelScanStoreBuilder</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/community/neo4j-slf4j/pom.xml
+++ b/community/neo4j-slf4j/pom.xml
@@ -49,6 +49,20 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>org/neo4j/logging/slf4j/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/community/udc/pom.xml
+++ b/community/udc/pom.xml
@@ -121,37 +121,12 @@
       <plugin>
         <groupId>org.neo4j.build.plugins</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default</id>
-            <phase>${clirr-check-phase}</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
-          <failOnError>true</failOnError>
-          <logResults>true</logResults>
-          <!-- This is temporarily hard-coded, because the versionsBack attribute seems to not work on OS X, we'll
-           need to fix that.
-           OBS: Set this to one version ahead, i.e. if you'd like it to compare against 1.9.3 then set it to 1.9.4
-            -->
-          <comparisonVersion>1.9.M05</comparisonVersion>
-          <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
           <includes>
             <include>org/neo4j/ext/udc</include>
           </includes>
 
-          <!-- Allowed breaking changes in Neo4j 2.0 -->
-          <!-- These rules should be looked over and modified appropriately in 2.1 -->
-          <excludeMessageCodes>
-            <param>6006</param><!-- Field was made final. -->
-            <param>7012</param><!-- Method added to interface -->
-          </excludeMessageCodes>
           <excludes>
-            <!-- Ignore known breaking changes introduced in 2.0 and 2.1 -->
-
             <!-- Some constants (not terribly public) were made irrelevant and removed in 2.1 -->
             <exclude>org/neo4j/ext/udc/UdcConstants</exclude>
           </excludes>

--- a/enterprise/backup/pom.xml
+++ b/enterprise/backup/pom.xml
@@ -47,6 +47,30 @@
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>org/neo4j/backup/OnlineBackupExtensionFactory.Dependencies</include>
+            <include>org/neo4j/backup/OnlineBackupKernelExtension.BackupProvider</include>
+            <include>org/neo4j/backup/TheBackupInterface</include>
+            <include>org/neo4j/backup/BackupExtensionService</include>
+            <include>org/neo4j/backup/BackupTool</include>
+            <include>org/neo4j/backup/OnlineBackup</include>
+            <include>org/neo4j/backup/OnlineBackupExtensionFactory</include>
+            <!--<include>org/neo4j/backup/OnlineBackupKernelExtension</include> broken atm -->
+            <include>org/neo4j/backup/OnlineBackupSettings</include>
+            <include>org/neo4j/backup/StoreCopyResponsePacker</include>
+            <include>org/neo4j/backup/IncrementalBackupNotPossibleException</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>

--- a/enterprise/management/pom.xml
+++ b/enterprise/management/pom.xml
@@ -50,6 +50,31 @@
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>${bundle.namespace}.Main</mainClass>
+              <packageName>${bundle.namespace}</packageName>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>org/neo4j/management/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>
@@ -91,21 +116,5 @@
           <scope>test</scope>
       </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <mainClass>${bundle.namespace}.Main</mainClass>
-              <packageName>${bundle.namespace}</packageName>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <doclint-groups>reference</doclint-groups>
     <jetty.version>9.2.9.v20150224</jetty.version>
     <findbugs.version>3.0.1</findbugs.version>
+    <clirr.comparisonVersion>3.0.1</clirr.comparisonVersion>
     <git.commit>unknown-commit</git.commit>
   </properties>
 
@@ -106,6 +107,26 @@
           <groupId>org.neo4j.build.plugins</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
           <version>1.0.1</version>
+          <executions>
+            <execution>
+              <id>default</id>
+              <phase>${clirr-check-phase}</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <failOnError>true</failOnError>
+            <logResults>true</logResults>
+            <!-- OBS: Set this to one version ahead, i.e. if you'd like it to compare against 1.9.3 then set it to 1.9.4-->
+            <comparisonVersion>${clirr.comparisonVersion}</comparisonVersion>
+            <ignoreMaintenenceVersions>false</ignoreMaintenenceVersions>
+            <excludeMessageCodes>
+              <param>6006</param><!-- Field was made final. -->
+              <param>7012</param><!-- Method added to interface -->
+            </excludeMessageCodes>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Update pom clirr plugin configurations to include packages mentioned in public javadoc.
Clear copy paste of clirr configuration, introduce ${clirr.comparisonVersion} variable to specify base comparison version.
Currently failing packages are disabled.