### PR TITLE
Fixed that `STARTS WITH`, `ENDS WITH`, or `CONTAINS` on a non-string should returns null

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
@@ -42,6 +42,36 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     fNode = createLabeledNode("LABEL")
   }
 
+  test("should return null when end with is used on none strings"){
+    val result = executeWithAllPlanners("""
+                                          | CREATE ({name: 1})
+                                          | WITH *
+                                          | MATCH (a)
+                                          | WHERE a.name ENDS WITH 'foo'
+                                          | RETURN a.name""".stripMargin)
+    result.columnAs("a.name").toList should be (List())
+  }
+
+  test("should return null when contains is used on none strings"){
+    val result = executeWithAllPlanners("""
+                                          | CREATE ({name: 1})
+                                          | WITH *
+                                          | MATCH (a)
+                                          | WHERE a.name CONTAINS 'foo'
+                                          | RETURN a.name""".stripMargin)
+    result.columnAs("a.name").toList should be (List())
+  }
+
+  test("should return null when starts with is used on none strings"){
+    val result = executeWithAllPlanners("""
+                                          | CREATE ({name: 1})
+                                          | WITH *
+                                          | MATCH (a)
+                                          | WHERE a.name STARTS WITH 'foo'
+                                          | RETURN a.name""".stripMargin)
+    result.columnAs("a.name").toList should be (List())
+  }
+
   // *** TESTS OF PREFIX SEARCH
   test("should not plan an IndexSeek when index doesn't exist") {
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
@@ -42,7 +42,7 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     fNode = createLabeledNode("LABEL")
   }
 
-  test("should return null when end with is used on none strings"){
+  test("should return null when END WITH is used on non-strings"){
     val result = executeWithAllPlanners("""
                                           | CREATE ({name: 1})
                                           | WITH *
@@ -52,7 +52,7 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     result.columnAs("a.name").toList should be (List())
   }
 
-  test("should return null when contains is used on none strings"){
+  test("should return null when CONTAINS is used on non-strings"){
     val result = executeWithAllPlanners("""
                                           | CREATE ({name: 1})
                                           | WITH *
@@ -62,7 +62,7 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     result.columnAs("a.name").toList should be (List())
   }
 
-  test("should return null when starts with is used on none strings that contains integers") {
+  test("should return null when CONTAINS is used on non-strings that contains integers") {
     val result = executeWithAllPlanners("""
                                           | CREATE ({name: 1})
                                           | WITH *
@@ -72,7 +72,7 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     result.columnAs("a.name").toList should be(List())
   }
 
-  test("should return null when starts with is used on none strings"){
+  test("should return null when STARTS WITH is used on non-strings"){
     val result = executeWithAllPlanners("""
                                           | CREATE ({name: 1})
                                           | WITH *

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithAcceptanceTest.scala
@@ -62,6 +62,16 @@ class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
     result.columnAs("a.name").toList should be (List())
   }
 
+  test("should return null when starts with is used on none strings that contains integers") {
+    val result = executeWithAllPlanners("""
+                                          | CREATE ({name: 1})
+                                          | WITH *
+                                          | MATCH (a)
+                                          | WHERE a.name CONTAINS '1'
+                                          | RETURN a.name""".stripMargin)
+    result.columnAs("a.name").toList should be(List())
+  }
+
   test("should return null when starts with is used on none strings"){
     val result = executeWithAllPlanners("""
                                           | CREATE ({name: 1})

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StringMatchingAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StringMatchingAcceptanceTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.pipes.{IndexSeekByRange, UniqueIn
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.{Node, ResourceIterator}
 
-class StartsWithAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+class StringMatchingAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
   var aNode: Node = null
   var bNode: Node = null

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Predicate.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Predicate.scala
@@ -175,7 +175,7 @@ trait StringOperator {
     case (null, _) => None
     case (_, null) => None
     case (l: String, r: String) => Some(compare(l,r))
-    case (l, r) => throw new CypherTypeException(s"Expected two strings, but got $l and $r")
+    case (_, _) => None
   }
 
   def lhs: Expression

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Predicate.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/Predicate.scala
@@ -172,8 +172,6 @@ case class PropertyExists(variable: Expression, propertyKey: KeyToken) extends P
 trait StringOperator {
   self: Predicate =>
   override def isMatch(m: ExecutionContext)(implicit state: QueryState) = (lhs(m), rhs(m)) match {
-    case (null, _) => None
-    case (_, null) => None
     case (l: String, r: String) => Some(compare(l,r))
     case (_, _) => None
   }


### PR DESCRIPTION
changelog: Attempting to apply `STARTS WITH`, `ENDS WITH`, or `CONTAINS` on a non-string now returns `null`