### PR TITLE
Fixed handling of paths with spaces in them on Windows

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -179,7 +179,7 @@ Function Get-Java
       # Parse Java config settings - GC
       $option = (Get-Neo4jSetting -Name 'dbms.logs.gc.enabled' -Neo4jServer $Neo4jServer)
       if (($option -ne $null) -and ($option.Value.ToLower() -eq 'true')) {
-        $ShellArgs += "-Xloggc:$($Neo4jServer.Home)/gc.log"
+        $ShellArgs += "-Xloggc:`"$($Neo4jServer.Home)/gc.log`""
 
         $option = (Get-Neo4jSetting -Name 'dbms.logs.gc.options' -Neo4jServer $Neo4jServer)
         if ($option -eq $null) {
@@ -208,7 +208,10 @@ Function Get-Java
           $ShellArgs += "-XX:NumberOfGCLogFiles=5"
         }
       }
-      $ShellArgs += @("-Dfile.encoding=UTF-8",$serverMainClass,"--config-dir=$($Neo4jServer.ConfDir)","--home-dir=$($Neo4jServer.Home)")
+        $ShellArgs += @("-Dfile.encoding=UTF-8",
+                        $serverMainClass,
+                        "--config-dir=`"$($Neo4jServer.ConfDir)`"",
+                        "--home-dir=`"$($Neo4jServer.Home)`"")
     }
 
     # Shell arguments for the utility classes e.g. Import, Shell

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -55,7 +55,7 @@ Function Get-Java
     [Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='UtilityInvoke')]
     [Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInvoke')]
     [PSCustomObject]$Neo4jServer
-        
+
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInvoke')]
     [switch]$ForServer
 
@@ -63,21 +63,21 @@ Function Get-Java
     [switch]$ForUtility
 
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='UtilityInvoke')]
-    [string]$StartingClass    
+    [string]$StartingClass
   )
-  
+
   Begin
   {
   }
-  
+
   Process
   {
     $javaPath = ''
     $javaCMD = ''
-    
+
     $EnvJavaHome = Get-Neo4jEnv 'JAVA_HOME'
     $EnvClassPrefix = Get-Neo4jEnv 'CLASSPATH_PREFIX'
-    
+
     # Is JAVA specified in an environment variable
     if (($javaPath -eq '') -and ($EnvJavaHome -ne $null))
     {
@@ -87,7 +87,7 @@ Function Get-Java
     }
 
     # Attempt to find Java in registry
-    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'    
+    $regKey = 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment'
     if (($javaPath -eq '') -and (Test-Path -Path $regKey))
     {
       $regJavaVersion = ''
@@ -107,7 +107,7 @@ Function Get-Java
     }
 
     # Attempt to find Java in registry (32bit Java on 64bit OS)
-    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'    
+    $regKey = 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment'
     if (($javaPath -eq '') -and (Test-Path -Path $regKey))
     {
       $regJavaVersion = ''
@@ -125,7 +125,7 @@ Function Get-Java
         $javaPath = ''
       }
     }
-    
+
     # Attempt to find Java in the search path
     if ($javaPath -eq '')
     {
@@ -210,7 +210,7 @@ Function Get-Java
       }
       $ShellArgs += @("-Dfile.encoding=UTF-8",$serverMainClass,"--config-dir=$($Neo4jServer.ConfDir)","--home-dir=$($Neo4jServer.Home)")
     }
-    
+
     # Shell arguments for the utility classes e.g. Import, Shell
     if ($PsCmdlet.ParameterSetName -eq 'UtilityInvoke')
     {
@@ -230,14 +230,14 @@ Function Get-Java
       $ShellArgs += @("-classpath $($EnvClassPrefix);$ClassPath",
                       "-Dbasedir=`"$($Neo4jServer.Home)`"", `
                       '-Dfile.encoding=UTF-8')
-            
+
       # Add the starting class
       $ShellArgs += @($StartingClass)
     }
 
     Write-Output @{'java' = $javaCMD; 'args' = $ShellArgs}
   }
-  
+
   End
   {
   }

