### PR TITLE
Update legacy indexes to preserve documents sort fields on update

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
@@ -44,10 +44,9 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,36 +67,16 @@ public abstract class IndexType
         }
 
         @Override
-        public void addToDocument( Document document, String key, Object value )
+        void removeFieldsFromDocument( Document document, String key, Object value )
         {
-            document.add( instantiateField( key, value, StringField.TYPE_STORED ) );
-            document.add( instantiateSortField( key, value ) );
+            removeFieldsFromDocument( document, key, key, value );
         }
 
         @Override
-        void removeFieldsFromDocument( Document document, String key, Object value )
+        protected void addNewFieldToDocument( Document document, String key, Object value )
         {
-            Set<String> values = null;
-            if ( value != null )
-            {
-                String stringValue = value.toString();
-                values = new HashSet<>( Arrays.asList(
-                        document.getValues( key ) ) );
-                if ( !values.remove( stringValue ) )
-                {
-                    return;
-                }
-            }
-            removeFieldFromDocument( document, key );
-            if ( value != null )
-            {
-                for ( String existingValue : values )
-                {
-                    addToDocument( document, key, existingValue );
-                }
-            }
-
-            restoreNumericFields( document );
+            document.add( instantiateField( key, value, StringField.TYPE_STORED ) );
+            document.add( instantiateSortField( key, value ) );
         }
 
         @Override
@@ -115,6 +94,7 @@ public abstract class IndexType
 
     private static class CustomType extends IndexType
     {
+        public static final String EXACT_FIELD_SUFFIX = "_e";
         private final Similarity similarity;
 
         CustomType( Analyzer analyzer, boolean toLowerCase, Similarity similarity )
@@ -139,14 +119,14 @@ public abstract class IndexType
 
         private String exactKey( String key )
         {
-            return key + "_e";
+            return key + EXACT_FIELD_SUFFIX;
         }
 
+        // TODO We should honor ValueContext instead of doing value.toString() here.
+        // if changing it, also change #get to honor ValueContext.
         @Override
-        public void addToDocument( Document document, String key, Object value )
+        protected void addNewFieldToDocument( Document document, String key, Object value )
         {
-            // TODO We should honor ValueContext instead of doing value.toString() here.
-            // if changing it, also change #get to honor ValueContext.
             document.add( new StringField( exactKey( key ), value.toString(), Store.YES ) );
             document.add( instantiateField( key, value, TextField.TYPE_STORED ) );
             document.add( instantiateSortField( key, value ) );
@@ -160,30 +140,21 @@ public abstract class IndexType
         }
 
         @Override
+        protected boolean haveSortedField( IndexableField field )
+        {
+            return !field.name().endsWith( EXACT_FIELD_SUFFIX ) && super.haveSortedField( field );
+        }
+
+        @Override
         void removeFieldsFromDocument( Document document, String key, Object value )
         {
-            String exactKey = exactKey( key );
-            Set<String> values = null;
-            if ( value != null )
-            {
-                String stringValue = value.toString();
-                values = new HashSet<>( Arrays.asList( document.getValues( exactKey ) ) );
-                if ( !values.remove( stringValue ) )
-                {
-                    return;
-                }
-            }
-            document.removeFields( exactKey );
-            removeFieldFromDocument( document, key );
-            if ( value != null )
-            {
-                for ( String existingValue : values )
-                {
-                    addToDocument( document, key, existingValue );
-                }
-            }
+            removeFieldsFromDocument( document, key, exactKey( key ), value );
+        }
 
-            restoreNumericFields( document );
+        @Override
+        protected boolean isStoredField( IndexableField field )
+        {
+            return !field.name().endsWith( CustomType.EXACT_FIELD_SUFFIX ) && super.isStoredField( field );
         }
 
         @Override
@@ -202,6 +173,14 @@ public abstract class IndexType
         this.toLowerCase = toLowerCase;
     }
 
