### PR TITLE
Fix bug where network thread worker would stop if inbound channel queue was full

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/TestNetwork.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/TestNetwork.java
@@ -309,7 +309,8 @@ public class TestNetwork<T>
         {
             if ( !disconnected )
             {
-                Q.add( message );
+                // do not throw is the queue is full, emulate the drop of messages instead
+                Q.offer( message );
             }
         }
 


### PR DESCRIPTION
When enqueueing a new message in the inboud channel if the queue is
full an exception is throw which effectively kills the network thread,
hence the test fails.  Instead of throwing we simply drop the incoming
message and allow the network thread to keep running.  This is what
would happen in practice in a real case scenario so the code should
handle it and the test should not fail.