### PR TITLE
Handle interruptions during initialization

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.store.format.CapabilityType;
 import org.neo4j.kernel.impl.store.format.FormatFamily;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.standard.MetaDataRecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
@@ -185,11 +186,15 @@ public class NeoStores implements AutoCloseable
         try
         {
             String expectedStoreVersion = recordFormats.storeVersion();
-            String actualStoreVersion = versionLongToString( getRecord( pageCache, neoStoreFileName, STORE_VERSION ) );
-            RecordFormats actualStoreFormat = RecordFormatSelector.selectForVersion( actualStoreVersion );
-            if ( !isCompatibleFormats( actualStoreFormat ) )
+            long record = getRecord( pageCache, neoStoreFileName, STORE_VERSION );
+            if ( record != MetaDataRecordFormat.FIELD_NOT_PRESENT )
             {
-                throw new UnexpectedStoreVersionException( actualStoreVersion, expectedStoreVersion );
+                String actualStoreVersion = versionLongToString( record );
+                RecordFormats actualStoreFormat = RecordFormatSelector.selectForVersion( actualStoreVersion );
+                if ( !isCompatibleFormats( actualStoreFormat ) )
+                {
+                    throw new UnexpectedStoreVersionException( actualStoreVersion, expectedStoreVersion );
+                }
             }
         }
         catch ( NoSuchFileException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -166,7 +166,7 @@ public class CommonAbstractStoreTest
     public void failStoreInitializationWhenHeaderRecordCantBeRead() throws IOException
     {
         File storeFile = dir.file( "a" );
-        PageCache pageCache = Mockito.mock( PageCache.class );
+        PageCache pageCache = mock( PageCache.class );
         PagedFile pagedFile = mock( PagedFile.class );
         PageCursor pageCursor = mock( PageCursor.class );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
@@ -25,16 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -46,7 +40,6 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.PageCacheRule;
-import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
@@ -175,7 +168,6 @@ public class StoreFactoryTest
         StoreFactory storeFactory = storeFactory( Config.empty() );
         storeFactory.openAllNeoStores( true ).close();
         FileSystemAbstraction fs = fsRule.get();
-        File[] files = fs.listFiles( storeDir, ( file, s ) -> !s.endsWith( ".id" ) );
         for ( File f : fs.listFiles( storeDir ) )
         {
             fs.truncate( f, 0 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
@@ -217,12 +217,7 @@ public class WriteTransactionCommandOrderingTest
         }
 
         @Override
-        protected void checkStorage( boolean createIfNotExists )
-        {
-        }
-
-        @Override
-        protected void loadStorage()
+        protected void checkAndLoadStorage( boolean createIfNotExists )
         {
         }
     }
@@ -244,12 +239,7 @@ public class WriteTransactionCommandOrderingTest
         }
 
         @Override
-        protected void checkStorage( boolean createIfNotExists )
-        {
-        }
-
-        @Override
-        protected void loadStorage()
+        protected void checkAndLoadStorage( boolean createIfNotExists )
         {
         }
 
@@ -279,14 +269,10 @@ public class WriteTransactionCommandOrderingTest
         }
 
         @Override
-        protected void checkStorage( boolean createIfNotExists )
+        protected void checkAndLoadStorage( boolean createIfNotExists )
         {
         }
 
-        @Override
-        protected void loadStorage()
-        {
-        }
     }
 
     private static class OrderVerifyingCommandHandler extends CommandVisitor.Adapter

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -49,7 +49,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
     public static final int WEB_SERVER_STARTUP_ERROR_CODE = 1;
     public static final int GRAPH_DATABASE_STARTUP_ERROR_CODE = 2;
 