+    abstract void removeFieldsFromDocument( Document document, String key, Object value );
+
+    abstract void removeFieldFromDocument( Document document, String name );
+
+    abstract void addNewFieldToDocument( Document document, String key, Object value );
+
+    abstract Query get( String key, Object value );
+
     static IndexType getIndexType( Map<String, String> config )
     {
         String type = config.get( LuceneIndexImplementation.KEY_TYPE );
@@ -213,14 +192,14 @@ public abstract class IndexType
         if ( type != null )
         {
             // Use the built in alternatives... "exact" or "fulltext"
-            if ( type.equals( "exact" ) )
+            if ( "exact".equals( type ) )
             {
                 // In the exact case we default to false
                 boolean toLowerCase = TRUE.equals( toLowerCaseUnbiased );
 
                 result = toLowerCase ? new CustomType( new LowerCaseKeywordAnalyzer(), true, similarity ) : EXACT;
             }
-            else if ( type.equals( "fulltext" ) )
+            else if ( "fulltext".equals( type ) )
             {
                 // In the fulltext case we default to true
                 boolean toLowerCase = !FALSE.equals( toLowerCaseUnbiased );
@@ -250,6 +229,17 @@ public abstract class IndexType
             result = new CustomType( customAnalyzer, toLowerCase, similarity );
         }
         return result;
+    }
+
+    public void addToDocument( Document document, String key, Object value )
+    {
+        addNewFieldToDocument( document, key, value );
+        restoreSortFields( document );
+    }
+
+    protected boolean isStoredField( IndexableField field )
+    {
+        return field.fieldType().stored() && !FullTxData.TX_STATE_KEY.equals( field.name() );
     }
 
     private static boolean parseBoolean( String string, boolean valueIfNull )
@@ -284,8 +274,6 @@ public abstract class IndexType
         return null;
     }
 
-    abstract Query get( String key, Object value );
-
     TxData newTxData( LuceneLegacyIndex index )
     {
         return new ExactTxData( index );
@@ -314,8 +302,6 @@ public abstract class IndexType
             throw new RuntimeException( e );
         }
     }
-
-    abstract void addToDocument( Document document, String key, Object value );
 
     public static IndexableField instantiateField( String key, Object value, FieldType fieldType )
     {
@@ -368,7 +354,14 @@ public abstract class IndexType
         }
         else
         {
-            field = new SortedSetDocValuesField( key, new BytesRef( value.toString() ) );
+            if ( LuceneLegacyIndex.KEY_DOC_ID.equals( key ) )
+            {
+                field = new NumericDocValuesField( key, Long.parseLong( value.toString() ) );
+            }
+            else
+            {
+                field = new SortedSetDocValuesField( key, new BytesRef( value.toString() ) );
+            }
         }
         return field;
     }
@@ -385,10 +378,6 @@ public abstract class IndexType
         }
     }
 
-    abstract void removeFieldsFromDocument( Document document, String key, Object value );
-
-    abstract void removeFieldFromDocument( Document document, String name );
-
     private void clearDocument( Document document )
     {
         Set<String> names = new HashSet<>();
@@ -403,23 +392,72 @@ public abstract class IndexType
         }
     }
 
