### PR TITLE
Adds PageCursor#clear()

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
@@ -289,9 +289,8 @@ class ByteArrayPageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
         Arrays.fill( buffer.array(), (byte) 0 );
-        buffer.position( 0 );
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
@@ -22,6 +22,7 @@ package org.neo4j.index.gbptree;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
@@ -285,5 +286,12 @@ class ByteArrayPageCursor extends PageCursor
     public PageCursor openLinkedCursor( long pageId )
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear()
+    {
+        Arrays.fill( buffer.array(), (byte) 0 );
+        buffer.position( 0 );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
@@ -323,4 +323,10 @@ class PageAwareByteArrayCursor extends PageCursor
     {
         return current.openLinkedCursor( pageId );
     }
+
+    @Override
+    public void clear()
+    {
+        current.clear();
+    }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
@@ -325,8 +325,8 @@ class PageAwareByteArrayCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
-        current.clear();
+        current.zapPage();
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TestPageCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TestPageCursor.java
@@ -280,6 +280,12 @@ public class TestPageCursor extends PageCursor
         return actual.openLinkedCursor( pageId );
     }
 
+    @Override
+    public void zapPage()
+    {
+        actual.zapPage();
+    }
+
     public void changed()
     {
         shouldRetry = true;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -261,6 +261,7 @@ public abstract class PageCursor implements AutoCloseable
      *
      * @see AutoCloseable#close()
      */
+    @Override
     public abstract void close();
 
     /**
@@ -340,4 +341,10 @@ public abstract class PageCursor implements AutoCloseable
      * @return A cursor that is linked with this cursor.
      */
     public abstract PageCursor openLinkedCursor( long pageId );
+
+    /**
+     * Sets all bytes in this page to zero, as if this page was newly allocated at the end of the file.
+     * Offset is also set to 0.
+     */
+    public abstract void clear();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -344,7 +344,6 @@ public abstract class PageCursor implements AutoCloseable
 
     /**
      * Sets all bytes in this page to zero, as if this page was newly allocated at the end of the file.
-     * Offset is also set to 0.
      */
-    public abstract void clear();
+    public abstract void zapPage();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -483,10 +483,10 @@ public class CompositePageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
-        first.clear();
-        second.clear();
+        first.zapPage();
+        second.zapPage();
     }
 
     /**

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -482,6 +482,13 @@ public class CompositePageCursor extends PageCursor
         throw new UnsupportedOperationException( "Linked cursors are not supported for composite cursors" );
     }
 
+    @Override
+    public void clear()
+    {
+        first.clear();
+        second.clear();
+    }
+
     /**
      * Build a CompositePageCursor that is a view of the first page cursor from its current offset through the given
      * length, concatenated with the second cursor from its current offset through the given length. The offsets are

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -255,9 +255,9 @@ public class DelegatingPageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
-        delegate.clear();
+        delegate.zapPage();
     }
 
     public DelegatingPageCursor( PageCursor delegate )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -32,106 +32,127 @@ public class DelegatingPageCursor extends PageCursor
 {
     private final PageCursor delegate;
 
+    @Override
     public byte getByte()
     {
         return delegate.getByte();
     }
 
+    @Override
     public int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes )
     {
         return delegate.copyTo( sourceOffset, targetCursor, targetOffset, lengthInBytes );
     }
 
+    @Override
     public void putInt( int value )
     {
         delegate.putInt( value );
     }
 
+    @Override
     public void getBytes( byte[] data )
     {
         delegate.getBytes( data );
     }
 
+    @Override
     public boolean next() throws IOException
     {
         return delegate.next();
     }
 
+    @Override
     public void putBytes( byte[] data )
     {
         delegate.putBytes( data );
     }
 
+    @Override
     public short getShort()
     {
         return delegate.getShort();
     }
 
+    @Override
     public File getCurrentFile()
     {
         return delegate.getCurrentFile();
     }
 
+    @Override
     public void putShort( short value )
     {
         delegate.putShort( value );
     }
 
+    @Override
     public short getShort( int offset )
     {
         return delegate.getShort( offset );
     }
 
+    @Override
     public int getCurrentPageSize()
     {
         return delegate.getCurrentPageSize();
     }
 
+    @Override
     public long getLong()
     {
         return delegate.getLong();
     }
 
+    @Override
     public void putLong( long value )
     {
         delegate.putLong( value );
     }
 
+    @Override
     public int getOffset()
     {
         return delegate.getOffset();
     }
 
+    @Override
     public void close()
     {
         delegate.close();
     }
 
+    @Override
     public void putByte( int offset, byte value )
     {
         delegate.putByte( offset, value );
     }
 
+    @Override
     public void putInt( int offset, int value )
     {
         delegate.putInt( offset, value );
     }
 
+    @Override
     public void putBytes( byte[] data, int arrayOffset, int length )
     {
         delegate.putBytes( data, arrayOffset, length );
     }
 
+    @Override
     public void rewind()
     {
         delegate.rewind();
     }
 
+    @Override
     public void putByte( byte value )
     {
         delegate.putByte( value );
     }
 
+    @Override
     public boolean checkAndClearBoundsFlag()
     {
         return delegate.checkAndClearBoundsFlag();
@@ -167,59 +188,76 @@ public class DelegatingPageCursor extends PageCursor
         return delegate.openLinkedCursor( pageId );
     }
 
+    @Override
     public long getCurrentPageId()
     {
         return delegate.getCurrentPageId();
     }
 
+    @Override
     public void putShort( int offset, short value )
     {
         delegate.putShort( offset, value );
     }
 
+    @Override
     public boolean next( long pageId ) throws IOException
     {
         return delegate.next( pageId );
     }
 
+    @Override
     public void putLong( int offset, long value )
     {
         delegate.putLong( offset, value );
     }
 
+    @Override
     public long getLong( int offset )
     {
         return delegate.getLong( offset );
     }
 
+    @Override
     public void getBytes( byte[] data, int arrayOffset, int length )
     {
         delegate.getBytes( data, arrayOffset, length );
     }
 
+    @Override
     public int getInt( int offset )
     {
         return delegate.getInt( offset );
     }
 
+    @Override
     public void setOffset( int offset )
     {
         delegate.setOffset( offset );
     }
 
+    @Override
     public byte getByte( int offset )
     {
         return delegate.getByte( offset );
     }
 
+    @Override
     public int getInt()
     {
         return delegate.getInt();
     }
 
+    @Override
     public boolean shouldRetry() throws IOException
     {
         return delegate.shouldRetry();
+    }
+
+    @Override
+    public void clear()
+    {
+        delegate.clear();
     }
 
     public DelegatingPageCursor( PageCursor delegate )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -778,7 +778,7 @@ abstract class MuninnPageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
         if ( pageSize == 0 )
         {
@@ -789,7 +789,6 @@ abstract class MuninnPageCursor extends PageCursor
         else
         {
             UnsafeUtil.setMemory( pointer, pageSize, (byte) 0 );
-            offset = 0;
         }
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -776,4 +776,20 @@ abstract class MuninnPageCursor extends PageCursor
             this.cursorException = message;
         }
     }
+
+    @Override
+    public void clear()
+    {
+        if ( pageSize == 0 )
+        {
+            // if this page has been closed then pageSize == 0 and we must adhere to making writes
+            // trigger outOfBounds when closed
+            outOfBounds = true;
+        }
+        else
+        {
+            UnsafeUtil.setMemory( pointer, pageSize, (byte) 0 );
+            offset = 0;
+        }
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -167,7 +167,7 @@ final class MuninnReadPageCursor extends MuninnPageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
         throw new IllegalStateException( "Cannot write to read-locked page" );
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -88,6 +88,7 @@ final class MuninnReadPageCursor extends MuninnPageCursor
         lockStamp = page.unlockExclusive();
     }
 
+    @Override
     protected void releaseCursor()
     {
         nextCursor = cursorSets.readCursors;
@@ -161,6 +162,12 @@ final class MuninnReadPageCursor extends MuninnPageCursor
 
     @Override
     public void putShort( short value )
+    {
+        throw new IllegalStateException( "Cannot write to read-locked page" );
+    }
+
+    @Override
+    public void clear()
     {
         throw new IllegalStateException( "Cannot write to read-locked page" );
     }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
@@ -124,11 +124,13 @@ class AdversarialReadPageCursor extends PageCursor
             this.currentReadIsPreparingInconsistent = currentReadIsPreparingInconsistent;
         }
 
+        @Override
         public void injectFailure( Class<? extends Throwable>... failureTypes )
         {
             adversary.injectFailure( failureTypes );
         }
 
+        @Override
         public boolean injectFailureOrMischief( Class<? extends Throwable>... failureTypes )
         {
             return adversary.injectFailureOrMischief( failureTypes );
@@ -169,7 +171,7 @@ class AdversarialReadPageCursor extends PageCursor
 
     private final PageCursor delegate;
     private AdversarialReadPageCursor linkedCursor;
-    private State state;
+    private final State state;
 
     AdversarialReadPageCursor( PageCursor delegate, Adversary adversary )
     {
@@ -452,6 +454,12 @@ class AdversarialReadPageCursor extends PageCursor
     public PageCursor openLinkedCursor( long pageId )
     {
         return linkedCursor = new AdversarialReadPageCursor( delegate.openLinkedCursor( pageId ), state );
+    }
+
+    @Override
+    public void clear()
+    {
+        throw new IllegalStateException( "Cannot write using read cursor" );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
@@ -457,7 +457,7 @@ class AdversarialReadPageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
         throw new IllegalStateException( "Cannot write using read cursor" );
     }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
@@ -302,4 +302,10 @@ class AdversarialWritePageCursor extends PageCursor
     {
         return linkedCursor = new AdversarialWritePageCursor( delegate.openLinkedCursor( pageId ), adversary );
     }
+
+    @Override
+    public void clear()
+    {
+        delegate.clear();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
@@ -304,8 +304,8 @@ class AdversarialWritePageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
-        delegate.clear();
+        delegate.zapPage();
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -88,6 +88,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -1183,6 +1184,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         testTemplate.accept( ( cursor ) -> cursor.putInt( 0, 1 ) );
         testTemplate.accept( ( cursor ) -> cursor.putLong( 0, 1 ) );
         testTemplate.accept( ( cursor ) -> cursor.putShort( 0, (short) 1 ) );
+        testTemplate.accept( ( cursor ) -> cursor.clear() );
     }
 
     private void checkUnboundReadCursorAccess( PageCursorAction action ) throws IOException
@@ -2489,6 +2491,9 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
 
     private void verifyWriteOffsets( PageCursor cursor )
     {
+        assertThat( cursor.getOffset(), is( 0 ) );
+        cursor.setOffset( filePageSize / 2 );
+        cursor.clear();
         assertThat( cursor.getOffset(), is( 0 ) );
         cursor.putLong( 1 );
         assertThat( cursor.getOffset(), is( 8 ) );
@@ -5369,5 +5374,47 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
 
         // Then verify that the old random data we put in 'b' has been replaced with the contents of 'a'
         verifyRecordsInFile( b, recordCount );
+    }
+
+    @Test
+    public void shouldZeroAllBytesOnClear() throws Exception
+    {
+        // GIVEN
+        configureStandardPageCache();
+        try ( PagedFile pagedFile = pageCache.map( file( "a" ), filePageSize ) )
+        {
+            long pageId = 0;
+            try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK ) )
+            {
+                ThreadLocalRandom rng = ThreadLocalRandom.current();
+                byte[] bytes = new byte[filePageSize];
+                rng.nextBytes( bytes );
+
+                assertTrue( cursor.next() );
+                cursor.putBytes( bytes );
+            }
+            // WHEN
+            byte[] allZeros = new byte[filePageSize];
+            try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK ) )
+            {
+                assertTrue( cursor.next() );
+                cursor.clear();
+
+                byte[] read = new byte[filePageSize];
+                cursor.getBytes( read );
+                assertFalse( cursor.checkAndClearBoundsFlag() );
+                assertArrayEquals( allZeros, read );
+            }
+            // THEN
+            try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
+            {
+                assertTrue( cursor.next() );
+
+                byte[] read = new byte[filePageSize];
+                cursor.getBytes( read );
+                assertFalse( cursor.checkAndClearBoundsFlag() );
+                assertArrayEquals( allZeros, read );
+            }
+        }
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -399,10 +399,9 @@ public class StubPageCursor extends PageCursor
     }
 
     @Override
-    public void clear()
+    public void zapPage()
     {
-        page.clear();
-        currentOffset = 0;
+        page.zapPage();
     }
 
     public Page getPage()

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -33,8 +33,8 @@ import org.neo4j.io.pagecache.impl.ByteBufferPage;
  */
 public class StubPageCursor extends PageCursor
 {
-    private long pageId;
-    private int pageSize;
+    private final long pageId;
+    private final int pageSize;
     protected ByteBufferPage page;
     private int currentOffset;
     private boolean observedOverflow;
@@ -396,6 +396,13 @@ public class StubPageCursor extends PageCursor
             throw new IndexOutOfBoundsException();
         }
         currentOffset = offset;