-    private NeoServer server;
+    private volatile NeoServer server;
     private Thread shutdownHook;
     private GraphDatabaseDependencies dependencies = GraphDatabaseDependencies.newDependencies();
     // in case we have errors loading/validating the configuration log to stdout

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -72,6 +72,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
     @SafeVarargs
     public final int start( File homeDir, Optional<File> configFile, Pair<String, String>... configOverrides )
     {
+        addShutdownHook();
         try
         {
             Config config = createConfig( homeDir, configFile, configOverrides );
@@ -89,8 +90,6 @@ public abstract class ServerBootstrapper implements Bootstrapper
 
             server = createNeoServer( config, dependencies, userLogProvider );
             server.start();
-
-            addShutdownHook();
 
             return OK;
         }

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTest.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import org.neo4j.server.helpers.CommunityServerBuilder;
+import org.neo4j.test.ThreadTestUtils;
+
+public abstract class NeoServerRestartTest
+{
+
+    @Test
+    public void shouldNotCorruptWhenImmediatelyStopped() throws IOException, InterruptedException
+    {
+        NeoServer server = getNeoServer();
+
+        CountDownLatch latch = new CountDownLatch( 1 );
+        ThreadTestUtils.fork( $waitThenStopServer( server, latch ) );
+        server.start();
+        //Wait for the server to stop.
+        latch.await();
+
+        server = getNeoServer();
+        server.start();
+        server.stop();
+    }
+
+    protected abstract NeoServer getNeoServer() throws IOException;
+
+    private Runnable $waitThenStopServer( NeoServer server, CountDownLatch latch )
+    {
+        return () -> {
+            try
+            {
+                //Make sure that we have started starting the database. This value is empirically chosen and may need
+                // to be revisited in the future.
+                Thread.sleep( 200 );
+                server.stop();
+                latch.countDown();
+            }
+            catch ( Exception e )
+            {
+                //This is ok, it is not what we are testing for.
+            }
+        };
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunity.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import java.io.IOException;
+
+import org.neo4j.server.helpers.CommunityServerBuilder;
+
+public class NeoServerRestartTestCommunity extends NeoServerRestartTest
+{
+    protected NeoServer getNeoServer() throws IOException
+    {
+        CommunityServerBuilder builder = CommunityServerBuilder.server();
+        return builder.build();
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunity.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -21,13 +21,15 @@ package org.neo4j.server;
 
 import java.io.IOException;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 
 public class NeoServerRestartTestCommunity extends NeoServerRestartTest
 {
-    protected NeoServer getNeoServer() throws IOException
+    protected NeoServer getNeoServer( String customPageSwapperName ) throws IOException
     {
-        CommunityServerBuilder builder = CommunityServerBuilder.server();
+        CommunityServerBuilder builder = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings
+                .pagecache_swapper.name(), customPageSwapperName );
         return builder.build();
     }
 }

--- a/community/server/src/test/resources/META-INF/services/org.neo4j.io.pagecache.PageSwapperFactory
+++ b/community/server/src/test/resources/META-INF/services/org.neo4j.io.pagecache.PageSwapperFactory
@@ -1,0 +1,1 @@
+org.neo4j.server.NeoServerRestartTest$CustomSwapper

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterprise.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterprise.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.enterprise;
+
+import java.io.IOException;
+
+import org.neo4j.server.NeoServer;
+import org.neo4j.server.NeoServerRestartTest;
+import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
+import org.neo4j.server.helpers.CommunityServerBuilder;
+
+public class NeoServerRestartTestEnterprise extends NeoServerRestartTest
+{
+    protected NeoServer getNeoServer() throws IOException
+    {
+        EnterpriseServerBuilder builder = EnterpriseServerBuilder.server();
+        return builder.build();
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterprise.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/NeoServerRestartTestEnterprise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -21,6 +21,7 @@ package org.neo4j.server.enterprise;
 
 import java.io.IOException;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.NeoServerRestartTest;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
@@ -28,9 +29,10 @@ import org.neo4j.server.helpers.CommunityServerBuilder;
 
 public class NeoServerRestartTestEnterprise extends NeoServerRestartTest
 {
-    protected NeoServer getNeoServer() throws IOException
+    protected NeoServer getNeoServer( String customPageSwapperName) throws IOException
     {
-        EnterpriseServerBuilder builder = EnterpriseServerBuilder.server();
+        CommunityServerBuilder builder = EnterpriseServerBuilder.server().withProperty( GraphDatabaseSettings
+                .pagecache_swapper.name(), customPageSwapperName );
         return builder.build();
     }
 }


### PR DESCRIPTION
This PR contains two things, fixing both the way startup and stopping of Server interacts, as well as allowing the database to repair broken or missing headers in store files when opening the database. The latter can be the case when the database is killed during initialization. 