### PR TITLE
GBTree stable generation copy-on-write

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
@@ -209,7 +209,7 @@ class ByteArrayPageCursor extends PageCursor
     @Override
     public int getCurrentPageSize()
     {
-        throw new UnsupportedOperationException();
+        return buffer.capacity();
     }
 
     @Override

--- a/community/index/src/main/java/org/neo4j/index/gbptree/ConsistencyChecker.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/ConsistencyChecker.java
@@ -44,10 +44,10 @@ class ConsistencyChecker<KEY>
     private final Comparator<KEY> comparator;
     private final Layout<KEY,?> layout;
     private final List<RightmostInChain<KEY>> rightmostPerLevel = new ArrayList<>();
-    private final int stableGeneration;
-    private final int unstableGeneration;
+    private final long stableGeneration;
+    private final long unstableGeneration;
 
-    ConsistencyChecker( TreeNode<KEY,?> node, Layout<KEY,?> layout, int stableGeneration, int unstableGeneration )
+    ConsistencyChecker( TreeNode<KEY,?> node, Layout<KEY,?> layout, long stableGeneration, long unstableGeneration )
     {
         this.node = node;
         this.readKey = layout.newKey();

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -75,7 +75,6 @@ import org.neo4j.io.pagecache.PagedFile;
  */
 public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
 {
-
     /**
      * Paged file in a {@link PageCache} providing the means of storage.
      */
@@ -315,6 +314,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
             }
             while ( cursor.shouldRetry() );
             checkOutOfBounds( cursor );
+
             if ( isInternal )
             {
                 PointerChecking.checkChildPointer( childId );

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -75,11 +75,6 @@ import org.neo4j.io.pagecache.PagedFile;
  */
 public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
 {
-    /**
-     * Page id of the meta page holding information about root id and custom user meta information.
-     * This page id is statically allocated throughout the life of a tree.
-     */
-    private static final int META_PAGE_ID = 0;
 
     /**
      * Paged file in a {@link PageCache} providing the means of storage.
@@ -120,7 +115,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
     /**
      * Current page id which contains the root of the tree.
      */
-    private volatile long rootId = META_PAGE_ID + 1;
+    private volatile long rootId = IdSpace.MIN_TREE_NODE_ID;
 
     /**
      * Last allocated page id, used for allocating new ids as more data gets inserted into the tree.
@@ -277,10 +272,10 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
 
     private PageCursor openMetaPageCursor( PagedFile pagedFile ) throws IOException
     {
-        PageCursor metaCursor = pagedFile.io( META_PAGE_ID, PagedFile.PF_SHARED_WRITE_LOCK );
+        PageCursor metaCursor = pagedFile.io( IdSpace.META_PAGE_ID, PagedFile.PF_SHARED_WRITE_LOCK );
         if ( !metaCursor.next() )
         {
-            throw new IllegalStateException( "Could not go to meta data page " + META_PAGE_ID );
+            throw new IllegalStateException( "Couldn't go to meta data page " + IdSpace.META_PAGE_ID );
         }
         return metaCursor;
     }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -321,10 +321,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
             {
                 PointerChecking.checkChildPointer( childId );
 
-                if ( !cursor.next( childId ) )
-                {
-                    throw new IllegalStateException( "Couldn't go to child " + childId );
-                }
+                bTreeNode.goTo( cursor, childId, stableGeneration, unstableGeneration );
             }
         }
         while ( isInternal && keyCount > 0 );
@@ -400,10 +397,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
 
     private void goToRoot( PageCursor cursor ) throws IOException
     {
-        if ( !cursor.next( rootId ) )
-        {
-            throw new IllegalStateException( "Could not go to root " + rootId );
-        }
+        bTreeNode.goTo( cursor, rootId, stableGeneration, unstableGeneration );
     }
 
     private void checkOutOfBounds( PageCursor cursor )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -123,14 +123,16 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>, IdProvider
 
     /**
      * Stable generation, i.e. generation which has survived the last {@link #flush()}.
+     * Unsigned int.
      */
-    private volatile int stableGeneration = 0;
+    private volatile long stableGeneration = 0;
 
     /**
      * Unstable generation, i.e. the current generation under evolution. This generation will be the
      * {@link #stableGeneration} in the next {@link #flush()}.
+     * Unsigned int.
      */
-    private volatile int unstableGeneration = 1;
+    private volatile long unstableGeneration = 1;
 
     /**
      * Opens an index {@code indexFile} in the {@code pageCache}, creating and initializing it if it doesn't exist.

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
@@ -64,7 +64,11 @@ class GenSafePointer
      */
     public static void write( PageCursor cursor, long generation, long pointer )
     {
-        assert generation >= MIN_GENERATION && generation <= MAX_GENERATION : generation;
+        if ( generation < MIN_GENERATION || generation > MAX_GENERATION )
+        {
+            throw new IllegalArgumentException( "Can not write pointer with generation " + generation +
+                    " because outside boundary for valid generation." );
+        }
         cursor.putInt( (int) generation );
         put6BLong( cursor, pointer );
         cursor.putShort( checksumOf( generation, pointer ) );

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
@@ -43,11 +43,11 @@ import org.neo4j.io.pagecache.PageCursor;
  */
 class GenSafePointer
 {
-    public static final long MIN_GENERATION = 1L;
+    static final long MIN_GENERATION = 1L;
     // unsigned int
-    public static final long MAX_GENERATION = 0xFFFFFFFFL;
-    public static final long GENERATION_MASK = 0xFFFFFFFFL;
-    public static final int UNSIGNED_SHORT_MASK = 0xFFFF;
+    static final long MAX_GENERATION = 0xFFFFFFFFL;
+    static final long GENERATION_MASK = 0xFFFFFFFFL;
+    static final int UNSIGNED_SHORT_MASK = 0xFFFF;
 
     static final int CHECKSUM_SIZE = 2;
     static final int SIZE =

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
@@ -64,14 +64,19 @@ class GenSafePointer
      */
     public static void write( PageCursor cursor, long generation, long pointer )
     {
+        assertGeneration( generation );
+        cursor.putInt( (int) generation );
+        put6BLong( cursor, pointer );
+        cursor.putShort( checksumOf( generation, pointer ) );
+    }
+
+    static void assertGeneration( long generation )
+    {
         if ( generation < MIN_GENERATION || generation > MAX_GENERATION )
         {
             throw new IllegalArgumentException( "Can not write pointer with generation " + generation +
                     " because outside boundary for valid generation." );
         }
-        cursor.putInt( (int) generation );
-        put6BLong( cursor, pointer );
-        cursor.putShort( checksumOf( generation, pointer ) );
     }
 
     public static long readGeneration( PageCursor cursor )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointer.java
@@ -78,8 +78,7 @@ class GenSafePointer
     public static long readPointer( PageCursor cursor )
     {
         long result = get6BLong( cursor );
-        // TODO Could we change NULL to 0 instead?
-        return result == 0xFFFF_FFFFFFFFL ? -1 : result;
+        return result;
     }
 
     public static short readChecksum( PageCursor cursor )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointerPair.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointerPair.java
@@ -111,7 +111,7 @@ class GenSafePointerPair
      * @param unstableGeneration unstable index generation.
      * @return most recent readable pointer, or failure. Check result using {@link #isSuccess(long)}.
      */
-    public static long read( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    public static long read( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         // Try A
         long generationA = readGeneration( cursor );
@@ -218,7 +218,7 @@ class GenSafePointerPair
      * @param unstableGeneration unstable index generation, which will be the generation to write in the slot.
      * @return {@code true} on success, otherwise {@code false} on failure.
      */
-    public static long write( PageCursor cursor, long pointer, int stableGeneration, int unstableGeneration )
+    public static long write( PageCursor cursor, long pointer, long stableGeneration, long unstableGeneration )
     {
         // Later there will be a selection which "slot" of GSP out of the two to write into.
         int offset = cursor.getOffset();
@@ -374,7 +374,7 @@ class GenSafePointerPair
         return generationA > generationB ? GEN_A_BIG : generationB > generationA ? GEN_B_BIG : GEN_EQUAL;
     }
 
-    private static byte pointerState( int stableGeneration, int unstableGeneration,
+    private static byte pointerState( long stableGeneration, long unstableGeneration,
             long generation, long pointer, boolean checksumIsCorrect )
     {
         if ( GenSafePointer.isEmpty( generation, pointer ) )
@@ -405,7 +405,7 @@ class GenSafePointerPair
      * Checks to see if a result from read/write was successful. If not more failure information can be extracted
      * using {@link #failureDescription(long)}.
      *
-     * @param result result from {@link #read(PageCursor, int, int)} or {@link #write(PageCursor, long, int, int)}.
+     * @param result result from {@link #read(PageCursor, long, long)} or {@link #write(PageCursor, long, long, long)}.
      * @return {@code true} if successful read/write, otherwise {@code false}.
      */
     public static boolean isSuccess( long result )
@@ -414,7 +414,7 @@ class GenSafePointerPair
     }
 
     /**
-     * Calling {@link #read(PageCursor, int, int)} (potentially also {@link #write(PageCursor, long, int, int)})
+     * Calling {@link #read(PageCursor, long, long)} (potentially also {@link #write(PageCursor, long, long, long)})
      * can fail due to seeing an unexpected state of the two GSPs. Failing right there and then isn't an option
      * due to how the page cache works and that something read from a {@link PageCursor} must not be interpreted
      * until after passing a {@link PageCursor#shouldRetry()} returning {@code false}. This creates a need for
@@ -422,8 +422,8 @@ class GenSafePointerPair
      * the caller which interprets the result fail in a proper place. That place can make use of this method
      * by getting a human-friendly description about the failure.
      *
-     * @param result result from {@link #read(PageCursor, int, int)} or
-     * {@link #write(PageCursor, long, int, int)}.
+     * @param result result from {@link #read(PageCursor, long, long)} or
+     * {@link #write(PageCursor, long, long, long)}.
      * @return a human-friendly description of the failure.
      */
     public static String failureDescription( long result )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointerPair.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GenSafePointerPair.java
@@ -387,9 +387,8 @@ class GenSafePointerPair
         }
         if ( generation < MIN_GENERATION )
         {
-            // todo Better error message?
             throw new UnsupportedOperationException( "Generation was less than MIN_GENERATION " + MIN_GENERATION +
-                                                     " but checksum was correct. This should not happen." );
+                    " and but checksum was correct. Pointer was " + generation + "," + pointer );
         }
         if ( generation <= stableGeneration )
         {

--- a/community/index/src/main/java/org/neo4j/index/gbptree/IdSpace.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/IdSpace.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.gbptree;
+
+public class IdSpace
+{
+    /**
+     * Page id of the meta page holding information about root id and custom user meta information.
+     * This page id is statically allocated throughout the life of a tree.
+     */
+    static final long META_PAGE_ID = 0L;
+
+    /**
+     * Min value allowed as tree node id.
+     */
+    static final long MIN_TREE_NODE_ID = 1L;
+}

--- a/community/index/src/main/java/org/neo4j/index/gbptree/IdSpace.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/IdSpace.java
@@ -28,7 +28,19 @@ public class IdSpace
     static final long META_PAGE_ID = 0L;
 
     /**
+     * State page with IDs such as free-list, highId, rootId and more. There are two such pages alternating
+     * between checkpoints, this is the first.
+     */
+    static final long STATE_PAGE_A = 1L;
+
+    /**
+     * State page with IDs such as free-list, highId, rootId and more. There are two such pages alternating
+     * between checkpoints, this is the second.
+     */
+    static final long STATE_PAGE_B = 2L;
+
+    /**
      * Min value allowed as tree node id.
      */
-    static final long MIN_TREE_NODE_ID = 1L;
+    static final long MIN_TREE_NODE_ID = 3L;
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
@@ -231,6 +231,7 @@ class InternalTreeLogic<KEY,VALUE>
     {
         long current = cursor.getCurrentPageId();
         long oldRight = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
+        PointerChecking.checkSiblingPointer( oldRight );
         long newRight = idProvider.acquireNewId();
 
         // Find position to insert new key
@@ -386,6 +387,7 @@ class InternalTreeLogic<KEY,VALUE>
 
         long current = cursor.getCurrentPageId();
         long oldRight = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
+        PointerChecking.checkSiblingPointer( oldRight );
         long newRight = idProvider.acquireNewId();
 
         // BALANCE KEYS AND VALUES
@@ -529,6 +531,7 @@ class InternalTreeLogic<KEY,VALUE>
 
         long currentId = cursor.getCurrentPageId();
         long childId = bTreeNode.childAt( cursor, pos, stableGeneration, unstableGeneration );
+        PointerChecking.checkChildPointer( childId );
         bTreeNode.goTo( cursor, childId, stableGeneration, unstableGeneration );
 
         VALUE result = remove( cursor, structurePropagation, key, into, stableGeneration, unstableGeneration );
@@ -619,6 +622,10 @@ class InternalTreeLogic<KEY,VALUE>
         long newGenId = idProvider.acquireNewId();
         try ( PageCursor newGenCursor = cursor.openLinkedCursor( newGenId ) )
         {
+            if ( !newGenCursor.next() )
+            {
+                throw new IllegalStateException( "Could not go to new node " + newGenId );
+            }
             cursor.copyTo( 0, newGenCursor, 0, cursor.getCurrentPageSize() );
             bTreeNode.setGen( newGenCursor, unstableGeneration );
         }
@@ -640,7 +647,9 @@ class InternalTreeLogic<KEY,VALUE>
         //              v                                     v                                      v
         // (leftSiblingOfStableNode) -[rightSibling]-> (newUnstableNode) <-[leftSibling]- (rightSiblingOfStableNode)
         long leftSibling = bTreeNode.leftSibling( cursor, stableGeneration, unstableGeneration );
+        PointerChecking.checkSiblingPointer( leftSibling );
         long rightSibling = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
+        PointerChecking.checkSiblingPointer( rightSibling );
         if ( leftSibling != TreeNode.NO_NODE_FLAG )
         {
             bTreeNode.goTo( cursor, leftSibling, stableGeneration, unstableGeneration );

--- a/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
@@ -116,7 +116,7 @@ class InternalTreeLogic<KEY,VALUE>
      * @throws IOException  on cursor failure
      */
     public SplitResult<KEY> insert( PageCursor cursor, KEY key, VALUE value, ValueMerger<VALUE> valueMerger,
-            IndexWriter.Options options, int stableGeneration, int unstableGeneration ) throws IOException
+            IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
     {
         if ( bTreeNode.isLeaf( cursor ) )
         {
@@ -166,7 +166,7 @@ class InternalTreeLogic<KEY,VALUE>
      * @throws IOException  on cursor failure
      */
     private SplitResult<KEY> insertInInternal( PageCursor cursor, long nodeId, int keyCount,
-            KEY primKey, long rightChild, IndexWriter.Options options, int stableGeneration, int unstableGeneration )
+            KEY primKey, long rightChild, IndexWriter.Options options, long stableGeneration, long unstableGeneration )
                     throws IOException
     {
         if ( keyCount < bTreeNode.internalMaxKeyCount() )
@@ -206,7 +206,8 @@ class InternalTreeLogic<KEY,VALUE>
      * @throws IOException  on cursor failure
      */
     private SplitResult<KEY> splitInternal( PageCursor cursor, long fullNode, KEY primKey, long newRightChild,
-            int keyCount, IndexWriter.Options options, int stableGeneration, int unstableGeneration ) throws IOException
+            int keyCount, IndexWriter.Options options, long stableGeneration, long unstableGeneration )
+                    throws IOException
     {
         long current = cursor.getCurrentPageId();
         long newLeft = current;
@@ -300,7 +301,7 @@ class InternalTreeLogic<KEY,VALUE>
      * @throws IOException  on cursor failure
      */
     private SplitResult<KEY> insertInLeaf( PageCursor cursor, KEY key, VALUE value, ValueMerger<VALUE> valueMerger,
-            IndexWriter.Options options, int stableGeneration, int unstableGeneration ) throws IOException
+            IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
     {
         int keyCount = bTreeNode.keyCount( cursor );
         int search = search( cursor, bTreeNode, key, readKey, keyCount );
@@ -344,7 +345,7 @@ class InternalTreeLogic<KEY,VALUE>
      * @throws IOException  if cursor.next( newRight ) fails
      */
     private SplitResult<KEY> splitLeaf( PageCursor cursor, KEY newKey, VALUE newValue, int keyCount,
-            IndexWriter.Options options, int stableGeneration, int unstableGeneration ) throws IOException
+            IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
     {
         // To avoid moving cursor between pages we do all operations on left node first.
         // Save data that needs transferring and then add it to right node.
@@ -468,7 +469,7 @@ class InternalTreeLogic<KEY,VALUE>
         return split;
     }
 
-    public VALUE remove( PageCursor cursor, KEY key, VALUE into, int stableGeneration, int unstableGeneration )
+    public VALUE remove( PageCursor cursor, KEY key, VALUE into, long stableGeneration, long unstableGeneration )
             throws IOException
     {
         if ( bTreeNode.isLeaf( cursor ) )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
@@ -27,7 +27,6 @@ import org.neo4j.io.pagecache.PageCursor;
 
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
-
 import static org.neo4j.index.gbptree.KeySearch.isHit;
 import static org.neo4j.index.gbptree.KeySearch.positionOf;
 import static org.neo4j.index.gbptree.KeySearch.search;
@@ -58,7 +57,7 @@ import static org.neo4j.index.gbptree.KeySearch.search;
  *   During this split, reader could see this state:
  *   L[E1,E2,E4,E5] -> R[E3,E4,E5]
  *           ^  ^           x  x
- *   Reader will need to ignore lower keys already seen (TODO how to do in non-unique index?)
+ *   Reader will need to ignore lower keys already seen, assuming unique keys
  * </pre>
  * SCENARIO2 (new key ends up in left leaf)
  * <pre>
@@ -82,8 +81,6 @@ class InternalTreeLogic<KEY,VALUE>
     private final byte[] tmpForKeys;
     private final byte[] tmpForValues;
     private final byte[] tmpForChildren;
-    private final SplitResult<KEY> internalSplitResult = new SplitResult<>();
-    private final SplitResult<KEY> leafSplitResult = new SplitResult<>();
     private final Layout<KEY,VALUE> layout;
     private final KEY readKey;
     private final VALUE readValue;
@@ -97,30 +94,49 @@ class InternalTreeLogic<KEY,VALUE>
         this.tmpForKeys = new byte[(maxKeyCount + 1) * layout.keySize()];
         this.tmpForValues = new byte[(maxKeyCount + 1) * layout.valueSize()];
         this.tmpForChildren = new byte[(maxKeyCount + 2) * bTreeNode.childSize()];
-        this.internalSplitResult.primKey = layout.newKey();
-        this.leafSplitResult.primKey = layout.newKey();
         this.readKey = layout.newKey();
         this.readValue = layout.newValue();
     }
 
     /**
+     * Insert {@code key} and associate it with {@code value} if {@code key} does not already exist in
+     * tree.
+     * <p>
+     * If {@code key} already exists in tree, {@code valueMerger} will be used to decide how to merge existing value
+     * with {@code value}.
+     * <p>
+     * Insert may cause structural changes in the tree in form of splits and or new generation of nodes being created.
+     * Note that a split in a leaf can propagate all the way up to root node.
+     * <p>
+     * Structural changes in tree that need to propagate to the level above will be reported through the provided
+     * {@link StructurePropagation} by overwriting state. This is safe because structure changes happens one level
+     * at the time.
+     * {@link StructurePropagation} is provided from outside to minimize garbage.
+     * <p>
+     * When this method returns, {@code structurePropagation} will be populated with information about split or new
+     * gen version of root. This needs to be handled by caller.
+     * <p>
      * Leaves cursor at same page as when called. No guarantees on offset.
-     * @param cursor        {@link org.neo4j.io.pagecache.PageCursor} pinned to page where insertion is to be done.
-     * @param key           key to be inserted
-     * @param value         value to be associated with key
-     * @param valueMerger   {@link ValueMerger} for deciding what to do with existing keys
-     * @param options       options for this insert
+     *
+     * @param cursor {@link PageCursor} pinned to page where insertion is to be done.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param key key to be inserted
+     * @param value value to be associated with key
+     * @param valueMerger {@link ValueMerger} for deciding what to do with existing keys
+     * @param options options for this insert
      * @param stableGeneration stable generation, i.e. generations <= this generation are considered stable.
      * @param unstableGeneration unstable generation, i.e. generation which is under development right now.
-     * @return              {@link SplitResult} from insert to be used caller.
-     * @throws IOException  on cursor failure
+     * @throws IOException on cursor failure
      */
-    public SplitResult<KEY> insert( PageCursor cursor, KEY key, VALUE value, ValueMerger<VALUE> valueMerger,
-            IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
+    void insert( PageCursor cursor, StructurePropagation<KEY> structurePropagation, KEY key, VALUE value,
+            ValueMerger<VALUE> valueMerger, IndexWriter.Options options,
+            long stableGeneration, long unstableGeneration ) throws IOException
     {
         if ( bTreeNode.isLeaf( cursor ) )
         {
-            return insertInLeaf( cursor, key, value, valueMerger, options, stableGeneration, unstableGeneration );
+            insertInLeaf( cursor, structurePropagation, key, value, valueMerger, options,
+                    stableGeneration, unstableGeneration );
+            return;
         }
 
         int keyCount = bTreeNode.keyCount( cursor );
@@ -135,40 +151,45 @@ class InternalTreeLogic<KEY,VALUE>
         long childId = bTreeNode.childAt( cursor, pos, stableGeneration, unstableGeneration );
         PointerChecking.checkChildPointer( childId );
 
-        goTo( cursor, childId );
+        goTo( cursor, childId, stableGeneration, unstableGeneration );
 
-        SplitResult<KEY> split = insert( cursor, key, value, valueMerger, options, stableGeneration,
-                unstableGeneration );
+        insert( cursor, structurePropagation, key, value, valueMerger, options, stableGeneration, unstableGeneration );
 
-        goTo( cursor, currentId );
+        goTo( cursor, currentId, stableGeneration, unstableGeneration );
 
-        if ( split != null )
+        if ( structurePropagation.hasNewGen )
         {
-            return insertInInternal( cursor, currentId, keyCount, split.primKey, split.right, options,
-                    stableGeneration, unstableGeneration );
+            structurePropagation.hasNewGen = false;
+            bTreeNode.setChildAt( cursor, structurePropagation.left, pos, stableGeneration, unstableGeneration );
         }
-        return null;
+        if ( structurePropagation.hasSplit )
+        {
+            structurePropagation.hasSplit = false;
+            insertInInternal( cursor, structurePropagation, currentId, keyCount, structurePropagation.primKey,
+                    structurePropagation.right, options, stableGeneration, unstableGeneration );
+        }
     }
 
     /**
      * Leaves cursor at same page as when called. No guarantees on offset.
-     *
+     * <p>
      * Insertion in internal is always triggered by a split in child.
      * The result of a split is a primary key that is sent upwards in the b+tree and the newly created right child.
      *
-     * @param cursor        {@link org.neo4j.io.pagecache.PageCursor} pinned to page containing internal node,
-     *                      current node
-     * @param nodeId        id of current node
-     * @param keyCount      the key count of current node
-     * @param primKey       the primary key to be inserted
-     * @param rightChild    the right child of primKey
-     * @return              {@link SplitResult} from insert to be used caller.
-     * @throws IOException  on cursor failure
+     * @param cursor {@link PageCursor} pinned to page containing internal node,
+     * current node
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param nodeId id of current node
+     * @param keyCount the key count of current node
+     * @param primKey the primary key to be inserted
+     * @param rightChild the right child of primKey
+     * @throws IOException on cursor failure
      */
-    private SplitResult<KEY> insertInInternal( PageCursor cursor, long nodeId, int keyCount,
-            KEY primKey, long rightChild, IndexWriter.Options options, long stableGeneration, long unstableGeneration )
-                    throws IOException
+    private void insertInInternal( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            long nodeId, int keyCount, KEY primKey, long rightChild, IndexWriter.Options options,
+            long stableGeneration, long unstableGeneration ) throws IOException
     {
+        createUnstableVersionIfNeeded( cursor, structurePropagation, stableGeneration, unstableGeneration );
         if ( keyCount < bTreeNode.internalMaxKeyCount() )
         {
             // No overflow
@@ -183,34 +204,32 @@ class InternalTreeLogic<KEY,VALUE>
             // Increase key count
             bTreeNode.setKeyCount( cursor, keyCount + 1 );
 
-            return null;
+            return;
         }
 
         // Overflow
-        return splitInternal( cursor, nodeId, primKey, rightChild, keyCount, options,
+        splitInternal( cursor, structurePropagation, nodeId, primKey, rightChild, keyCount, options,
                 stableGeneration, unstableGeneration );
     }
 
     /**
-     *
      * Leaves cursor at same page as when called. No guarantees on offset.
-     *
+     * <p>
      * Split in internal node caused by an insertion of primKey and newRightChild
      *
-     * @param cursor        {@link org.neo4j.io.pagecache.PageCursor} pinned to page containing internal node, fullNode.
-     * @param fullNode      id of node to be split.
-     * @param primKey       primary key to be inserted, causing the split
+     * @param cursor {@link PageCursor} pinned to page containing internal node, fullNode.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param fullNode id of node to be split.
+     * @param primKey primary key to be inserted, causing the split
      * @param newRightChild right child of primKey
-     * @param keyCount      key count for fullNode
-     * @return              {@link SplitResult} from insert to be used caller.
-     * @throws IOException  on cursor failure
+     * @param keyCount key count for fullNode
+     * @throws IOException on cursor failure
      */
-    private SplitResult<KEY> splitInternal( PageCursor cursor, long fullNode, KEY primKey, long newRightChild,
-            int keyCount, IndexWriter.Options options, long stableGeneration, long unstableGeneration )
-                    throws IOException
+    private void splitInternal( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            long fullNode, KEY primKey, long newRightChild, int keyCount, IndexWriter.Options options,
+            long stableGeneration, long unstableGeneration ) throws IOException
     {
         long current = cursor.getCurrentPageId();
-        long newLeft = current;
         long oldRight = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
         long newRight = idProvider.acquireNewId();
 
@@ -227,16 +246,16 @@ class InternalTreeLogic<KEY,VALUE>
         int keyCountAfterInsert = keyCount + 1;
         int middlePos = middle( keyCountAfterInsert, options.splitRetentionFactor() );
 
-        SplitResult<KEY> split = internalSplitResult;
-        split.left = newLeft;
-        split.right = newRight;
+        structurePropagation.hasSplit = true;
+        structurePropagation.left = current;
+        structurePropagation.right = newRight;
 
         {   // Update new right
             // NOTE: don't include middle
-            goTo( cursor, newRight );
+            goTo( cursor, newRight, stableGeneration, unstableGeneration );
             bTreeNode.initializeInternal( cursor, stableGeneration, unstableGeneration );
             bTreeNode.setRightSibling( cursor, oldRight, stableGeneration, unstableGeneration );
-            bTreeNode.setLeftSibling( cursor, newLeft, stableGeneration, unstableGeneration );
+            bTreeNode.setLeftSibling( cursor, current, stableGeneration, unstableGeneration );
             bTreeNode.writeKeys( cursor, tmpForKeys, middlePos + 1, 0, keyCountAfterInsert - (middlePos + 1) );
             bTreeNode.writeChildren( cursor, tmpForChildren, middlePos + 1, 0,
                     keyCountAfterInsert - middlePos /*there's one more child than key to copy*/ );
@@ -247,19 +266,19 @@ class InternalTreeLogic<KEY,VALUE>
             PageCursor buffer = ByteArrayPageCursor.wrap( tmpForKeys, middleOffset, bTreeNode.keySize() );
 
             // Populate split result
-            layout.readKey( buffer, split.primKey );
+            layout.readKey( buffer, structurePropagation.primKey );
         }
 
         // Update old right with new left sibling (newRight)
         if ( oldRight != TreeNode.NO_NODE_FLAG )
         {
-            goTo( cursor, oldRight );
+            goTo( cursor, oldRight, stableGeneration, unstableGeneration );
             bTreeNode.setLeftSibling( cursor, newRight, stableGeneration, unstableGeneration );
         }
 
         // Update left node
         // Move cursor back to left
-        goTo( cursor, fullNode );
+        goTo( cursor, fullNode, stableGeneration, unstableGeneration );
         bTreeNode.setKeyCount( cursor, middlePos );
         if ( pos < middlePos )
         {
@@ -274,8 +293,6 @@ class InternalTreeLogic<KEY,VALUE>
         }
 
         bTreeNode.setRightSibling( cursor, newRight, stableGeneration, unstableGeneration );
-
-        return split;
     }
 
     private static int middle( int keyCountAfterInsert, float splitLeftChildSize )
@@ -288,19 +305,20 @@ class InternalTreeLogic<KEY,VALUE>
 
     /**
      * Leaves cursor at same page as when called. No guarantees on offset.
-     *
+     * <p>
      * Split in leaf node caused by an insertion of key and value
      *
-     * @param cursor        {@link org.neo4j.io.pagecache.PageCursor} pinned to page containing leaf node targeted for
-     *                      insertion.
-     * @param key           key to be inserted
-     * @param value         value to be associated with key
-     * @param valueMerger   {@link ValueMerger} for deciding what to do with existing keys
-     * @param options       options for this insert
-     * @return              {@link SplitResult} from insert to be used caller.
-     * @throws IOException  on cursor failure
+     * @param cursor {@link PageCursor} pinned to page containing leaf node targeted for
+     * insertion.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param key key to be inserted
+     * @param value value to be associated with key
+     * @param valueMerger {@link ValueMerger} for deciding what to do with existing keys
+     * @param options options for this insert
+     * @throws IOException on cursor failure
      */
-    private SplitResult<KEY> insertInLeaf( PageCursor cursor, KEY key, VALUE value, ValueMerger<VALUE> valueMerger,
+    private void insertInLeaf( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            KEY key, VALUE value, ValueMerger<VALUE> valueMerger,
             IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
     {
         int keyCount = bTreeNode.keyCount( cursor );
@@ -313,11 +331,14 @@ class InternalTreeLogic<KEY,VALUE>
             VALUE mergedValue = valueMerger.merge( readValue, value );
             if ( mergedValue != null )
             {
+                createUnstableVersionIfNeeded( cursor, structurePropagation, stableGeneration, unstableGeneration );
                 // simple, just write the merged value right in there
                 bTreeNode.setValueAt( cursor, mergedValue, pos );
             }
-            return null; // No split has occurred
+            return; // No split has occurred
         }
+
+        createUnstableVersionIfNeeded( cursor, structurePropagation, stableGeneration, unstableGeneration );
 
         if ( keyCount < bTreeNode.leafMaxKeyCount() )
         {
@@ -326,26 +347,27 @@ class InternalTreeLogic<KEY,VALUE>
             bTreeNode.insertValueAt( cursor, value, pos, keyCount, tmpForValues );
             bTreeNode.setKeyCount( cursor, keyCount + 1 );
 
-            return null; // No split has occurred
+            return; // No split has occurred
         }
-
         // Overflow, split leaf
-        return splitLeaf( cursor, key, value, keyCount, options, stableGeneration, unstableGeneration );
+        splitLeaf( cursor, structurePropagation, key, value, keyCount, options, stableGeneration, unstableGeneration );
     }
 
     /**
      * Leaves cursor at same page as when called. No guarantees on offset.
      * Cursor is expected to be pointing to full leaf.
-     * @param cursor        cursor pointing into full (left) leaf that should be split in two.
-     * @param newKey        key to be inserted
-     * @param newValue      value to be inserted (in association with key)
-     * @param keyCount      number of keys in this leaf (it was already read anyway)
-     * @param options       options for this insert
-     * @return              {@link SplitResult} with necessary information to inform parent
-     * @throws IOException  if cursor.next( newRight ) fails
+     *
+     * @param cursor cursor pointing into full (left) leaf that should be split in two.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param newKey key to be inserted
+     * @param newValue value to be inserted (in association with key)
+     * @param keyCount number of keys in this leaf (it was already read anyway)
+     * @param options options for this insert
+     * @throws IOException if cursor.next( newRight ) fails
      */
-    private SplitResult<KEY> splitLeaf( PageCursor cursor, KEY newKey, VALUE newValue, int keyCount,
-            IndexWriter.Options options, long stableGeneration, long unstableGeneration ) throws IOException
+    private void splitLeaf( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            KEY newKey, VALUE newValue, int keyCount, IndexWriter.Options options,
+            long stableGeneration, long unstableGeneration ) throws IOException
     {
         // To avoid moving cursor between pages we do all operations on left node first.
         // Save data that needs transferring and then add it to right node.
@@ -363,7 +385,6 @@ class InternalTreeLogic<KEY,VALUE>
         //
 
         long current = cursor.getCurrentPageId();
-        long newLeft = current;
         long oldRight = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
         long newRight = idProvider.acquireNewId();
 
@@ -425,24 +446,24 @@ class InternalTreeLogic<KEY,VALUE>
         // We now have everything we need to start working on newRight
         // and everything that needs to be updated in left has been so.
 
-        SplitResult<KEY> split = leafSplitResult;
-        split.left = newLeft;
-        split.right = newRight;
+        structurePropagation.hasSplit = true;
+        structurePropagation.left = current;
+        structurePropagation.right = newRight;
 
         if ( middlePos == pos )
         {
-            layout.copyKey( newKey, split.primKey );
+            layout.copyKey( newKey, structurePropagation.primKey );
         }
         else
         {
-            bTreeNode.keyAt( cursor, split.primKey, pos < middlePos ? middlePos - 1 : middlePos );
+            bTreeNode.keyAt( cursor, structurePropagation.primKey, pos < middlePos ? middlePos - 1 : middlePos );
         }
 
         {   // Update new right
-            goTo( cursor, newRight );
+            goTo( cursor, newRight, stableGeneration, unstableGeneration );
             bTreeNode.initializeLeaf( cursor, stableGeneration, unstableGeneration );
             bTreeNode.setRightSibling( cursor, oldRight, stableGeneration, unstableGeneration );
-            bTreeNode.setLeftSibling( cursor, newLeft, stableGeneration, unstableGeneration );
+            bTreeNode.setLeftSibling( cursor, current, stableGeneration, unstableGeneration );
             bTreeNode.writeKeys( cursor, tmpForKeys, middlePos, 0, keyCountAfterInsert - middlePos );
             bTreeNode.writeValues( cursor, tmpForValues, middlePos, 0, keyCountAfterInsert - middlePos );
             bTreeNode.setKeyCount( cursor, keyCountAfterInsert - middlePos );
@@ -451,12 +472,12 @@ class InternalTreeLogic<KEY,VALUE>
         // Update old right with new left sibling (newRight)
         if ( oldRight != TreeNode.NO_NODE_FLAG )
         {
-            goTo( cursor, oldRight );
+            goTo( cursor, oldRight, stableGeneration, unstableGeneration );
             bTreeNode.setLeftSibling( cursor, newRight, stableGeneration, unstableGeneration );
         }
 
         // Update left child
-        goTo( cursor, current );
+        goTo( cursor, current, stableGeneration, unstableGeneration );
         bTreeNode.setKeyCount( cursor, middlePos );
         // If pos < middle. Write shifted values to left node. Else, don't write anything.
         if ( pos < middlePos )
@@ -465,16 +486,37 @@ class InternalTreeLogic<KEY,VALUE>
             bTreeNode.writeValues( cursor, tmpForValues, pos, pos, middlePos - pos );
         }
         bTreeNode.setRightSibling( cursor, newRight, stableGeneration, unstableGeneration );
-
-        return split;
     }
 
-    public VALUE remove( PageCursor cursor, KEY key, VALUE into, long stableGeneration, long unstableGeneration )
-            throws IOException
+    /**
+     * Remove given {@code key} and associated value from tree if it exists. The removed value will be stored in
+     * provided {@code into} which will be returned for convenience.
+     * <p>
+     * If the given {@code key} does not exist in tree, return {@code null}.
+     * <p>
+     * Structural changes in tree that need to propagate to the level above will be reported through the provided
+     * {@link StructurePropagation} by overwriting state. This is safe because structure changes happens one level
+     * at the time.
+     * {@link StructurePropagation} is provided from outside to minimize garbage.
+     * <p>
+     * Leaves cursor at same page as when called. No guarantees on offset.
+     *
+     * @param cursor {@link PageCursor} pinned to page where remove should traversing tree from.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param key key to be removed
+     * @param into {@code VALUE} instance to write removed value to
+     * @param stableGeneration stable generation, i.e. generations <= this generation are considered stable.
+     * @param unstableGeneration unstable generation, i.e. generation which is under development right now.
+     * @return Provided {@code into}, populated with removed value for convenience if {@code key} was removed.
+     * Otherwise {@code null}.
+     * @throws IOException on cursor failure
+     */
+    VALUE remove( PageCursor cursor, StructurePropagation<KEY> structurePropagation, KEY key, VALUE into,
+            long stableGeneration, long unstableGeneration ) throws IOException
     {
         if ( bTreeNode.isLeaf( cursor ) )
         {
-            return removeFromLeaf( cursor, key, into );
+            return  removeFromLeaf( cursor, structurePropagation, key, into, stableGeneration, unstableGeneration );
         }
 
         int keyCount = bTreeNode.keyCount( cursor );
@@ -486,16 +528,41 @@ class InternalTreeLogic<KEY,VALUE>
         }
 
         long currentId = cursor.getCurrentPageId();
-        goTo( cursor, bTreeNode.childAt( cursor, pos, stableGeneration, unstableGeneration ) );
+        long childId = bTreeNode.childAt( cursor, pos, stableGeneration, unstableGeneration );
+        goTo( cursor, childId, stableGeneration, unstableGeneration );
 
-        VALUE result = remove( cursor, key, into, stableGeneration, unstableGeneration );
+        VALUE result = remove( cursor, structurePropagation, key, into, stableGeneration, unstableGeneration );
 
-        goTo( cursor, currentId );
+        goTo( cursor, currentId, stableGeneration, unstableGeneration );
+        if ( structurePropagation.hasNewGen )
+        {
+            structurePropagation.hasNewGen = false;
+            bTreeNode.setChildAt( cursor, structurePropagation.left, pos, stableGeneration, unstableGeneration );
+        }
 
         return result;
     }
 
-    private VALUE removeFromLeaf( PageCursor cursor, KEY key, VALUE into )
+    /**
+     * Remove given {@code key} and associated value from tree if it exists. The removed value will be stored in
+     * provided {@code into} which will be returned for convenience.
+     * <p>
+     * If the given {@code key} does not exist in tree, return {@code null}.
+     * <p>
+     * Leaves cursor at same page as when called. No guarantees on offset.
+     *
+     * @param cursor {@link PageCursor} pinned to page where remove is to be done.
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param key key to be removed
+     * @param into {@code VALUE} instance to write removed value to
+     * @param stableGeneration stable generation, i.e. generations <= this generation are considered stable.
+     * @param unstableGeneration unstable generation, i.e. generation which is under development right now.
+     * @return Provided {@code into}, populated with removed value for convenience if {@code key} was removed.
+     * Otherwise {@code null}.
+     * @throws IOException on cursor failure
+     */
+    private VALUE removeFromLeaf( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            KEY key, VALUE into, long stableGeneration, long unstableGeneration ) throws IOException
     {
         int keyCount = bTreeNode.keyCount( cursor );
 
@@ -509,6 +576,8 @@ class InternalTreeLogic<KEY,VALUE>
         }
 
         // Remove key/value
+        createUnstableVersionIfNeeded( cursor, structurePropagation, stableGeneration, unstableGeneration );
+
         bTreeNode.removeKeyAt( cursor, pos, keyCount, tmpForKeys );
         bTreeNode.valueAt( cursor, into, pos );
         bTreeNode.removeValueAt( cursor, pos, keyCount, tmpForValues );
@@ -519,11 +588,95 @@ class InternalTreeLogic<KEY,VALUE>
         return into;
     }
 
-    private void goTo( PageCursor cursor, long childId ) throws IOException
+    /**
+     * Create a new node and copy content from current node (where {@code cursor} sits) if current node is not already
+     * of {@code unstableGeneration}.
+     * <p>
+     * Neighbouring nodes' sibling pointers will be updated to point to new node.
+     * <p>
+     * Current node will be updated with new gen pointer to new node.
+     * <p>
+     * {@code structurePropagation} will be updated with information about this new node so that it can report to
+     * level above.
+     *
+     * @param cursor {@link PageCursor} pinned to page containing node to potentially create a new version of
+     * @param structurePropagation {@link StructurePropagation} used to report structure changes between tree levels.
+     * @param stableGeneration stable generation, i.e. generations <= this generation are considered stable.
+     * @param unstableGeneration unstable generation, i.e. generation which is under development right now.
+     * @throws IOException on cursor failure
+     */
+    private void createUnstableVersionIfNeeded( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
+            long stableGeneration, long unstableGeneration ) throws IOException
+    {
+        long nodeGen = bTreeNode.gen( cursor );
+        if ( nodeGen == unstableGeneration )
+        {
+            // Don't copy
+            return;
+        }
+
+        // Do copy
+        long newGenId = idProvider.acquireNewId();
+        try ( PageCursor newGenCursor = cursor.openLinkedCursor( newGenId ) )
+        {
+            cursor.copyTo( 0, newGenCursor, 0, cursor.getCurrentPageSize() );
+            bTreeNode.setGen( newGenCursor, unstableGeneration );
+        }
+
+        // Insert new gen pointer in old stable version
+        //   (stableNode)
+        //        |
+        //    [newgen]
+        //        |
+        //        v
+        // (newUnstableNode)
+        bTreeNode.setNewGen( cursor, newGenId, stableGeneration, unstableGeneration );
+
+        // Redirect sibling pointers
+        //               ---------[leftSibling]---------(stableNode)----------[rightSibling]---------
+        //              |                                     |                                      |
+        //              |                                  [newgen]                                  |
+        //              |                                     |                                      |
+        //              v                                     v                                      v
+        // (leftSiblingOfStableNode) -[rightSibling]-> (newUnstableNode) <-[leftSibling]- (rightSiblingOfStableNode)
+        long leftSibling = bTreeNode.leftSibling( cursor, stableGeneration, unstableGeneration );
+        long rightSibling = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
+        if ( leftSibling != TreeNode.NO_NODE_FLAG )
+        {
+            goTo( cursor, leftSibling, stableGeneration, unstableGeneration );
+            bTreeNode.setRightSibling( cursor, newGenId, stableGeneration, unstableGeneration );
+        }
+        if ( rightSibling != TreeNode.NO_NODE_FLAG )
+        {
+            goTo( cursor, rightSibling, stableGeneration, unstableGeneration );
+            bTreeNode.setLeftSibling( cursor, newGenId, stableGeneration, unstableGeneration );
+        }
+
+        // Leave cursor at new tree node
+        goTo( cursor, newGenId, stableGeneration, unstableGeneration );
+
+        // Propagate structure change
+        structurePropagation.hasNewGen = true;
+        structurePropagation.left = newGenId;
+    }
+
+    private void goTo( PageCursor cursor, long childId, long stableGeneration, long unstableGeneration )
+            throws IOException
     {
         if ( !cursor.next( childId ) )
         {
             throw new IllegalStateException( "Could not go to " + childId );
+        }
+        verifyGen( cursor, stableGeneration, unstableGeneration );
+    }
+
+    private void verifyGen( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    {
+        long gen = bTreeNode.gen( cursor );
+        if ( ( gen > stableGeneration && gen < unstableGeneration ) || gen > unstableGeneration )
+        {
+            throw new IllegalStateException( "Reached a node with generation=" + gen +
+                    ", stableGeneration=" + stableGeneration + ", unstableGeneration=" + unstableGeneration );
         }
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
@@ -42,4 +42,17 @@ class PointerChecking
                                              IdSpace.MIN_TREE_NODE_ID );
         }
     }
+
+    static void checkSiblingPointer( long result )
+    {
+        if ( !GenSafePointerPair.isSuccess( result ) )
+        {
+            throw new IllegalStateException( GenSafePointerPair.failureDescription( result ) );
+        }
+        if ( result < IdSpace.MIN_TREE_NODE_ID && result != TreeNode.NO_NODE_FLAG )
+        {
+            throw new IllegalStateException( "Pointer to id " + result + " not allowed. Minimum node id allowed is " +
+                    IdSpace.MIN_TREE_NODE_ID );
+        }
+    }
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
@@ -28,7 +28,7 @@ class PointerChecking
      * if failure. Must be called after a consistent read from page cache (after {@link PageCursor#shouldRetry()}.
      *
      * @param result result from {@link GenSafePointerPair#READ} or
-     * {@link GenSafePointerPair#write(PageCursor, long, int, int)}.
+     * {@link GenSafePointerPair#write(PageCursor, long, long, long)}.
      */
     static void checkChildPointer( long result )
     {

--- a/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/PointerChecking.java
@@ -30,21 +30,16 @@ class PointerChecking
      * @param result result from {@link GenSafePointerPair#READ} or
      * {@link GenSafePointerPair#write(PageCursor, long, int, int)}.
      */
-    public static void checkChildPointer( long result )
+    static void checkChildPointer( long result )
     {
-        // TODO: The NO_NODE_FLAG being -1 generally conflicts with how GSPP results are built up,
-        // most notably -1 sets all bits to 1 and so any additional flags are overwritten.
-        // As a work-around we can for the time being check -1 explicitly before checking flags.
-
-        // TODO: include information on current page and perhaps path here
-        if ( result == TreeNode.NO_NODE_FLAG )
-        {
-            throw new IllegalStateException( "Generally uninitialized GSPP" );
-        }
-
         if ( !GenSafePointerPair.isSuccess( result ) )
         {
             throw new IllegalStateException( GenSafePointerPair.failureDescription( result ) );
+        }
+        if ( result < IdSpace.MIN_TREE_NODE_ID )
+        {
+            throw new IllegalStateException( "Pointer to id " + result + " not allowed. Minimum node id allowed is " +
+                                             IdSpace.MIN_TREE_NODE_ID );
         }
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/RightmostInChain.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/RightmostInChain.java
@@ -33,13 +33,13 @@ import static org.neo4j.index.gbptree.TreeNode.NO_NODE_FLAG;
 class RightmostInChain<KEY>
 {
     private final TreeNode<KEY,?> node;
-    private final int stableGeneration;
-    private final int unstableGeneration;
+    private final long stableGeneration;
+    private final long unstableGeneration;
 
     private long currentRightmost;
     private long expectedNextRightmost;
 
-    RightmostInChain( TreeNode<KEY,?> node, int stableGeneration, int unstableGeneration )
+    RightmostInChain( TreeNode<KEY,?> node, long stableGeneration, long unstableGeneration )
     {
         this.node = node;
         this.stableGeneration = stableGeneration;

--- a/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
@@ -139,12 +139,9 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>
             {
                 if ( bTreeNode.isNode( rightSibling ) )
                 {
-                    if ( !cursor.next( rightSibling ) )
-                    {
-                        // TODO: Check if rightSibling is within expected range before calling next.
-                        // TODO: Possibly by getting highest expected from IdProvider
-                        throw new IllegalStateException( "Could not go to right sibling " + rightSibling );
-                    }
+                    // TODO: Check if rightSibling is within expected range before calling next.
+                    // TODO: Possibly by getting highest expected from IdProvider
+                    bTreeNode.goTo( cursor, rightSibling, stableGeneration, unstableGeneration );
                     pos = -1;
                     reread = true;
                     continue; // in the outer loop, with the position reset to the beginning of the right sibling

--- a/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
@@ -124,7 +124,6 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>
                 else
                 {
                     // Read the next value in this leaf
-                    // TODO this is a hack for caching item order for unsorted tree node thingie
                     bTreeNode.keyAt( cursor, mutableKey, pos );
                     bTreeNode.valueAt( cursor, mutableValue, pos );
                 }
@@ -141,6 +140,8 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>
                 {
                     if ( !cursor.next( rightSibling ) )
                     {
+                        // TODO: Check if rightSibling is within expected range before calling next.
+                        // TODO: Possibly by getting highest expected from IdProvider
                         throw new IllegalStateException( "Could not go to right sibling " + rightSibling );
                     }
                     pos = -1;
@@ -156,8 +157,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>
                          ( !first && layout.compare( prevKey, mutableKey ) >= 0 ) )
                     {
                         // We've come across a bad read in the middle of a split
-                        // This is outlined in IndexModifier, skip this value (it's fine)
-                        // TODO: perhaps describe the circumstances here quickly as well
+                        // This is outlined in InternalTreeLogic, skip this value (it's fine)
                         reread = true;
                         continue;
                     }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
@@ -57,11 +57,12 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>
     private boolean currentContainsEnd;
     private boolean reread;
     private boolean resetPosition;
-    private final int stableGeneration;
-    private final int unstableGeneration;
+    private final long stableGeneration;
+    private final long unstableGeneration;
 
     SeekCursor( PageCursor leafCursor, KEY mutableKey, VALUE mutableValue, TreeNode<KEY,VALUE> bTreeNode,
-            KEY fromInclusive, KEY toExclusive, Layout<KEY,VALUE> layout, int stableGeneration, int unstableGeneration,
+            KEY fromInclusive, KEY toExclusive, Layout<KEY,VALUE> layout,
+            long stableGeneration, long unstableGeneration,
             int firstPosToRead, int keyCount )
     {
         this.cursor = leafCursor;

--- a/community/index/src/main/java/org/neo4j/index/gbptree/StructurePropagation.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/StructurePropagation.java
@@ -25,9 +25,16 @@ package org.neo4j.index.gbptree;
  *
  * @param <KEY> type of key.
  */
-class SplitResult<KEY>
+class StructurePropagation<KEY>
 {
-    KEY primKey;
+    boolean hasNewGen;
+    boolean hasSplit;
+    final KEY primKey;
     long left;
     long right;
+
+    StructurePropagation( KEY primKey )
+    {
+        this.primKey = primKey;
+    }
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -187,10 +187,10 @@ class TreeNode<KEY,VALUE>
         GenSafePointerPair.write( cursor, leftSiblingId, stableGeneration, unstableGeneration );
     }
 
-    void setNewGen( PageCursor cursor, long pageId, long stableGeneration, long unstableGeneration )
+    void setNewGen( PageCursor cursor, long newGenId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_NEWGEN );
-        GenSafePointerPair.write( cursor, pageId, stableGeneration, unstableGeneration );
+        GenSafePointerPair.write( cursor, newGenId, stableGeneration, unstableGeneration );
     }
 
     // BODY METHODS

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -164,9 +164,10 @@ class TreeNode<KEY,VALUE>
         return GenSafePointerPair.read( cursor, stableGeneration, unstableGeneration );
     }
 
-    void setGen( PageCursor cursor, long unstableGeneration )
+    void setGen( PageCursor cursor, long generation )
     {
-        cursor.putInt( BYTE_POS_GEN, (int) (unstableGeneration & GenSafePointer.GENERATION_MASK) );
+        GenSafePointer.assertGeneration( generation );
+        cursor.putInt( BYTE_POS_GEN, (int) generation );
     }
 
     void setKeyCount( PageCursor cursor, int count )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -73,7 +73,7 @@ class TreeNode<KEY,VALUE>
 
     private static final byte LEAF_FLAG = 1;
     private static final byte INTERNAL_FLAG = 0;
-    static final long NO_NODE_FLAG = -1;
+    static final long NO_NODE_FLAG = 0;
 
     private final int internalMaxKeyCount;
     private final int leafMaxKeyCount;

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -392,7 +392,6 @@ class TreeNode<KEY,VALUE>
         cursor.getBytes( into, 0, insertPosition * recordSize );
 
         // Read newRecord
-        // TODO: A bit expensive to wrap in a PageCursor tin foil just to write this middle key
         PageCursor buffer = ByteArrayPageCursor.wrap( into, insertPosition * recordSize, recordSize );
         newRecordWriter.accept( buffer );
 

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -104,7 +104,7 @@ class TreeNode<KEY,VALUE>
         }
     }
 
-    private void initialize( PageCursor cursor, byte type, int stableGeneration, int unstableGeneration )
+    private void initialize( PageCursor cursor, byte type, long stableGeneration, long unstableGeneration )
     {
         cursor.putByte( BYTE_POS_TYPE, type );
         setGen( cursor, unstableGeneration );
@@ -114,12 +114,12 @@ class TreeNode<KEY,VALUE>
         setNewGen( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
     }
 
-    void initializeLeaf( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    void initializeLeaf( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         initialize( cursor, LEAF_FLAG, stableGeneration, unstableGeneration );
     }
 
-    void initializeInternal( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    void initializeInternal( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         initialize( cursor, INTERNAL_FLAG, stableGeneration, unstableGeneration );
     }
@@ -146,19 +146,19 @@ class TreeNode<KEY,VALUE>
         return cursor.getInt( BYTE_POS_KEYCOUNT );
     }
 
-    long rightSibling( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    long rightSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_RIGHTSIBLING );
         return GenSafePointerPair.read( cursor, stableGeneration, unstableGeneration );
     }
 
-    long leftSibling( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    long leftSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_LEFTSIBLING );
         return GenSafePointerPair.read( cursor, stableGeneration, unstableGeneration );
     }
 
-    long newGen( PageCursor cursor, int stableGeneration, int unstableGeneration )
+    long newGen( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_NEWGEN );
         return GenSafePointerPair.read( cursor, stableGeneration, unstableGeneration );
@@ -175,19 +175,19 @@ class TreeNode<KEY,VALUE>
         cursor.putInt( BYTE_POS_KEYCOUNT, count );
     }
 
-    void setRightSibling( PageCursor cursor, long rightSiblingId, int stableGeneration, int unstableGeneration )
+    void setRightSibling( PageCursor cursor, long rightSiblingId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_RIGHTSIBLING );
         GenSafePointerPair.write( cursor, rightSiblingId, stableGeneration, unstableGeneration );
     }
 
-    void setLeftSibling( PageCursor cursor, long leftSiblingId, int stableGeneration, int unstableGeneration )
+    void setLeftSibling( PageCursor cursor, long leftSiblingId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_LEFTSIBLING );
         GenSafePointerPair.write( cursor, leftSiblingId, stableGeneration, unstableGeneration );
     }
 
-    void setNewGen( PageCursor cursor, long pageId, int stableGeneration, int unstableGeneration )
+    void setNewGen( PageCursor cursor, long pageId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_NEWGEN );
         GenSafePointerPair.write( cursor, pageId, stableGeneration, unstableGeneration );
@@ -273,26 +273,26 @@ class TreeNode<KEY,VALUE>
         layout.writeValue( cursor, value );
     }
 
-    long childAt( PageCursor cursor, int pos, int stableGeneration, int unstableGeneration )
+    long childAt( PageCursor cursor, int pos, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( childOffset( pos ) );
         return GenSafePointerPair.read( cursor, stableGeneration, unstableGeneration );
     }
 
     void insertChildAt( PageCursor cursor, long child, int pos, int keyCount, byte[] tmp,
-            int stableGeneration, int unstableGeneration )
+            long stableGeneration, long unstableGeneration )
     {
         insertSlotAt( cursor, pos, keyCount + 1, childOffset( 0 ), SIZE_PAGE_REFERENCE, tmp );
         setChildAt( cursor, child, pos, stableGeneration, unstableGeneration );
     }
 
-    void setChildAt( PageCursor cursor, long child, int pos, int stableGeneration, int unstableGeneration )
+    void setChildAt( PageCursor cursor, long child, int pos, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( childOffset( pos ) );
         writeChild( cursor, child, stableGeneration, unstableGeneration );
     }
 
-    void writeChild( PageCursor cursor, long child, int stableGeneration, int unstableGeneration)
+    void writeChild( PageCursor cursor, long child, long stableGeneration, long unstableGeneration)
     {
         GenSafePointerPair.write( cursor, child, stableGeneration, unstableGeneration );
     }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -138,7 +138,7 @@ class TreeNode<KEY,VALUE>
 
     long gen( PageCursor cursor )
     {
-        return cursor.getInt( BYTE_POS_GEN ) & 0xFFFFFFFFL;
+        return cursor.getInt( BYTE_POS_GEN ) & GenSafePointer.GENERATION_MASK;
     }
 
     int keyCount( PageCursor cursor )
@@ -166,7 +166,7 @@ class TreeNode<KEY,VALUE>
 
     void setGen( PageCursor cursor, long unstableGeneration )
     {
-        cursor.putInt( BYTE_POS_GEN, (int) (unstableGeneration & 0xFFFF_FFFFFFFFL) );
+        cursor.putInt( BYTE_POS_GEN, (int) (unstableGeneration & GenSafePointer.GENERATION_MASK) );
     }
 
     void setKeyCount( PageCursor cursor, int count )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreePrinter.java
@@ -43,7 +43,7 @@ class TreePrinter
      * @throws IOException on page cache access error.
      */
     public static <KEY,VALUE> void printTree( PageCursor cursor, TreeNode<KEY,VALUE> treeNode,
-            Layout<KEY,VALUE> layout, int stableGeneration, int unstableGeneration, PrintStream out )
+            Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration, PrintStream out )
                     throws IOException
     {
         int level = 0;
@@ -67,7 +67,7 @@ class TreePrinter
     }
 
     private static <KEY,VALUE> void printKeysOfSiblings( PageCursor cursor,
-            TreeNode<KEY,VALUE> bTreeNode, Layout<KEY,VALUE> layout, int stableGeneration, int unstableGeneration,
+            TreeNode<KEY,VALUE> bTreeNode, Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration,
             PrintStream out ) throws IOException
     {
         while ( true )
@@ -83,7 +83,7 @@ class TreePrinter
     }
 
     private static <KEY,VALUE> void printKeys( PageCursor cursor, TreeNode<KEY,VALUE> bTreeNode,
-            Layout<KEY,VALUE> layout, int stableGeneration, int unstableGeneration, PrintStream out )
+            Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration, PrintStream out )
     {
         boolean isLeaf = bTreeNode.isLeaf( cursor );
         int keyCount = bTreeNode.keyCount( cursor );

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeTest.java
@@ -71,7 +71,7 @@ public class GBPTreeTest
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder( new File( "target" ) );
     @Rule
-    public final RandomRule random = new RandomRule().withSeed( 1 );
+    public final RandomRule random = new RandomRule();
     private PageCache pageCache;
     private File indexFile;
     private final Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerPairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerPairTest.java
@@ -973,19 +973,19 @@ public class GenSafePointerPairTest
         return GenSafePointerPair.write( cursor, pointer, STABLE_GENERATION, UNSTABLE_GENERATION );
     }
 
-    private void writeSlotA( int generation )
+    private void writeSlotA( long generation )
     {
         cursor.setOffset( 0 );
         writeSlot( generation, POINTER_A );
     }
 
-    private void writeSlotB( int generation )
+    private void writeSlotB( long generation )
     {
         cursor.setOffset( GenSafePointer.SIZE );
         writeSlot( generation, POINTER_B );
     }
 
-    private void writeSlot( int generation, long pointer )
+    private void writeSlot( long generation, long pointer )
     {
         GenSafePointer.write( cursor, generation, pointer );
     }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerPairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerPairTest.java
@@ -175,8 +175,6 @@ public class GenSafePointerPairTest
         assertEquals( POINTER_B, readSlotB() );
     }
 
-    // TODO: On all writes, verify slot result
-
     @Test
     public void readEmptyBrokenShouldFail() throws Exception
     {

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerTest.java
@@ -172,7 +172,7 @@ public class GenSafePointerTest
         short reference = 0;
         for ( int i = 0; i < count; i++ )
         {
-            gsp.generation = random.nextLong( 0xFFFFFFFFL );
+            gsp.generation = random.nextLong( GenSafePointer.MAX_GENERATION );
             gsp.pointer = random.nextLong( 0xFFFF_FFFFFFFFL );
             short checksum = checksumOf( gsp );
             if ( i == 0 )

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GenSafePointerTest.java
@@ -161,24 +161,6 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldWriteAndReadMinusOnePointer() throws Exception
-    {
-        // GIVEN
-        long pointer = -1;
-        GSP expected = gsp( 12345, pointer );
-        write( cursor, 0, expected );
-
-        // WHEN
-        GSP read = new GSP();
-        boolean matches = read( cursor, 0, read );
-
-        // THEN
-        assertTrue( matches );
-        assertEquals( expected, read );
-        assertEquals( pointer, read.pointer );
-    }
-
-    @Test
     public void shouldHaveLowAccidentalChecksumCollision() throws Exception
     {
         // GIVEN

--- a/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
@@ -693,9 +693,14 @@ public class InternalTreeLogicTest
         return treeLogic.remove( cursor, insertKey, into, STABLE_GENERATION, UNSTABLE_GENERATION );
     }
 
-    private class SimpleIdProvider implements IdProvider
+    private static class SimpleIdProvider implements IdProvider
     {
-        private long lastId = -1;
+        private long lastId;
+
+        private SimpleIdProvider()
+        {
+            reset();
+        }
 
         @Override
         public long acquireNewId()
@@ -706,7 +711,7 @@ public class InternalTreeLogicTest
 
         private void reset()
         {
-            lastId = -1;
+            lastId = IdSpace.MIN_TREE_NODE_ID - 1;
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
@@ -33,6 +33,7 @@ import org.neo4j.test.rule.RandomRule;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -46,8 +47,9 @@ public class InternalTreeLogicTest
         return base;
     };
 
-    private static final int STABLE_GENERATION = 1;
-    private static final int UNSTABLE_GENERATION = 2;
+    private static final long OLD_STABLE_GENERATION = 1;
+    private static final long STABLE_GENERATION = 2;
+    private static final long UNSTABLE_GENERATION = 3;
     private final int pageSize = 256;
 
     private final SimpleIdProvider id = new SimpleIdProvider();
@@ -72,16 +74,15 @@ public class InternalTreeLogicTest
     public void setUp() throws IOException
     {
         id.reset();
-        cursor.initialize();
         long newId = id.acquireNewId();
         cursor.next( newId );
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
     }
 
     @Test
     public void modifierMustInsertAtFirstPositionInEmptyLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = 1L;
         long value = 1L;
         assertThat( node.keyCount( cursor ), is( 0 ) );
@@ -98,6 +99,7 @@ public class InternalTreeLogicTest
     @Test
     public void modifierMustSortCorrectlyOnInsertFirstInLeaf() throws Exception
     {
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // given
@@ -113,6 +115,7 @@ public class InternalTreeLogicTest
     @Test
     public void modifierMustSortCorrectlyOnInsertLastInLeaf() throws Exception
     {
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // given
@@ -127,6 +130,7 @@ public class InternalTreeLogicTest
     @Test
     public void modifierMustSortCorrectlyOnInsertInMiddleOfLeaf() throws Exception
     {
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // given
@@ -142,6 +146,7 @@ public class InternalTreeLogicTest
     public void modifierMustSplitWhenInsertingMiddleOfFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             long key = i % 2 == 0 ? i : maxKeyCount * 2 - i;
@@ -158,6 +163,7 @@ public class InternalTreeLogicTest
     public void modifierMustSplitWhenInsertingLastInFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = 0;
         while ( key < maxKeyCount )
         {
@@ -175,6 +181,7 @@ public class InternalTreeLogicTest
     public void modifierMustSplitWhenInsertingFirstInFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             long key = i + 1;
@@ -191,6 +198,7 @@ public class InternalTreeLogicTest
     public void modifierMustLeaveCursorOnSamePageAfterSplitInLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long pageId = cursor.getCurrentPageId();
         long key = 0;
         while ( key < maxKeyCount )
@@ -212,6 +220,7 @@ public class InternalTreeLogicTest
     public void modifierMustUpdatePointersInSiblingsToSplit() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long someLargeNumber = maxKeyCount * 1000;
         long i = 0;
         while ( i < maxKeyCount )
@@ -255,6 +264,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveFirstInEmptyLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = 1L;
         long value = 1L;
         insert( key, value );
@@ -270,6 +280,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveFirstInFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             insert( i, i );
@@ -290,6 +301,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveInMiddleInFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         int middle = maxKeyCount / 2;
         for ( int i = 0; i < maxKeyCount; i++ )
         {
@@ -313,6 +325,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveLastInFullLeaf() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             insert( i, i );
@@ -334,6 +347,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveFromLeftChild() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -355,6 +369,7 @@ public class InternalTreeLogicTest
     public void modifierMustRemoveFromRightChildButNotFromInternalWithHitOnInternalSearch() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -388,6 +403,7 @@ public class InternalTreeLogicTest
     public void modifierMustLeaveCursorOnInitialPageAfterRemove() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -406,6 +422,7 @@ public class InternalTreeLogicTest
     public void modifierMustNotRemoveWhenKeyDoesNotExist() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             insert( i, i );
@@ -427,6 +444,7 @@ public class InternalTreeLogicTest
     public void modifierMustNotRemoveWhenKeyOnlyExistInInternal() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -466,6 +484,7 @@ public class InternalTreeLogicTest
     @Test
     public void modifierMustProduceConsistentTreeWithRandomInserts() throws Exception
     {
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         int numberOfEntries = 100_000;
         for ( int i = 0; i < numberOfEntries; i++ )
         {
@@ -487,6 +506,7 @@ public class InternalTreeLogicTest
     public void modifierMustOverwriteWithOverwriteMerger() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = random.nextLong();
         long firstValue = random.nextLong();
         insert( key, firstValue );
@@ -504,6 +524,7 @@ public class InternalTreeLogicTest
     public void modifierMustKeepExistingWithKeepExistingMerger() throws Exception
     {
         // given
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = random.nextLong();
         long firstValue = random.nextLong();
         insert( key, firstValue, ValueMergers.keepExisting() );
@@ -525,6 +546,7 @@ public class InternalTreeLogicTest
     public void shouldMergeValueInRootLeaf() throws Exception
     {
         // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long key = 10;
         long baseValue = 100;
         insert( key, baseValue );
@@ -546,6 +568,7 @@ public class InternalTreeLogicTest
     public void shouldMergeValueInLeafLeftOfParentKey() throws Exception
     {
         // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -572,6 +595,7 @@ public class InternalTreeLogicTest
     public void shouldMergeValueInLeafAtParentKey() throws Exception
     {
         // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         for ( int i = 0; !structurePropagation.hasSplit; i++ )
         {
             insert( i, i );
@@ -598,6 +622,7 @@ public class InternalTreeLogicTest
     public void shouldMergeValueInLeafBetweenTwoParentKeys() throws Exception
     {
         // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         long rootId = -1;
         long middle = -1;
         long firstSplitPrimKey = -1;
@@ -628,6 +653,301 @@ public class InternalTreeLogicTest
         assertEquals( baseValue + toAdd, valueAt( pos ).longValue() );
     }
 
+    @Test
+    public void shouldCreateNewVersionWhenInsertInStableRootAsLeaf() throws Exception
+    {
+        // GIVEN root
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long oldGenId = cursor.getCurrentPageId();
+
+        // WHEN root -[newGen]-> newGen root
+        insert( 1L, 1L, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long newGenId = cursor.getCurrentPageId();
+
+        // THEN
+        assertTrue( structurePropagation.hasNewGen );
+        assertEquals( newGenId, structurePropagation.left );
+        assertNotEquals( oldGenId, newGenId );
+        assertEquals( 1, node.keyCount( cursor ) );
+
+        node.goTo( cursor, oldGenId, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertEquals( newGenId, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( 0, node.keyCount( cursor ) );
+    }
+
+    @Test
+    public void shouldCreateNewVersionWhenRemoveInStableRootAsLeaf() throws Exception
+    {
+        // GIVEN root
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long key = 1L;
+        long value = 10L;
+        insert( key, value, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long oldGenId = cursor.getCurrentPageId();
+
+        // WHEN root -[newGen]-> newGen root
+        remove( key, readValue, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long newGenId = cursor.getCurrentPageId();
+
+        // THEN
+        assertTrue( structurePropagation.hasNewGen );
+        assertEquals( newGenId, structurePropagation.left );
+        assertNotEquals( oldGenId, newGenId );
+        assertEquals( 0, node.keyCount( cursor ) );
+
+        node.goTo( cursor, oldGenId, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertEquals( newGenId, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( 1, node.keyCount( cursor ) );
+    }
+
+    @Test
+    public void shouldCreateNewVersionWhenInsertInStableLeaf() throws Exception
+    {
+        // GIVEN:
+        //       ------root-------
+        //      /        |         \
+        //     v         v          v
+        //   left <--> middle <--> right
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long targetLastId = id.lastId() + 3; // 2 splits and 1 new allocated root
+        long i = 0;
+        for ( ; id.lastId() < targetLastId; i++ )
+        {
+            insert( i, i, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            if ( structurePropagation.hasSplit )
+            {
+                newRootFromSplit( structurePropagation, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            }
+        }
+        assertEquals( 2, node.keyCount( cursor ) );
+        long leftChild = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long middleChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long rightChild = node.childAt( cursor, 2, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertSiblings( leftChild, middleChild, rightChild );
+
+        // WHEN
+        long root = cursor.getCurrentPageId();
+        long middleKey = i / 2; // Should be located in middle leaf
+        long newValue = middleKey * 100;
+        insert( middleKey, newValue, STABLE_GENERATION, UNSTABLE_GENERATION );
+        cursor.next( 5 );
+        cursor.next( root );
+
+        // THEN
+        // root have new middle child
+        long expectedNewMiddleChild = targetLastId + 1;
+        assertEquals( expectedNewMiddleChild, id.lastId() );
+        long newMiddleChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertEquals( expectedNewMiddleChild, newMiddleChild );
+
+        // old middle child has new gen
+        cursor.next( middleChild );
+        assertEquals( newMiddleChild, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+
+        // old middle child has seen no change
+        assertKeyAssociatedWithValue( middleKey, middleKey );
+
+        // new middle child has seen change
+        cursor.next( newMiddleChild );
+        assertKeyAssociatedWithValue( middleKey, newValue );
+
+        // sibling pointers updated
+        assertSiblings( leftChild, newMiddleChild, rightChild );
+    }
+
+    @Test
+    public void shouldCreateNewVersionWhenRemoveInStableLeaf() throws Exception
+    {
+        // GIVEN:
+        //       ------root-------
+        //      /        |         \
+        //     v         v          v
+        //   left <--> middle <--> right
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long targetLastId = id.lastId() + 3; // 2 splits and 1 new allocated root
+        long i = 0;
+        for ( ; id.lastId() < targetLastId; i++ )
+        {
+            insert( i, i, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            if ( structurePropagation.hasSplit )
+            {
+                newRootFromSplit( structurePropagation, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            }
+        }
+        assertEquals( 2, node.keyCount( cursor ) );
+        long leftChild = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long middleChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long rightChild = node.childAt( cursor, 2, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertSiblings( leftChild, middleChild, rightChild );
+
+        // WHEN
+        long root = cursor.getCurrentPageId();
+        long middleKey = i / 2; // Should be located in middle leaf
+        remove( middleKey, insertValue, STABLE_GENERATION, UNSTABLE_GENERATION );
+        cursor.next( 5 );
+        cursor.next( root );
+
+        // THEN
+        // root have new middle child
+        long expectedNewMiddleChild = targetLastId + 1;
+        assertEquals( expectedNewMiddleChild, id.lastId() );
+        long newMiddleChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertEquals( expectedNewMiddleChild, newMiddleChild );
+
+        // old middle child has new gen
+        cursor.next( middleChild );
+        assertEquals( newMiddleChild, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+
+        // old middle child has seen no change
+        assertKeyAssociatedWithValue( middleKey, middleKey );
+
+        // new middle child has seen change
+        cursor.next( newMiddleChild );
+        assertKeyNotFound( middleKey );
+
+        // sibling pointers updated
+        assertSiblings( leftChild, newMiddleChild, rightChild );
+    }
+
+    @Test
+    public void shouldCreateNewVersionWhenInsertInStableRootAsInternal() throws Exception
+    {
+        // GIVEN:
+        //                       root
+        //                   ----   ----
+        //                  /           \
+        //                 v             v
+        //               left <-------> right
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        long i = 0;
+        int countToProduceAboveImageAndFullRight =
+                maxKeyCount /*will split root leaf into two half left/right*/ + maxKeyCount / 2;
+        for ( ; i < countToProduceAboveImageAndFullRight; i++ )
+        {
+            insert( i, i, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            if ( structurePropagation.hasSplit )
+            {
+                newRootFromSplit( structurePropagation, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            }
+        }
+        long root = cursor.getCurrentPageId();
+        assertEquals( 1, node.keyCount( cursor ) );
+        long leftChild = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long rightChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertSiblings( leftChild, rightChild, TreeNode.NO_NODE_FLAG );
+
+        // WHEN
+        //                       root(newGen)
+        //                   ----  | ---------------
+        //                  /      |                \
+        //                 v       v                 v
+        //               left <-> right(newGen) <--> farRight
+        insert( i, i, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertTrue( structurePropagation.hasNewGen );
+        long newRoot = cursor.getCurrentPageId();
+        leftChild = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        rightChild = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+
+        // THEN
+        // siblings are correct
+        long farRightChild = node.childAt( cursor, 2, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertSiblings( leftChild, rightChild, farRightChild );
+
+        // old root points to new gen root
+        cursor.next( root );
+        assertEquals( newRoot, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+    }
+
+    @Test
+    public void shouldCreateNewVersionWhenInsertInStableInternal() throws Exception
+    {
+        // GIVEN:
+        node.initializeLeaf( cursor, OLD_STABLE_GENERATION, STABLE_GENERATION );
+        int rootAllocations = 0;
+        for ( int i = 0; rootAllocations < 2; i++ )
+        {
+            long keyAndValue = i * maxKeyCount;
+            insert( keyAndValue, keyAndValue, OLD_STABLE_GENERATION, STABLE_GENERATION );
+            if ( structurePropagation.hasSplit )
+            {
+                newRootFromSplit( structurePropagation, OLD_STABLE_GENERATION, STABLE_GENERATION );
+                rootAllocations++;
+            }
+        }
+        long root = cursor.getCurrentPageId();
+        assertEquals( 1, node.keyCount( cursor ) );
+        long leftInternal = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long rightInternal = node.childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        assertSiblings( leftInternal, rightInternal, TreeNode.NO_NODE_FLAG );
+        cursor.next( leftInternal );
+        int leftInternalKeyCount = node.keyCount( cursor );
+        assertTrue( node.isInternal( cursor ) );
+        long leftLeaf = node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        cursor.next( leftLeaf );
+        long firstKeyInLeaf = node.keyAt( cursor, readKey, 0 ).longValue();
+        cursor.next( root );
+
+        // WHEN
+        long targetLastId = id.lastId() + 3; /*one for newGen in leaf, one for split leaf, one for newGen in internal*/
+        for ( int i = 0; id.lastId() < targetLastId; i++ )
+        {
+            insert( firstKeyInLeaf + i, firstKeyInLeaf + i, STABLE_GENERATION, UNSTABLE_GENERATION );
+            assertFalse( structurePropagation.hasSplit ); // there should be no root split
+        }
+
+        // THEN
+        // root hasn't been split further
+        assertEquals( root, cursor.getCurrentPageId() );
+
+        // there's a new generation of left internal w/ one more key in
+        long newGenLeftInternal = id.lastId();
+        assertEquals( newGenLeftInternal, node.childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        cursor.next( newGenLeftInternal );
+        int newGenLeftInternalKeyCount = node.keyCount( cursor );
+        assertEquals( leftInternalKeyCount + 1, newGenLeftInternalKeyCount );
+
+        // and left internal points to the new gen
+        cursor.next( leftInternal );
+        assertEquals( newGenLeftInternal, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertSiblings( newGenLeftInternal, rightInternal, TreeNode.NO_NODE_FLAG );
+    }
+
+    private void assertKeyAssociatedWithValue( long key, long expectedValue )
+    {
+        insertKey.setValue( key );
+        int search = KeySearch.search( cursor, node, insertKey, readKey, node.keyCount( cursor ) );
+        assertTrue( KeySearch.isHit( search ) );
+        int keyPos = KeySearch.positionOf( search );
+        node.valueAt( cursor, readValue, keyPos );
+        assertEquals( expectedValue, readValue.longValue() );
+    }
+
+    private void assertKeyNotFound( long key )
+    {
+        insertKey.setValue( key );
+        int search = KeySearch.search( cursor, node, insertKey, readKey, node.keyCount( cursor ) );
+        assertFalse( KeySearch.isHit( search ) );
+    }
+
+    private void assertSiblings( long left, long middle, long right ) throws IOException
+    {
+        long origin = cursor.getCurrentPageId();
+        cursor.next( middle );
+        assertEquals( right, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( left, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        if ( left != TreeNode.NO_NODE_FLAG )
+        {
+            cursor.next( left );
+            assertEquals( middle, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        }
+        if ( right != TreeNode.NO_NODE_FLAG )
+        {
+            cursor.next( right );
+            assertEquals( middle, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        }
+        cursor.next( origin );
+    }
+
     // KEEP even if unused
     private void printTree() throws IOException
     {
@@ -641,14 +961,21 @@ public class InternalTreeLogicTest
 
     private long newRootFromSplit( StructurePropagation<MutableLong> split ) throws IOException
     {
+        return newRootFromSplit( split, STABLE_GENERATION, UNSTABLE_GENERATION );
+    }
+
+    private long newRootFromSplit( StructurePropagation<MutableLong> split,
+            long stableGeneration, long unstableGeneration ) throws IOException
+    {
         assertTrue( split.hasSplit );
         long rootId = id.acquireNewId();
         cursor.next( rootId );
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, stableGeneration, unstableGeneration );
         node.insertKeyAt( cursor, split.primKey, 0, 0, tmp );
         node.setKeyCount( cursor, 1 );
-        node.setChildAt( cursor, split.left, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setChildAt( cursor, split.right, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setChildAt( cursor, split.left, 0, stableGeneration, unstableGeneration );
+        node.setChildAt( cursor, split.right, 1, stableGeneration, unstableGeneration );
+        split.hasSplit = false;
         return rootId;
     }
 
@@ -681,20 +1008,37 @@ public class InternalTreeLogicTest
         insert( key, value, overwrite() );
     }
 
+    private void insert( long key, long value, long stableGeneration, long unstableGeneration ) throws IOException
+    {
+        insert( key, value, stableGeneration, unstableGeneration, overwrite() );
+    }
+
     private void insert( long key, long value, ValueMerger<MutableLong> valueMerger ) throws IOException
+    {
+        insert( key, value, STABLE_GENERATION, UNSTABLE_GENERATION, valueMerger );
+    }
+
+    private void insert( long key, long value, long stableGeneration, long unstableGeneration,
+            ValueMerger<MutableLong> valueMerger ) throws IOException
     {
         structurePropagation.hasSplit = false;
         structurePropagation.hasNewGen = false;
         insertKey.setValue( key );
         insertValue.setValue( value );
         treeLogic.insert( cursor, structurePropagation, insertKey, insertValue, valueMerger, DEFAULTS,
-                STABLE_GENERATION, UNSTABLE_GENERATION );
+                stableGeneration, unstableGeneration );
     }
 
     private MutableLong remove( long key, MutableLong into ) throws IOException
     {
+        return remove( key, into, STABLE_GENERATION, UNSTABLE_GENERATION );
+    }
+
+    private MutableLong remove( long key, MutableLong into, long stableGeneration, long unstableGeneration )
+            throws IOException
+    {
         insertKey.setValue( key );
-        return treeLogic.remove( cursor, structurePropagation, insertKey, into, STABLE_GENERATION, UNSTABLE_GENERATION );
+        return treeLogic.remove( cursor, structurePropagation, insertKey, into, stableGeneration, unstableGeneration );
     }
 
     private static class SimpleIdProvider implements IdProvider
@@ -710,6 +1054,11 @@ public class InternalTreeLogicTest
         public long acquireNewId()
         {
             lastId++;
+            return lastId;
+        }
+
+        long lastId()
+        {
             return lastId;
         }
 

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
@@ -32,17 +32,27 @@ import static org.neo4j.index.gbptree.ByteArrayPageCursor.*;
 class PageAwareByteArrayCursor extends PageCursor
 {
     private final int pageSize;
+    private final List<byte[]> pages;
+
     private PageCursor current;
     private long currentPageId = UNBOUND_PAGE_ID;
-    private List<byte[]> pages = new ArrayList<>();
+    private long nextPageId;
+    private PageCursor linkedCursor;
 
     PageAwareByteArrayCursor( int pageSize )
     {
+        this( new ArrayList<>(), pageSize, 0 );
+    }
+
+    private PageAwareByteArrayCursor( List<byte[]> pages, int pageSize, long nextPageId )
+    {
+        this.pages = pages;
         this.pageSize = pageSize;
+        this.nextPageId = nextPageId;
         initialize();
     }
 
-    public void initialize()
+    private void initialize()
     {
         currentPageId = UNBOUND_PAGE_ID;
         current = null;
@@ -70,14 +80,8 @@ class PageAwareByteArrayCursor extends PageCursor
     @Override
     public boolean next() throws IOException
     {
-        if ( currentPageId == UNBOUND_PAGE_ID )
-        {
-            currentPageId = 0;
-        }
-        else
-        {
-            currentPageId++;
-        }
+        currentPageId = nextPageId;
+        nextPageId++;
         assertPages();
 
         byte[] page = page( currentPageId );
@@ -279,19 +283,29 @@ class PageAwareByteArrayCursor extends PageCursor
     @Override
     public void close()
     {
+        if ( linkedCursor != null )
+        {
+            linkedCursor.close();
+        }
         current.close();
     }
 
     @Override
     public boolean shouldRetry() throws IOException
     {
-        return current.shouldRetry();
+        return linkedCursor != null && linkedCursor.shouldRetry() || current.shouldRetry();
     }
 
     @Override
     public boolean checkAndClearBoundsFlag()
     {
-        return current.checkAndClearBoundsFlag();
+        boolean result = false;
+        if ( linkedCursor != null )
+        {
+            result = linkedCursor.checkAndClearBoundsFlag();
+        }
+        result |= current.checkAndClearBoundsFlag();
+        return result;
     }
 
     @Override
@@ -321,6 +335,12 @@ class PageAwareByteArrayCursor extends PageCursor
     @Override
     public PageCursor openLinkedCursor( long pageId )
     {
-        return current.openLinkedCursor( pageId );
+        PageCursor toReturn = new PageAwareByteArrayCursor( pages, pageSize, pageId );
+        if ( linkedCursor != null )
+        {
+            linkedCursor.close();
+        }
+        linkedCursor = toReturn;
+        return toReturn;
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PointerCheckingTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PointerCheckingTest.java
@@ -96,7 +96,7 @@ public class PointerCheckingTest
     {
         // GIVEN
         PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-        int generation = 1;
+        long generation = 1;
         PointerChecking.checkChildPointer( write( cursor, 123, 0, generation ) );
         cursor.setOffset( 0 );
 
@@ -112,7 +112,7 @@ public class PointerCheckingTest
     {
         // GIVEN
         PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-        int generation = 1;
+        long generation = 1;
 
         // WHEN
         long result = write( cursor, 123, 0, generation );

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PointerCheckingTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PointerCheckingTest.java
@@ -30,8 +30,13 @@ import static org.neo4j.index.gbptree.GenSafePointerPair.write;
 
 public class PointerCheckingTest
 {
+    private final PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
+    private final int firstGeneration = 1;
+    private final int secondGeneration = 2;
+    private final int thirdGeneration = 3;
+
     @Test
-    public void shouldThrowOnNoNode() throws Exception
+    public void checkChildShouldThrowOnNoNode() throws Exception
     {
         // WHEN
         try
@@ -46,10 +51,9 @@ public class PointerCheckingTest
     }
 
     @Test
-    public void shouldThrowOnReadFailure() throws Exception
+    public void checkChildShouldThrowOnReadFailure() throws Exception
     {
         // GIVEN
-        PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
         long result = GenSafePointerPair.read( cursor, 0, 1 );
 
         // WHEN
@@ -65,17 +69,13 @@ public class PointerCheckingTest
     }
 
     @Test
-    public void shouldThrowOnWriteFailure() throws Exception
+    public void checkChildShouldThrowOnWriteFailure() throws Exception
     {
         // GIVEN
-        PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-        int firstGeneration = 1;
-        int secondGeneration = 2;
-        int thirdGeneration = 3;
         write( cursor, 123, 0, firstGeneration );
-        cursor.setOffset( 0 );
+        cursor.rewind();
         write( cursor, 456, firstGeneration, secondGeneration );
-        cursor.setOffset( 0 );
+        cursor.rewind();
 
         // WHEN
         // This write will see first and second written pointers and think they belong to CRASHed generation
@@ -92,32 +92,95 @@ public class PointerCheckingTest
     }
 
     @Test
-    public void shouldPassOnReadSuccess() throws Exception
+    public void checkChildShouldPassOnReadSuccess() throws Exception
     {
         // GIVEN
-        PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-        long generation = 1;
-        PointerChecking.checkChildPointer( write( cursor, 123, 0, generation ) );
-        cursor.setOffset( 0 );
+        PointerChecking.checkChildPointer( write( cursor, 123, 0, firstGeneration ) );
+        cursor.rewind();
 
         // WHEN
-        long result = read( cursor, 0, generation );
+        long result = read( cursor, 0, firstGeneration );
 
         // THEN
         PointerChecking.checkChildPointer( result );
     }
 
     @Test
-    public void shouldPassOnWriteSuccess() throws Exception
+    public void checkChildShouldPassOnWriteSuccess() throws Exception
     {
-        // GIVEN
-        PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-        long generation = 1;
-
         // WHEN
-        long result = write( cursor, 123, 0, generation );
+        long result = write( cursor, 123, 0, firstGeneration );
 
         // THEN
         PointerChecking.checkChildPointer( result );
+    }
+
+    @Test
+    public void checkSiblingShouldPassOnReadSuccessForNoNodePointer() throws Exception
+    {
+        // GIVEN
+        write( cursor, TreeNode.NO_NODE_FLAG, firstGeneration, secondGeneration );
+        cursor.rewind();
+
+        // WHEN
+        long result = read( cursor, firstGeneration, secondGeneration );
+
+        // THEN
+        PointerChecking.checkSiblingPointer( result );
+    }
+
+    @Test
+    public void checkSiblingShouldPassOnReadSuccessForNodePointer() throws Exception
+    {
+        // GIVEN
+        long pointer = 101;
+        write( cursor, pointer, firstGeneration, secondGeneration );
+        cursor.rewind();
+
+        // WHEN
+        long result = read( cursor, firstGeneration, secondGeneration );
+
+        // THEN
+        PointerChecking.checkSiblingPointer( result );
+    }
+
+    @Test
+    public void checkSiblingShouldThrowOnReadFailure() throws Exception
+    {
+        // WHEN
+        long result = read( cursor, firstGeneration, secondGeneration );
+
+        // WHEN
+        try
+        {
+            PointerChecking.checkSiblingPointer( result );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN good
+        }
+    }
+
+    @Test
+    public void checkSiblingShouldThrowOnReadIllegalPointer() throws Exception
+    {
+        // GIVEN
+        GenSafePointer.write( cursor, secondGeneration, IdSpace.STATE_PAGE_A );
+        cursor.rewind();
+
+        // WHEN
+        long result = read( cursor, firstGeneration, secondGeneration );
+
+        // WHEN
+        try
+        {
+            PointerChecking.checkSiblingPointer( result );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // THEN good
+        }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
@@ -55,7 +55,6 @@ public class SeekCursorTest
     @Before
     public void setUp() throws IOException
     {
-        delegate.initialize();
         pageCursor.next( 0L );
         treeNode.initializeLeaf( pageCursor, STABLE_GENERATION, UNSTABLE_GENERATION );
     }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
@@ -71,11 +71,11 @@ public class TreeNodeTest
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
-        node.setGen( cursor, 0xFFFFFFFFL );
+        node.setGen( cursor, GenSafePointer.MAX_GENERATION );
 
         // THEN
         long gen = node.gen( cursor );
-        assertEquals( 0xFFFFFFFFL, gen );
+        assertEquals( GenSafePointer.MAX_GENERATION, gen );
     }
 
     @Test

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
@@ -65,6 +65,22 @@ public class TreeNodeTest
     }
 
     @Test
+    public void shouldInitializeInternal() throws Exception
+    {
+        // WHEN
+        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+
+        // THEN
+        assertFalse( node.isLeaf( cursor ) );
+        assertTrue( node.isInternal( cursor ) );
+        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
+        assertEquals( 0, node.keyCount( cursor ) );
+        assertEquals( NO_NODE_FLAG, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+    }
+
+    @Test
     public void shouldWriteAndReadMaxGen() throws Exception
     {
         // GIVEN
@@ -79,19 +95,39 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldInitializeInternal() throws Exception
+    public void shouldThrowIfWriteTooLargeGen() throws Exception
     {
-        // WHEN
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
-        assertFalse( node.isLeaf( cursor ) );
-        assertTrue( node.isInternal( cursor ) );
-        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
-        assertEquals( 0, node.keyCount( cursor ) );
-        assertEquals( NO_NODE_FLAG, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        try
+        {
+            node.setGen( cursor, GenSafePointer.MAX_GENERATION + 1 );
+            fail( "Expected throw" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Good
+        }
+    }
+
+    @Test
+    public void shouldThrowIfWriteTooSmallGen() throws Exception
+    {
+        // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+
+        // THEN
+        try
+        {
+            node.setGen( cursor, GenSafePointer.MIN_GENERATION - 1 );
+            fail( "Expected throw" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Good
+        }
     }
 
     private void shouldSetAndGetKey() throws Exception

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
@@ -57,10 +57,25 @@ public class TreeNodeTest
         // THEN
         assertTrue( node.isLeaf( cursor ) );
         assertFalse( node.isInternal( cursor ) );
+        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, node.newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+    }
+
+    @Test
+    public void shouldWriteAndReadMaxGen() throws Exception
+    {
+        // GIVEN
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+
+        // WHEN
+        node.setGen( cursor, 0xFFFFFFFFL );
+
+        // THEN
+        long gen = node.gen( cursor );
+        assertEquals( 0xFFFFFFFFL, gen );
     }
 
     @Test
@@ -72,6 +87,7 @@ public class TreeNodeTest
         // THEN
         assertFalse( node.isLeaf( cursor ) );
         assertTrue( node.isInternal( cursor ) );
+        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, node.leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, node.rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );


### PR DESCRIPTION
Further implements tree generations by making sure changes aren't applied in stables nodes, but instead copying stable node into unstable generation and making change there. Nodes now each have a generation and stable node gets "new generation" forward-pointer to the new generation node. The new-generation pointer is rarely actually traversed because parent nodes redirect to new nodes directly, they are there for when reader goes to a stable node, which concurrently gets a new version of itself created.

This PR is a reasonably coherent chunk of this generation work and focuses on InternalTreeLogic, whereas there's further work to be done inside GBPTree to complete the generation work.