-    // Re-add numeric field since their index info is lost after reading the fields from the index store
-    protected void restoreNumericFields( Document document )
+    // Re-add field since their index info is lost after reading the fields from the index store
+    void restoreSortFields( Document document )
     {
-        List<IndexableField> numericFields = new ArrayList<>();
+        Map<String,Object> fieldsWithoutSortFields = new HashMap<>();
         for ( IndexableField field : document.getFields() )
         {
-            if ( field.numericValue() != null && !field.name().equals( LuceneLegacyIndex.KEY_DOC_ID ) &&
-                    DocValuesType.NONE.equals( field.fieldType().docValuesType() ) )
+            if ( isStoredField( field ) )
             {
-                numericFields.add( field );
+                IndexableField[] fields = document.getFields( field.name() );
+                if ( !haveSortField( fields ) )
+                {
+                    fieldsWithoutSortFields.put( field.name(), getFieldValue( field ) );
+                }
             }
         }
-        for ( IndexableField field : numericFields )
+        for ( Map.Entry<String,Object> entry : fieldsWithoutSortFields.entrySet() )
         {
-            removeFieldFromDocument( document, field.name() );
-            addToDocument( document, field.name(), field.numericValue() );
+            removeFieldsFromDocument( document, entry.getKey(), entry.getValue() );
+            addNewFieldToDocument( document, entry.getKey(), entry.getValue() );
         }
+    }
+
+    void removeFieldsFromDocument( Document document, String key, String exactKey, Object value )
+    {
+        Set<String> values = null;
+        if ( value != null )
+        {
+            String stringValue = value.toString();
+            values = new HashSet<>( Arrays.asList( document.getValues( exactKey ) ) );
+            if ( !values.remove( stringValue ) )
+            {
+                return;
+            }
+        }
+        removeFieldFromDocument( document, key );
+
+        if ( value != null )
+        {
+            for ( String existingValue : values )
+            {
+                addNewFieldToDocument( document, key, existingValue );
+            }
+        }
+    }
+
+    private boolean haveSortField( IndexableField[] fields )
+    {
+        for ( IndexableField field : fields )
+        {
+            if ( !DocValuesType.NONE.equals( field.fieldType().docValuesType() ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean haveSortedField( IndexableField field )
+    {
+        return DocValuesType.NONE.equals( field.fieldType().docValuesType() ) && getFieldValue( field ) != null;
+    }
+
+    private Object getFieldValue( IndexableField field )
+    {
+        Number numericFieldValue = field.numericValue();
+        return numericFieldValue != null ? numericFieldValue : field.stringValue();
     }
 
     public static Document newBaseDocument( long entityId )

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
@@ -140,12 +140,6 @@ public abstract class IndexType
         }
 
         @Override
-        protected boolean haveSortedField( IndexableField field )
-        {
-            return !field.name().endsWith( EXACT_FIELD_SUFFIX ) && super.haveSortedField( field );
-        }
-
-        @Override
         void removeFieldsFromDocument( Document document, String key, Object value )
         {
             removeFieldsFromDocument( document, key, exactKey( key ), value );
@@ -447,11 +441,6 @@ public abstract class IndexType
             }
         }
         return false;
-    }
-
-    protected boolean haveSortedField( IndexableField field )
-    {
-        return DocValuesType.NONE.equals( field.fieldType().docValuesType() ) && getFieldValue( field ) != null;
     }
 
     private Object getFieldValue( IndexableField field )

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
@@ -36,18 +36,20 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
@@ -121,7 +123,9 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
     @Test
     public void queryIndexWithSortByNumeric() throws Exception
     {
-        Index<Node> index = nodeIndex( stringMap() );
+        Index<Node> index = nodeIndex();
+        commitTx();
+
         String numericProperty = "NODE_ID";
 
         try ( Transaction transaction = graphDb.beginTx() )
@@ -135,25 +139,15 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
             transaction.success();
         }
 
-        try ( Transaction transaction = graphDb.beginTx() )
-        {
-            QueryContext queryContext = new QueryContext( numericProperty + ":**" );
-            queryContext.sort( new Sort( new SortedNumericSortField( numericProperty, SortField.Type.INT, false ) ) );
-            IndexHits<Node> nodes = index.query( queryContext );
-
-            int expectedIndexId = 0;
-            for ( Node node : nodes )
-            {
-                assertEquals("Nodes should be sorted by numeric property", expectedIndexId++, node.getProperty( numericProperty ));
-            }
-            transaction.success();
-        }
+        queryAndSortNodesByNumericProperty( index, numericProperty );
     }
 
     @Test
     public void queryIndexWithSortByString() throws Exception
     {
-        Index<Node> index = nodeIndex( stringMap() );
+        Index<Node> index = nodeIndex();
+        commitTx();
+
         String stringProperty = "NODE_NAME";
 
         String[] names = new String[]{"Fry", "Leela", "Bender", "Amy", "Hubert", "Calculon"};
@@ -168,21 +162,143 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
             transaction.success();
         }
 
