### PR TITLE
Generated SSL certificate files should only be readable by owner.

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/security/ssl/Certificates.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/Certificates.java
@@ -193,5 +193,9 @@ public class Certificates
             writer.writeObject( new PemObject( type, encodedContent ) );
             writer.flush();
         }
+        path.setReadable( false, false );
+        path.setWritable( false, false );
+        path.setReadable( true );
+        path.setWritable( true );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/CertificatesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/CertificatesIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.ssl;
+
+import org.apache.commons.lang.SystemUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+import static org.neo4j.test.TargetDirectory.testDirForTest;
+
+public class CertificatesIT
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void createSelfSignedCertificate() throws Exception
+    {
+        assumeTrue( !SystemUtils.IS_OS_WINDOWS );
+
+        Certificates certificates = new Certificates();
+        certificates
+                .createSelfSignedCertificate( testDirectory.file( "certificate" ), testDirectory.file( "privateKey" ),
+                        "localhost" );
+
+        PosixFileAttributes certificateAttributes =
+                Files.getFileAttributeView( testDirectory.file( "certificate" ).toPath(), PosixFileAttributeView.class )
+                        .readAttributes();
+
+        assertTrue( certificateAttributes.permissions().contains( PosixFilePermission.OWNER_READ ) );
+        assertTrue( certificateAttributes.permissions().contains( PosixFilePermission.OWNER_WRITE ) );
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OWNER_EXECUTE ) );
+
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.GROUP_READ ) );
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.GROUP_WRITE ) );
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.GROUP_EXECUTE ) );
+
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_READ ) );
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_WRITE ) );
+        assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_EXECUTE ) );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/security/ssl/CertificatesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/ssl/CertificatesIT.java
@@ -65,5 +65,21 @@ public class CertificatesIT
         assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_READ ) );
         assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_WRITE ) );
         assertFalse( certificateAttributes.permissions().contains( PosixFilePermission.OTHERS_EXECUTE ) );
+
+        PosixFileAttributes privateKey =
+                Files.getFileAttributeView( testDirectory.file( "privateKey" ).toPath(), PosixFileAttributeView.class )
+                        .readAttributes();
+
+        assertTrue( privateKey.permissions().contains( PosixFilePermission.OWNER_READ ) );
+        assertTrue( privateKey.permissions().contains( PosixFilePermission.OWNER_WRITE ) );
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.OWNER_EXECUTE ) );
+
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.GROUP_READ ) );
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.GROUP_WRITE ) );
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.GROUP_EXECUTE ) );
+
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.OTHERS_READ ) );
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.OTHERS_WRITE ) );
+        assertFalse( privateKey.permissions().contains( PosixFilePermission.OTHERS_EXECUTE ) );
     }
 }


### PR DESCRIPTION
## Before

```
$ bin/neo4j console
WARNING: Max 1024 open files allowed, minimum of 40 000 recommended. See the Neo4j manual.
Starting Neo4j Server console-mode...
2016-12-13 14:39:03.450+0100 INFO  No SSL certificate found, generating a self-signed certificate..
2016-12-13 14:39:07.268+0100 INFO  Successfully started database
2016-12-13 14:39:07.299+0100 INFO  Starting HTTP on port 7474 (4 threads available)
2016-12-13 14:39:07.497+0100 INFO  Enabling HTTPS on port 7473
2016-12-13 14:39:07.569+0100 INFO  Mounting static content at /webadmin
2016-12-13 14:39:07.621+0100 INFO  Mounting static content at /browser
2016-12-13 14:39:08.598+0100 INFO  Remote interface ready and available at http://localhost:7474/
^C2016-12-13 14:39:28.383+0100 INFO  Neo4j Server shutdown initiated by request
2016-12-13 14:39:28.393+0100 INFO  Successfully shutdown Neo4j Server
2016-12-13 14:39:28.505+0100 INFO  Successfully stopped database
2016-12-13 14:39:28.505+0100 INFO  Successfully shutdown database
$ ls -l conf/ssl
total 8
-rw-r--r-- 1 srbaker srbaker 631 Dec 13 14:39 snakeoil.cert
-rw-r--r-- 1 srbaker srbaker 912 Dec 13 14:39 snakeoil.key
```

## After

```
$ bin/neo4j console
WARNING: Max 1024 open files allowed, minimum of 40 000 recommended. See the Neo4j manual.
Starting Neo4j Server console-mode...
2016-12-13 14:47:02.547+0100 INFO  No SSL certificate found, generating a self-signed certificate..
2016-12-13 14:47:06.039+0100 INFO  Successfully started database
2016-12-13 14:47:06.063+0100 INFO  Starting HTTP on port 7474 (4 threads available)
2016-12-13 14:47:06.269+0100 INFO  Enabling HTTPS on port 7473
2016-12-13 14:47:06.327+0100 INFO  Mounting static content at /webadmin
2016-12-13 14:47:06.371+0100 INFO  Mounting static content at /browser
2016-12-13 14:47:07.399+0100 INFO  Remote interface ready and available at http://localhost:7474/
^C2016-12-13 14:47:13.193+0100 INFO  Neo4j Server shutdown initiated by request
2016-12-13 14:47:13.204+0100 INFO  Successfully shutdown Neo4j Server
2016-12-13 14:47:13.452+0100 INFO  Successfully stopped database
2016-12-13 14:47:13.452+0100 INFO  Successfully shutdown database
$ ls -l conf/ssl/
total 8
-rw------- 1 srbaker srbaker 631 Dec 13 14:47 snakeoil.cert
-rw------- 1 srbaker srbaker 916 Dec 13 14:47 snakeoil.key
```

changelog [security]