### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Terms.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/Terms.java
@@ -56,14 +56,14 @@ public class Terms
         {
             throw new IllegalStateException( "Must append in order" );
         }
-        else if ( term < terms[size - 1] )
+        else if ( size > 0 && term < terms[size - 1] )
         {
             throw new IllegalStateException( "Non-monotonic term" );
         }
 
         max = index;
 
-        if ( term != terms[size - 1] )
+        if ( size == 0 || term != terms[size - 1] )
         {
             setSize( size + 1 );
             indexes[size - 1] = index;
@@ -167,6 +167,6 @@ public class Terms
 
     synchronized long latest()
     {
-        return terms[size - 1];
+        return size == 0 ? -1 : terms[size - 1];
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
@@ -360,7 +360,6 @@ public class TermsTest
     public void shouldPruneSeveralCompleteRanges() throws Exception
     {
         // given
-        // given
         long term = 5;
         long prevIndex = 10;
         terms = new Terms( prevIndex, term );
@@ -386,6 +385,33 @@ public class TermsTest
 
         assertEquals( 3, getIndexesSize() );
         assertEquals( 3, getTermsSize() );
+    }
+
+    @Test
+    public void shouldAppendNewItemsIfThereAreNoEntries() throws Exception
+    {
+        // given
+        long term = 5;
+        long prevIndex = 10;
+        terms = new Terms( prevIndex, term );
+
+        // when
+        terms.truncate( prevIndex );
+
+        // then
+        assertEquals( -1, terms.get( prevIndex ) );
+        assertEquals( -1, terms.latest() );
+        assertEquals( 0, getIndexesSize() );
+        assertEquals( 0, getTermsSize() );
+
+        // and when
+        terms.append( prevIndex, 5 );
+
+        // then
+        assertEquals( term, terms.get( prevIndex ) );
+        assertEquals( term, terms.latest() );
+        assertEquals( 1, getIndexesSize() );
+        assertEquals( 1, getTermsSize() );
     }
 
     private int getTermsSize() throws NoSuchFieldException, IllegalAccessException


### PR DESCRIPTION
In Terms class if the size of the arrays becomes zero due to
truncation, the next tentative of appending a new entry fails with an
AIOBE.  This commit will allow entries to be appended in case the size
is zero.