### PR TITLE
Add deferred locks to a list of enterprise edition dependencies

### DIFF
--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -119,6 +119,11 @@ terms of the relevant Commercial Agreement.
           <artifactId>neo4j-harness-enterprise</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.neo4j</groupId>
+          <artifactId>neo4j-deferred-locks</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
Add deferred locks to a list of dependencies to publish it into maven repo as part of release.