### PR TITLE
Close reader that used to count number of entries in the label scan index.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -70,7 +70,6 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.DefaultIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
@@ -117,6 +116,7 @@ import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StorageStatement;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.storageengine.api.lock.ResourceLocker;
@@ -222,7 +222,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
             labelScanStore = labelScanStoreProvider.getLabelScanStore();
 
             schemaIndexProviderMap = new DefaultSchemaIndexProviderMap( indexProvider );
-            indexStoreView = new DynamicIndexStoreView( labelScanStore, lockService, neoStores );
+            indexStoreView = new DynamicIndexStoreView( labelScanStore, lockService, neoStores, logProvider );
             indexingService = IndexingServiceFactory.createIndexingService( config, scheduler, schemaIndexProviderMap,
                     indexStoreView, tokenNameLookup,
                     Iterators.asList( new SchemaStorage( neoStores.getSchemaStore() ).allIndexRules() ), logProvider,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/DynamicIndexStoreViewTest.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.logging.NullLogProvider;
 import org.neo4j.register.Register;
 import org.neo4j.register.Registers;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
@@ -48,6 +49,7 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DynamicIndexStoreViewTest
@@ -83,8 +85,8 @@ public class DynamicIndexStoreViewTest
         mockLabelNodeCount( countStore, 2 );
         mockLabelNodeCount( countStore, 3 );
 
-        DynamicIndexStoreView storeView =
-                new DynamicIndexStoreView( labelScanStore, LockService.NO_LOCK_SERVICE, neoStores );
+        DynamicIndexStoreView storeView = new DynamicIndexStoreView( labelScanStore, LockService.NO_LOCK_SERVICE,
+                neoStores, NullLogProvider.getInstance() );
 
         StoreScan<Exception> storeScan = storeView
                 .visitNodes( new int[]{1, 2, 3}, propertyKeyIdFilter, propertyUpdateVisitor, labelUpdateVisitor );
@@ -93,6 +95,17 @@ public class DynamicIndexStoreViewTest
 
         Mockito.verify( nodeStore, times( 10 ) )
                 .getRecord( anyLong(), any( NodeRecord.class ), any( RecordLoad.class ) );
+    }
+
+    @Test
+    public void closeAllEntriesScanReaderWhenCheckingLabelScanStore() throws Exception
+    {
+        DynamicIndexStoreView storeView = new DynamicIndexStoreView( labelScanStore, LockService.NO_LOCK_SERVICE,
+                neoStores, NullLogProvider.getInstance() );
+
+        storeView.visitNodes( new int[]{1, 2, 3}, propertyKeyIdFilter, propertyUpdateVisitor, labelUpdateVisitor );
+
+        verify( nodeLabelRanges ).close();
     }
 
     @Test
@@ -110,8 +123,8 @@ public class DynamicIndexStoreViewTest
         mockLabelNodeCount( countStore, 2 );
         mockLabelNodeCount( countStore, 6 );
 
-        DynamicIndexStoreView storeView =
-                new DynamicIndexStoreView( labelScanStore, LockService.NO_LOCK_SERVICE, neoStores );
+        DynamicIndexStoreView storeView = new DynamicIndexStoreView( labelScanStore, LockService.NO_LOCK_SERVICE,
+                neoStores, NullLogProvider.getInstance() );
 
         StoreScan<Exception> storeScan = storeView
                 .visitNodes( new int[]{2, 6}, propertyKeyIdFilter, propertyUpdateVisitor, labelUpdateVisitor );

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -377,7 +377,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         DynamicIndexStoreViewWrapper( LabelScanStore labelScanStore, LockService locks, NeoStores neoStores,
                 List<NodePropertyUpdate> updates )
         {
-            super( labelScanStore, locks, neoStores );
+            super( labelScanStore, locks, neoStores, NullLogProvider.getInstance() );
             this.updates = updates;
         }
 


### PR DESCRIPTION
Close all entries reader that used during index population.
Log error in case if reader can't be closed and fallback to all node scan in that case.