### PR TITLE
Fail store initialisation in case when header record can't be read

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -284,7 +284,8 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
                     }
                     else
                     {
-                        throw new StoreNotFoundException( "Store file not found: " + storageFileName );
+                        throw new StoreNotFoundException( "Fail to read header record of store file: " +
+                                storageFileName);
                     }
                 }
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -282,6 +282,10 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
                                     pageCache.pageSize() + " bytes.");
                         }
                     }
+                    else
+                    {
+                        throw new StoreNotFoundException( "Store file not found: " + storageFileName );
+                    }
                 }
             }
         }
@@ -869,7 +873,10 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
              * It is the case since we wand to mark the id generator as closed cleanly ONLY IF
              * also the store file is cleanly shutdown.
              */
-            storeFile.close();
+            if ( storeFile != null )
+            {
+                storeFile.close();
+            }
             if ( idGenerator != null )
             {
                 if ( contains( openOptions, DELETE_ON_CLOSE ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreNotFoundException.java
@@ -19,9 +19,14 @@
  */
 package org.neo4j.kernel.impl.store;
 
-public class StoreNotFoundException extends StoreFailureException
+class StoreNotFoundException extends StoreFailureException
 {
-    public StoreNotFoundException( String msg, Throwable cause )
+    StoreNotFoundException( String msg )
+    {
+        super( msg );
+    }
+
+    StoreNotFoundException( String msg, Throwable cause )
     {
         super( msg, cause );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -177,7 +177,7 @@ public class CommonAbstractStoreTest
         RecordFormats recordFormats = StandardV3_0.RECORD_FORMATS;
 
         expectedException.expect( StoreNotFoundException.class );
-        expectedException.expectMessage( "Store file not found: " + storeFile.getAbsolutePath()  );
+        expectedException.expectMessage( "Fail to read header record of store file: " + storeFile.getAbsolutePath() );
 
         try ( DynamicArrayStore dynamicArrayStore = new DynamicArrayStore( storeFile, config, IdType.NODE_LABELS,
                 idGeneratorFactory, pageCache, NullLogProvider.getInstance(),


### PR DESCRIPTION
Throw StoreNotFoundException in case if we can't read first page of a store file to get header information out of it.