### PR TITLE
Fix bug in node count from count store instruction

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -71,7 +71,6 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     relate(node2, node1)
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a)--() RETURN DISTINCT a")
     result.toList should equal(List(Map("a" -> node1), Map("a" -> node2)))
-
   }
 
   test("distinct aggregation on array property") {
@@ -80,5 +79,13 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     createNode("prop"-> Array(1337))
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a) RETURN DISTINCT a.prop")
     result.toComparableResult should equal(List(Map("a.prop" -> List(1337)), Map("a.prop" -> List(42))))
+  }
+
+  test("Node count from count store plan should work with labeled nodes") {
+    val node1 = createLabeledNode("Person")
+    val node2 = createLabeledNode("Person")
+    val node3 = createNode()
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a:Person) WITH count(a) as c RETURN c")
+    result.toList should equal(List(Map("c" -> 2L)))
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
@@ -29,7 +29,7 @@ case class NodeCountFromCountStoreInstruction(opName: String, variable: Variable
       body.incrementDbHits()
       if (label.nonEmpty) {
         val (token, _) = label.get
-        val expression = token.map(t => body.constantExpression(Int.box(t))).getOrElse(body.loadVariable(tokenVar))
+        val expression = token.map(t => body.token(Int.box(t))).getOrElse(body.loadVariable(tokenVar))
         body.assign(variable.name, variable.codeGenType,
                     generator.nodeCountFromCountStore(expression))
       } else {
@@ -49,6 +49,7 @@ case class NodeCountFromCountStoreInstruction(opName: String, variable: Variable
     label.foreach {
       case (token, name) if token.isEmpty =>
         generator.lookupLabelId(tokenVar, name)
+      case _ => ()
     }
   }
 


### PR DESCRIPTION
The node count from count store instruction in the compiled runtime
should work with pre-existing labels.