+    }
+
+    @Override
+    public void clear()
+    {
+        page.clear();
+        currentOffset = 0;
     }
 
     public Page getPage()

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
@@ -25,12 +25,14 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
+import org.neo4j.io.ByteUnit;
 import org.neo4j.io.pagecache.Page;
 
 /** A page backed by a simple byte buffer. */
 public class ByteBufferPage implements Page
 {
     private static final MethodHandle addressOfMH = addressOfMH();
+    private static final byte[] ZEROS = new byte[(int) ByteUnit.kibiBytes( 1 )];
 
     private static MethodHandle addressOfMH()
     {
@@ -134,5 +136,18 @@ public class ByteBufferPage implements Page
     public long address()
     {
         return addressOf( buffer );
+    }
+
+    public void clear()
+    {
+        int remaining = buffer.capacity();
+        buffer.position( 0 );
+        while ( remaining >= ZEROS.length )
+        {
+            buffer.put( ZEROS );
+            remaining -= ZEROS.length;
+        }
+        buffer.put( ZEROS, 0, remaining );
+        buffer.position( 0 );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/ByteBufferPage.java
@@ -25,14 +25,13 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
-import org.neo4j.io.ByteUnit;
 import org.neo4j.io.pagecache.Page;
+import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /** A page backed by a simple byte buffer. */
 public class ByteBufferPage implements Page
 {
     private static final MethodHandle addressOfMH = addressOfMH();
-    private static final byte[] ZEROS = new byte[(int) ByteUnit.kibiBytes( 1 )];
 
     private static MethodHandle addressOfMH()
     {
@@ -138,16 +137,8 @@ public class ByteBufferPage implements Page
         return addressOf( buffer );
     }
 
-    public void clear()
+    public void zapPage()
     {
-        int remaining = buffer.capacity();
-        buffer.position( 0 );
-        while ( remaining >= ZEROS.length )
-        {
-            buffer.put( ZEROS );
-            remaining -= ZEROS.length;
-        }
-        buffer.put( ZEROS, 0, remaining );
-        buffer.position( 0 );
+        UnsafeUtil.setMemory( address(), size(), (byte) 0 );
     }
 }


### PR DESCRIPTION
which sets all bytes in the page to 0. Useful when reusing pages which have had
previous data in them. Clearing makes reused pages look like completely new ones.