+        String[] sortedNames = new String[]{"Leela", "Hubert", "Fry", "Calculon", "Bender", "Amy"};
+        queryAndSortNodesByStringProperty(index, stringProperty, sortedNames );
+    }
+
+    @Test
+    public void queryIndexWithSortByNumericAfterOtherPropertyUpdate()
+    {
+        Index<Node> index = nodeIndex();
+        commitTx();
+
+        String yearProperty = "year";
+        String priceProperty = "price";
+
+        Label nodeLabel = Label.label( "priceyNodes" );
+
         try ( Transaction transaction = graphDb.beginTx() )
         {
-            QueryContext queryContext = new QueryContext( stringProperty + ":**" );
-            queryContext.sort( new Sort( new SortedSetSortField( stringProperty, true ) ) );
-            IndexHits<Node> nodes = index.query( queryContext );
-
-            int nameIndex = 0;
-            String[] sortedNames = new String[]{"Leela", "Hubert", "Fry", "Calculon", "Bender", "Amy"};
-            for ( Node node : nodes )
+            for ( int i = 0; i < 15; i++ )
             {
-                assertEquals("Nodes should be sorted by string property", sortedNames[nameIndex++],
-                        node.getProperty( stringProperty ));
+                Node node = graphDb.createNode(nodeLabel);
+                node.setProperty( yearProperty, i );
+                node.setProperty( priceProperty, i );
+                index.add( node, yearProperty, new ValueContext( i ).indexNumeric() );
+                index.add( node, priceProperty, new ValueContext( i ).indexNumeric() );
             }
             transaction.success();
         }
+
+        doubleNumericPropertyValueForAllNodesWithLabel( index, priceProperty, nodeLabel );
+
+        queryAndSortNodesByNumericProperty( index, yearProperty );
+        queryAndSortNodesByNumericProperty( index, priceProperty, (value) -> value * 2 );
+    }
+
+    @Test
+    public void queryIndexWithSortByNumericAfterSamePropertyUpdate()
+    {
+        Index<Node> index = nodeIndex( stringMap() );
+        commitTx();
+        String numericProperty = "PRODUCT_ID";
+
+        Label updatableIndexesProperty = Label.label( "updatableIndexes" );
+
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            for ( int i = 0; i < 15; i++ )
+            {
+                Node node = graphDb.createNode(updatableIndexesProperty);
+                node.setProperty( numericProperty, i );
+                index.add( node, numericProperty, new ValueContext( i ).indexNumeric() );
+            }
+            transaction.success();
+        }
+
+        doubleNumericPropertyValueForAllNodesWithLabel( index, numericProperty, updatableIndexesProperty );
+        queryAndSortNodesByNumericProperty( index, numericProperty, i -> i * 2 );
+    }
+
+    @Test
+    public void queryIndexWithSortByStringAfterOtherPropertyUpdate()
+    {
+
+        Index<Node> index = nodeIndex( stringMap() );
+        commitTx();
+
+        String nameProperty = "NODE_NAME";
+        String jobNameProperty = "NODE_JOB_NAME";
+
+        String[] names = new String[]{"Fry", "Leela", "Bender", "Amy", "Hubert", "Calculon"};
+        String[] jobs = new String[]{"delivery boy", "pilot", "gambler", "intern", "professor", "actor"};
+        Label characters = Label.label( "characters" );
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            for ( int i = 0; i < names.length; i++ )
+            {
+                Node node = graphDb.createNode(characters);
+                node.setProperty( nameProperty, names[i] );
+                node.setProperty( jobNameProperty, jobs[i] );
+                index.add( node, nameProperty, names[i] );
+                index.add( node, jobNameProperty, jobs[i] );
+            }
+            transaction.success();
+        }
+
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            ResourceIterator<Node> nodes = graphDb.findNodes( characters );
+            nodes.stream().forEach( node ->
+            {
+                node.setProperty( jobNameProperty, "junior " + node.getProperty( jobNameProperty ) );
+                index.add( node, jobNameProperty, node.getProperty( jobNameProperty ) );
+            } );
+            transaction.success();
+        }
+
+        String[] sortedNames = new String[]{"Leela", "Hubert", "Fry", "Calculon", "Bender", "Amy"};
+        String[] sortedJobs = {"junior professor", "junior pilot", "junior intern", "junior gambler",
+                "junior delivery boy", "junior actor"};
+        queryAndSortNodesByStringProperty( index, nameProperty, sortedNames );
+        queryAndSortNodesByStringProperty( index, jobNameProperty, sortedJobs );
+    }
+
+    @Test
+    public void queryIndexWithSortByStringAfterSamePropertyUpdate()
+    {
+        Index<Node> index = nodeIndex( stringMap() );
+        commitTx();
+
+        String nameProperty = "NODE_NAME";
+        Label heroes = Label.label( "heroes" );
+
+        String[] names = new String[]{"Fry", "Leela", "Bender", "Amy", "Hubert", "Calculon"};
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            for ( String name : names )
+            {
+                Node node = graphDb.createNode(heroes);
+                node.setProperty( nameProperty, name );
+                index.add( node, nameProperty, name );
+            }
+            transaction.success();
+        }
+
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            ResourceIterator<Node> nodes = graphDb.findNodes( heroes );
+            nodes.stream().forEach( node -> {
+                node.setProperty( nameProperty, "junior " + node.getProperty( nameProperty )  );
+                index.remove( node, nameProperty );
+                index.add( node, nameProperty,  node.getProperty( nameProperty ));
+            } );
+            transaction.success();
+        }
+
+        String[] sortedNames = new String[]{"junior Leela", "junior Hubert", "junior Fry", "junior Calculon",
+                "junior Bender", "junior Amy"};
+        queryAndSortNodesByStringProperty( index, nameProperty, sortedNames );
     }
 
     @Test
