### PR TITLE
Make sure that LockResults always have a message, when the status is not OK_LOCKED

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -316,7 +316,9 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( NoSuchEntryException | ConcurrentAccessException e)
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED, "Unable to acquire exclusive lock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.NOT_LOCKED,
+                    "Unable to acquire exclusive lock: " + e.getMessage() ) );
         }
         try
         {
@@ -328,11 +330,14 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( DeadlockDetectedException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.DEAD_LOCKED,"Can't acquire exclusive lock, because it would have caused a deadlock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.DEAD_LOCKED,
+                    "Cannot acquire exclusive lock, because it would have caused a deadlock: " + e.getMessage() ) );
         }
         catch ( IllegalResourceException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.NOT_LOCKED, "Cannot lock given resource: " + e.getMessage() ) );
         }
         finally
         {
@@ -352,7 +357,9 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( NoSuchEntryException | ConcurrentAccessException e)
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED, "Unable to acquire shared lock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.NOT_LOCKED,
+                    "Unable to acquire shared lock: " + e.getMessage() ) );
         }
         try
         {
@@ -365,11 +372,14 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( DeadlockDetectedException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.DEAD_LOCKED, e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.DEAD_LOCKED,
+                    "Cannot acquire shared lock, because it would have caused a deadlock: " + e.getMessage() ) );
         }
         catch ( IllegalResourceException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED ) );
+            return spi.packTransactionObligationResponse( context, new LockResult(
+                    LockStatus.NOT_LOCKED, "Cannot lock given resource: " + e.getMessage() ) );
         }
         finally
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -48,20 +48,16 @@ import static org.neo4j.com.Protocol.writeString;
 
 public interface MasterClient extends Master
 {
-    static final ObjectSerializer<LockResult> LOCK_SERIALIZER = new ObjectSerializer<LockResult>()
+    ObjectSerializer<LockResult> LOCK_SERIALIZER = ( responseObject, result ) ->
     {
-        @Override
-        public void write( LockResult responseObject, ChannelBuffer result ) throws IOException
+        result.writeByte( responseObject.getStatus().ordinal() );
+        if ( responseObject.getStatus().hasMessage() )
         {
-            result.writeByte( responseObject.getStatus().ordinal() );
-            if ( responseObject.getStatus().hasMessage() )
-            {
-                writeString( result, responseObject.getMessage() );
-            }
+            writeString( result, responseObject.getMessage() );
         }
     };
 
-    static final Deserializer<LockResult> LOCK_RESULT_DESERIALIZER = new Deserializer<LockResult>()
+    Deserializer<LockResult> LOCK_RESULT_DESERIALIZER = new Deserializer<LockResult>()
     {
         @Override
         public LockResult read( ChannelBuffer buffer, ByteBuffer temporaryBuffer ) throws IOException
@@ -105,26 +101,26 @@ public interface MasterClient extends Master
         }
     };
 
-    public static final ProtocolVersion CURRENT = MasterClient310.PROTOCOL_VERSION;
+    ProtocolVersion CURRENT = MasterClient310.PROTOCOL_VERSION;
 
     @Override
-    public Response<Integer> createRelationshipType( RequestContext context, final String name );
+    Response<Integer> createRelationshipType( RequestContext context, final String name );
 
     @Override
-    public Response<Void> newLockSession( RequestContext context );
+    Response<Void> newLockSession( RequestContext context );
 
     @Override
-    public Response<Long> commit( RequestContext context, final TransactionRepresentation channel );
+    Response<Long> commit( RequestContext context, final TransactionRepresentation channel );
 
     @Override
-    public Response<Void> pullUpdates( RequestContext context );
+    Response<Void> pullUpdates( RequestContext context );
 
-    public Response<Void> pullUpdates( RequestContext context, TxHandler txHandler );
+    Response<Void> pullUpdates( RequestContext context, TxHandler txHandler );
 
     @Override
-    public Response<Void> copyStore( RequestContext context, final StoreWriter writer );
+    Response<Void> copyStore( RequestContext context, final StoreWriter writer );
 
-    public void setComExceptionHandler( ComExceptionHandler handler );
+    void setComExceptionHandler( ComExceptionHandler handler );
 
-    public ProtocolVersion getProtocolVersion();
+    ProtocolVersion getProtocolVersion();
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -78,7 +78,7 @@ public interface MasterClient extends Master
                 throw Exceptions.withMessage( e, format( "%s | read invalid ordinal %d. First %db of this channel buffer is:%n%s",
                         e.getMessage(), statusOrdinal, maxBytesToPrint, beginningOfBufferAsHexString( buffer, maxBytesToPrint ) ) );
             }
-            return status.hasMessage() ? new LockResult( LockStatus.DEAD_LOCKED, readString( buffer ) ) : new LockResult( status );
+            return status.hasMessage() ? new LockResult( status, readString( buffer ) ) : new LockResult( status );
         }
 
         private String beginningOfBufferAsHexString( ChannelBuffer buffer, int maxBytesToPrint )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockStatus.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockStatus.java
@@ -21,19 +21,19 @@ package org.neo4j.kernel.ha.lock;
 
 public enum LockStatus
 {
-    OK_LOCKED,
-    NOT_LOCKED,
-    DEAD_LOCKED
+    OK_LOCKED( false ),
+    NOT_LOCKED( true ),
+    DEAD_LOCKED( true );
+
+    private final boolean hasMessage;
+
+    LockStatus( boolean hasMessage )
     {
-        @Override
-        public boolean hasMessage()
-        {
-            return true;
-        }
-    };
+        this.hasMessage = hasMessage;
+    }
 
     public boolean hasMessage()
     {
-        return false;
+        return hasMessage;
     }
 }


### PR DESCRIPTION
This should help us investigate any locking related HA test failures that might pop up.