--- a/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
@@ -9,11 +9,11 @@ $global:mockNeo4jHome = 'TestDrive:\Neo4j'
 
 Function global:New-MockJavaHome() {
   $javaHome = "TestDrive:\JavaHome"
-  
+
   New-Item $javaHome -ItemType Directory | Out-Null
   New-Item "$javaHome\bin" -ItemType Directory | Out-Null
   New-Item "$javaHome\bin\server" -ItemType Directory | Out-Null
-  
+
   "This is a mock java.exe" | Out-File "$javaHome\bin\java.exe"
   "This is a mock java.exe" | Out-File "$javaHome\bin\server\jvm.dll"
 
@@ -49,7 +49,7 @@ Function global:New-MockNeo4jInstall(
   New-Item "$RootDir\bin" -ItemType Directory | Out-Null
   New-Item "$RootDir\bin\tools" -ItemType Directory | Out-Null
   New-Item "$RootDir\conf" -ItemType Directory | Out-Null
-  
+
   if ($IncludeFiles) {
     'TempFile' | Out-File -FilePath "$RootDir\lib\neo4j-server-$($ServerVersion).jar"
     if ($ServerType -eq 'Enterprise') { 'TempFile' | Out-File -FilePath "$RootDir\lib\neo4j-server-enterprise-$($ServerVersion).jar" }
@@ -57,16 +57,16 @@ Function global:New-MockNeo4jInstall(
     # Additional Jars
     'TempFile' | Out-File -FilePath "$RootDir\lib\lib1.jar"
     'TempFile' | Out-File -FilePath "$RootDir\bin\bin1.jar"
-    
+
     # Procrun service files
     'TempFile' | Out-File -FilePath "$RootDir\bin\tools\prunsrv-amd64.exe"
     'TempFile' | Out-File -FilePath "$RootDir\bin\tools\prunsrv-i386.exe"
-  
+
     # Create fake neo4j.conf
     $neoConf = $NeoConfSettings -join "`n`r"
     if ($DatabaseMode -ne '') {
       $neoConf += "`n`rdbms.mode=$DatabaseMode"
-    }    
+    }
     $neoConf | Out-File -FilePath "$RootDir\conf\neo4j.conf"
 
     # Create fake neo4j-wrapper.conf
@@ -74,7 +74,7 @@ Function global:New-MockNeo4jInstall(
     if ([string]$WindowsService -ne '') { $neoConf += "`n`rdbms.windows_service_name=$WindowsService" }
     $neoConf | Out-File -FilePath "$RootDir\conf\neo4j-wrapper.conf"
   }
-  
+
   $serverObject = (New-Object -TypeName PSCustomObject -Property @{
     'Home' = $RootDir;
     'ConfDir' = "$RootDir\conf";

--- a/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
@@ -35,6 +35,7 @@ Function global:New-InvalidNeo4jInstall($ServerType = 'Enterprise', $ServerVersi
 
 Function global:New-MockNeo4jInstall(
   $IncludeFiles = $true,
+  $RootDir = $global:mockNeo4jHome,
   $ServerType = 'Community',
   $ServerVersion = '0.0',
   $DatabaseMode = '',
@@ -43,7 +44,6 @@ Function global:New-MockNeo4jInstall(
   $NeoWrapperConfSettings = @()
   ) {
   # Creates a skeleton directory and file structure of a Neo4j Installation
-  $RootDir = $global:mockNeo4jHome
   New-Item $RootDir -ItemType Directory | Out-Null
   New-Item "$RootDir\lib" -ItemType Directory | Out-Null
   New-Item "$RootDir\bin" -ItemType Directory | Out-Null

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -35,7 +35,7 @@ InModuleScope Neo4j-Management {
 
     Context "Legacy Java install in JAVA_HOME environment variable" {
       Mock Confirm-JavaVersion -Verifiable { $false }
-      
+
       It "should throw if java is not supported" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
@@ -47,7 +47,7 @@ InModuleScope Neo4j-Management {
 
     Context "Invalid Java install in JAVA_HOME environment variable" {
       Mock Test-Path { $false } -ParameterFile { $Path -like "$javaHome\bin\java.exe" }
-      
+
       It "should throw if java missing" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
@@ -57,14 +57,14 @@ InModuleScope Neo4j-Management {
       Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       $result = Get-Java
 
       It "should return java location from registry" {
@@ -80,14 +80,14 @@ InModuleScope Neo4j-Management {
       Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       $result = Get-Java
 
       It "should return java location from registry" {
@@ -104,14 +104,14 @@ InModuleScope Neo4j-Management {
       Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
       Mock Test-Path -Verifiable { return $true } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
-      }      
+      }
       Mock Get-ItemProperty -Verifiable { return @{ 'CurrentVersion' = '9.9'} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment')
       }
       Mock Get-ItemProperty -Verifiable { return @{ 'JavaHome' = $javaHome} } -ParameterFilter {
         ($Path -eq 'Registry::HKLM\SOFTWARE\JavaSoft\Java Runtime Environment\9.9')
       }
-            
+
       It "should throw if java missing" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
@@ -125,7 +125,7 @@ InModuleScope Neo4j-Management {
       Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
 
       Mock Get-Command -Verifiable { return @{ 'Path' = "$javaHome\bin\java.exe" } }
-            
+
       $result = Get-Java
 
       It "should return java location from search path" {
@@ -140,12 +140,12 @@ InModuleScope Neo4j-Management {
     Context "No Java install at all" {
       Mock Get-Neo4jEnv { $null } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
       Mock Get-Command { $null }
-      
+
       It "should throw if java not detected" {
         { Get-Java -ErrorAction Stop } | Should Throw
       }
     }
-    
+
     # ForServer tests
     Context "Server Invoke - Community v3.0" {
       $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community'
@@ -261,7 +261,7 @@ InModuleScope Neo4j-Management {
       It "should have correct Starting Class" {
         $resultArgs | Should Match ([regex]::Escape(' someclass'))
       }
-    }    
+    }
 
   }
 }

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -264,9 +264,9 @@ InModuleScope Neo4j-Management {
     }
 
 	Context "Server Invoke - Should handle paths with spaces" {
-        $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community' `
-	      -RootDir 'TestDrive:\Neo4j Home' `
-          -NeoConfSettings 'dbms.logs.gc.enabled=true'
+      $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community' `
+	    -RootDir 'TestDrive:\Neo4j Home' `
+        -NeoConfSettings 'dbms.logs.gc.enabled=true'
 
       $result = Get-Java -ForServer -Neo4jServer $serverObject
 	  $argList = $result.args


### PR DESCRIPTION
Scripts were changed between 2.3 and 3.0 so the error doesn't exist on 2.3

Fixes an issue on Windows where the database can't be started if it's on a Path with a space in it. Error because powershell splits strings on spaces into separate array items.