### PR TITLE
Update LuceneBatchInserterIndexProviderNewImpl expectation of specific batch inserter

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserters.java
@@ -29,6 +29,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.unsafe.batchinsert.internal.BatchInserterImpl;
 import org.neo4j.unsafe.batchinsert.internal.FileSystemClosingBatchInserter;
+import org.neo4j.unsafe.batchinsert.internal.IndexConfigStoreProvider;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -47,7 +48,8 @@ public final class BatchInserters
     public static BatchInserter inserter( File storeDir ) throws IOException
     {
         DefaultFileSystemAbstraction fileSystem = createFileSystem();
-        return new FileSystemClosingBatchInserter( inserter( storeDir, fileSystem, stringMap() ), fileSystem );
+        BatchInserter batchInserter = inserter( storeDir, fileSystem, stringMap() );
+        return new FileSystemClosingBatchInserter( batchInserter, (IndexConfigStoreProvider) batchInserter, fileSystem );
     }
 
     public static BatchInserter inserter( File storeDir, FileSystemAbstraction fs ) throws IOException
@@ -58,8 +60,8 @@ public final class BatchInserters
     public static BatchInserter inserter( File storeDir, Map<String,String> config ) throws IOException
     {
         DefaultFileSystemAbstraction fileSystem = createFileSystem();
-        return new FileSystemClosingBatchInserter( inserter( storeDir, fileSystem, config, loadKernelExtension() ),
-                fileSystem );
+        BatchInserter inserter = inserter( storeDir, fileSystem, config, loadKernelExtension() );
+        return new FileSystemClosingBatchInserter( inserter, (IndexConfigStoreProvider) inserter, fileSystem );
     }
 
     public static BatchInserter inserter( File storeDir, FileSystemAbstraction fs, Map<String,String> config ) throws IOException
@@ -71,7 +73,8 @@ public final class BatchInserters
             Map<String, String> config, Iterable<KernelExtensionFactory<?>> kernelExtensions ) throws IOException
     {
         DefaultFileSystemAbstraction fileSystem = createFileSystem();
-        return new FileSystemClosingBatchInserter( new BatchInserterImpl( storeDir, fileSystem, config, kernelExtensions ), fileSystem );
+        BatchInserterImpl inserter = new BatchInserterImpl( storeDir, fileSystem, config, kernelExtensions );
+        return new FileSystemClosingBatchInserter( inserter, inserter, fileSystem );
     }
 
     public static BatchInserter inserter( File storeDir, FileSystemAbstraction fileSystem,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -1070,7 +1070,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     }
 
     @Override
