### PR TITLE
Index optimisations

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/WritableAbstractDatabaseIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/WritableAbstractDatabaseIndex.java
@@ -36,8 +36,6 @@ public class WritableAbstractDatabaseIndex<T extends AbstractLuceneIndex> implem
 {
     // lock used to guard commits and close of lucene indexes from separate threads
     protected final ReentrantLock commitCloseLock = new ReentrantLock();
-    // lock guard concurrent creation of new partitions
-    protected final ReentrantLock partitionsLock = new ReentrantLock();
 
     protected T luceneIndex;
 
@@ -157,15 +155,7 @@ public class WritableAbstractDatabaseIndex<T extends AbstractLuceneIndex> implem
     @Override
     public LuceneAllDocumentsReader allDocumentsReader()
     {
-        partitionsLock.lock();
-        try
-        {
-            return luceneIndex.allDocumentsReader();
-        }
-        finally
-        {
-            partitionsLock.unlock();
-        }
+        return luceneIndex.allDocumentsReader();
     }
 
     /**
@@ -191,34 +181,18 @@ public class WritableAbstractDatabaseIndex<T extends AbstractLuceneIndex> implem
     @Override
     public void maybeRefreshBlocking() throws IOException
     {
-        partitionsLock.lock();
-        try
-        {
-            luceneIndex.maybeRefreshBlocking();
-        }
-        finally
-        {
-            partitionsLock.unlock();
-        }
+        luceneIndex.maybeRefreshBlocking();
     }
 
     /**
-     * Add new partition to the index.
+     * Add new partition to the index. Must only be called by a single thread at a time.
      *
      * @return newly created partition
      * @throws IOException
      */
     public AbstractIndexPartition addNewPartition() throws IOException
     {
-        partitionsLock.lock();
-        try
-        {
-            return luceneIndex.addNewPartition();
-        }
-        finally
-        {
-            partitionsLock.unlock();
-        }
+        return luceneIndex.addNewPartition();
     }
 
     /**

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/WritableDatabaseLabelScanIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/WritableDatabaseLabelScanIndex.java
@@ -44,15 +44,7 @@ public class WritableDatabaseLabelScanIndex extends WritableAbstractDatabaseInde
     @Override
     public LabelScanReader getLabelScanReader()
     {
-//        partitionsLock.lock();
-        try
-        {
-            return luceneIndex.getLabelScanReader();
-        }
-        finally
-        {
-//            partitionsLock.unlock();
-        }
+        return luceneIndex.getLabelScanReader();
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/WritableDatabaseLabelScanIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/WritableDatabaseLabelScanIndex.java
@@ -44,14 +44,14 @@ public class WritableDatabaseLabelScanIndex extends WritableAbstractDatabaseInde
     @Override
     public LabelScanReader getLabelScanReader()
     {
-        partitionsLock.lock();
+//        partitionsLock.lock();
         try
         {
             return luceneIndex.getLabelScanReader();
         }
         finally
         {
-            partitionsLock.unlock();
+//            partitionsLock.unlock();
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/WritableDatabaseSchemaIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/WritableDatabaseSchemaIndex.java
@@ -54,15 +54,7 @@ public class WritableDatabaseSchemaIndex extends WritableAbstractDatabaseIndex<L
     @Override
     public IndexReader getIndexReader() throws IOException
     {
-        partitionsLock.lock();
-        try
-        {
-            return luceneIndex.getIndexReader();
-        }
-        finally
-        {
-            partitionsLock.unlock();
-        }
+        return luceneIndex.getIndexReader();
     }
 
     /**


### PR DESCRIPTION
```
       High selectivity read    Low selectivity read     Medium selectivity read   Write
3.0:   0.581 ± 0.056  ops/ms    0.027 ± 0.003  ops/ms    0.143 ± 0.013  ops/ms      66.295 ± 2.103  ops/ms
3.1:   0.497 ± 0.073  ops/ms    0.022 ± 0.002  ops/ms    0.120 ± 0.011  ops/ms     105.256 ± 10.828 ops/ms
Now:   1.512 ± 0.137  ops/ms    0.030 ± 0.002  ops/ms    0.174 ± 0.019  ops/ms     104.168 ± 1.766  ops/ms
```

I think the removal of the `partition` lock is safe because of the use of a `CopyOnWriteArrayList`, plus I added extra synchronisation in the places that need atomicity at a higher level, but please check the correctness thoroughly.

**Note:** This should not be merged until _after_ 3.1 GA.