@@ -1053,15 +1169,15 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         creator.delete( b );
         restartTx();
 
-        Iterators.count( (Iterator<Node>) index.get( key, value ) );
+        Iterators.count( index.get( key, value ) );
         rollbackTx();
         beginTx();
 
-        Iterators.count( (Iterator<Node>) index.get( key, value ) );
+        Iterators.count( index.get( key, value ) );
         index.add( c, "something", "whatever" );
         restartTx();
 
-        Iterators.count( (Iterator<Node>) index.get( key, value ) );
+        Iterators.count( index.get( key, value ) );
     }
 
     @Test
@@ -2022,4 +2138,68 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
             // THEN Good
         }
     }
+
+    private void queryAndSortNodesByNumericProperty( Index<Node> index, String numericProperty )
+    {
+        queryAndSortNodesByNumericProperty( index, numericProperty, Function.identity() );
+    }
+
+    private void queryAndSortNodesByNumericProperty( Index<Node> index, String numericProperty,
+            Function<Integer,? extends Number> expectedValueProvider )
+    {
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            QueryContext queryContext = new QueryContext( numericProperty + ":**" );
+            queryContext.sort( new Sort( new SortedNumericSortField( numericProperty, SortField.Type.INT, false ) ) );
+            IndexHits<Node> nodes = index.query( queryContext );
+
+            int nodeIndex = 0;
+            for ( Node node : nodes )
+            {
+                assertEquals("Nodes should be sorted by numeric property",
+                        expectedValueProvider.apply( nodeIndex++), node.getProperty( numericProperty ));
+            }
+            transaction.success();
+        }
+    }
+
+    private void queryAndSortNodesByStringProperty( Index<Node> index, String stringProperty, String[] values )
+    {
+        queryAndSortNodesByStringProperty( index, stringProperty, ( i ) -> values[i] );
+    }
+
+    private void queryAndSortNodesByStringProperty( Index<Node> index, String stringProperty,
+            Function<Integer, String> expectedValueProvider )
+    {
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            QueryContext queryContext = new QueryContext( stringProperty + ":**" );
+            queryContext.sort( new Sort( new SortedSetSortField( stringProperty, true ) ) );
+            IndexHits<Node> nodes = index.query( queryContext );
+
+            int nodeIndex = 0;
+            for ( Node node : nodes )
+            {
+                assertEquals("Nodes should be sorted by string property", expectedValueProvider.apply( nodeIndex++ ),
+                        node.getProperty( stringProperty ));
+            }
+            transaction.success();
+        }
+    }
+
+    private void doubleNumericPropertyValueForAllNodesWithLabel( Index<Node> index, String numericProperty,
+            Label label )
+    {
+        try ( Transaction transaction = graphDb.beginTx() )
+        {
+            ResourceIterator<Node> nodes = graphDb.findNodes( label );
+            nodes.stream().forEach( node -> {
+                node.setProperty( numericProperty, (Integer) node.getProperty( numericProperty ) * 2 );
+                index.remove( node, numericProperty );
+                index.add( node, numericProperty,  new ValueContext( node.getProperty( numericProperty )).indexNumeric() );
+            } );
+            transaction.success();
+        }
+    }
+
 }


### PR DESCRIPTION
Legacy indexes use stored fields to store user data and sorted doc value typed fields to make sorting smooth.
After retrieval of any saved document from index store only stored fields are visible (not sort fields)
and in case if we will re-save that document we will loose any sorted fields that we had before in the index for that document.
This PR introduce functionality that will restore all 'missing' sort fields to make sure that documents can be always sorted.