-    public IndexConfigStore getIndexConfigStore()
+    public IndexConfigStore getIndexStore()
     {
         return this.indexStore;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -162,7 +162,7 @@ import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 import static org.neo4j.kernel.impl.store.PropertyStore.encodeString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
-public class BatchInserterImpl implements BatchInserter
+public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvider
 {
     private final LifeSupport life;
     private final NeoStores neoStores;
@@ -1069,8 +1069,8 @@ public class BatchInserterImpl implements BatchInserter
         return storeDir.getPath();
     }
 
-    // needed by lucene-index
-    public IndexConfigStore getIndexStore()
+    @Override
+    public IndexConfigStore getIndexConfigStore()
     {
         return this.indexStore;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
@@ -28,17 +28,21 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintCreator;
 import org.neo4j.graphdb.schema.IndexCreator;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchRelationship;
 
-public class FileSystemClosingBatchInserter implements BatchInserter
+public class FileSystemClosingBatchInserter implements BatchInserter, IndexConfigStoreProvider
 {
     private final BatchInserter delegate;
+    private final IndexConfigStoreProvider configStoreProvider;
     private final FileSystemAbstraction fileSystem;
 
-    public FileSystemClosingBatchInserter( BatchInserter delegate, FileSystemAbstraction fileSystem )
+    public FileSystemClosingBatchInserter( BatchInserter delegate, IndexConfigStoreProvider configStoreProvider,
+            FileSystemAbstraction fileSystem )
     {
         this.delegate = delegate;
+        this.configStoreProvider = configStoreProvider;
         this.fileSystem = fileSystem;
     }
 
@@ -202,5 +206,11 @@ public class FileSystemClosingBatchInserter implements BatchInserter
         {
             throw new UncheckedIOException( e );
         }
+    }
+
+    @Override
+    public IndexConfigStore getIndexConfigStore()
+    {
+        return configStoreProvider.getIndexConfigStore();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
@@ -209,8 +209,8 @@ public class FileSystemClosingBatchInserter implements BatchInserter, IndexConfi
     }
 
     @Override
-    public IndexConfigStore getIndexConfigStore()
+    public IndexConfigStore getIndexStore()
     {
-        return configStoreProvider.getIndexConfigStore();
+        return configStoreProvider.getIndexStore();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert.internal;
+
+
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider;
+
+/**
+ * Provider of index store for batch inserter index providers
+ * @see BatchInserterIndexProvider
+ */
+public interface IndexConfigStoreProvider
+{
+    IndexConfigStore getIndexConfigStore();
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/IndexConfigStoreProvider.java
@@ -29,5 +29,5 @@ import org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider;
  */
 public interface IndexConfigStoreProvider
 {
-    IndexConfigStore getIndexConfigStore();
+    IndexConfigStore getIndexStore();
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserterTest.java
@@ -35,9 +35,10 @@ public class FileSystemClosingBatchInserterTest
     public void closeFileSystemOnShutdown() throws Exception
     {
         BatchInserter batchInserter = mock( BatchInserter.class );
+        IndexConfigStoreProvider configStoreProvider = mock( IndexConfigStoreProvider.class );
         FileSystemAbstraction fileSystem = mock( FileSystemAbstraction.class );
         FileSystemClosingBatchInserter inserter =
-                new FileSystemClosingBatchInserter( batchInserter, fileSystem );
+                new FileSystemClosingBatchInserter( batchInserter, configStoreProvider, fileSystem );
 
         inserter.shutdown();
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneBatchInserterIndexProviderNewImpl.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneBatchInserterIndexProviderNewImpl.java
@@ -52,7 +52,7 @@ public class LuceneBatchInserterIndexProviderNewImpl implements BatchInserterInd
     public LuceneBatchInserterIndexProviderNewImpl( final BatchInserter inserter )
     {
         this.inserter = inserter;
-        this.indexStore = ((IndexConfigStoreProvider) inserter).getIndexConfigStore();
+        this.indexStore = ((IndexConfigStoreProvider) inserter).getIndexStore();
         this.relationshipLookup = id ->
         {
             // TODO too may objects allocated here

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneBatchInserterIndexProviderNewImplTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneBatchInserterIndexProviderNewImplTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.impl.lucene.legacy;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
+import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+import org.neo4j.unsafe.batchinsert.BatchInserters;
+
+public class LuceneBatchInserterIndexProviderNewImplTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    @Test
+    public void createBatchIndexFromAnyIndexStoreProvider() throws Exception
+    {
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir() ) );
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir(), fileSystemRule.get() ) );
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir(), getConfig() ) );
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir(), getConfig(), getExtensions() ) );
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir(), fileSystemRule.get(), getConfig() ) );
+        createEndCloseIndexProvider( BatchInserters.inserter( getStoreDir(), fileSystemRule.get(), getConfig(),
+                getExtensions() ) );
+    }
+
+    private void createEndCloseIndexProvider( BatchInserter inserter )
+    {
+        LuceneBatchInserterIndexProviderNewImpl provider = new LuceneBatchInserterIndexProviderNewImpl( inserter );
+        provider.shutdown();
+        inserter.shutdown();
+    }
+
+    private Iterable<KernelExtensionFactory<?>> getExtensions()
+    {
+        return Iterables.asIterable( new InMemoryIndexProviderFactory(), new InMemoryLabelScanStoreExtension() );
+    }
+
+    private Map<String,String> getConfig()
+    {
+        return MapUtil.stringMap();
+    }
+
+    private File getStoreDir()
+    {
+        return testDirectory.graphDbDir();
+    }
+}


### PR DESCRIPTION
Introduce new interface IndexConfigStoreProvider that responsible for providing config store
and use it as an expected type in LuceneBatchInserterIndexProviderNewImpl instead of BatchInserterImpl.
Modifications here is quite limited since most of the involved classes are part of public API