### PR TITLE
Include CPU active time, lock wait time, and query status in ListQueries

### DIFF
--- a/community/common/src/main/java/org/neo4j/time/Clocks.java
+++ b/community/common/src/main/java/org/neo4j/time/Clocks.java
@@ -20,6 +20,8 @@
 package org.neo4j.time;
 
 import java.time.Clock;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -71,5 +73,12 @@ public class Clocks
     public static FakeClock fakeClock( long initialTime, TimeUnit unit )
     {
         return new FakeClock( initialTime, unit );
+    }
+
+    public static FakeClock fakeClock( TemporalAccessor initialTime )
+    {
+        FakeClock clock = new FakeClock( initialTime.getLong( ChronoField.INSTANT_SECONDS ), TimeUnit.SECONDS );
+        clock.forward( initialTime.getLong( ChronoField.NANO_OF_SECOND ), TimeUnit.NANOSECONDS );
+        return clock;
     }
 }

--- a/community/common/src/main/java/org/neo4j/time/Clocks.java
+++ b/community/common/src/main/java/org/neo4j/time/Clocks.java
@@ -77,8 +77,7 @@ public class Clocks
 
     public static FakeClock fakeClock( TemporalAccessor initialTime )
     {
-        FakeClock clock = new FakeClock( initialTime.getLong( ChronoField.INSTANT_SECONDS ), TimeUnit.SECONDS );
-        clock.forward( initialTime.getLong( ChronoField.NANO_OF_SECOND ), TimeUnit.NANOSECONDS );
-        return clock;
+        return new FakeClock( initialTime.getLong( ChronoField.INSTANT_SECONDS ), TimeUnit.SECONDS )
+                .forward( initialTime.getLong( ChronoField.NANO_OF_SECOND ), TimeUnit.NANOSECONDS );
     }
 }

--- a/community/common/src/main/java/org/neo4j/time/CpuClock.java
+++ b/community/common/src/main/java/org/neo4j/time/CpuClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/common/src/main/java/org/neo4j/time/CpuClock.java
+++ b/community/common/src/main/java/org/neo4j/time/CpuClock.java
@@ -29,7 +29,7 @@ public abstract class CpuClock
         private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 
         @Override
-        public long cpuTime( long threadId )
+        public long cpuTimeNanos( long threadId )
         {
             if ( !threadMXBean.isThreadCpuTimeSupported() )
             {
@@ -50,9 +50,9 @@ public abstract class CpuClock
      *         the thread to get the used CPU time for.
      * @return the current CPU time used by the thread, in nanoseconds.
      */
-    public final long cpuTime( Thread thread )
+    public final long cpuTimeNanos( Thread thread )
     {
-        return cpuTime( thread.getId() );
+        return cpuTimeNanos( thread.getId() );
     }
 
     /**
@@ -62,5 +62,5 @@ public abstract class CpuClock
      *         the id of the thread to get the used CPU time for.
      * @return the current CPU time used by the thread, in nanoseconds.
      */
-    public abstract long cpuTime( long threadId );
+    public abstract long cpuTimeNanos( long threadId );
 }

--- a/community/common/src/main/java/org/neo4j/time/CpuClock.java
+++ b/community/common/src/main/java/org/neo4j/time/CpuClock.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.time;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+public abstract class CpuClock
+{
+    public static CpuClock CPU_CLOCK = new CpuClock()
+    {
+        private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+        @Override
+        public long cpuTime( long threadId )
+        {
+            if ( !threadMXBean.isThreadCpuTimeSupported() )
+            {
+                return -1;
+            }
+            if ( !threadMXBean.isThreadCpuTimeEnabled() )
+            {
+                threadMXBean.setThreadCpuTimeEnabled( true );
+            }
+            return threadMXBean.getThreadCpuTime( threadId );
+        }
+    };
+
+    /**
+     * Returns the current CPU time used by the thread, in nanoseconds.
+     *
+     * @param thread
+     *         the thread to get the used CPU time for.
+     * @return the current CPU time used by the thread, in nanoseconds.
+     */
+    public final long cpuTime( Thread thread )
+    {
+        return cpuTime( thread.getId() );
+    }
+
+    /**
+     * Returns the current CPU time used by the thread, in nanoseconds.
+     *
+     * @param threadId
+     *         the id of the thread to get the used CPU time for.
+     * @return the current CPU time used by the thread, in nanoseconds.
+     */
+    public abstract long cpuTime( long threadId );
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.api.{KernelStatement, KernelTransactionImplementati
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
 import org.neo4j.kernel.impl.factory.CanWrite
 import org.neo4j.kernel.impl.proc.Procedures
+import org.neo4j.kernel.impl.locking.LockTracer
 import org.neo4j.kernel.impl.query.{Neo4jTransactionalContext, Neo4jTransactionalContextFactory, QuerySource}
 import org.neo4j.storageengine.api.StorageStatement
 import org.neo4j.test.TestGraphDatabaseFactory
@@ -60,7 +61,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     when(kernelTransaction.securityContext()).thenReturn(AUTH_DISABLED)
     val storeStatement = mock[StorageStatement]
     val operations = mock[StatementOperationParts](RETURNS_DEEP_STUBS)
-    statement = new KernelStatement(kernelTransaction, null, storeStatement, new Procedures(), new CanWrite())
+    statement = new KernelStatement(kernelTransaction, null, storeStatement, new Procedures(), new CanWrite(), LockTracer.NONE)
     statement.initialize(null, operations)
     statement.acquire()
   }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -155,6 +155,7 @@ import org.neo4j.logging.Logger;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.storageengine.api.StoreReadLayer;
+import org.neo4j.time.SystemNanoClock;
 
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;
 
@@ -257,7 +258,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     private final Procedures procedures;
     private final IOLimiter ioLimiter;
     private final AvailabilityGuard availabilityGuard;
-    private final Clock clock;
+    private final SystemNanoClock clock;
 
     private Dependencies dependencies;
     private LifeSupport life;
@@ -309,7 +310,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             Procedures procedures,
             IOLimiter ioLimiter,
             AvailabilityGuard availabilityGuard,
-            Clock clock,
+            SystemNanoClock clock,
             AccessCapability accessCapability )
     {
         this.storeDir = storeDir;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api;
 import java.util.Map;
 
 import org.neo4j.kernel.impl.query.QuerySource;
+import org.neo4j.time.CpuClock;
 
 import static java.lang.String.format;
 
@@ -37,6 +38,9 @@ public class ExecutingQuery
     private final String queryText;
     private final Map<String, Object> queryParameters;
     private final long startTime;
+    private final Thread threadExecutingTheQuery;
+    private final CpuClock cpuClock;
+    private final long cpuTimeWhenQueryStarted;
     private Map<String,Object> metaData;
 
     public ExecutingQuery(
@@ -46,7 +50,9 @@ public class ExecutingQuery
             String queryText,
             Map<String,Object> queryParameters,
             long startTime,
-            Map<String,Object> metaData
+            Map<String,Object> metaData,
+            Thread threadExecutingTheQuery,
+            CpuClock cpuClock
     ) {
         this.queryId = queryId;
         this.querySource = querySource;
@@ -55,6 +61,9 @@ public class ExecutingQuery
         this.queryParameters = queryParameters;
         this.startTime = startTime;
         this.metaData = metaData;
+        this.threadExecutingTheQuery = threadExecutingTheQuery;
+        this.cpuClock = cpuClock;
+        this.cpuTimeWhenQueryStarted = cpuClock.cpuTime( threadExecutingTheQuery );
     }
 
     @Override
@@ -109,6 +118,14 @@ public class ExecutingQuery
     public long startTime()
     {
         return startTime;
+    }
+
+    /**
+     * @return the CPU time used by the query, in nanoseconds.
+     */
+    public long cpuTime()
+    {
+        return cpuClock.cpuTime( threadExecutingTheQuery ) - cpuTimeWhenQueryStarted;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -77,7 +77,7 @@ public class ExecutingQuery
         this.metaData = metaData;
         this.threadExecutingTheQuery = threadExecutingTheQuery;
         this.cpuClock = cpuClock;
-        this.cpuTimeNanosWhenQueryStarted = cpuClock.cpuTime( threadExecutingTheQuery );
+        this.cpuTimeNanosWhenQueryStarted = cpuClock.cpuTimeNanos( threadExecutingTheQuery );
     }
 
     @Override
@@ -144,7 +144,7 @@ public class ExecutingQuery
      */
     public long cpuTime()
     {
-        return cpuClock.cpuTime( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted;
+        return cpuClock.cpuTimeNanos( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted;
     }
 
     public long waitTime()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -143,9 +143,9 @@ public class ExecutingQuery
     /**
      * @return the CPU time used by the query, in nanoseconds.
      */
-    public long cpuTimeMicros()
+    public long cpuTimeMillis()
     {
-        return NANOSECONDS.toMicros( cpuClock.cpuTimeNanos( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted );
+        return NANOSECONDS.toMillis( cpuClock.cpuTimeNanos( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted );
     }
 
     public long waitTimeMillis()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -54,6 +54,8 @@ public class ExecutingQuery
     private final long cpuTimeNanosWhenQueryStarted;
     private Map<String,Object> metaData;
     private volatile ExecutingQueryStatus status = ExecutingQueryStatus.RUNNING;
+    /** Updated through {@link #WAIT_TIME} */
+    @SuppressWarnings( "unused" )
     private volatile long waitTimeNanos;
 
     public ExecutingQuery(

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -31,6 +30,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.time.CpuClock;
 import org.neo4j.time.SystemNanoClock;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 /**
@@ -42,7 +42,6 @@ public class ExecutingQuery
             newUpdater( ExecutingQuery.class, "waitTimeNanos" );
     private final long queryId;
     private final Locks.Tracer lockTracer = ExecutingQuery.this::waitForLock;
-
     private final String username;
     private final QuerySource querySource;
     private final String queryText;
@@ -97,7 +96,6 @@ public class ExecutingQuery
         ExecutingQuery that = (ExecutingQuery) o;
 
         return queryId == that.queryId;
-
     }
 
     @Override
@@ -136,7 +134,7 @@ public class ExecutingQuery
         return startTime;
     }
 
-    public long elapsedTime()
+    public long elapsedTimeMillis()
     {
         return clock.millis() - startTime;
     }
@@ -144,14 +142,14 @@ public class ExecutingQuery
     /**
      * @return the CPU time used by the query, in nanoseconds.
      */
-    public long cpuTime()
+    public long cpuTimeMicros()
     {
-        return cpuClock.cpuTimeNanos( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted;
+        return NANOSECONDS.toMicros( cpuClock.cpuTimeNanos( threadExecutingTheQuery ) - cpuTimeNanosWhenQueryStarted );
     }
 
-    public long waitTime()
+    public long waitTimeMillis()
     {
-        return TimeUnit.NANOSECONDS.toMillis( waitTimeNanos + status.waitTimeNanos( clock ) );
+        return NANOSECONDS.toMillis( waitTimeNanos + status.waitTimeNanos( clock ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -24,7 +24,8 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
+import org.neo4j.kernel.impl.locking.LockWaitEvent;
 import org.neo4j.kernel.impl.query.QuerySource;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.time.CpuClock;
@@ -41,7 +42,7 @@ public class ExecutingQuery
     private static final AtomicLongFieldUpdater<ExecutingQuery> WAIT_TIME =
             newUpdater( ExecutingQuery.class, "waitTimeNanos" );
     private final long queryId;
-    private final Locks.Tracer lockTracer = ExecutingQuery.this::waitForLock;
+    private final LockTracer lockTracer = ExecutingQuery.this::waitForLock;
     private final String username;
     private final QuerySource querySource;
     private final String queryText;
@@ -163,7 +164,7 @@ public class ExecutingQuery
         return metaData;
     }
 
-    public Locks.Tracer lockTracer()
+    public LockTracer lockTracer()
     {
         return lockTracer;
     }
@@ -173,14 +174,14 @@ public class ExecutingQuery
         return status.toMap( clock );
     }
 
-    private Locks.WaitEvent waitForLock( ResourceType resourceType, long[] resourceIds )
+    private LockWaitEvent waitForLock( ResourceType resourceType, long[] resourceIds )
     {
         WaitingOnLockEvent event = new WaitingOnLockEvent( resourceType, resourceIds );
         status = event;
         return event;
     }
 
-    private class WaitingOnLockEvent extends ExecutingQueryStatus.WaitingOnLock implements Locks.WaitEvent
+    private class WaitingOnLockEvent extends ExecutingQueryStatus.WaitingOnLock implements LockWaitEvent
     {
         private final ExecutingQueryStatus previous = status;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
@@ -82,7 +82,7 @@ abstract class ExecutingQueryStatus
         {
             Map<String,Object> map = new HashMap<>();
             map.put( "state", "WAITING" );
-            map.put( "time", TimeUnit.NANOSECONDS.toMillis( waitTimeNanos( clock ) ) );
+            map.put( "waitTimeMillis", TimeUnit.NANOSECONDS.toMillis( waitTimeNanos( clock ) ) );
             map.put( "resourceType", resourceType.toString() );
             map.put( "resourceIds", resourceIds );
             return map;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,12 +26,23 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.time.SystemNanoClock;
 
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Internal representation of the status of an executing query.
+ *
+ * This is used for inspecting the state of a query.
+ *
+ * @see ExecutingQuery#status
+ */
 abstract class ExecutingQueryStatus
 {
     abstract long waitTimeNanos( SystemNanoClock clock );
 
     abstract Map<String,Object> toMap( SystemNanoClock clock );
 
+    private static final Map<String,Object> RUNNING_STATE = unmodifiableMap( singletonMap( "state", "RUNNING" ) );
     static final ExecutingQueryStatus RUNNING = new ExecutingQueryStatus()
     {
         @Override
@@ -45,7 +54,7 @@ abstract class ExecutingQueryStatus
         @Override
         Map<String,Object> toMap( SystemNanoClock clock )
         {
-            return Collections.singletonMap( "state", "RUNNING" );
+            return RUNNING_STATE;
         }
     };
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+import org.neo4j.time.SystemNanoClock;
+
+abstract class ExecutingQueryStatus
+{
+    abstract long waitTimeNanos( SystemNanoClock clock );
+
+    abstract Map<String,Object> toMap( SystemNanoClock clock );
+
+    static final ExecutingQueryStatus RUNNING = new ExecutingQueryStatus()
+    {
+        @Override
+        long waitTimeNanos( SystemNanoClock clock )
+        {
+            return 0;
+        }
+
+        @Override
+        Map<String,Object> toMap( SystemNanoClock clock )
+        {
+            return Collections.singletonMap( "state", "RUNNING" );
+        }
+    };
+
+    static class WaitingOnLock extends ExecutingQueryStatus
+    {
+        private final ResourceType resourceType;
+        private final long[] resourceIds;
+        private final long startTimeNanos;
+
+        WaitingOnLock( ResourceType resourceType, long[] resourceIds, long startTimeNanos )
+        {
+            this.resourceType = resourceType;
+            this.resourceIds = resourceIds;
+            this.startTimeNanos = startTimeNanos;
+        }
+
+        @Override
+        long waitTimeNanos( SystemNanoClock clock )
+        {
+            return clock.nanos() - startTimeNanos;
+        }
+
+        @Override
+        Map<String,Object> toMap( SystemNanoClock clock )
+        {
+            Map<String,Object> map = new HashMap<>();
+            map.put( "state", "WAITING" );
+            map.put( "time", TimeUnit.NANOSECONDS.toMillis( waitTimeNanos( clock ) ) );
+            map.put( "resourceType", resourceType.toString() );
+            map.put( "resourceIds", resourceIds );
+            return map;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -57,6 +57,7 @@ import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.storageengine.api.LabelItem;
 import org.neo4j.storageengine.api.NodeItem;
@@ -331,7 +332,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         // If we find the node - hold a shared lock. If we don't find a node - hold an exclusive lock.
         // If locks are deferred than both shared and exclusive locks will be taken only at commit time.
         Locks.Client locks = state.locks().optimistic();
-        Locks.Tracer lockTracer = state.lockTracer();
+        LockTracer lockTracer = state.lockTracer();
         long indexEntryId = indexEntryResourceId( labelId, propertyKeyId, stringVal );
 
         locks.acquireShared( lockTracer, INDEX_ENTRY, indexEntryId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExecutingQueryList.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExecutingQueryList.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.ExecutingQuery;
-import org.neo4j.kernel.impl.locking.Locks;
 
 abstract class ExecutingQueryList
 {
@@ -33,6 +32,8 @@ abstract class ExecutingQueryList
     abstract ExecutingQueryList push( ExecutingQuery newExecutingQuery );
 
     abstract ExecutingQueryList remove( ExecutingQuery executingQuery );
+
+    abstract <T> T reduce( T defaultValue, Function<ExecutingQuery,T> accessor, BiFunction<T,T,T> combinator );
 
     static ExecutingQueryList EMPTY = new ExecutingQueryList()
     {
@@ -60,8 +61,6 @@ abstract class ExecutingQueryList
             return defaultValue;
         }
     };
-
-    abstract <T> T reduce( T defaultValue, Function<ExecutingQuery,T> accessor, BiFunction<T,T,T> combinator );
 
     private static class Entry extends ExecutingQueryList
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -39,7 +39,7 @@ import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.factory.AccessCapability;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
@@ -192,9 +192,9 @@ public class KernelStatement implements TxStateHolder, Statement
         return statementLocks;
     }
 
-    public Locks.Tracer lockTracer()
+    public LockTracer lockTracer()
     {
-        return executingQueryList.reduce( Locks.Tracer.NONE, ExecutingQuery::lockTracer, Locks.Tracer::combine );
+        return executingQueryList.reduce( LockTracer.NONE, ExecutingQuery::lockTracer, LockTracer::combine );
     }
 
     public final void acquire()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -73,12 +73,14 @@ public class KernelStatement implements TxStateHolder, Statement
     private StatementLocks statementLocks;
     private int referenceCount;
     private volatile ExecutingQueryList executingQueryList;
+    private final LockTracer systemLockTracer;
 
     public KernelStatement( KernelTransactionImplementation transaction,
                             TxStateHolder txStateHolder,
                             StorageStatement storeStatement,
                             Procedures procedures,
-                            AccessCapability accessCapability )
+                            AccessCapability accessCapability,
+                            LockTracer systemLockTracer )
     {
         this.transaction = transaction;
         this.txStateHolder = txStateHolder;
@@ -86,6 +88,7 @@ public class KernelStatement implements TxStateHolder, Statement
         this.accessCapability = accessCapability;
         this.facade = new OperationsFacade( transaction, this, procedures );
         this.executingQueryList = ExecutingQueryList.EMPTY;
+        this.systemLockTracer = systemLockTracer;
     }
 
     @Override
@@ -194,7 +197,7 @@ public class KernelStatement implements TxStateHolder, Statement
 
     public LockTracer lockTracer()
     {
-        return executingQueryList.reduce( LockTracer.NONE, ExecutingQuery::lockTracer, LockTracer::combine );
+        return executingQueryList.reduce( systemLockTracer, ExecutingQuery::lockTracer, LockTracer::combine );
     }
 
     public final void acquire()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.factory.AccessCapability;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
@@ -189,6 +190,11 @@ public class KernelStatement implements TxStateHolder, Statement
     public StatementLocks locks()
     {
         return statementLocks;
+    }
+
+    public Locks.Tracer lockTracer()
+    {
+        return executingQueryList.reduce( Locks.Tracer.NONE, ExecutingQuery::lockTracer, Locks.Tracer::combine );
     }
 
     public final void acquire()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionStateImpl;
 import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -310,7 +311,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
                     new KernelTransactionImplementation( statementOperations, schemaWriteGuard, hooks,
                             constraintIndexCreator, procedures, transactionHeaderInformationFactory,
                             transactionCommitProcess, transactionMonitor, legacyIndexTxStateSupplier, localTxPool,
-                            clock, tracers.transactionTracer, storageEngine, accessCapability );
+                            clock, tracers.transactionTracer, tracers.lockTracer, storageEngine, accessCapability );
 
             this.transactions.add( tx );
             return tx;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -54,6 +54,7 @@ import org.neo4j.kernel.impl.api.operations.LockOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -486,7 +487,7 @@ public class LockingStatementOperations implements
     @Override
     public Property graphSetProperty( KernelStatement state, DefinedProperty property )
     {
-        state.locks().optimistic().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
+        state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
         state.assertOpen();
         return entityWriteDelegate.graphSetProperty( state, property );
     }
@@ -494,7 +495,7 @@ public class LockingStatementOperations implements
     @Override
     public Property graphRemoveProperty( KernelStatement state, int propertyKeyId )
     {
-        state.locks().optimistic().acquireExclusive( ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
+        state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.GRAPH_PROPS, ResourceTypes.graphPropertyResource() );
         state.assertOpen();
         return entityWriteDelegate.graphRemoveProperty( state, propertyKeyId );
     }
@@ -502,14 +503,14 @@ public class LockingStatementOperations implements
     @Override
     public void acquireExclusive( KernelStatement state, ResourceType resourceType, long resourceId )
     {
-        state.locks().pessimistic().acquireExclusive( resourceType, resourceId );
+        state.locks().pessimistic().acquireExclusive( state.lockTracer(), resourceType, resourceId );
         state.assertOpen();
     }
 
     @Override
     public void acquireShared( KernelStatement state, ResourceType resourceType, long resourceId )
     {
-        state.locks().pessimistic().acquireShared( resourceType, resourceId );
+        state.locks().pessimistic().acquireShared( state.lockTracer(), resourceType, resourceId );
         state.assertOpen();
     }
 
@@ -539,7 +540,7 @@ public class LockingStatementOperations implements
     {
         if ( !state.hasTxStateWithChanges() || !state.txState().nodeIsAddedInThisTx( nodeId ) )
         {
-            state.locks().optimistic().acquireExclusive( ResourceTypes.NODE, nodeId );
+            state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeId );
         }
     }
 
@@ -547,7 +548,7 @@ public class LockingStatementOperations implements
     {
         if ( !state.hasTxStateWithChanges() || !state.txState().relationshipIsAddedInThisTx( relationshipId ) )
         {
-            state.locks().optimistic().acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
+            state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.RELATIONSHIP, relationshipId );
         }
     }
 
@@ -555,7 +556,7 @@ public class LockingStatementOperations implements
     {
         if ( !SCHEMA_WRITES_DISABLE )
         {
-            state.locks().optimistic().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+            state.locks().optimistic().acquireShared( state.lockTracer(), ResourceTypes.SCHEMA, schemaResource() );
         }
     }
 
@@ -567,7 +568,7 @@ public class LockingStatementOperations implements
         }
         else
         {
-            state.locks().optimistic().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+            state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.SCHEMA, schemaResource() );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.impl.api.operations.QueryRegistrationOperations;
 import org.neo4j.kernel.impl.query.QuerySource;
 import org.neo4j.kernel.impl.util.MonotonicCounter;
+import org.neo4j.time.CpuClock;
 
 public class StackingQueryRegistrationOperations implements QueryRegistrationOperations
 {
@@ -60,9 +61,10 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
     )
     {
         long queryId = lastQueryId.incrementAndGet();
+        Thread thread = Thread.currentThread();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, querySource, statement.username(), queryText, queryParameters,
-                        clock.millis(), statement.getTransaction().getMetaData() );
+                        clock.millis(), statement.getTransaction().getMetaData(), thread, CpuClock.CPU_CLOCK );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.time.Clock;
 import java.util.Map;
 import java.util.stream.Stream;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -28,14 +28,15 @@ import org.neo4j.kernel.impl.api.operations.QueryRegistrationOperations;
 import org.neo4j.kernel.impl.query.QuerySource;
 import org.neo4j.kernel.impl.util.MonotonicCounter;
 import org.neo4j.time.CpuClock;
+import org.neo4j.time.SystemNanoClock;
 
 public class StackingQueryRegistrationOperations implements QueryRegistrationOperations
 {
 
     private final MonotonicCounter lastQueryId = MonotonicCounter.newAtomicMonotonicCounter();
-    private final Clock clock;
+    private final SystemNanoClock clock;
 
-    public StackingQueryRegistrationOperations( Clock clock )
+    public StackingQueryRegistrationOperations( SystemNanoClock clock )
     {
         this.clock = clock;
     }
@@ -64,7 +65,7 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
         Thread thread = Thread.currentThread();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, querySource, statement.username(), queryText, queryParameters,
-                        clock.millis(), statement.getTransaction().getMetaData(), thread, CpuClock.CPU_CLOCK );
+                        statement.getTransaction().getMetaData(), thread, clock, CpuClock.CPU_CLOCK );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
@@ -27,6 +27,7 @@ import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.storageengine.api.Direction;
 import org.neo4j.storageengine.api.NodeItem;
@@ -101,7 +102,7 @@ class TwoPhaseNodeForRelationshipLocking
             PrimitiveLongIterator nodeIdIterator = nodeIds.iterator();
             while ( nodeIdIterator.hasNext() )
             {
-                state.locks().optimistic().acquireExclusive( ResourceTypes.NODE, nodeIdIterator.next() );
+                state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeIdIterator.next() );
             }
 
             // perform the action on each relationship, we will retry if the the relationship iterator contains new relationships

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -63,6 +63,7 @@ import org.neo4j.logging.Level;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.time.Clocks;
+import org.neo4j.time.SystemNanoClock;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
@@ -108,7 +109,7 @@ public class PlatformModule
 
     public final TransactionStats transactionMonitor;
 
-    public final Clock clock;
+    public final SystemNanoClock clock;
 
     public PlatformModule( File providedStoreDir, Map<String, String> params, DatabaseInfo databaseInfo,
             GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )
@@ -192,9 +193,9 @@ public class PlatformModule
         publishPlatformInfo( dependencies.resolveDependency( UsageData.class ) );
     }
 
-    protected Clock createClock()
+    protected SystemNanoClock createClock()
     {
-        return Clocks.systemClock();
+        return Clocks.nanoClock();
     }
 
     @SuppressWarnings( "unchecked" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import java.util.Arrays;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+final class CombinedTracer implements Locks.Tracer
+{
+    private final Locks.Tracer[] tracers;
+
+    public CombinedTracer( Locks.Tracer... tracers )
+    {
+        this.tracers = tracers;
+    }
+
+    @Override
+    public Locks.WaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+    {
+        Locks.WaitEvent[] events = new Locks.WaitEvent[tracers.length];
+        for ( int i = 0; i < events.length; i++ )
+        {
+            events[i] = tracers[i].waitForLock( resourceType, resourceIds );
+        }
+        return new CombinedEvent( events );
+    }
+
+    @Override
+    public Locks.Tracer combine( Locks.Tracer tracer )
+    {
+        if ( tracer == NONE )
+        {
+            return this;
+        }
+        Locks.Tracer[] tracers;
+        if ( tracer instanceof CombinedTracer )
+        {
+            Locks.Tracer[] those = ((CombinedTracer) tracer).tracers;
+            tracers = Arrays.copyOf( this.tracers, this.tracers.length + those.length );
+            for ( int i = 0; i < those.length; i++ )
+            {
+                tracers[this.tracers.length + i] = those[i];
+            }
+        }
+        else
+        {
+            tracers = Arrays.copyOf( this.tracers, this.tracers.length + 1 );
+            tracers[this.tracers.length] = tracer;
+        }
+        return new CombinedTracer( tracers );
+    }
+
+    private static class CombinedEvent implements Locks.WaitEvent
+    {
+        private final Locks.WaitEvent[] events;
+
+        CombinedEvent( Locks.WaitEvent[] events )
+        {
+            this.events = events;
+        }
+
+        @Override
+        public void close()
+        {
+            for ( Locks.WaitEvent event : events )
+            {
+                event.close();
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
@@ -23,11 +23,18 @@ import java.util.Arrays;
 
 import org.neo4j.storageengine.api.lock.ResourceType;
 
+/**
+ * A {@link Locks.Tracer} that combines multiple {@linkplain Locks.Tracer tracers} into one, invoking each of them for
+ * the {@linkplain #waitForLock(ResourceType, long...) wait events} received.
+ * <p>
+ * This is used for when there is a stack of queries in a transaction, or when a system-configured tracer combines with
+ * the query specific tracers.
+ */
 final class CombinedTracer implements Locks.Tracer
 {
     private final Locks.Tracer[] tracers;
 
-    public CombinedTracer( Locks.Tracer... tracers )
+    CombinedTracer( Locks.Tracer... tracers )
     {
         this.tracers = tracers;
     }
@@ -55,10 +62,7 @@ final class CombinedTracer implements Locks.Tracer
         {
             Locks.Tracer[] those = ((CombinedTracer) tracer).tracers;
             tracers = Arrays.copyOf( this.tracers, this.tracers.length + those.length );
-            for ( int i = 0; i < those.length; i++ )
-            {
-                tracers[this.tracers.length + i] = those[i];
-            }
+            System.arraycopy( those, 0, tracers, this.tracers.length, those.length );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+public interface LockTracer
+{
+    LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds );
+
+    default LockTracer combine( LockTracer tracer )
+    {
+        if ( tracer == NONE )
+        {
+            return this;
+        }
+        return new CombinedTracer( this, tracer );
+    }
+
+    LockTracer NONE = new LockTracer()
+    {
+        @Override
+        public LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+        {
+            return LockWaitEvent.NONE;
+        }
+
+        @Override
+        public LockTracer combine( LockTracer tracer )
+        {
+            return tracer;
+        }
+    };
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockWaitEvent.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockWaitEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+public interface LockWaitEvent extends AutoCloseable
+{
+    @Override
+    void close();
+
+    LockWaitEvent NONE = () ->
+    {
+    };
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -82,10 +82,10 @@ public interface Locks
          * @param resourceType type or resource(s) to lock.
          * @param resourceIds id(s) of resources to lock. Multiple ids should be ordered consistently by all callers
          */
-        void acquireShared( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
+        void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
         @Override
-        void acquireExclusive( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
+        void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
         /** Try grabbing exclusive lock, not waiting and returning a boolean indicating if we got the lock. */
         boolean tryExclusiveLock( ResourceType resourceType, long resourceId );
@@ -126,43 +126,4 @@ public interface Locks
     void accept(Visitor visitor);
 
     void close();
-
-    interface Tracer
-    {
-        WaitEvent waitForLock( ResourceType resourceType, long... resourceIds );
-
-        default Tracer combine( Tracer tracer )
-        {
-            if ( tracer == NONE )
-            {
-                return this;
-            }
-            return new CombinedTracer( this, tracer );
-        }
-
-        Tracer NONE = new Tracer()
-        {
-            @Override
-            public WaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
-            {
-                return WaitEvent.NONE;
-            }
-
-            @Override
-            public Tracer combine( Tracer tracer )
-            {
-                return tracer;
-            }
-        };
-    }
-
-    interface WaitEvent extends AutoCloseable
-    {
-        @Override
-        void close();
-
-        WaitEvent NONE = () ->
-        {
-        };
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -25,12 +25,12 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 public class NoOpClient implements Locks.Client
 {
     @Override
-    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -25,12 +25,12 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 public class NoOpClient implements Locks.Client
 {
     @Override
-    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 
     @Override
-    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
@@ -45,13 +45,13 @@ public class ReadOnlyLocks implements Locks
     private static class ReadOnlyClient extends NoOpClient
     {
         @Override
-        public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireShared( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             fail();
         }
 
         @Override
-        public void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireExclusive( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             fail();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ReadOnlyLocks.java
@@ -45,13 +45,13 @@ public class ReadOnlyLocks implements Locks
     private static class ReadOnlyClient extends NoOpClient
     {
         @Override
-        public void acquireShared( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             fail();
         }
 
         @Override
-        public void acquireExclusive( Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             fail();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -88,7 +88,7 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( ResourceType resourceType, long...resourceIds )
+    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try
@@ -122,7 +122,7 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long...resourceIds )
+    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -104,7 +104,7 @@ public class CommunityLockClient implements Locks.Client
                 else
                 {
                     resource = new LockResource( resourceType, resourceId );
-                    if ( manager.getReadLock( resource, lockTransaction ) )
+                    if ( manager.getReadLock( tracer, resource, lockTransaction ) )
                     {
                         localLocks.put( resourceId, resource );
                     }
@@ -138,7 +138,7 @@ public class CommunityLockClient implements Locks.Client
                 else
                 {
                     resource = new LockResource( resourceType, resourceId );
-                    if ( manager.getWriteLock( resource, lockTransaction ) )
+                    if ( manager.getWriteLock( tracer, resource, lockTransaction ) )
                     {
                         localLocks.put( resourceId, resource );
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -29,6 +29,7 @@ import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongObjectVisitor;
 import org.neo4j.kernel.impl.locking.LockClientStateHolder;
 import org.neo4j.kernel.impl.locking.LockClientStoppedException;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.storageengine.api.lock.ResourceType;
 
@@ -88,7 +89,7 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
+    public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try
@@ -122,7 +123,7 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
+    public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds )
     {
         stateHolder.incrementActiveClients( this );
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.transaction.IllegalResourceException;
 import org.neo4j.logging.Logger;
 
@@ -50,7 +50,7 @@ public class LockManagerImpl
         this.lockAcquisitionTimeoutMillis = config.get( GraphDatabaseSettings.lock_acquisition_timeout );
     }
 
-    public boolean getReadLock( Locks.Tracer tracer, LockResource resource, Object tx )
+    public boolean getReadLock( LockTracer tracer, LockResource resource, Object tx )
             throws DeadlockDetectedException, IllegalResourceException
     {
         return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireReadLock( tracer, tx ) );
@@ -62,7 +62,7 @@ public class LockManagerImpl
         return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).tryAcquireReadLock( tx ) );
     }
 
-    public boolean getWriteLock( Locks.Tracer tracer, LockResource resource, Object tx )
+    public boolean getWriteLock( LockTracer tracer, LockResource resource, Object tx )
             throws DeadlockDetectedException, IllegalResourceException
     {
         return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireWriteLock( tracer, tx ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/LockManagerImpl.java
@@ -27,6 +27,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.transaction.IllegalResourceException;
 import org.neo4j.logging.Logger;
 
@@ -49,10 +50,10 @@ public class LockManagerImpl
         this.lockAcquisitionTimeoutMillis = config.get( GraphDatabaseSettings.lock_acquisition_timeout );
     }
 
-    public boolean getReadLock( LockResource resource, Object tx )
+    public boolean getReadLock( Locks.Tracer tracer, LockResource resource, Object tx )
             throws DeadlockDetectedException, IllegalResourceException
     {
-        return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireReadLock( tx ) );
+        return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireReadLock( tracer, tx ) );
     }
 
     public boolean tryReadLock( LockResource resource, Object tx )
@@ -61,10 +62,10 @@ public class LockManagerImpl
         return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).tryAcquireReadLock( tx ) );
     }
 
-    public boolean getWriteLock( LockResource resource, Object tx )
+    public boolean getWriteLock( Locks.Tracer tracer, LockResource resource, Object tx )
             throws DeadlockDetectedException, IllegalResourceException
     {
-        return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireWriteLock( tx ) );
+        return unusedResourceGuard( resource, tx, getRWLockForAcquiring( resource, tx ).acquireWriteLock( tracer, tx ) );
     }
 
     public boolean tryWriteLock( LockResource resource, Object tx )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
@@ -27,8 +27,9 @@ import java.util.ListIterator;
 import org.neo4j.helpers.MathUtil;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.locking.LockAcquisitionTimeoutException;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.LockType;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockWaitEvent;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.logging.Logger;
 
@@ -187,12 +188,12 @@ class RWLock
      * @return true is lock was acquired, false otherwise
      * @throws DeadlockDetectedException if a deadlock is detected
      */
-    synchronized boolean acquireReadLock( Locks.Tracer tracer, Object tx ) throws DeadlockDetectedException
+    synchronized boolean acquireReadLock( LockTracer tracer, Object tx ) throws DeadlockDetectedException
     {
         TxLockElement tle = getOrCreateLockElement( tx );
 
         LockRequest lockRequest = null;
-        Locks.WaitEvent waitEvent = null;
+        LockWaitEvent waitEvent = null;
         // used to track do we need to add lock request to a waiting queue or we still have it there
         boolean addLockRequest = true;
         try
@@ -375,12 +376,12 @@ class RWLock
      * @return true is lock was acquired, false otherwise
      * @throws DeadlockDetectedException if a deadlock is detected
      */
-    synchronized boolean acquireWriteLock( Locks.Tracer tracer, Object tx ) throws DeadlockDetectedException
+    synchronized boolean acquireWriteLock( LockTracer tracer, Object tx ) throws DeadlockDetectedException
     {
         TxLockElement tle = getOrCreateLockElement( tx );
 
         LockRequest lockRequest = null;
-        Locks.WaitEvent waitEvent = null;
+        LockWaitEvent waitEvent = null;
         // used to track do we need to add lock request to a waiting queue or we still have it there
         boolean addLockRequest = true;
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
@@ -28,6 +28,7 @@ import org.neo4j.helpers.MathUtil;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.locking.LockAcquisitionTimeoutException;
 import org.neo4j.kernel.impl.locking.LockType;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.logging.Logger;
 
@@ -186,11 +187,12 @@ class RWLock
      * @return true is lock was acquired, false otherwise
      * @throws DeadlockDetectedException if a deadlock is detected
      */
-    synchronized boolean acquireReadLock( Object tx ) throws DeadlockDetectedException
+    synchronized boolean acquireReadLock( Locks.Tracer tracer, Object tx ) throws DeadlockDetectedException
     {
         TxLockElement tle = getOrCreateLockElement( tx );
 
         LockRequest lockRequest = null;
+        Locks.WaitEvent waitEvent = null;
         // used to track do we need to add lock request to a waiting queue or we still have it there
         boolean addLockRequest = true;
         try
@@ -210,6 +212,10 @@ class RWLock
                     waitingThreadList.addFirst( lockRequest );
                 }
 
+                if ( waitEvent == null )
+                {
+                    waitEvent = tracer.waitForLock( resource.type(), resource.resourceId() );
+                }
                 addLockRequest = waitUninterruptedly( lockAcquisitionTimeBoundary );
                 ragManager.stopWaitOn( this, tx );
             }
@@ -233,6 +239,10 @@ class RWLock
         }
         finally
         {
+            if ( waitEvent != null )
+            {
+                waitEvent.close();
+            }
             cleanupWaitingListRequests( lockRequest, tle, addLockRequest );
             // for cases when spurious wake up was the reason why we waked up, but also there
             // was an interruption as described at 17.2 just clearing interruption flag
@@ -365,11 +375,12 @@ class RWLock
      * @return true is lock was acquired, false otherwise
      * @throws DeadlockDetectedException if a deadlock is detected
      */
-    synchronized boolean acquireWriteLock( Object tx ) throws DeadlockDetectedException
+    synchronized boolean acquireWriteLock( Locks.Tracer tracer, Object tx ) throws DeadlockDetectedException
     {
         TxLockElement tle = getOrCreateLockElement( tx );
 
         LockRequest lockRequest = null;
+        Locks.WaitEvent waitEvent = null;
         // used to track do we need to add lock request to a waiting queue or we still have it there
         boolean addLockRequest = true;
         try
@@ -389,6 +400,10 @@ class RWLock
                     waitingThreadList.addFirst( lockRequest );
                 }
 
+                if ( waitEvent == null )
+                {
+                    waitEvent = tracer.waitForLock( resource.type(), resource.resourceId() );
+                }
                 addLockRequest = waitUninterruptedly( lockAcquisitionTimeBoundary );
                 ragManager.stopWaitOn( this, tx );
             }
@@ -412,6 +427,10 @@ class RWLock
         }
         finally
         {
+            if ( waitEvent != null )
+            {
+                waitEvent.close();
+            }
             cleanupWaitingListRequests( lockRequest, tle, addLockRequest );
             // for cases when spurious wake up was the reason why we waked up, but also there
             // was an interruption as described at 17.2 just clearing interruption flag

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -89,7 +89,7 @@ public class RelationshipCreator
             RelationshipRecord rel = relChange.forReadingLinkage();
             if ( relCount( node.getId(), rel ) >= denseNodeThreshold )
             {
-                locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relId );
+                locks.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relId );
                 // Re-read the record after we've locked it since another transaction might have
                 // changed in the meantime.
                 relChange = relRecords.getOrLoad( relId, null );
@@ -188,7 +188,7 @@ public class RelationshipCreator
             connectRelationshipToDenseNode( node, relRecord, relRecords, relGroupRecords, locks );
             if ( relId != Record.NO_NEXT_RELATIONSHIP.intValue() )
             {   // Lock and load the next relationship in the chain
-                locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relId );
+                locks.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relId );
                 relRecord = relRecords.getOrLoad( relId, null ).forChangingLinkage();
             }
         }
@@ -200,7 +200,7 @@ public class RelationshipCreator
         long newCount = 1;
         if ( firstRelId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
-            locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
+            locks.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
             RelationshipRecord firstRel = relRecords.getOrLoad( firstRelId, null ).forChangingLinkage();
             boolean changed = false;
             if ( firstRel.getFirstNode() == nodeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -88,7 +89,7 @@ public class RelationshipCreator
             RelationshipRecord rel = relChange.forReadingLinkage();
             if ( relCount( node.getId(), rel ) >= denseNodeThreshold )
             {
-                locks.acquireExclusive( ResourceTypes.RELATIONSHIP, relId );
+                locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relId );
                 // Re-read the record after we've locked it since another transaction might have
                 // changed in the meantime.
                 relChange = relRecords.getOrLoad( relId, null );
@@ -187,7 +188,7 @@ public class RelationshipCreator
             connectRelationshipToDenseNode( node, relRecord, relRecords, relGroupRecords, locks );
             if ( relId != Record.NO_NEXT_RELATIONSHIP.intValue() )
             {   // Lock and load the next relationship in the chain
-                locks.acquireExclusive( ResourceTypes.RELATIONSHIP, relId );
+                locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relId );
                 relRecord = relRecords.getOrLoad( relId, null ).forChangingLinkage();
             }
         }
@@ -199,7 +200,7 @@ public class RelationshipCreator
         long newCount = 1;
         if ( firstRelId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
-            locks.acquireExclusive( ResourceTypes.RELATIONSHIP, firstRelId );
+            locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
             RelationshipRecord firstRel = relRecords.getOrLoad( firstRelId, null ).forChangingLinkage();
             boolean changed = false;
             if ( firstRel.getFirstNode() == nodeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -77,7 +77,7 @@ public class RelationshipDeleter
             return;
         }
 
-        locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, otherRelId );
+        locks.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, otherRelId );
         RelationshipRecord otherRel = relChanges.getOrLoad( otherRelId, null ).forChangingLinkage();
         boolean changed = false;
         long newId = pointer.get( rel );
@@ -192,7 +192,7 @@ public class RelationshipDeleter
         boolean firstInChain = relIsFirstInChain( nodeId, rel );
         if ( !firstInChain )
         {
-            locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
+            locks.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
         }
         RelationshipRecord firstRel = relRecords.getOrLoad( firstRelId, null ).forChangingLinkage();
         if ( nodeId == firstRel.getFirstNode() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -76,7 +77,7 @@ public class RelationshipDeleter
             return;
         }
 
-        locks.acquireExclusive( ResourceTypes.RELATIONSHIP, otherRelId );
+        locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, otherRelId );
         RelationshipRecord otherRel = relChanges.getOrLoad( otherRelId, null ).forChangingLinkage();
         boolean changed = false;
         long newId = pointer.get( rel );
@@ -191,7 +192,7 @@ public class RelationshipDeleter
         boolean firstInChain = relIsFirstInChain( nodeId, rel );
         if ( !firstInChain )
         {
-            locks.acquireExclusive( ResourceTypes.RELATIONSHIP, firstRelId );
+            locks.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, firstRelId );
         }
         RelationshipRecord firstRel = relRecords.getOrLoad( firstRelId, null ).forChangingLinkage();
         if ( nodeId == firstRel.getFirstNode() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.monitoring.tracing;
 
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -64,4 +65,16 @@ public interface TracerFactory
      * @return The created instance.
      */
     CheckPointTracer createCheckPointTracer( Monitors monitors, JobScheduler jobScheduler );
+
+    /**
+     * Create a new LockTracer instance.
+     *
+     * @param monitors the monitoring manager
+     * @param jobScheduler a scheduler for async jobs
+     * @return The created instance.
+     */
+    default LockTracer createLockTracer( Monitors monitors, JobScheduler jobScheduler )
+    {
+        return LockTracer.NONE;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.monitoring.tracing;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -99,6 +100,7 @@ public class Tracers
     public final PageCacheTracer pageCacheTracer;
     public final TransactionTracer transactionTracer;
     public final CheckPointTracer checkPointTracer;
+    public final LockTracer lockTracer;
 
     /**
      * Create a Tracers subsystem with the desired implementation, if it can be found and created.
@@ -117,6 +119,7 @@ public class Tracers
             pageCacheTracer = PageCacheTracer.NULL;
             transactionTracer = TransactionTracer.NULL;
             checkPointTracer = CheckPointTracer.NULL;
+            lockTracer = LockTracer.NONE;
         }
         else
         {
@@ -148,6 +151,7 @@ public class Tracers
             pageCacheTracer = foundFactory.createPageCacheTracer( monitors, jobScheduler );
             transactionTracer = foundFactory.createTransactionTracer( monitors, jobScheduler );
             checkPointTracer = foundFactory.createCheckPointTracer( monitors, jobScheduler );
+            lockTracer = foundFactory.createLockTracer( monitors, jobScheduler );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
@@ -21,7 +21,7 @@ package org.neo4j.storageengine.api.lock;
 
 import java.util.Arrays;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 
 public interface ResourceLocker
 {
@@ -34,7 +34,7 @@ public interface ResourceLocker
      * @param resourceType type or resource(s) to lock.
      * @param resourceIds id(s) of resources to lock. Multiple ids should be ordered consistently by all callers
      */
-    void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
+    void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
     ResourceLocker NONE = ( tracer, resourceType, resourceIds ) ->
     {

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceLocker.java
@@ -21,6 +21,8 @@ package org.neo4j.storageengine.api.lock;
 
 import java.util.Arrays;
 
+import org.neo4j.kernel.impl.locking.Locks;
+
 public interface ResourceLocker
 {
     /**
@@ -28,13 +30,13 @@ public interface ResourceLocker
      * while one client holds an exclusive lock. If the lock cannot be acquired,
      * behavior is specified by the {@link WaitStrategy} for the given {@link ResourceType}.
      *
+     * @param tracer
      * @param resourceType type or resource(s) to lock.
      * @param resourceIds id(s) of resources to lock. Multiple ids should be ordered consistently by all callers
-     * of this method.
      */
-    void acquireExclusive( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
+    void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException;
 
-    ResourceLocker NONE = ( resourceType, resourceIds ) ->
+    ResourceLocker NONE = ( tracer, resourceType, resourceIds ) ->
     {
         throw new UnsupportedOperationException(
                 "Unexpected call to lock a resource " + resourceType + " " + Arrays.toString( resourceIds ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.neo4j.time.Clocks;
+import org.neo4j.time.FakeClock;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.api.ExecutingQueryTest.resourceType;
+
+public class ExecutingQueryStatusTest
+{
+    private final FakeClock clock = Clocks.fakeClock( ZonedDateTime.parse( "2016-12-16T16:14:12+01:00" ) );
+
+    @Test
+    public void shouldProduceSensibleMapRepresentationInRunningState() throws Exception
+    {
+        // when
+        Map<String,Object> status = ExecutingQueryStatus.RUNNING.toMap( clock );
+
+        // then
+        assertEquals( singletonMap( "state", "RUNNING" ), status );
+    }
+
+    @Test
+    public void shouldProduceSensibleMapRepresentationInWaitingState() throws Exception
+    {
+        // given
+        long[] resourceIds = {17};
+        ExecutingQueryStatus.WaitingOnLock status =
+                new ExecutingQueryStatus.WaitingOnLock( resourceType( "NODE" ), resourceIds, clock.nanos() );
+        clock.forward( 17, TimeUnit.MILLISECONDS );
+
+        // when
+        Map<String,Object> statusMap = status.toMap( clock );
+
+        // then
+        Map<String,Object> expected = new HashMap<>();
+        expected.put( "state", "WAITING" );
+        expected.put( "time", 17L );
+        expected.put( "resourceType", "NODE" );
+        expected.put( "resourceIds", resourceIds );
+        assertEquals( expected, statusMap );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
@@ -62,7 +62,7 @@ public class ExecutingQueryStatusTest
         // then
         Map<String,Object> expected = new HashMap<>();
         expected.put( "state", "WAITING" );
-        expected.put( "time", 17L );
+        expected.put( "waitTimeMillis", 17L );
         expected.put( "resourceType", "NODE" );
         expected.put( "resourceIds", resourceIds );
         assertEquals( expected, statusMap );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.query.QuerySource;
+import org.neo4j.storageengine.api.lock.ResourceType;
+import org.neo4j.storageengine.api.lock.WaitStrategy;
+import org.neo4j.test.FakeCpuClock;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.FakeClock;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ExecutingQueryTest
+{
+    private final FakeClock clock = Clocks.fakeClock( ZonedDateTime.parse( "2016-12-03T15:10:00+01:00" ) );
+    private final FakeCpuClock cpuClock = new FakeCpuClock();
+    private ExecutingQuery query = new ExecutingQuery(
+            1,
+            new QuerySource(),
+            "neo4j",
+            "hello world",
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Thread.currentThread(),
+            clock,
+            cpuClock );
+
+    @Test
+    public void shouldReportElapsedTime() throws Exception
+    {
+        // when
+        clock.forward( 10, TimeUnit.SECONDS );
+        long elapsedTime = query.elapsedTime();
+
+        // then
+        assertEquals( 10_000, elapsedTime );
+    }
+
+    @Test
+    public void shouldReportWaitTime() throws Exception
+    {
+        // initial
+        assertEquals( singletonMap( "state", "RUNNING" ), query.status() );
+
+        // when
+        clock.forward( 10, TimeUnit.SECONDS );
+        try ( Locks.WaitEvent event = lock( "NODE", 17 ) )
+        {
+            clock.forward( 5, TimeUnit.SECONDS );
+
+            // then
+            assertThat( query.status(), CoreMatchers.<Map<String,Object>>allOf(
+                    hasEntry( "state", "WAITING" ),
+                    hasEntry( "time", 5_000L ),
+                    hasEntry( "resourceType", "NODE" ),
+                    hasEntry( equalTo( "resourceIds" ), longArray( 17 ) ) ) );
+            assertEquals( 5_000, query.waitTime() );
+        }
+        assertEquals( singletonMap( "state", "RUNNING" ), query.status() );
+        assertEquals( 5_000, query.waitTime() );
+
+        // when
+        clock.forward( 2, TimeUnit.SECONDS );
+        try ( Locks.WaitEvent event = lock( "RELATIONSHIP", 612 ) )
+        {
+            clock.forward( 1, TimeUnit.SECONDS );
+
+            // then
+            assertThat( query.status(), CoreMatchers.<Map<String,Object>>allOf(
+                    hasEntry( "state", "WAITING" ),
+                    hasEntry( "time", 1_000L ),
+                    hasEntry( "resourceType", "RELATIONSHIP" ),
+                    hasEntry( equalTo( "resourceIds" ), longArray( 612 ) ) ) );
+            assertEquals( 6_000, query.waitTime() );
+        }
+        assertEquals( singletonMap( "state", "RUNNING" ), query.status() );
+        assertEquals( 6_000, query.waitTime() );
+    }
+
+    @Test
+    public void shouldReportCpuTime() throws Exception
+    {
+        // given
+        cpuClock.add( 60, TimeUnit.MILLISECONDS );
+
+        // when
+        long cpuTime = query.cpuTime();
+
+        // then
+        assertEquals( 60_000_000, cpuTime );
+    }
+
+    private Locks.WaitEvent lock( String resourceType, long resourceId )
+    {
+        return query.lockTracer().waitForLock( resourceType( resourceType ), resourceId );
+    }
+
+    static ResourceType resourceType( String string )
+    {
+        return new ResourceType()
+        {
+            @Override
+            public String toString()
+            {
+                return string;
+            }
+
+            @Override
+            public int typeId()
+            {
+                throw new UnsupportedOperationException( "not used" );
+            }
+
+            @Override
+            public WaitStrategy waitStrategy()
+            {
+                throw new UnsupportedOperationException( "not used" );
+            }
+        };
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static Matcher<Object> longArray( long... expected )
+    {
+        return (Matcher) new TypeSafeMatcher<long[]>()
+        {
+            @Override
+            protected boolean matchesSafely( long[] item )
+            {
+                return Arrays.equals( expected, item );
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendValue( expected );
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -119,10 +119,10 @@ public class ExecutingQueryTest
         cpuClock.add( 60, TimeUnit.MILLISECONDS );
 
         // when
-        long cpuTime = query.cpuTimeMicros();
+        long cpuTime = query.cpuTimeMillis();
 
         // then
-        assertEquals( 60_000, cpuTime );
+        assertEquals( 60, cpuTime );
     }
 
     private LockWaitEvent lock( String resourceType, long resourceId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -65,7 +65,7 @@ public class ExecutingQueryTest
     {
         // when
         clock.forward( 10, TimeUnit.SECONDS );
-        long elapsedTime = query.elapsedTime();
+        long elapsedTime = query.elapsedTimeMillis();
 
         // then
         assertEquals( 10_000, elapsedTime );
@@ -86,13 +86,13 @@ public class ExecutingQueryTest
             // then
             assertThat( query.status(), CoreMatchers.<Map<String,Object>>allOf(
                     hasEntry( "state", "WAITING" ),
-                    hasEntry( "time", 5_000L ),
+                    hasEntry( "waitTimeMillis", 5_000L ),
                     hasEntry( "resourceType", "NODE" ),
                     hasEntry( equalTo( "resourceIds" ), longArray( 17 ) ) ) );
-            assertEquals( 5_000, query.waitTime() );
+            assertEquals( 5_000, query.waitTimeMillis() );
         }
         assertEquals( singletonMap( "state", "RUNNING" ), query.status() );
-        assertEquals( 5_000, query.waitTime() );
+        assertEquals( 5_000, query.waitTimeMillis() );
 
         // when
         clock.forward( 2, TimeUnit.SECONDS );
@@ -103,13 +103,13 @@ public class ExecutingQueryTest
             // then
             assertThat( query.status(), CoreMatchers.<Map<String,Object>>allOf(
                     hasEntry( "state", "WAITING" ),
-                    hasEntry( "time", 1_000L ),
+                    hasEntry( "waitTimeMillis", 1_000L ),
                     hasEntry( "resourceType", "RELATIONSHIP" ),
                     hasEntry( equalTo( "resourceIds" ), longArray( 612 ) ) ) );
-            assertEquals( 6_000, query.waitTime() );
+            assertEquals( 6_000, query.waitTimeMillis() );
         }
         assertEquals( singletonMap( "state", "RUNNING" ), query.status() );
-        assertEquals( 6_000, query.waitTime() );
+        assertEquals( 6_000, query.waitTimeMillis() );
     }
 
     @Test
@@ -119,10 +119,10 @@ public class ExecutingQueryTest
         cpuClock.add( 60, TimeUnit.MILLISECONDS );
 
         // when
-        long cpuTime = query.cpuTime();
+        long cpuTime = query.cpuTimeMicros();
 
         // then
-        assertEquals( 60_000_000, cpuTime );
+        assertEquals( 60_000, cpuTime );
     }
 
     private Locks.WaitEvent lock( String resourceType, long resourceId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -31,7 +31,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockWaitEvent;
 import org.neo4j.kernel.impl.query.QuerySource;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
@@ -79,7 +79,7 @@ public class ExecutingQueryTest
 
         // when
         clock.forward( 10, TimeUnit.SECONDS );
-        try ( Locks.WaitEvent event = lock( "NODE", 17 ) )
+        try ( LockWaitEvent event = lock( "NODE", 17 ) )
         {
             clock.forward( 5, TimeUnit.SECONDS );
 
@@ -96,7 +96,7 @@ public class ExecutingQueryTest
 
         // when
         clock.forward( 2, TimeUnit.SECONDS );
-        try ( Locks.WaitEvent event = lock( "RELATIONSHIP", 612 ) )
+        try ( LockWaitEvent event = lock( "RELATIONSHIP", 612 ) )
         {
             clock.forward( 1, TimeUnit.SECONDS );
 
@@ -125,7 +125,7 @@ public class ExecutingQueryTest
         assertEquals( 60_000, cpuTime );
     }
 
-    private Locks.WaitEvent lock( String resourceType, long resourceId )
+    private LockWaitEvent lock( String resourceType, long resourceId )
     {
         return query.lockTracer().waitForLock( resourceType( resourceType ), resourceId );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocks;
@@ -87,7 +88,7 @@ public class KernelTransactionFactory
                 mock( Pool.class ),
                 Clocks.systemClock(),
                 NULL,
-                storageEngine, new CanWrite() );
+                LockTracer.NONE, storageEngine, new CanWrite() );
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -49,6 +49,21 @@ public class ExecutingQueryListTest
     }
 
     @Test
+    public void shouldNotChangeAListWhenRemovingAQueryThatIsNotInTheList() throws Exception
+    {
+        // given
+        ExecutingQuery query1 = createExecutingQuery( 1, "query1" );
+        ExecutingQuery query2 = createExecutingQuery( 2, "query2" );
+        ExecutingQueryList list = ExecutingQueryList.EMPTY.push( query1 );
+
+        // when
+        ExecutingQueryList result = list.remove( query2 );
+
+        // then
+        assertThat( result, equalTo( list ) );
+    }
+
+    @Test
     public void addingQueriesKeepsInsertOrder()
     {
         // Given

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.impl.query.QuerySource;
+import org.neo4j.time.CpuClock;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
@@ -114,6 +115,6 @@ public class ExecutingQueryListTest
     private ExecutingQuery createExecutingQuery( int queryId, String query )
     {
         return new ExecutingQuery( queryId, QuerySource.UNKNOWN, "me", query,
-                Collections.emptyMap(), 10, Collections.emptyMap() );
+                Collections.emptyMap(), 10, Collections.emptyMap(), Thread.currentThread(), CpuClock.CPU_CLOCK );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -21,12 +21,14 @@ package org.neo4j.kernel.impl.api;
 
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.impl.query.QuerySource;
+import org.neo4j.time.Clocks;
 import org.neo4j.time.CpuClock;
 
 import static java.util.Arrays.asList;
@@ -115,6 +117,9 @@ public class ExecutingQueryListTest
     private ExecutingQuery createExecutingQuery( int queryId, String query )
     {
         return new ExecutingQuery( queryId, QuerySource.UNKNOWN, "me", query,
-                Collections.emptyMap(), 10, Collections.emptyMap(), Thread.currentThread(), CpuClock.CPU_CLOCK );
+                Collections.emptyMap(), Collections.emptyMap(), Thread.currentThread(),
+                Clocks.nanoClock(),
+                CpuClock.CPU_CLOCK
+        );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -46,7 +47,8 @@ public class KernelStatementTest
         when( transaction.getReasonIfTerminated() ).thenReturn( Optional.of( Status.Transaction.Terminated ) );
         when( transaction.securityContext() ).thenReturn( AUTH_DISABLED );
 
-        KernelStatement statement = new KernelStatement( transaction, null, mock( StorageStatement.class ), null, new CanWrite() );
+        KernelStatement statement = new KernelStatement( transaction, null, mock( StorageStatement.class ), null, new CanWrite(),
+                LockTracer.NONE );
         statement.acquire();
 
         statement.readOperations().nodeExists( 0 );
@@ -58,7 +60,7 @@ public class KernelStatementTest
         // given
         StorageStatement storeStatement = mock( StorageStatement.class );
         KernelStatement statement = new KernelStatement( mock( KernelTransactionImplementation.class ),
-                null, storeStatement, new Procedures(), new CanWrite() );
+                null, storeStatement, new Procedures(), new CanWrite(), LockTracer.NONE );
         statement.acquire();
 
         // when
@@ -77,7 +79,7 @@ public class KernelStatementTest
         AccessCapability accessCapability = mock( AccessCapability.class );
         Procedures procedures = mock( Procedures.class );
         KernelStatement statement = new KernelStatement( transaction, txStateHolder,
-                storeStatement, procedures, accessCapability );
+                storeStatement, procedures, accessCapability, LockTracer.NONE );
 
         statement.assertOpen();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -332,7 +333,7 @@ public class KernelTransactionTerminationTest
                     mock( ConstraintIndexCreator.class ), new Procedures(), TransactionHeaderInformationFactory.DEFAULT,
                     mock( TransactionCommitProcess.class ), monitor, () -> mock( LegacyIndexTransactionState.class ),
                     mock( Pool.class ), Clocks.fakeClock(), TransactionTracer.NULL,
-                    mock( StorageEngine.class, RETURNS_MOCKS ), new CanWrite() );
+                    LockTracer.NONE, mock( StorageEngine.class, RETURNS_MOCKS ), new CanWrite() );
 
             this.monitor = monitor;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
@@ -138,7 +139,7 @@ public class KernelTransactionTestBase
     {
         return new KernelTransactionImplementation( operationContainer, schemaWriteGuard,
                 hooks, null, null, headerInformationFactory, commitProcess, transactionMonitor, legacyIndexStateSupplier,
-                txPool, clock, TransactionTracer.NULL, storageEngine, new CanWrite() );
+                txPool, clock, TransactionTracer.NULL, LockTracer.NONE, storageEngine, new CanWrite() );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -87,7 +87,7 @@ public class LockingStatementOperationsTest
     private final KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
     private final TxState txState = new TxState();
     private final KernelStatement state = new KernelStatement( transaction, new SimpleTxStateHolder( txState ),
-            mock( StorageStatement.class ), new Procedures(), new CanWrite() );
+            mock( StorageStatement.class ), new Procedures(), new CanWrite(), LockTracer.NONE );
     private final SchemaStateOperations schemaStateOps;
 
     public LockingStatementOperationsTest()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -112,7 +112,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -124,7 +124,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -135,7 +135,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -149,7 +149,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -164,7 +164,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -178,7 +178,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -190,7 +190,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeDelete( state, 123 );
 
         //THEN
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeDelete( state, 123 );
     }
 
@@ -202,7 +202,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeDelete( state, 123 );
 
         //THEN
-        order.verify( locks, never() ).acquireExclusive( ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeDelete( state, 123 );
     }
 
@@ -218,7 +218,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( rule, result );
-        order.verify( locks ).acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).indexCreate( state, 123, 456 );
     }
 
@@ -232,7 +232,7 @@ public class LockingStatementOperationsTest
         lockingOps.indexDrop( state, rule );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).indexDrop( state, rule );
     }
 
@@ -248,7 +248,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( rules, result );
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).indexesGetAll( state );
     }
 
@@ -264,7 +264,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraint, result );
-        order.verify( locks ).acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).uniquePropertyConstraintCreate( state, 123, 456 );
     }
 
@@ -278,7 +278,7 @@ public class LockingStatementOperationsTest
         lockingOps.constraintDrop( state, constraint );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).constraintDrop( state, constraint );
     }
 
@@ -294,7 +294,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetForLabelAndPropertyKey( state, 123, 456 );
     }
 
@@ -310,7 +310,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetForLabel( state, 123 );
     }
 
@@ -326,7 +326,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetAll( state );
     }
 
@@ -340,7 +340,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateGetOrCreate( state, null, creator );
 
         // then
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateGetOrCreate( state, null, creator );
     }
 
@@ -351,7 +351,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateContains( state, null );
 
         // then
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateContains( state, null );
     }
 
@@ -362,7 +362,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateFlush( state );
 
         // then
-        order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateFlush( state );
     }
 
@@ -373,8 +373,8 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipCreate( state, 1, 2, 3 );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 2 );
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 3 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 2 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 3 );
         order.verify( entityWriteOps ).relationshipCreate( state, 1, 2, 3 );
     }
 
@@ -391,8 +391,8 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
             lockingOrder.verifyNoMoreInteractions();
             reset( locks );
         }
@@ -403,8 +403,8 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
             lockingOrder.verifyNoMoreInteractions();
         }
     }
@@ -433,9 +433,9 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, highId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
             lockingOrder.verifyNoMoreInteractions();
             reset( locks );
         }
@@ -455,9 +455,9 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, highId );
-            lockingOrder.verify( locks ).acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
             lockingOrder.verifyNoMoreInteractions();
         }
     }
@@ -472,7 +472,7 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireExclusive( ResourceTypes.RELATIONSHIP, 123 );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
         order.verify( entityWriteOps ).relationshipSetProperty( state, 123, property );
     }
 
@@ -487,7 +487,7 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipSetProperty( state, 123, property );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( ResourceTypes.RELATIONSHIP, 123 );
+        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
         order.verify( entityWriteOps ).relationshipSetProperty( state, 123, property );
     }
 
@@ -504,7 +504,7 @@ public class LockingStatementOperationsTest
 
         lockingOps.nodeDetachDelete( state, nodeId );
 
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, nodeId );
         order.verify( entityWriteOps ).nodeDetachDelete( state, nodeId );
     }
@@ -534,8 +534,8 @@ public class LockingStatementOperationsTest
 
         lockingOps.nodeDetachDelete( state, startNodeId );
 
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, startNodeId );
-        order.verify( locks ).acquireExclusive( ResourceTypes.NODE, endNodeId );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, startNodeId );
+        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, endNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, startNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, endNodeId );
         order.verify( entityWriteOps ).nodeDetachDelete( state, startNodeId );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -51,6 +51,7 @@ import org.neo4j.kernel.impl.api.store.CursorRelationshipIterator;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.api.store.StoreSingleNodeCursor;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
@@ -112,7 +113,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -124,7 +125,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -135,7 +136,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
@@ -149,7 +150,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -164,7 +165,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -178,7 +179,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
@@ -190,7 +191,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeDelete( state, 123 );
 
         //THEN
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeDelete( state, 123 );
     }
 
@@ -202,7 +203,7 @@ public class LockingStatementOperationsTest
         lockingOps.nodeDelete( state, 123 );
 
         //THEN
-        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
         order.verify( entityWriteOps ).nodeDelete( state, 123 );
     }
 
@@ -218,7 +219,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( rule, result );
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).indexCreate( state, 123, 456 );
     }
 
@@ -232,7 +233,7 @@ public class LockingStatementOperationsTest
         lockingOps.indexDrop( state, rule );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).indexDrop( state, rule );
     }
 
@@ -248,7 +249,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( rules, result );
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).indexesGetAll( state );
     }
 
@@ -264,7 +265,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraint, result );
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).uniquePropertyConstraintCreate( state, 123, 456 );
     }
 
@@ -278,7 +279,7 @@ public class LockingStatementOperationsTest
         lockingOps.constraintDrop( state, constraint );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).constraintDrop( state, constraint );
     }
 
@@ -294,7 +295,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetForLabelAndPropertyKey( state, 123, 456 );
     }
 
@@ -310,7 +311,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetForLabel( state, 123 );
     }
 
@@ -326,7 +327,7 @@ public class LockingStatementOperationsTest
 
         // then
         assertSame( constraints, result );
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaReadOps ).constraintsGetAll( state );
     }
 
@@ -340,7 +341,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateGetOrCreate( state, null, creator );
 
         // then
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateGetOrCreate( state, null, creator );
     }
 
@@ -351,7 +352,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateContains( state, null );
 
         // then
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateContains( state, null );
     }
 
@@ -362,7 +363,7 @@ public class LockingStatementOperationsTest
         lockingOps.schemaStateFlush( state );
 
         // then
-        order.verify( locks ).acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaStateOps ).schemaStateFlush( state );
     }
 
@@ -373,8 +374,8 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipCreate( state, 1, 2, 3 );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 2 );
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 3 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 2 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3 );
         order.verify( entityWriteOps ).relationshipCreate( state, 1, 2, 3 );
     }
 
@@ -391,8 +392,8 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
             lockingOrder.verifyNoMoreInteractions();
             reset( locks );
         }
@@ -403,8 +404,8 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
             lockingOrder.verifyNoMoreInteractions();
         }
     }
@@ -433,9 +434,9 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
             lockingOrder.verifyNoMoreInteractions();
             reset( locks );
         }
@@ -455,9 +456,9 @@ public class LockingStatementOperationsTest
 
             // THEN
             InOrder lockingOrder = inOrder( locks );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, lowId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, highId );
-            lockingOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
             lockingOrder.verifyNoMoreInteractions();
         }
     }
@@ -472,7 +473,7 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipSetProperty( state, 123, property );
 
         // then
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
         order.verify( entityWriteOps ).relationshipSetProperty( state, 123, property );
     }
 
@@ -487,7 +488,7 @@ public class LockingStatementOperationsTest
         lockingOps.relationshipSetProperty( state, 123, property );
 
         // then
-        order.verify( locks, never() ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
+        order.verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 123 );
         order.verify( entityWriteOps ).relationshipSetProperty( state, 123, property );
     }
 
@@ -504,7 +505,7 @@ public class LockingStatementOperationsTest
 
         lockingOps.nodeDetachDelete( state, nodeId );
 
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, nodeId );
         order.verify( entityWriteOps ).nodeDetachDelete( state, nodeId );
     }
@@ -534,8 +535,8 @@ public class LockingStatementOperationsTest
 
         lockingOps.nodeDetachDelete( state, startNodeId );
 
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, startNodeId );
-        order.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, endNodeId );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, startNodeId );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, endNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, startNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, endNodeId );
         order.verify( entityWriteOps ).nodeDetachDelete( state, startNodeId );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -70,6 +71,7 @@ public class StatementLifecycleTest
     private KernelStatement getKernelStatement( KernelTransactionImplementation transaction,
             StorageStatement storageStatement )
     {
-        return new KernelStatement( transaction, null, storageStatement, new Procedures(), new CanWrite() );
+        return new KernelStatement( transaction, null, storageStatement, new Procedures(), new CanWrite(),
+                LockTracer.NONE );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.util.HashSet;
-import java.util.NoSuchElementException;
-import java.util.Set;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.function.ThrowingConsumer;
@@ -62,6 +62,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
 
     {
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
+        when( state.lockTracer() ).thenReturn( Locks.Tracer.NONE );
     }
 
     @Test
@@ -82,10 +83,10 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 43L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
     }
 
@@ -107,18 +108,18 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
 
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 40L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 41L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, nodeId );
 
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( ResourceTypes.NODE, 43L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
     }
 
@@ -131,7 +132,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
 
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
-        verify( locks ).acquireExclusive( ResourceTypes.NODE, nodeId );
+        verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
         verifyNoMoreInteractions( locks );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
@@ -62,7 +63,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
 
     {
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
-        when( state.lockTracer() ).thenReturn( Locks.Tracer.NONE );
+        when( state.lockTracer() ).thenReturn( LockTracer.NONE );
     }
 
     @Test
@@ -83,10 +84,10 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 43L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
     }
 
@@ -108,18 +109,18 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
 
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 40L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 41L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, nodeId );
 
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 43L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
     }
 
@@ -132,7 +133,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
 
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
-        verify( locks ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, nodeId );
+        verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
         verifyNoMoreInteractions( locks );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -61,6 +61,7 @@ public class ConstraintEnforcingEntityOperationsTest
         when( schemaReadOps.indexGetState( state, indexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
         this.locks = mock( Locks.Client.class );
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
+        when( state.lockTracer() ).thenReturn( Locks.Tracer.NONE );
 
         this.ops = new ConstraintEnforcingEntityOperations( new StandardConstraintSemantics(), null, readOps, schemaWriteOps, schemaReadOps );
     }
@@ -77,7 +78,9 @@ public class ConstraintEnforcingEntityOperationsTest
 
         // then
         assertEquals( expectedNodeId, nodeId );
-        verify( locks).acquireShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
+        verify( locks).acquireShared(
+                Locks.Tracer.NONE,
+                INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verifyNoMoreInteractions( locks );
     }
 
@@ -92,8 +95,12 @@ public class ConstraintEnforcingEntityOperationsTest
 
         // then
         assertEquals( NO_SUCH_NODE, nodeId );
-        verify( locks ).acquireShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
-        verify( locks ).acquireExclusive( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
+        verify( locks ).acquireShared(
+                Locks.Tracer.NONE,
+                INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
+        verify( locks ).acquireExclusive(
+                Locks.Tracer.NONE,
+                INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verifyNoMoreInteractions( locks );
     }
@@ -112,8 +119,12 @@ public class ConstraintEnforcingEntityOperationsTest
 
         // then
         assertEquals( expectedNodeId, nodeId );
-        verify( locks, times(2) ).acquireShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
-        verify( locks ).acquireExclusive( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
+        verify( locks, times(2) ).acquireShared(
+                Locks.Tracer.NONE,
+                INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
+        verify( locks ).acquireExclusive(
+                Locks.Tracer.NONE,
+                INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseExclusive( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verifyNoMoreInteractions( locks );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.impl.api.ConstraintEnforcingEntityOperations;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 
@@ -61,7 +62,7 @@ public class ConstraintEnforcingEntityOperationsTest
         when( schemaReadOps.indexGetState( state, indexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
         this.locks = mock( Locks.Client.class );
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
-        when( state.lockTracer() ).thenReturn( Locks.Tracer.NONE );
+        when( state.lockTracer() ).thenReturn( LockTracer.NONE );
 
         this.ops = new ConstraintEnforcingEntityOperations( new StandardConstraintSemantics(), null, readOps, schemaWriteOps, schemaReadOps );
     }
@@ -79,7 +80,7 @@ public class ConstraintEnforcingEntityOperationsTest
         // then
         assertEquals( expectedNodeId, nodeId );
         verify( locks).acquireShared(
-                Locks.Tracer.NONE,
+                LockTracer.NONE,
                 INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verifyNoMoreInteractions( locks );
     }
@@ -96,10 +97,10 @@ public class ConstraintEnforcingEntityOperationsTest
         // then
         assertEquals( NO_SUCH_NODE, nodeId );
         verify( locks ).acquireShared(
-                Locks.Tracer.NONE,
+                LockTracer.NONE,
                 INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).acquireExclusive(
-                Locks.Tracer.NONE,
+                LockTracer.NONE,
                 INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verifyNoMoreInteractions( locks );
@@ -120,10 +121,10 @@ public class ConstraintEnforcingEntityOperationsTest
         // then
         assertEquals( expectedNodeId, nodeId );
         verify( locks, times(2) ).acquireShared(
-                Locks.Tracer.NONE,
+                LockTracer.NONE,
                 INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).acquireExclusive(
-                Locks.Tracer.NONE,
+                LockTracer.NONE,
                 INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseShared( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );
         verify( locks ).releaseExclusive( INDEX_ENTRY, indexEntryResourceId( labelId, propertyKeyId, value ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.factory.CanWrite;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -66,7 +67,8 @@ public abstract class DiskLayerTest
         db = (GraphDatabaseAPI) createGraphDatabase();
         DependencyResolver resolver = db.getDependencyResolver();
         this.disk = resolver.resolveDependency( StorageEngine.class ).storeReadLayer();
-        this.state = new KernelStatement( null, null, disk.newStatement(), new Procedures(), new CanWrite() );
+        this.state = new KernelStatement( null, null, disk.newStatement(), new Procedures(), new CanWrite(),
+                LockTracer.NONE );
     }
 
     protected GraphDatabaseService createGraphDatabase()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -47,7 +47,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -66,7 +66,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
         clientC.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // But exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -83,7 +83,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -44,7 +44,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void exclusiveShouldWaitForExclusive() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -60,10 +60,10 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void exclusiveShouldWaitForShared() throws Exception
     {
         // When
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then other shared locks are allowed
-        clientC.acquireShared( NODE, 1L );
+        clientC.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // But exclusive locks should wait
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -80,7 +80,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void sharedShouldWaitForExclusive() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
         Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -135,7 +135,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void shouldUpgradeExclusiveOnTry() throws Exception
     {
         // Given I've grabbed a shared lock
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // When
         assertTrue( clientA.tryExclusiveLock( NODE, 1L ) );
@@ -147,7 +147,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleSharedLocks()
     {
-        clientA.acquireShared( NODE, 10, 100, 1000 );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
 
         assertFalse( clientB.tryExclusiveLock( NODE, 10 ) );
         assertFalse( clientB.tryExclusiveLock( NODE, 100 ) );
@@ -159,7 +159,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleExclusiveLocks()
     {
-        clientA.acquireExclusive( NODE, 10, 100, 1000 );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -171,8 +171,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleAlreadyAcquiredSharedLocks()
     {
-        clientA.acquireShared( NODE, 10, 100, 1000 );
-        clientA.acquireShared( NODE, 100, 1000, 10000 );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.tryExclusiveLock( NODE, 10 ) );
         assertFalse( clientB.tryExclusiveLock( NODE, 100 ) );
@@ -185,8 +185,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleAlreadyAcquiredExclusiveLocks()
     {
-        clientA.acquireExclusive( NODE, 10, 100, 1000 );
-        clientA.acquireExclusive( NODE, 100, 1000, 10000 );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -199,8 +199,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleSharedLocksWhileHavingSomeExclusiveLocks()
     {
-        clientA.acquireExclusive( NODE, 10, 100, 1000 );
-        clientA.acquireShared( NODE, 100, 1000, 10000 );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -213,7 +213,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldReleaseSharedLocksAcquiredInABatch()
     {
-        clientA.acquireShared( NODE, 1, 10, 100 );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1, 10, 100 );
         assertEquals( 3, lockCount() );
 
         clientA.releaseShared( NODE, 1 );
@@ -229,7 +229,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldReleaseExclusiveLocksAcquiredInABatch()
     {
-        clientA.acquireExclusive( NODE, 1, 10, 100 );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1, 10, 100 );
         assertEquals( 3, lockCount() );
 
         clientA.releaseExclusive( NODE, 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquireAndReleaseLocksCompatibility.java
@@ -44,10 +44,10 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void exclusiveShouldWaitForExclusive() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // Then
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -60,13 +60,13 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void exclusiveShouldWaitForShared() throws Exception
     {
         // When
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // Then other shared locks are allowed
-        clientC.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientC.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // But exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -80,10 +80,10 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void sharedShouldWaitForExclusive() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -135,7 +135,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     public void shouldUpgradeExclusiveOnTry() throws Exception
     {
         // Given I've grabbed a shared lock
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // When
         assertTrue( clientA.tryExclusiveLock( NODE, 1L ) );
@@ -147,7 +147,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleSharedLocks()
     {
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 10, 100, 1000 );
 
         assertFalse( clientB.tryExclusiveLock( NODE, 10 ) );
         assertFalse( clientB.tryExclusiveLock( NODE, 100 ) );
@@ -159,7 +159,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleExclusiveLocks()
     {
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 10, 100, 1000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -171,8 +171,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleAlreadyAcquiredSharedLocks()
     {
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.tryExclusiveLock( NODE, 10 ) );
         assertFalse( clientB.tryExclusiveLock( NODE, 100 ) );
@@ -185,8 +185,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleAlreadyAcquiredExclusiveLocks()
     {
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -199,8 +199,8 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldAcquireMultipleSharedLocksWhileHavingSomeExclusiveLocks()
     {
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 10, 100, 1000 );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 100, 1000, 10000 );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 10, 100, 1000 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 100, 1000, 10000 );
 
         assertFalse( clientB.trySharedLock( NODE, 10 ) );
         assertFalse( clientB.trySharedLock( NODE, 100 ) );
@@ -213,7 +213,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldReleaseSharedLocksAcquiredInABatch()
     {
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1, 10, 100 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1, 10, 100 );
         assertEquals( 3, lockCount() );
 
         clientA.releaseShared( NODE, 1 );
@@ -229,7 +229,7 @@ public class AcquireAndReleaseLocksCompatibility extends LockingCompatibilityTes
     @Test
     public void shouldReleaseExclusiveLocksAcquiredInABatch()
     {
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1, 10, 100 );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1, 10, 100 );
         assertEquals( 3, lockCount() );
 
         clientA.releaseExclusive( NODE, 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
@@ -78,10 +78,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateSharedLockAcquisition() throws ExecutionException, InterruptedException
     {
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> sharedLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client2.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -94,10 +94,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateExclusiveLockAcquisitionForExclusivelyLockedResource() throws InterruptedException
     {
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -110,10 +110,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test (timeout = TEST_TIMEOUT)
     public void terminateExclusiveLockAcquisitionForSharedLockedResource() throws InterruptedException
     {
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -126,11 +126,11 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateExclusiveLockAcquisitionForSharedLockedResourceWithSharedLockHeld() throws InterruptedException
     {
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client2.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client2.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
@@ -78,10 +78,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateSharedLockAcquisition() throws ExecutionException, InterruptedException
     {
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> sharedLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireShared( ResourceTypes.NODE, 1 );
+            client2.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -94,10 +94,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateExclusiveLockAcquisitionForExclusivelyLockedResource() throws InterruptedException
     {
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -110,10 +110,10 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test (timeout = TEST_TIMEOUT)
     public void terminateExclusiveLockAcquisitionForSharedLockedResource() throws InterruptedException
     {
-        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 
@@ -126,11 +126,11 @@ public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSui
     @Test( timeout = TEST_TIMEOUT )
     public void terminateExclusiveLockAcquisitionForSharedLockedResourceWithSharedLockHeld() throws InterruptedException
     {
-        client.acquireShared( ResourceTypes.NODE, 1 );
-        client2.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client2.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         Future<Boolean> exclusiveLockAcquisition = threadB.execute( state ->
         {
-            client2.acquireExclusive( ResourceTypes.NODE, 1 );
+            client2.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             return true;
         } );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -43,7 +43,7 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
         // GIVEN a lock manager and working clients
         try ( Client client = locks.newClient() )
         {
-            client.acquireExclusive( ResourceTypes.NODE, 0 );
+            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0 );
         }
 
         // WHEN
@@ -65,9 +65,9 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
     public void closeShouldWaitAllOperationToFinish()
     {
         // given
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireShared( NODE, 3L );
-        clientB.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 3L );
+        clientB.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         acquireShared( clientC, NODE, 2L );
         acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
         acquireExclusive( clientC, NODE, 1L ).callAndAssertWaiting();
@@ -91,14 +91,14 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
     public void shouldNotBeAbleToAcquireSharedLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
     }
 
     @Test( expected = LockClientStoppedException.class )
     public void shouldNotBeAbleToAcquireExclusiveLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
     }
 
     @Test( expected = LockClientStoppedException.class )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -43,7 +43,7 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
         // GIVEN a lock manager and working clients
         try ( Client client = locks.newClient() )
         {
-            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0 );
+            client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 0 );
         }
 
         // WHEN
@@ -65,12 +65,12 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
     public void closeShouldWaitAllOperationToFinish()
     {
         // given
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 3L );
-        clientB.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        acquireShared( clientC, Locks.Tracer.NONE, NODE, 2L );
-        acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
-        acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 3L );
+        clientB.acquireShared( LockTracer.NONE, NODE, 1L );
+        acquireShared( clientC, LockTracer.NONE, NODE, 2L );
+        acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientC, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientB.close();
@@ -91,14 +91,14 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
     public void shouldNotBeAbleToAcquireSharedLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
     }
 
     @Test( expected = LockClientStoppedException.class )
     public void shouldNotBeAbleToAcquireExclusiveLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
     }
 
     @Test( expected = LockClientStoppedException.class )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -68,9 +68,9 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 3L );
         clientB.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        acquireShared( clientC, NODE, 2L );
-        acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
-        acquireExclusive( clientC, NODE, 1L ).callAndAssertWaiting();
+        acquireShared( clientC, Locks.Tracer.NONE, NODE, 2L );
+        acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientB.close();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
@@ -56,24 +56,24 @@ public class DeadlockCompatibility extends LockingCompatibilityTestSuite.Compati
     public void shouldDetectTwoClientExclusiveDeadlock() throws Exception
     {
         assertDetectsDeadlock(
-                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 1L ),
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
+                acquireExclusive( clientA, LockTracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 2L ),
 
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
-                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 2L ) );
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ),
+                acquireExclusive( clientA, LockTracer.NONE, NODE, 2L ) );
     }
 
     @Test
     public void shouldDetectThreeClientExclusiveDeadlock() throws Exception
     {
         assertDetectsDeadlock(
-                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 1L ),
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
-                acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 3L ),
+                acquireExclusive( clientA, LockTracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 2L ),
+                acquireExclusive( clientC, LockTracer.NONE, NODE, 3L ),
 
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
-                acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 2L ),
-                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 3L ) );
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ),
+                acquireExclusive( clientC, LockTracer.NONE, NODE, 2L ),
+                acquireExclusive( clientA, LockTracer.NONE, NODE, 3L ) );
     }
 
     @Test
@@ -81,11 +81,11 @@ public class DeadlockCompatibility extends LockingCompatibilityTestSuite.Compati
     {
         assertDetectsDeadlock(
 
-                acquireShared( clientA, Locks.Tracer.NONE, NODE, 1L ),
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
+                acquireShared( clientA, LockTracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 2L ),
 
-                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
-                acquireShared( clientA, Locks.Tracer.NONE, NODE, 2L ) );
+                acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ),
+                acquireShared( clientA, LockTracer.NONE, NODE, 2L ) );
     }
 
     private void assertDetectsDeadlock( LockCommand... commands )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/DeadlockCompatibility.java
@@ -56,24 +56,24 @@ public class DeadlockCompatibility extends LockingCompatibilityTestSuite.Compati
     public void shouldDetectTwoClientExclusiveDeadlock() throws Exception
     {
         assertDetectsDeadlock(
-                acquireExclusive( clientA, NODE, 1L ),
-                acquireExclusive( clientB, NODE, 2L ),
+                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
 
-                acquireExclusive( clientB, NODE, 1L ),
-                acquireExclusive( clientA, NODE, 2L ) );
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
+                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 2L ) );
     }
 
     @Test
     public void shouldDetectThreeClientExclusiveDeadlock() throws Exception
     {
         assertDetectsDeadlock(
-                acquireExclusive( clientA, NODE, 1L ),
-                acquireExclusive( clientB, NODE, 2L ),
-                acquireExclusive( clientC, NODE, 3L ),
+                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
+                acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 3L ),
 
-                acquireExclusive( clientB, NODE, 1L ),
-                acquireExclusive( clientC, NODE, 2L ),
-                acquireExclusive( clientA, NODE, 3L ) );
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
+                acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 2L ),
+                acquireExclusive( clientA, Locks.Tracer.NONE, NODE, 3L ) );
     }
 
     @Test
@@ -81,11 +81,11 @@ public class DeadlockCompatibility extends LockingCompatibilityTestSuite.Compati
     {
         assertDetectsDeadlock(
 
-                acquireShared( clientA, NODE, 1L ),
-                acquireExclusive( clientB, NODE, 2L ),
+                acquireShared( clientA, Locks.Tracer.NONE, NODE, 1L ),
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 2L ),
 
-                acquireExclusive( clientB, NODE, 1L ),
-                acquireShared( clientA, NODE, 2L ) );
+                acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ),
+                acquireShared( clientA, Locks.Tracer.NONE, NODE, 2L ) );
     }
 
     private void assertDetectsDeadlock( LockCommand... commands )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
@@ -41,11 +41,11 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldAcquireExclusiveIfClientIsOnlyOneHoldingShared() throws Exception
     {
         // When
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -64,11 +64,11 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldRetainExclusiveLockAfterReleasingSharedLock() throws Exception
     {
         // When
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -87,11 +87,11 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldRetainSharedLockWhenAcquiredAfterExclusiveLock() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // Then this should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -110,12 +110,12 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void sharedLocksShouldStack() throws Exception
     {
         // When
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -135,12 +135,12 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void exclusiveLocksShouldBeReentrantAndBlockOtherExclusiveLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -160,12 +160,12 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void exclusiveLocksShouldBeReentrantAndBlockOtherSharedLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
         clientA.tryExclusiveLock( NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -185,11 +185,11 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void sharedLocksShouldNotReplaceExclusiveLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -208,14 +208,14 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldUpgradeAndDowngradeSameSharedLock()
     {
         // when
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientB.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientB.acquireShared( LockTracer.NONE, NODE, 1L );
 
         LockIdentityExplorer sharedLockExplorer = new LockIdentityExplorer( NODE, 1L );
         locks.accept( sharedLockExplorer );
 
         // then xclusive should wait for shared from other client to be released
-        Future<Object> exclusiveLockFuture = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> exclusiveLockFuture = acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // and when
         clientA.releaseShared( NODE, 1L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
@@ -41,8 +41,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldAcquireExclusiveIfClientIsOnlyOneHoldingShared() throws Exception
     {
         // When
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -64,8 +64,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldRetainExclusiveLockAfterReleasingSharedLock() throws Exception
     {
         // When
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
         Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -87,8 +87,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldRetainSharedLockWhenAcquiredAfterExclusiveLock() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then this should wait
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -110,9 +110,9 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void sharedLocksShouldStack() throws Exception
     {
         // When
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -135,9 +135,9 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void exclusiveLocksShouldBeReentrantAndBlockOtherExclusiveLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
         Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -160,8 +160,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void exclusiveLocksShouldBeReentrantAndBlockOtherSharedLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         clientA.tryExclusiveLock( NODE, 1L );
 
         // Then exclusive locks should wait
@@ -185,8 +185,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void sharedLocksShouldNotReplaceExclusiveLocks() throws Exception
     {
         // When
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
         Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
@@ -208,8 +208,8 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
     public void shouldUpgradeAndDowngradeSameSharedLock()
     {
         // when
-        clientA.acquireShared( NODE, 1L );
-        clientB.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientB.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         LockIdentityExplorer sharedLockExplorer = new LockIdentityExplorer( NODE, 1L );
         locks.accept( sharedLockExplorer );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
@@ -45,7 +45,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -68,7 +68,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -91,7 +91,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then this should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -115,7 +115,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -140,7 +140,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -165,7 +165,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.tryExclusiveLock( NODE, 1L );
 
         // Then exclusive locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseExclusive( NODE, 1L );
@@ -189,7 +189,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // Then shared locks should wait
-        Future<Object> clientBLock = acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> clientBLock = acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // And when
         clientA.releaseShared( NODE, 1L );
@@ -215,7 +215,7 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
         locks.accept( sharedLockExplorer );
 
         // then xclusive should wait for shared from other client to be released
-        Future<Object> exclusiveLockFuture = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        Future<Object> exclusiveLockFuture = acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // and when
         clientA.releaseShared( NODE, 1L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
@@ -53,7 +53,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state ) throws AcquireLockTimeoutException
             {
                 state.doing( "+R " + resource + ", wait:" + wait );
-                state.client.acquireShared( NODE, resource );
+                state.client.acquireShared( Locks.Tracer.NONE, NODE, resource );
                 state.done();
             }
         }, wait );
@@ -67,7 +67,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state ) throws AcquireLockTimeoutException
             {
                 state.doing( "+W " + resource + ", wait:" + wait );
-                state.client.acquireExclusive( NODE, resource );
+                state.client.acquireExclusive( Locks.Tracer.NONE, NODE, resource );
                 state.done();
             }
         }, wait );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
@@ -53,7 +53,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state ) throws AcquireLockTimeoutException
             {
                 state.doing( "+R " + resource + ", wait:" + wait );
-                state.client.acquireShared( Locks.Tracer.NONE, NODE, resource );
+                state.client.acquireShared( LockTracer.NONE, NODE, resource );
                 state.done();
             }
         }, wait );
@@ -67,7 +67,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
             protected void acquireLock( LockWorkerState state ) throws AcquireLockTimeoutException
             {
                 state.doing( "+W " + resource + ", wait:" + wait );
-                state.client.acquireExclusive( Locks.Tracer.NONE, NODE, resource );
+                state.client.acquireExclusive( LockTracer.NONE, NODE, resource );
                 state.done();
             }
         }, wait );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockWorker.java
@@ -114,7 +114,7 @@ public class LockWorker extends OtherThreadExecutor<LockWorkerState>
         for ( String op : state.completedOperations )
             logger.log( op );
         logger.log( "Doing right now:" );
-        logger.log( state.doing );
+        logger.log( state.doing == null ? "???" : state.doing );
     }
 
     private abstract static class AcquireLockCommand implements WorkerCommand<LockWorkerState, Void>

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -186,7 +186,7 @@ public abstract class LockingCompatibilityTestSuite
                 @Override
                 public void doWork( Locks.Client client ) throws AcquireLockTimeoutException
                 {
-                    client.acquireExclusive( resourceType, key );
+                    client.acquireExclusive( Locks.Tracer.NONE, resourceType, key );
                 }
             };
         }
@@ -201,7 +201,7 @@ public abstract class LockingCompatibilityTestSuite
                 @Override
                 public void doWork( Locks.Client client ) throws AcquireLockTimeoutException
                 {
-                    client.acquireShared( resourceType, key );
+                    client.acquireShared( Locks.Tracer.NONE, resourceType, key );
                 }
             };
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -179,7 +179,7 @@ public abstract class LockingCompatibilityTestSuite
 
         protected LockCommand acquireExclusive(
                 final Locks.Client client,
-                final Locks.Tracer tracer,
+                final LockTracer tracer,
                 final ResourceType resourceType,
                 final long key )
         {
@@ -195,7 +195,7 @@ public abstract class LockingCompatibilityTestSuite
 
         protected LockCommand acquireShared(
                 Locks.Client client,
-                final Locks.Tracer tracer,
+                final LockTracer tracer,
                 final ResourceType resourceType,
                 final long key )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -58,7 +58,8 @@ import static org.neo4j.test.rule.concurrent.OtherThreadRule.isWaiting;
         RWLockCompatibility.class,
         StopCompatibility.class,
         CloseCompatibility.class,
-        AcquisitionTimeoutCompatibility.class
+        AcquisitionTimeoutCompatibility.class,
+        TracerCompatibility.class,
 })
 public abstract class LockingCompatibilityTestSuite
 {
@@ -178,6 +179,7 @@ public abstract class LockingCompatibilityTestSuite
 
         protected LockCommand acquireExclusive(
                 final Locks.Client client,
+                final Locks.Tracer tracer,
                 final ResourceType resourceType,
                 final long key )
         {
@@ -186,13 +188,14 @@ public abstract class LockingCompatibilityTestSuite
                 @Override
                 public void doWork( Locks.Client client ) throws AcquireLockTimeoutException
                 {
-                    client.acquireExclusive( Locks.Tracer.NONE, resourceType, key );
+                    client.acquireExclusive( tracer, resourceType, key );
                 }
             };
         }
 
         protected LockCommand acquireShared(
                 Locks.Client client,
+                final Locks.Tracer tracer,
                 final ResourceType resourceType,
                 final long key )
         {
@@ -201,7 +204,7 @@ public abstract class LockingCompatibilityTestSuite
                 @Override
                 public void doWork( Locks.Client client ) throws AcquireLockTimeoutException
                 {
-                    client.acquireShared( Locks.Tracer.NONE, resourceType, key );
+                    client.acquireShared( tracer, resourceType, key );
                 }
             };
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
@@ -195,7 +195,7 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         }
         catch ( Exception e )
         {
-            LockWorkFailureDump dumper = new LockWorkFailureDump( testDir.directory( getClass().getSimpleName() ) );
+            LockWorkFailureDump dumper = new LockWorkFailureDump( testDir.file( getClass().getSimpleName() ) );
             File file = dumper.dumpState( locks, t1, t2, t3, t4 );
             throw new RuntimeException( "Failed, forensics information dumped to " + file.getAbsolutePath(), e );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
@@ -69,7 +69,7 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
             // good
         }
 
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
         try
         {
             clientA.releaseExclusive( NODE, 1L );
@@ -81,7 +81,7 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         }
 
         clientA.releaseShared( NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
         try
         {
             clientA.releaseShared( NODE, 1L );
@@ -93,13 +93,13 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         }
         clientA.releaseExclusive( NODE, 1L );
 
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
         clientA.releaseExclusive( NODE, 1L );
         clientA.releaseShared( NODE, 1L );
 
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
         clientA.releaseShared( NODE, 1L );
         clientA.releaseExclusive( NODE, 1L );
 
@@ -107,11 +107,11 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         {
             if ( (i % 2) == 0 )
             {
-                clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+                clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
             }
             else
             {
-                clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+                clientA.acquireShared( LockTracer.NONE, NODE, 1L );
             }
         }
         for ( int i = 9; i >= 0; i-- )
@@ -253,12 +253,12 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
                             float f = rand.nextFloat();
                             if ( f < readWriteRatio )
                             {
-                                client.acquireShared( Locks.Tracer.NONE, NODE, nodeId );
+                                client.acquireShared( LockTracer.NONE, NODE, nodeId );
                                 lockStack.push( READ );
                             }
                             else
                             {
-                                client.acquireExclusive( Locks.Tracer.NONE, NODE, nodeId );
+                                client.acquireExclusive( LockTracer.NONE, NODE, nodeId );
                                 lockStack.push( WRITE );
                             }
                         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/RWLockCompatibility.java
@@ -69,7 +69,7 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
             // good
         }
 
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         try
         {
             clientA.releaseExclusive( NODE, 1L );
@@ -81,7 +81,7 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         }
 
         clientA.releaseShared( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         try
         {
             clientA.releaseShared( NODE, 1L );
@@ -93,13 +93,13 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         }
         clientA.releaseExclusive( NODE, 1L );
 
-        clientA.acquireShared( NODE, 1L );
-        clientA.acquireExclusive( NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         clientA.releaseExclusive( NODE, 1L );
         clientA.releaseShared( NODE, 1L );
 
-        clientA.acquireExclusive( NODE, 1L );
-        clientA.acquireShared( NODE, 1L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         clientA.releaseShared( NODE, 1L );
         clientA.releaseExclusive( NODE, 1L );
 
@@ -107,11 +107,11 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
         {
             if ( (i % 2) == 0 )
             {
-                clientA.acquireExclusive( NODE, 1L );
+                clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
             }
             else
             {
-                clientA.acquireShared( NODE, 1L );
+                clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
             }
         }
         for ( int i = 9; i >= 0; i-- )
@@ -253,12 +253,12 @@ public class RWLockCompatibility extends LockingCompatibilityTestSuite.Compatibi
                             float f = rand.nextFloat();
                             if ( f < readWriteRatio )
                             {
-                                client.acquireShared( NODE, nodeId );
+                                client.acquireShared( Locks.Tracer.NONE, NODE, nodeId );
                                 lockStack.push( READ );
                             }
                             else
                             {
-                                client.acquireExclusive( NODE, nodeId );
+                                client.acquireExclusive( Locks.Tracer.NONE, NODE, nodeId );
                                 lockStack.push( WRITE );
                             }
                         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
@@ -81,11 +81,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     public void releaseWriteLockWaitersOnStop()
     {
         // given
-        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
-        clientB.acquireShared( Locks.Tracer.NONE, NODE, 2L );
-        clientC.acquireShared( Locks.Tracer.NONE, NODE, 3L );
-        acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
-        acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        clientA.acquireShared( LockTracer.NONE, NODE, 1L );
+        clientB.acquireShared( LockTracer.NONE, NODE, 2L );
+        clientC.acquireShared( LockTracer.NONE, NODE, 3L );
+        acquireExclusive( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientC, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientC.stop();
@@ -101,9 +101,9 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     @Test
     public void releaseReadLockWaitersOnStop()
     {  // given
-        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
-        clientB.acquireExclusive( Locks.Tracer.NONE, NODE, 2L );
-        acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1L );
+        clientB.acquireExclusive( LockTracer.NONE, NODE, 2L );
+        acquireShared( clientB, LockTracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientB.stop();
@@ -118,13 +118,13 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     @Test( expected = LockClientStoppedException.class )
     public void acquireSharedThrowsWhenClientStopped()
     {
-        stoppedClient().acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        stoppedClient().acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
     }
 
     @Test( expected = LockClientStoppedException.class )
     public void acquireExclusiveThrowsWhenClientStopped()
     {
-        stoppedClient().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        stoppedClient().acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
     }
 
     @Test( expected = LockClientStoppedException.class )
@@ -356,14 +356,14 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
 
     private AcquiredLock acquireSharedLockInThisThread()
     {
-        client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+        client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
         assertLocksHeld( RESOURCE_ID );
         return AcquiredLock.shared( client, RESOURCE_TYPE, RESOURCE_ID );
     }
 
     private AcquiredLock acquireExclusiveLockInThisThread()
     {
-        client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+        client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
         assertLocksHeld( RESOURCE_ID );
         return AcquiredLock.exclusive( client, RESOURCE_TYPE, RESOURCE_ID );
     }
@@ -387,11 +387,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             Locks.Client client = newLockClient( lockAcquisition );
             if ( shared )
             {
-                client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             else
             {
-                client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             return null;
         } );
@@ -413,11 +413,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
                 {
                     if ( firstShared )
                     {
-                        client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                        client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                     }
                     else
                     {
-                        client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                        client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                     }
                     fail( "Transaction termination expected" );
                 }
@@ -435,11 +435,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             {
                 if ( secondShared )
                 {
-                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
             }
             return null;
@@ -458,12 +458,12 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
         {
             try ( Locks.Client client = newLockClient( lockAcquisition ) )
             {
-                client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
 
                 sharedLockAcquired.countDown();
                 await( startExclusiveLock );
 
-                client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             return null;
         } );
@@ -483,22 +483,22 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             {
                 if ( shared )
                 {
-                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
+                    client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
+                    client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
                 }
 
                 firstLockAcquired.countDown();
 
                 if ( shared )
                 {
-                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireShared( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireExclusive( LockTracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
             }
             return null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
@@ -84,8 +84,8 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
         clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         clientB.acquireShared( Locks.Tracer.NONE, NODE, 2L );
         clientC.acquireShared( Locks.Tracer.NONE, NODE, 3L );
-        acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
-        acquireExclusive( clientC, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientC, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientC.stop();
@@ -103,7 +103,7 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     {  // given
         clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         clientB.acquireExclusive( Locks.Tracer.NONE, NODE, 2L );
-        acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+        acquireShared( clientB, Locks.Tracer.NONE, NODE, 1L ).callAndAssertWaiting();
 
         // when
         clientB.stop();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
@@ -81,9 +81,9 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     public void releaseWriteLockWaitersOnStop()
     {
         // given
-        clientA.acquireShared( NODE, 1L );
-        clientB.acquireShared( NODE, 2L );
-        clientC.acquireShared( NODE, 3L );
+        clientA.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        clientB.acquireShared( Locks.Tracer.NONE, NODE, 2L );
+        clientC.acquireShared( Locks.Tracer.NONE, NODE, 3L );
         acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
         acquireExclusive( clientC, NODE, 1L ).callAndAssertWaiting();
 
@@ -101,8 +101,8 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     @Test
     public void releaseReadLockWaitersOnStop()
     {  // given
-        clientA.acquireExclusive( NODE, 1L );
-        clientB.acquireExclusive( NODE, 2L );
+        clientA.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        clientB.acquireExclusive( Locks.Tracer.NONE, NODE, 2L );
         acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
 
         // when
@@ -118,13 +118,13 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
     @Test( expected = LockClientStoppedException.class )
     public void acquireSharedThrowsWhenClientStopped()
     {
-        stoppedClient().acquireShared( ResourceTypes.NODE, 1 );
+        stoppedClient().acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
     }
 
     @Test( expected = LockClientStoppedException.class )
     public void acquireExclusiveThrowsWhenClientStopped()
     {
-        stoppedClient().acquireExclusive( ResourceTypes.NODE, 1 );
+        stoppedClient().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
     }
 
     @Test( expected = LockClientStoppedException.class )
@@ -356,14 +356,14 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
 
     private AcquiredLock acquireSharedLockInThisThread()
     {
-        client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+        client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
         assertLocksHeld( RESOURCE_ID );
         return AcquiredLock.shared( client, RESOURCE_TYPE, RESOURCE_ID );
     }
 
     private AcquiredLock acquireExclusiveLockInThisThread()
     {
-        client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+        client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
         assertLocksHeld( RESOURCE_ID );
         return AcquiredLock.exclusive( client, RESOURCE_TYPE, RESOURCE_ID );
     }
@@ -387,11 +387,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             Locks.Client client = newLockClient( lockAcquisition );
             if ( shared )
             {
-                client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             else
             {
-                client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             return null;
         } );
@@ -413,11 +413,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
                 {
                     if ( firstShared )
                     {
-                        client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+                        client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                     }
                     else
                     {
-                        client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+                        client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                     }
                     fail( "Transaction termination expected" );
                 }
@@ -435,11 +435,11 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             {
                 if ( secondShared )
                 {
-                    client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
             }
             return null;
@@ -458,12 +458,12 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
         {
             try ( Locks.Client client = newLockClient( lockAcquisition ) )
             {
-                client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
 
                 sharedLockAcquired.countDown();
                 await( startExclusiveLock );
 
-                client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+                client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
             }
             return null;
         } );
@@ -483,22 +483,22 @@ public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibili
             {
                 if ( shared )
                 {
-                    client.acquireShared( RESOURCE_TYPE, OTHER_RESOURCE_ID );
+                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( RESOURCE_TYPE, OTHER_RESOURCE_ID );
+                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, OTHER_RESOURCE_ID );
                 }
 
                 firstLockAcquired.countDown();
 
                 if ( shared )
                 {
-                    client.acquireShared( RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireShared( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
                 else
                 {
-                    client.acquireExclusive( RESOURCE_TYPE, RESOURCE_ID );
+                    client.acquireExclusive( Locks.Tracer.NONE, RESOURCE_TYPE, RESOURCE_ID );
                 }
             }
             return null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+import static java.lang.String.format;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
+
+@Ignore( "Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite." )
+public class TracerCompatibility extends LockingCompatibilityTestSuite.Compatibility
+{
+    public TracerCompatibility( LockingCompatibilityTestSuite suite )
+    {
+        super( suite );
+    }
+
+    @Test
+    public void shouldTraceWaitTimeWhenTryingToAcquireExclusiveLockAndExclusiveIsHeld() throws Exception
+    {
+        // given
+        Tracer tracerA = new Tracer(), tracerB = new Tracer();
+        clientA.acquireExclusive( tracerA, NODE, 17 );
+
+        // when
+        Future<Object> future = acquireExclusive( clientB, tracerB, NODE, 17 ).callAndAssertWaiting();
+
+        // then
+        clientA.releaseExclusive( NODE, 17 );
+        future.get();
+        tracerA.assertCalls( 0 );
+        tracerB.assertCalls( 1 );
+    }
+
+    @Test
+    public void shouldTraceWaitTimeWhenTryingToAcquireSharedLockAndExclusiveIsHeld() throws Exception
+    {
+        // given
+        Tracer tracerA = new Tracer(), tracerB = new Tracer();
+        clientA.acquireExclusive( tracerA, NODE, 17 );
+
+        // when
+        Future<Object> future = acquireShared( clientB, tracerB, NODE, 17 ).callAndAssertWaiting();
+
+        // then
+        clientA.releaseExclusive( NODE, 17 );
+        future.get();
+        tracerA.assertCalls( 0 );
+        tracerB.assertCalls( 1 );
+    }
+
+    @Test
+    public void shouldTraceWaitTimeWhenTryingToAcquireExclusiveLockAndSharedIsHeld() throws Exception
+    {
+        // given
+        Tracer tracerA = new Tracer(), tracerB = new Tracer();
+        clientA.acquireShared( tracerA, NODE, 17 );
+
+        // when
+        Future<Object> future = acquireExclusive( clientB, tracerB, NODE, 17 ).callAndAssertWaiting();
+
+        // then
+        clientA.releaseShared( NODE, 17 );
+        future.get();
+        tracerA.assertCalls( 0 );
+        tracerB.assertCalls( 1 );
+    }
+
+    static class Tracer implements Locks.Tracer, Locks.WaitEvent
+    {
+        int done;
+        final List<StackTraceElement[]> waitCalls = new ArrayList<>();
+
+        @Override
+        public Locks.WaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+        {
+            waitCalls.add( Thread.currentThread().getStackTrace() );
+            return this;
+        }
+
+        @Override
+        public void close()
+        {
+            done++;
+        }
+
+        void assertCalls( int expected )
+        {
+            if ( waitCalls.size() != done )
+            {
+                throw withCallTraces( new AssertionError( "Should complete waiting as many times as started." ) );
+            }
+            if ( done != expected )
+            {
+                throw withCallTraces( new AssertionError( format( "Expected %d calls, but got %d", expected, done ) ) );
+            }
+        }
+
+        private <EX extends Throwable> EX withCallTraces( EX failure )
+        {
+            for ( StackTraceElement[] waitCall : waitCalls )
+            {
+                RuntimeException call = new RuntimeException( "Wait called" );
+                call.setStackTrace( waitCall );
+                failure.addSuppressed( call );
+            }
+            return failure;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
@@ -90,13 +90,13 @@ public class TracerCompatibility extends LockingCompatibilityTestSuite.Compatibi
         tracerB.assertCalls( 1 );
     }
 
-    static class Tracer implements Locks.Tracer, Locks.WaitEvent
+    static class Tracer implements LockTracer, LockWaitEvent
     {
         int done;
         final List<StackTraceElement[]> waitCalls = new ArrayList<>();
 
         @Override
-        public Locks.WaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+        public LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
         {
             waitCalls.add( Thread.currentThread().getStackTrace() );
             return this;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.time.Clocks;
 
@@ -47,9 +48,9 @@ public class LockManagerImplTest
         LockManagerImpl lockManager = createLockManager();
 
         // expect
-        assertTrue( lockManager.getReadLock( node1, lockTransaction ) );
-        assertTrue( lockManager.getReadLock( node2, lockTransaction ) );
-        assertTrue( lockManager.getWriteLock( node2, lockTransaction ) );
+        assertTrue( lockManager.getReadLock( Locks.Tracer.NONE, node1, lockTransaction ) );
+        assertTrue( lockManager.getReadLock( Locks.Tracer.NONE, node2, lockTransaction ) );
+        assertTrue( lockManager.getWriteLock( Locks.Tracer.NONE, node2, lockTransaction ) );
 
         lockManager.releaseReadLock( node1, lockTransaction );
         lockManager.releaseReadLock( node2, lockTransaction );
@@ -82,7 +83,7 @@ public class LockManagerImplTest
         LockResource node = new LockResource( ResourceTypes.NODE, 1L );
         LockTransaction lockTransaction = new LockTransaction();
         LockManagerImpl lockManager = createLockManager();
-        lockManager.getWriteLock( node, lockTransaction );
+        lockManager.getWriteLock( Locks.Tracer.NONE, node, lockTransaction );
 
         // expect
         assertTrue( lockManager.tryReadLock( node, lockTransaction ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/LockManagerImplTest.java
@@ -25,7 +25,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.time.Clocks;
 
@@ -48,9 +48,9 @@ public class LockManagerImplTest
         LockManagerImpl lockManager = createLockManager();
 
         // expect
-        assertTrue( lockManager.getReadLock( Locks.Tracer.NONE, node1, lockTransaction ) );
-        assertTrue( lockManager.getReadLock( Locks.Tracer.NONE, node2, lockTransaction ) );
-        assertTrue( lockManager.getWriteLock( Locks.Tracer.NONE, node2, lockTransaction ) );
+        assertTrue( lockManager.getReadLock( LockTracer.NONE, node1, lockTransaction ) );
+        assertTrue( lockManager.getReadLock( LockTracer.NONE, node2, lockTransaction ) );
+        assertTrue( lockManager.getWriteLock( LockTracer.NONE, node2, lockTransaction ) );
 
         lockManager.releaseReadLock( node1, lockTransaction );
         lockManager.releaseReadLock( node2, lockTransaction );
@@ -83,7 +83,7 @@ public class LockManagerImplTest
         LockResource node = new LockResource( ResourceTypes.NODE, 1L );
         LockTransaction lockTransaction = new LockTransaction();
         LockManagerImpl lockManager = createLockManager();
-        lockManager.getWriteLock( Locks.Tracer.NONE, node, lockTransaction );
+        lockManager.getWriteLock( LockTracer.NONE, node, lockTransaction );
 
         // expect
         assertTrue( lockManager.tryReadLock( node, lockTransaction ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.DeadlockDetectedException;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.time.Clocks;
 
@@ -66,7 +66,7 @@ public class RWLockTest
         final Transaction tx1 = mock( Transaction.class );
 
         lock.mark();
-        lock.acquireWriteLock( Locks.Tracer.NONE, tx1 );
+        lock.acquireWriteLock( LockTracer.NONE, tx1 );
         lock.mark();
 
         assertEquals( 1, lock.getTxLockElementCount() );
@@ -83,7 +83,7 @@ public class RWLockTest
         final Transaction tx1 = mock( Transaction.class );
 
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, tx1 );
+        lock.acquireReadLock( LockTracer.NONE, tx1 );
         lock.mark();
 
         assertEquals( 1, lock.getTxLockElementCount() );
@@ -105,9 +105,9 @@ public class RWLockTest
         final LockTransaction anotherTransaction = new LockTransaction();
 
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
+        lock.acquireReadLock( LockTracer.NONE, lockTransaction );
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
+        lock.acquireReadLock( LockTracer.NONE, anotherTransaction );
 
         final CountDownLatch writerCompletedLatch = new CountDownLatch( 1 );
 
@@ -152,7 +152,7 @@ public class RWLockTest
         final CountDownLatch readerCompletedLatch = new CountDownLatch( 1 );
 
         lock.mark();
-        lock.acquireWriteLock( Locks.Tracer.NONE, transaction );
+        lock.acquireWriteLock( LockTracer.NONE, transaction );
 
         Runnable reader = createReader( lock, readerTransaction, readerCompletedLatch );
 
@@ -198,8 +198,8 @@ public class RWLockTest
 
         lock.mark();
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
-        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
+        lock.acquireReadLock( LockTracer.NONE, lockTransaction );
+        lock.acquireReadLock( LockTracer.NONE, anotherTransaction );
 
         // writer will be added to a waiting list
         // then spurious wake up will be simulated
@@ -208,7 +208,7 @@ public class RWLockTest
             try
             {
                 lock.mark();
-                lock.acquireWriteLock( Locks.Tracer.NONE, lockTransaction );
+                lock.acquireWriteLock( LockTracer.NONE, lockTransaction );
             }
             catch ( DeadlockDetectedException ignored )
             {
@@ -251,9 +251,9 @@ public class RWLockTest
         final CountDownLatch writerCompletedLatch = new CountDownLatch( 1 );
 
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
+        lock.acquireReadLock( LockTracer.NONE, lockTransaction );
         lock.mark();
-        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
+        lock.acquireReadLock( LockTracer.NONE, anotherTransaction );
 
         assertEquals( 2, lock.getReadCount() );
         assertEquals( 0, lock.getWriteCount() );
@@ -309,11 +309,11 @@ public class RWLockTest
         final CountDownLatch deadLockDetector = new CountDownLatch( 1 );
 
         lockNode1.mark();
-        lockNode1.acquireWriteLock( Locks.Tracer.NONE, client1Transaction );
+        lockNode1.acquireWriteLock( LockTracer.NONE, client1Transaction );
         lockNode2.mark();
-        lockNode2.acquireWriteLock( Locks.Tracer.NONE, client2Transaction );
+        lockNode2.acquireWriteLock( LockTracer.NONE, client2Transaction );
         lockNode3.mark();
-        lockNode3.acquireWriteLock( Locks.Tracer.NONE, client3Transaction );
+        lockNode3.acquireWriteLock( LockTracer.NONE, client3Transaction );
 
         Runnable readerLockNode2 = createReaderForDeadlock( lockNode3, client1Transaction, deadLockDetector );
         Runnable readerLockNode3 = createReaderForDeadlock( lockNode1, client2Transaction, deadLockDetector );
@@ -350,7 +350,7 @@ public class RWLockTest
 
         // when
         lock.mark();
-        assertTrue( lock.acquireWriteLock( Locks.Tracer.NONE, mainTransaction ) );
+        assertTrue( lock.acquireWriteLock( LockTracer.NONE, mainTransaction ) );
         executor.submit( reader );
         executor.submit( conflictingWriter );
 
@@ -379,7 +379,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            lock.acquireReadLock( Locks.Tracer.NONE, transaction );
+            lock.acquireReadLock( LockTracer.NONE, transaction );
             latch.countDown();
         };
     }
@@ -389,7 +389,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            Assert.assertFalse( lock.acquireReadLock( Locks.Tracer.NONE, transaction ) );
+            Assert.assertFalse( lock.acquireReadLock( LockTracer.NONE, transaction ) );
             latch.countDown();
         };
     }
@@ -399,7 +399,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            lock.acquireWriteLock( Locks.Tracer.NONE, transaction );
+            lock.acquireWriteLock( LockTracer.NONE, transaction );
             latch.countDown();
         };
     }
@@ -409,7 +409,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            Assert.assertFalse( lock.acquireWriteLock( Locks.Tracer.NONE, transaction ) );
+            Assert.assertFalse( lock.acquireWriteLock( LockTracer.NONE, transaction ) );
             latch.countDown();
         };
     }
@@ -421,7 +421,7 @@ public class RWLockTest
             try
             {
                 node.mark();
-                node.acquireReadLock( Locks.Tracer.NONE, transaction );
+                node.acquireReadLock( LockTracer.NONE, transaction );
             }
             catch ( DeadlockDetectedException e )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.time.Clocks;
 
@@ -65,7 +66,7 @@ public class RWLockTest
         final Transaction tx1 = mock( Transaction.class );
 
         lock.mark();
-        lock.acquireWriteLock( tx1 );
+        lock.acquireWriteLock( Locks.Tracer.NONE, tx1 );
         lock.mark();
 
         assertEquals( 1, lock.getTxLockElementCount() );
@@ -82,7 +83,7 @@ public class RWLockTest
         final Transaction tx1 = mock( Transaction.class );
 
         lock.mark();
-        lock.acquireReadLock( tx1 );
+        lock.acquireReadLock( Locks.Tracer.NONE, tx1 );
         lock.mark();
 
         assertEquals( 1, lock.getTxLockElementCount() );
@@ -104,9 +105,9 @@ public class RWLockTest
         final LockTransaction anotherTransaction = new LockTransaction();
 
         lock.mark();
-        lock.acquireReadLock( lockTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
         lock.mark();
-        lock.acquireReadLock( anotherTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
 
         final CountDownLatch writerCompletedLatch = new CountDownLatch( 1 );
 
@@ -151,7 +152,7 @@ public class RWLockTest
         final CountDownLatch readerCompletedLatch = new CountDownLatch( 1 );
 
         lock.mark();
-        lock.acquireWriteLock( transaction );
+        lock.acquireWriteLock( Locks.Tracer.NONE, transaction );
 
         Runnable reader = createReader( lock, readerTransaction, readerCompletedLatch );
 
@@ -197,8 +198,8 @@ public class RWLockTest
 
         lock.mark();
         lock.mark();
-        lock.acquireReadLock( lockTransaction );
-        lock.acquireReadLock( anotherTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
 
         // writer will be added to a waiting list
         // then spurious wake up will be simulated
@@ -207,7 +208,7 @@ public class RWLockTest
             try
             {
                 lock.mark();
-                lock.acquireWriteLock( lockTransaction );
+                lock.acquireWriteLock( Locks.Tracer.NONE, lockTransaction );
             }
             catch ( DeadlockDetectedException ignored )
             {
@@ -250,9 +251,9 @@ public class RWLockTest
         final CountDownLatch writerCompletedLatch = new CountDownLatch( 1 );
 
         lock.mark();
-        lock.acquireReadLock( lockTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, lockTransaction );
         lock.mark();
-        lock.acquireReadLock( anotherTransaction );
+        lock.acquireReadLock( Locks.Tracer.NONE, anotherTransaction );
 
         assertEquals( 2, lock.getReadCount() );
         assertEquals( 0, lock.getWriteCount() );
@@ -308,11 +309,11 @@ public class RWLockTest
         final CountDownLatch deadLockDetector = new CountDownLatch( 1 );
 
         lockNode1.mark();
-        lockNode1.acquireWriteLock( client1Transaction );
+        lockNode1.acquireWriteLock( Locks.Tracer.NONE, client1Transaction );
         lockNode2.mark();
-        lockNode2.acquireWriteLock( client2Transaction );
+        lockNode2.acquireWriteLock( Locks.Tracer.NONE, client2Transaction );
         lockNode3.mark();
-        lockNode3.acquireWriteLock( client3Transaction );
+        lockNode3.acquireWriteLock( Locks.Tracer.NONE, client3Transaction );
 
         Runnable readerLockNode2 = createReaderForDeadlock( lockNode3, client1Transaction, deadLockDetector );
         Runnable readerLockNode3 = createReaderForDeadlock( lockNode1, client2Transaction, deadLockDetector );
@@ -349,7 +350,7 @@ public class RWLockTest
 
         // when
         lock.mark();
-        assertTrue( lock.acquireWriteLock( mainTransaction ) );
+        assertTrue( lock.acquireWriteLock( Locks.Tracer.NONE, mainTransaction ) );
         executor.submit( reader );
         executor.submit( conflictingWriter );
 
@@ -378,7 +379,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            lock.acquireReadLock( transaction );
+            lock.acquireReadLock( Locks.Tracer.NONE, transaction );
             latch.countDown();
         };
     }
@@ -388,7 +389,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            Assert.assertFalse( lock.acquireReadLock( transaction ) );
+            Assert.assertFalse( lock.acquireReadLock( Locks.Tracer.NONE, transaction ) );
             latch.countDown();
         };
     }
@@ -398,7 +399,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            lock.acquireWriteLock( transaction );
+            lock.acquireWriteLock( Locks.Tracer.NONE, transaction );
             latch.countDown();
         };
     }
@@ -408,7 +409,7 @@ public class RWLockTest
     {
         return () -> {
             lock.mark();
-            Assert.assertFalse( lock.acquireWriteLock( transaction ) );
+            Assert.assertFalse( lock.acquireWriteLock( Locks.Tracer.NONE, transaction ) );
             latch.countDown();
         };
     }
@@ -420,7 +421,7 @@ public class RWLockTest
             try
             {
                 node.mark();
-                node.acquireReadLock( transaction );
+                node.acquireReadLock( Locks.Tracer.NONE, transaction );
             }
             catch ( DeadlockDetectedException e )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -32,6 +32,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
@@ -135,7 +136,7 @@ public class RelationshipCreatorTest
         }
 
         @Override
-        public void acquireExclusive( ResourceType resourceType, long... resourceIds )
+        public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
                 throws AcquireLockTimeoutException
         {
             assertEquals( ResourceTypes.RELATIONSHIP, resourceType );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -32,7 +32,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
@@ -136,7 +136,7 @@ public class RelationshipCreatorTest
         }
 
         @Override
-        public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
+        public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds )
                 throws AcquireLockTimeoutException
         {
             assertEquals( ResourceTypes.RELATIONSHIP, resourceType );

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -30,7 +30,7 @@ public class FakeCpuClock extends CpuClock
     private final PrimitiveLongLongMap cpuTimes = Primitive.offHeapLongLongMap();
 
     @Override
-    public long cpuTime( long threadId )
+    public long cpuTimeNanos( long threadId )
     {
         return Math.max( 0, cpuTimes.get( threadId ) );
     }
@@ -47,6 +47,6 @@ public class FakeCpuClock extends CpuClock
 
     public void add( long threadId, long nanos )
     {
-        cpuTimes.put( threadId, cpuTime( threadId ) + nanos );
+        cpuTimes.put( threadId, cpuTimeNanos( threadId ) + nanos );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongLongMap;
+import org.neo4j.time.CpuClock;
+
+public class FakeCpuClock extends CpuClock
+{
+    private final PrimitiveLongLongMap cpuTimes = Primitive.offHeapLongLongMap();
+
+    @Override
+    public long cpuTime( long threadId )
+    {
+        return Math.max( 0, cpuTimes.get( threadId ) );
+    }
+
+    public void add( long delta, TimeUnit unit )
+    {
+        add( unit.toNanos( delta ) );
+    }
+
+    public void add( long nanos )
+    {
+        add( Thread.currentThread().getId(), nanos );
+    }
+
+    public void add( long threadId, long nanos )
+    {
+        cpuTimes.put( threadId, cpuTime( threadId ) + nanos );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/rule/ImpermanentDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/ImpermanentDatabaseRule.java
@@ -61,12 +61,12 @@ public class ImpermanentDatabaseRule extends DatabaseRule
         return ((TestGraphDatabaseFactory) factory).newImpermanentDatabaseBuilder();
     }
 
-    private TestGraphDatabaseFactory maybeSetUserLogProvider( TestGraphDatabaseFactory factory )
+    protected final TestGraphDatabaseFactory maybeSetUserLogProvider( TestGraphDatabaseFactory factory )
     {
         return ( userLogProvider == null ) ? factory : factory.setUserLogProvider( userLogProvider );
     }
 
-    private TestGraphDatabaseFactory maybeSetInternalLogProvider( TestGraphDatabaseFactory factory )
+    protected final TestGraphDatabaseFactory maybeSetInternalLogProvider( TestGraphDatabaseFactory factory )
     {
         return ( internalLogProvider == null ) ? factory : factory.setInternalLogProvider( internalLogProvider );
     }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -67,6 +67,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.logging.NullLog;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.time.Clocks;
 
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
@@ -123,7 +124,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
                 IOLimiter.unlimited(),
-                mock( AvailabilityGuard.class ), Clock.systemUTC(), new CanWrite() );
+                mock( AvailabilityGuard.class ), Clocks.nanoClock(), new CanWrite() );
 
         return dataSource;
     }

--- a/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/CommunityLockAcquisitionTimeoutIT.java
@@ -56,6 +56,7 @@ import org.neo4j.test.mockito.matcher.RootCauseMatcher;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
+import org.neo4j.time.SystemNanoClock;
 
 import static org.junit.Assert.fail;
 
@@ -226,7 +227,7 @@ public class CommunityLockAcquisitionTimeoutIT
         {
             return new PlatformModule( storeDir, params, databaseInfo, dependencies, graphDatabaseFacade ) {
                 @Override
-                protected Clock createClock()
+                protected SystemNanoClock createClock()
                 {
                     return fakeClock;
                 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -202,16 +202,16 @@ public class LeaderOnlyLockManager implements Locks
         }
 
         @Override
-        public void acquireShared( ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
+        public void acquireShared( Tracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
         {
-            localClient.acquireShared( resourceType, resourceId );
+            localClient.acquireShared( tracer, resourceType, resourceId );
         }
 
         @Override
-        public void acquireExclusive( ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
+        public void acquireExclusive( Tracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
         {
             ensureHoldingToken();
-            localClient.acquireExclusive( resourceType, resourceId );
+            localClient.acquireExclusive( tracer, resourceType, resourceId );
         }
 
         @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -27,6 +27,7 @@ import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.causalclustering.core.state.machines.tx.ReplicatedTransactionStateMachine;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.storageengine.api.lock.ResourceType;
@@ -202,13 +203,13 @@ public class LeaderOnlyLockManager implements Locks
         }
 
         @Override
-        public void acquireShared( Tracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
+        public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
         {
             localClient.acquireShared( tracer, resourceType, resourceId );
         }
 
         @Override
-        public void acquireExclusive( Tracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
+        public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceId ) throws AcquireLockTimeoutException
         {
             ensureHoldingToken();
             localClient.acquireExclusive( tracer, resourceType, resourceId );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
@@ -25,6 +25,7 @@ import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.replication.DirectReplicator;
 import org.neo4j.causalclustering.core.state.storage.InMemoryStateStorage;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
@@ -57,7 +58,7 @@ public class LeaderOnlyLockManagerTest
                 new LeaderOnlyLockManager( me, replicator, leaderLocator, locks, replicatedLockStateMachine );
 
         // when
-        lockManager.newClient().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0L );
+        lockManager.newClient().acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 0L );
 
         // then
     }
@@ -85,7 +86,7 @@ public class LeaderOnlyLockManagerTest
         Locks.Client lockClient = lockManager.newClient();
         try
         {
-            lockClient.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0L );
+            lockClient.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 0L );
             fail( "Should have thrown exception" );
         }
         catch ( AcquireLockTimeoutException e )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManagerTest.java
@@ -57,7 +57,7 @@ public class LeaderOnlyLockManagerTest
                 new LeaderOnlyLockManager( me, replicator, leaderLocator, locks, replicatedLockStateMachine );
 
         // when
-        lockManager.newClient().acquireExclusive( ResourceTypes.NODE, 0L );
+        lockManager.newClient().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0L );
 
         // then
     }
@@ -85,7 +85,7 @@ public class LeaderOnlyLockManagerTest
         Locks.Client lockClient = lockManager.newClient();
         try
         {
-            lockClient.acquireExclusive( ResourceTypes.NODE, 0L );
+            lockClient.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 0L );
             fail( "Should have thrown exception" );
         }
         catch ( AcquireLockTimeoutException e )

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -40,7 +40,7 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         assertNotStopped();
 
@@ -51,7 +51,7 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
+    public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds )
             throws AcquireLockTimeoutException
     {
         assertNotStopped();
@@ -129,11 +129,11 @@ public class DeferringLockClient implements Locks.Client
             long[] resourceIds = Arrays.copyOf( current, cursor );
             if ( exclusive )
             {
-                clientDelegate.acquireExclusive( Locks.Tracer.NONE, currentType, resourceIds );
+                clientDelegate.acquireExclusive( LockTracer.NONE, currentType, resourceIds );
             }
             else
             {
-                clientDelegate.acquireShared( Locks.Tracer.NONE, currentType, resourceIds );
+                clientDelegate.acquireShared( LockTracer.NONE, currentType, resourceIds );
             }
         }
     }

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -40,7 +40,7 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         assertNotStopped();
 
@@ -51,7 +51,7 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( ResourceType resourceType, long... resourceIds )
+    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
             throws AcquireLockTimeoutException
     {
         assertNotStopped();
@@ -129,11 +129,11 @@ public class DeferringLockClient implements Locks.Client
             long[] resourceIds = Arrays.copyOf( current, cursor );
             if ( exclusive )
             {
-                clientDelegate.acquireExclusive( currentType, resourceIds );
+                clientDelegate.acquireExclusive( Locks.Tracer.NONE, currentType, resourceIds );
             }
             else
             {
-                clientDelegate.acquireShared( currentType, resourceIds );
+                clientDelegate.acquireShared( Locks.Tracer.NONE, currentType, resourceIds );
             }
         }
     }

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -106,11 +106,11 @@ public class DeferringLockClientTest
 
             if ( exclusive )
             {
-                client.acquireExclusive( Locks.Tracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
+                client.acquireExclusive( LockTracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
             }
             else
             {
-                client.acquireShared( Locks.Tracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
+                client.acquireShared( LockTracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
             }
             expected.add( lockUnit );
         }
@@ -161,7 +161,7 @@ public class DeferringLockClientTest
         try
         {
             // WHEN
-            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
             fail( "Expected exception" );
         }
         catch ( LockClientStoppedException e )
@@ -182,7 +182,7 @@ public class DeferringLockClientTest
         try
         {
             // WHEN
-            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+            client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
             fail( "Expected exception" );
         }
         catch ( LockClientStoppedException e )
@@ -236,7 +236,7 @@ public class DeferringLockClientTest
         Locks.Client actualClient = mock( Locks.Client.class );
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
 
         try
         {
@@ -257,7 +257,7 @@ public class DeferringLockClientTest
         Locks.Client actualClient = mock( Locks.Client.class );
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         try
@@ -280,8 +280,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -299,8 +299,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseShared( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -318,8 +318,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseShared( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -337,13 +337,13 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 2 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 3 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 1 );
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 2 );
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 42 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 2 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 2 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.SCHEMA, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 42 );
 
         // WHEN
         client.acquireDeferredLocks();
@@ -370,8 +370,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -405,7 +405,7 @@ public class DeferringLockClientTest
         private final Set<LockUnit> actualLockUnits = new LinkedHashSet<>();
 
         @Override
-        public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             register( resourceType, false, resourceIds );
         }
@@ -425,7 +425,7 @@ public class DeferringLockClientTest
         }
 
         @Override
-        public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
+        public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds )
                 throws AcquireLockTimeoutException
         {
             register( resourceType, true, resourceIds );

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -106,11 +106,11 @@ public class DeferringLockClientTest
 
             if ( exclusive )
             {
-                client.acquireExclusive( lockUnit.resourceType(), lockUnit.resourceId() );
+                client.acquireExclusive( Locks.Tracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
             }
             else
             {
-                client.acquireShared( lockUnit.resourceType(), lockUnit.resourceId() );
+                client.acquireShared( Locks.Tracer.NONE, lockUnit.resourceType(), lockUnit.resourceId() );
             }
             expected.add( lockUnit );
         }
@@ -161,7 +161,7 @@ public class DeferringLockClientTest
         try
         {
             // WHEN
-            client.acquireExclusive( ResourceTypes.NODE, 1 );
+            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             fail( "Expected exception" );
         }
         catch ( LockClientStoppedException e )
@@ -182,7 +182,7 @@ public class DeferringLockClientTest
         try
         {
             // WHEN
-            client.acquireExclusive( ResourceTypes.NODE, 1 );
+            client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
             fail( "Expected exception" );
         }
         catch ( LockClientStoppedException e )
@@ -236,7 +236,7 @@ public class DeferringLockClientTest
         Locks.Client actualClient = mock( Locks.Client.class );
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
 
         try
         {
@@ -257,7 +257,7 @@ public class DeferringLockClientTest
         Locks.Client actualClient = mock( Locks.Client.class );
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         try
@@ -280,8 +280,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -299,8 +299,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( ResourceTypes.NODE, 1 );
-        client.acquireShared( ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseShared( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -318,8 +318,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( ResourceTypes.NODE, 1 );
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseShared( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -337,13 +337,13 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( ResourceTypes.NODE, 1 );
-        client.acquireExclusive( ResourceTypes.NODE, 2 );
-        client.acquireExclusive( ResourceTypes.NODE, 3 );
-        client.acquireExclusive( ResourceTypes.RELATIONSHIP, 1 );
-        client.acquireShared( ResourceTypes.RELATIONSHIP, 2 );
-        client.acquireShared( ResourceTypes.SCHEMA, 1 );
-        client.acquireExclusive( ResourceTypes.NODE, 42 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 2 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 3 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 2 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.SCHEMA, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 42 );
 
         // WHEN
         client.acquireDeferredLocks();
@@ -370,8 +370,8 @@ public class DeferringLockClientTest
         TestLocksClient actualClient = actualLocks.newClient();
         DeferringLockClient client = new DeferringLockClient( actualClient );
 
-        client.acquireShared( ResourceTypes.NODE, 1 );
-        client.acquireExclusive( ResourceTypes.NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
         client.releaseExclusive( ResourceTypes.NODE, 1 );
 
         // WHEN
@@ -405,7 +405,7 @@ public class DeferringLockClientTest
         private final Set<LockUnit> actualLockUnits = new LinkedHashSet<>();
 
         @Override
-        public void acquireShared( ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+        public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
         {
             register( resourceType, false, resourceIds );
         }
@@ -425,7 +425,7 @@ public class DeferringLockClientTest
         }
 
         @Override
-        public void acquireExclusive( ResourceType resourceType, long... resourceIds )
+        public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds )
                 throws AcquireLockTimeoutException
         {
             register( resourceType, true, resourceIds );

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -69,14 +69,14 @@ public class DeferringStatementLocksTest
         final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
 
         // WHEN
-        statementLocks.optimistic().acquireExclusive( ResourceTypes.NODE, 1 );
-        statementLocks.optimistic().acquireExclusive( ResourceTypes.RELATIONSHIP, 42 );
-        verify( client, never() ).acquireExclusive( any( ResourceType.class ), anyLong() );
+        statementLocks.optimistic().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        statementLocks.optimistic().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
+        verify( client, never() ).acquireExclusive( Locks.Tracer.NONE, any( ResourceType.class ), anyLong() );
         statementLocks.prepareForCommit();
 
         // THEN
-        verify( client ).acquireExclusive( ResourceTypes.NODE, 1 );
-        verify( client ).acquireExclusive( ResourceTypes.RELATIONSHIP, 42 );
+        verify( client ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
+        verify( client ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
         verifyNoMoreInteractions( client );
     }
 

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,7 +72,7 @@ public class DeferringStatementLocksTest
         // WHEN
         statementLocks.optimistic().acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         statementLocks.optimistic().acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
-        verify( client, never() ).acquireExclusive( LockTracer.NONE, any( ResourceType.class ), anyLong() );
+        verify( client, never() ).acquireExclusive( eq( LockTracer.NONE ), any( ResourceType.class ), anyLong() );
         statementLocks.prepareForCommit();
 
         // THEN

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -69,14 +69,14 @@ public class DeferringStatementLocksTest
         final DeferringStatementLocks statementLocks = new DeferringStatementLocks( client );
 
         // WHEN
-        statementLocks.optimistic().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        statementLocks.optimistic().acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
-        verify( client, never() ).acquireExclusive( Locks.Tracer.NONE, any( ResourceType.class ), anyLong() );
+        statementLocks.optimistic().acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        statementLocks.optimistic().acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
+        verify( client, never() ).acquireExclusive( LockTracer.NONE, any( ResourceType.class ), anyLong() );
         statementLocks.prepareForCommit();
 
         // THEN
-        verify( client ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1 );
-        verify( client ).acquireExclusive( Locks.Tracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
+        verify( client ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        verify( client ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
         verifyNoMoreInteractions( client );
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -324,7 +324,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         {
             for ( long resourceId : resourceIds )
             {
-                session.acquireExclusive( type, resourceId );
+                session.acquireExclusive( Locks.Tracer.NONE, type, resourceId );
             }
             return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.OK_LOCKED ) );
         }
@@ -366,7 +366,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         {
             for ( long resourceId : resourceIds )
             {
-                session.acquireShared( type, resourceId );
+                session.acquireShared( Locks.Tracer.NONE, type, resourceId );
             }
 
             return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.OK_LOCKED ) );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -32,6 +32,7 @@ import org.neo4j.com.Response;
 import org.neo4j.com.TransactionNotPresentOnMasterException;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -324,7 +325,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         {
             for ( long resourceId : resourceIds )
             {
-                session.acquireExclusive( Locks.Tracer.NONE, type, resourceId );
+                session.acquireExclusive( LockTracer.NONE, type, resourceId );
             }
             return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.OK_LOCKED ) );
         }
@@ -366,7 +367,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         {
             for ( long resourceId : resourceIds )
             {
-                session.acquireShared( Locks.Tracer.NONE, type, resourceId );
+                session.acquireShared( LockTracer.NONE, type, resourceId );
             }
 
             return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.OK_LOCKED ) );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.locking.LockClientStoppedException;
+import org.neo4j.kernel.impl.locking.LockTracer;
+import org.neo4j.kernel.impl.locking.LockWaitEvent;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.logging.Log;
@@ -100,7 +102,7 @@ class SlaveLocksClient implements Locks.Client
     }
 
     @Override
-    public void acquireShared( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
+    public void acquireShared( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws AcquireLockTimeoutException
     {
         assertNotStopped();
 
@@ -108,7 +110,7 @@ class SlaveLocksClient implements Locks.Client
         long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
         if ( newResourceIds.length > 0 )
         {
-            try ( Locks.WaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
+            try ( LockWaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
             {
                 acquireSharedOnMaster( resourceType, newResourceIds );
             }
@@ -128,7 +130,7 @@ class SlaveLocksClient implements Locks.Client
     }
 
     @Override
-    public void acquireExclusive( Locks.Tracer tracer, ResourceType resourceType, long... resourceIds ) throws
+    public void acquireExclusive( LockTracer tracer, ResourceType resourceType, long... resourceIds ) throws
             AcquireLockTimeoutException
     {
         assertNotStopped();
@@ -137,7 +139,7 @@ class SlaveLocksClient implements Locks.Client
         long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
         if ( newResourceIds.length > 0 )
         {
-            try ( Locks.WaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
+            try ( LockWaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
             {
                 acquireExclusiveOnMaster( resourceType, newResourceIds );
             }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.kernel.ha.com.master;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.com.RequestContext;
@@ -43,6 +43,7 @@ import org.neo4j.kernel.ha.cluster.DefaultConversationSPI;
 import org.neo4j.kernel.ha.com.master.MasterImpl.Monitor;
 import org.neo4j.kernel.ha.com.master.MasterImpl.SPI;
 import org.neo4j.kernel.ha.lock.LockResult;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.Locks.Client;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -54,9 +55,9 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -64,6 +65,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -259,7 +261,7 @@ public class MasterImplTest
         {
             latch.await();
             return null;
-        } ).when( client ).acquireExclusive( any( ResourceType.class ), anyLong() );
+        } ).when( client ).acquireExclusive( eq(Locks.Tracer.NONE), any( ResourceType.class ), anyLong() );
 
         return client;
     }
@@ -423,7 +425,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( type, 1 );
+        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -445,7 +447,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( type, 1 );
+        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -467,7 +469,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( type, 1 );
+        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -489,7 +491,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( type, 1 );
+        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -43,7 +43,7 @@ import org.neo4j.kernel.ha.cluster.DefaultConversationSPI;
 import org.neo4j.kernel.ha.com.master.MasterImpl.Monitor;
 import org.neo4j.kernel.ha.com.master.MasterImpl.SPI;
 import org.neo4j.kernel.ha.lock.LockResult;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks.Client;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -261,7 +261,7 @@ public class MasterImplTest
         {
             latch.await();
             return null;
-        } ).when( client ).acquireExclusive( eq(Locks.Tracer.NONE), any( ResourceType.class ), anyLong() );
+        } ).when( client ).acquireExclusive( eq( LockTracer.NONE), any( ResourceType.class ), anyLong() );
 
         return client;
     }
@@ -425,7 +425,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
+        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( LockTracer.NONE, type, 1 );
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -447,7 +447,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
+        doThrow( new DeadlockDetectedException( "" ) ).when( locks ).acquireExclusive( LockTracer.NONE, type, 1 );
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -469,7 +469,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
+        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( LockTracer.NONE, type, 1 );
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
@@ -491,7 +491,7 @@ public class MasterImplTest
         RequestContext context = createRequestContext( master );
         when( conversationSpi.acquireClient() ).thenReturn( locks );
         ResourceTypes type = ResourceTypes.NODE;
-        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( Locks.Tracer.NONE, type, 1 );
+        doThrow( new IllegalResourceException( "" ) ).when( locks ).acquireExclusive( LockTracer.NONE, type, 1 );
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.enterprise.lock.forseti.ForsetiLockManager;
+import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
@@ -166,7 +167,7 @@ public class SlaveLocksClientConcurrentTest
         @Override
         public void run()
         {
-            locksClient.acquireExclusive( resourceType, id );
+            locksClient.acquireExclusive( Locks.Tracer.NONE, resourceType, id );
             locksClient.close();
         }
     }
@@ -190,7 +191,7 @@ public class SlaveLocksClientConcurrentTest
             try
             {
                 resourceLatch.await();
-                locksClient.acquireShared( resourceType, id );
+                locksClient.acquireShared( Locks.Tracer.NONE, resourceType, id );
                 resourceReleaseLatch.countDown();
                 locksClient.close();
             }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
@@ -40,7 +40,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.enterprise.lock.forseti.ForsetiLockManager;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
@@ -167,7 +167,7 @@ public class SlaveLocksClientConcurrentTest
         @Override
         public void run()
         {
-            locksClient.acquireExclusive( Locks.Tracer.NONE, resourceType, id );
+            locksClient.acquireExclusive( LockTracer.NONE, resourceType, id );
             locksClient.close();
         }
     }
@@ -191,7 +191,7 @@ public class SlaveLocksClientConcurrentTest
             try
             {
                 resourceLatch.await();
-                locksClient.acquireShared( Locks.Tracer.NONE, resourceType, id );
+                locksClient.acquireShared( LockTracer.NONE, resourceType, id );
                 resourceReleaseLatch.countDown();
                 locksClient.close();
             }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -129,8 +129,8 @@ public class SlaveLocksClientTest
     public void shouldNotTakeSharedLockOnMasterIfWeAreAlreadyHoldingSaidLock()
     {
         // When taking a lock twice
-        client.acquireShared( NODE, 1 );
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
 
         // Then only a single network round-trip should be observed
         verify( master ).acquireSharedLock( null, NODE, 1 );
@@ -140,8 +140,8 @@ public class SlaveLocksClientTest
     public void shouldNotTakeExclusiveLockOnMasterIfWeAreAlreadyHoldingSaidLock()
     {
         // When taking a lock twice
-        client.acquireExclusive( NODE, 1 );
-        client.acquireExclusive( NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
 
         // Then only a single network roundtrip should be observed
         verify( master ).acquireExclusiveLock( null, NODE, 1 );
@@ -151,11 +151,11 @@ public class SlaveLocksClientTest
     public void shouldAllowAcquiringReleasingAndReacquiringExclusive() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireExclusive( NODE, 1L );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireExclusive( NODE, 1L );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -167,11 +167,11 @@ public class SlaveLocksClientTest
     public void shouldAllowAcquiringReleasingAndReacquiringShared() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireShared( NODE, 1L );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireShared( NODE, 1L );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -183,10 +183,10 @@ public class SlaveLocksClientTest
     public void shouldNotTalkToLocalLocksOnReentrancyExclusive() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireExclusive( NODE, 1L );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireExclusive( NODE, 1L );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -198,10 +198,10 @@ public class SlaveLocksClientTest
     public void shouldNotTalkToLocalLocksOnReentrancyShared() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireShared( NODE, 1L );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireShared( NODE, 1L );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -223,7 +223,7 @@ public class SlaveLocksClientTest
     public void shouldReturnDelegateIdIfInitialized() throws Exception
     {
         // Given
-        client.acquireExclusive( ResourceTypes.NODE, 1L );
+        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1L );
 
         // When
         int lockSessionId = client.getLockSessionId();
@@ -237,7 +237,7 @@ public class SlaveLocksClientTest
     {
         when( master.newLockSession( any( RequestContext.class ) ) ).thenThrow( new ComException() );
 
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -246,7 +246,7 @@ public class SlaveLocksClientTest
         when( master.newLockSession( any( RequestContext.class ) ) ).thenThrow(
                 new TransactionFailureException( Status.General.DatabaseUnavailable, "Not now" ) );
 
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -254,7 +254,7 @@ public class SlaveLocksClientTest
     {
         whenMasterAcquireShared().thenThrow( new ComException() );
 
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -262,7 +262,7 @@ public class SlaveLocksClientTest
     {
         whenMasterAcquireExclusive().thenThrow( new ComException() );
 
-        client.acquireExclusive( NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
     }
 
     @Test( expected = UnsupportedOperationException.class )
@@ -282,7 +282,7 @@ public class SlaveLocksClientTest
     {
         when( master.endLockSession( any( RequestContext.class ), anyBoolean() ) ).thenThrow( new ComException() );
 
-        client.acquireExclusive( NODE, 1 ); // initialise
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 ); // initialise
         client.close();
     }
 
@@ -293,7 +293,7 @@ public class SlaveLocksClientTest
 
         try
         {
-            client.acquireExclusive( NODE, 1 ); // initialise
+            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 ); // initialise
             client.close();
             fail( "Expected client.close to throw" );
         }
@@ -308,7 +308,7 @@ public class SlaveLocksClientTest
     {
         availabilityGuard.shutdown();
 
-        client.acquireExclusive( NODE, 1 );
+        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
     }
 
     @Test
@@ -320,7 +320,7 @@ public class SlaveLocksClientTest
         // WHEN
         try
         {
-            client.acquireExclusive( NODE, 0 );
+            client.acquireExclusive( Locks.Tracer.NONE, NODE, 0 );
             fail( "Should fail" );
         }
         catch ( TransientFailureException e )
@@ -335,7 +335,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = stoppedClient();
         try
         {
-            client.acquireShared( NODE, 1 );
+            client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -363,7 +363,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = stoppedClient();
         try
         {
-            client.acquireExclusive( NODE, 1 );
+            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -405,7 +405,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = closedClient();
         try
         {
-            client.acquireShared( NODE, 1 );
+            client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -433,7 +433,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = closedClient();
         try
         {
-            client.acquireExclusive( NODE, 1 );
+            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -472,7 +472,7 @@ public class SlaveLocksClientTest
     @Test
     public void stopLocalLocksAndEndLockSessionOnMasterWhenStopped()
     {
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
 
         client.stop();
 
@@ -483,7 +483,7 @@ public class SlaveLocksClientTest
     @Test
     public void closeLocalLocksAndEndLockSessionOnMasterWhenClosed()
     {
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
 
         client.close();
 
@@ -494,7 +494,7 @@ public class SlaveLocksClientTest
     @Test
     public void closeAfterStopped()
     {
-        client.acquireShared( NODE, 1 );
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
 
         client.stop();
         client.close();
@@ -554,7 +554,7 @@ public class SlaveLocksClientTest
         // WHEN
         try
         {
-            client.acquireExclusive( resourceType, nodeId );
+            client.acquireExclusive( Locks.Tracer.NONE, resourceType, nodeId );
             fail( "Should have failed" );
         }
         catch ( UnsupportedOperationException e )
@@ -579,7 +579,7 @@ public class SlaveLocksClientTest
 
     private SlaveLocksClient closedClient()
     {
-        client.acquireShared( NODE, 1 ); // trigger new lock session initialization
+        client.acquireShared( Locks.Tracer.NONE, NODE, 1 ); // trigger new lock session initialization
         client.close();
         return client;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.locking.LockClientStoppedException;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
@@ -129,8 +130,8 @@ public class SlaveLocksClientTest
     public void shouldNotTakeSharedLockOnMasterIfWeAreAlreadyHoldingSaidLock()
     {
         // When taking a lock twice
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
 
         // Then only a single network round-trip should be observed
         verify( master ).acquireSharedLock( null, NODE, 1 );
@@ -140,8 +141,8 @@ public class SlaveLocksClientTest
     public void shouldNotTakeExclusiveLockOnMasterIfWeAreAlreadyHoldingSaidLock()
     {
         // When taking a lock twice
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1 );
 
         // Then only a single network roundtrip should be observed
         verify( master ).acquireExclusiveLock( null, NODE, 1 );
@@ -151,11 +152,11 @@ public class SlaveLocksClientTest
     public void shouldAllowAcquiringReleasingAndReacquiringExclusive() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -167,11 +168,11 @@ public class SlaveLocksClientTest
     public void shouldAllowAcquiringReleasingAndReacquiringShared() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireShared( LockTracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireShared( LockTracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -183,10 +184,10 @@ public class SlaveLocksClientTest
     public void shouldNotTalkToLocalLocksOnReentrancyExclusive() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1L );
         client.releaseExclusive( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -198,10 +199,10 @@ public class SlaveLocksClientTest
     public void shouldNotTalkToLocalLocksOnReentrancyShared() throws Exception
     {
         // Given we have grabbed and released a lock
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireShared( LockTracer.NONE, NODE, 1L );
 
         // When we grab and release that lock again
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1L );
+        client.acquireShared( LockTracer.NONE, NODE, 1L );
         client.releaseShared( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
@@ -223,7 +224,7 @@ public class SlaveLocksClientTest
     public void shouldReturnDelegateIdIfInitialized() throws Exception
     {
         // Given
-        client.acquireExclusive( Locks.Tracer.NONE, ResourceTypes.NODE, 1L );
+        client.acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1L );
 
         // When
         int lockSessionId = client.getLockSessionId();
@@ -237,7 +238,7 @@ public class SlaveLocksClientTest
     {
         when( master.newLockSession( any( RequestContext.class ) ) ).thenThrow( new ComException() );
 
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -246,7 +247,7 @@ public class SlaveLocksClientTest
         when( master.newLockSession( any( RequestContext.class ) ) ).thenThrow(
                 new TransactionFailureException( Status.General.DatabaseUnavailable, "Not now" ) );
 
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -254,7 +255,7 @@ public class SlaveLocksClientTest
     {
         whenMasterAcquireShared().thenThrow( new ComException() );
 
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
     }
 
     @Test( expected = DistributedLockFailureException.class )
@@ -262,7 +263,7 @@ public class SlaveLocksClientTest
     {
         whenMasterAcquireExclusive().thenThrow( new ComException() );
 
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1 );
     }
 
     @Test( expected = UnsupportedOperationException.class )
@@ -282,7 +283,7 @@ public class SlaveLocksClientTest
     {
         when( master.endLockSession( any( RequestContext.class ), anyBoolean() ) ).thenThrow( new ComException() );
 
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 ); // initialise
+        client.acquireExclusive( LockTracer.NONE, NODE, 1 ); // initialise
         client.close();
     }
 
@@ -293,7 +294,7 @@ public class SlaveLocksClientTest
 
         try
         {
-            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 ); // initialise
+            client.acquireExclusive( LockTracer.NONE, NODE, 1 ); // initialise
             client.close();
             fail( "Expected client.close to throw" );
         }
@@ -308,7 +309,7 @@ public class SlaveLocksClientTest
     {
         availabilityGuard.shutdown();
 
-        client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireExclusive( LockTracer.NONE, NODE, 1 );
     }
 
     @Test
@@ -320,7 +321,7 @@ public class SlaveLocksClientTest
         // WHEN
         try
         {
-            client.acquireExclusive( Locks.Tracer.NONE, NODE, 0 );
+            client.acquireExclusive( LockTracer.NONE, NODE, 0 );
             fail( "Should fail" );
         }
         catch ( TransientFailureException e )
@@ -335,7 +336,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = stoppedClient();
         try
         {
-            client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+            client.acquireShared( LockTracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -363,7 +364,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = stoppedClient();
         try
         {
-            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+            client.acquireExclusive( LockTracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -405,7 +406,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = closedClient();
         try
         {
-            client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+            client.acquireShared( LockTracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -433,7 +434,7 @@ public class SlaveLocksClientTest
         SlaveLocksClient client = closedClient();
         try
         {
-            client.acquireExclusive( Locks.Tracer.NONE, NODE, 1 );
+            client.acquireExclusive( LockTracer.NONE, NODE, 1 );
         }
         catch ( Exception e )
         {
@@ -472,7 +473,7 @@ public class SlaveLocksClientTest
     @Test
     public void stopLocalLocksAndEndLockSessionOnMasterWhenStopped()
     {
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
 
         client.stop();
 
@@ -483,7 +484,7 @@ public class SlaveLocksClientTest
     @Test
     public void closeLocalLocksAndEndLockSessionOnMasterWhenClosed()
     {
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
 
         client.close();
 
@@ -494,7 +495,7 @@ public class SlaveLocksClientTest
     @Test
     public void closeAfterStopped()
     {
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 );
+        client.acquireShared( LockTracer.NONE, NODE, 1 );
 
         client.stop();
         client.close();
@@ -554,7 +555,7 @@ public class SlaveLocksClientTest
         // WHEN
         try
         {
-            client.acquireExclusive( Locks.Tracer.NONE, resourceType, nodeId );
+            client.acquireExclusive( LockTracer.NONE, resourceType, nodeId );
             fail( "Should have failed" );
         }
         catch ( UnsupportedOperationException e )
@@ -579,7 +580,7 @@ public class SlaveLocksClientTest
 
     private SlaveLocksClient closedClient()
     {
-        client.acquireShared( Locks.Tracer.NONE, NODE, 1 ); // trigger new lock session initialization
+        client.acquireShared( LockTracer.NONE, NODE, 1 ); // trigger new lock session initialization
         client.close();
         return client;
     }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -440,7 +440,8 @@ public class EnterpriseBuiltInDbmsProcedures
                 q.startTime(),
                 clock.instant().minusMillis( q.startTime() ).toEpochMilli(),
                 q.querySource(),
-                q.metaData()
+                q.metaData(),
+                q.cpuTime()
         );
     }
 
@@ -453,6 +454,7 @@ public class EnterpriseBuiltInDbmsProcedures
         public final String startTime;
         public final String elapsedTime;
         public final String connectionDetails;
+        public final long cpuTime;
         public final Map<String,Object> metaData;
 
         QueryStatusResult(
@@ -463,7 +465,8 @@ public class EnterpriseBuiltInDbmsProcedures
                 long startTime,
                 long elapsedTime,
                 QuerySource querySource,
-                Map<String,Object> txMetaData
+                Map<String,Object> txMetaData,
+                long cpuTime
         ) {
             this.queryId = queryId.toString();
             this.username = username;
@@ -473,6 +476,7 @@ public class EnterpriseBuiltInDbmsProcedures
             this.elapsedTime = formatInterval( elapsedTime );
             this.connectionDetails = querySource.toString();
             this.metaData = txMetaData;
+            this.cpuTime = cpuTime;
         }
 
         private static String formatTime( final long startTime )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -20,10 +20,6 @@
 package org.neo4j.kernel.enterprise.builtinprocs;
 
 import java.io.IOException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,20 +46,13 @@ import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.query.QuerySource;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
-import org.neo4j.time.Clocks;
 
 import static java.lang.String.format;
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.neo4j.function.ThrowingFunction.catchThrown;
@@ -247,7 +236,7 @@ public class EnterpriseBuiltInDbmsProcedures
             return getKernelTransactions().activeTransactions().stream()
                 .flatMap( KernelTransactionHandle::executingQueries )
                 .filter( query -> isAdminOrSelf( query.username() ) )
-                .map( catchThrown( InvalidArgumentsException.class, this::queryStatusResult ) );
+                .map( catchThrown( InvalidArgumentsException.class, QueryStatusResult::new ) );
         }
         catch ( UncaughtCheckedException uncaught )
         {
@@ -428,72 +417,6 @@ public class EnterpriseBuiltInDbmsProcedures
         }
     }
 
-    private QueryStatusResult queryStatusResult( ExecutingQuery q )
-            throws InvalidArgumentsException
-    {
-        return new QueryStatusResult(
-                ofInternalId( q.internalQueryId() ),
-                q.username(),
-                q.queryText(),
-                q.queryParameters(),
-                q.startTime(),
-                q.elapsedTime(),
-                q.querySource(),
-                q.metaData(),
-                q.cpuTime(),
-                q.status(),
-                q.waitTime()
-        );
-    }
-
-    public static class QueryStatusResult
-    {
-        public final String queryId;
-        public final String username;
-        public final String query;
-        public final Map<String,Object> parameters;
-        public final String startTime;
-        public final String elapsedTime;
-        public final String connectionDetails;
-        public final long cpuTime;
-        public final Map<String,Object> status;
-        public final long waitTime;
-        public final Map<String,Object> metaData;
-
-        QueryStatusResult(
-                QueryId queryId,
-                String username,
-                String query,
-                Map<String,Object> parameters,
-                long startTime,
-                long elapsedTime,
-                QuerySource querySource,
-                Map<String,Object> txMetaData,
-                long cpuTime,
-                Map<String,Object> status,
-                long waitTime
-        ) {
-            this.queryId = queryId.toString();
-            this.username = username;
-            this.query = query;
-            this.parameters = parameters;
-            this.startTime = formatTime( startTime );
-            this.elapsedTime = formatInterval( elapsedTime );
-            this.connectionDetails = querySource.toString();
-            this.metaData = txMetaData;
-            this.cpuTime = cpuTime;
-            this.status = status;
-            this.waitTime = waitTime;
-        }
-
-        private static String formatTime( final long startTime )
-        {
-            return OffsetDateTime
-                .ofInstant( Instant.ofEpochMilli( startTime ), ZoneId.systemDefault() )
-                .format( ISO_OFFSET_DATE_TIME );
-        }
-    }
-
     public static class QueryTerminationResult
     {
         public final String queryId;
@@ -540,14 +463,5 @@ public class EnterpriseBuiltInDbmsProcedures
             this.username = username;
             this.connectionCount = connectionCount;
         }
-    }
-
-    private static String formatInterval( final long l )
-    {
-        final long hr = MILLISECONDS.toHours( l );
-        final long min = MILLISECONDS.toMinutes( l - HOURS.toMillis( hr ) );
-        final long sec = MILLISECONDS.toSeconds( l - HOURS.toMillis( hr ) - MINUTES.toMillis( min ) );
-        final long ms = l - HOURS.toMillis( hr ) - MINUTES.toMillis( min ) - SECONDS.toMillis( sec );
-        return String.format( "%02d:%02d:%02d.%03d", hr, min, sec, ms );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -76,7 +76,6 @@ import static org.neo4j.procedure.Mode.DBMS;
 @SuppressWarnings( "unused" )
 public class EnterpriseBuiltInDbmsProcedures
 {
-    private static Clock clock = Clocks.systemClock();
     private static final int HARD_CHAR_LIMIT = 2048;
 
     @Context
@@ -438,10 +437,12 @@ public class EnterpriseBuiltInDbmsProcedures
                 q.queryText(),
                 q.queryParameters(),
                 q.startTime(),
-                clock.instant().minusMillis( q.startTime() ).toEpochMilli(),
+                q.elapsedTime(),
                 q.querySource(),
                 q.metaData(),
-                q.cpuTime()
+                q.cpuTime(),
+                q.status(),
+                q.waitTime()
         );
     }
 
@@ -455,6 +456,8 @@ public class EnterpriseBuiltInDbmsProcedures
         public final String elapsedTime;
         public final String connectionDetails;
         public final long cpuTime;
+        public final Map<String,Object> status;
+        public final long waitTime;
         public final Map<String,Object> metaData;
 
         QueryStatusResult(
@@ -466,7 +469,9 @@ public class EnterpriseBuiltInDbmsProcedures
                 long elapsedTime,
                 QuerySource querySource,
                 Map<String,Object> txMetaData,
-                long cpuTime
+                long cpuTime,
+                Map<String,Object> status,
+                long waitTime
         ) {
             this.queryId = queryId.toString();
             this.username = username;
@@ -477,6 +482,8 @@ public class EnterpriseBuiltInDbmsProcedures
             this.connectionDetails = querySource.toString();
             this.metaData = txMetaData;
             this.cpuTime = cpuTime;
+            this.status = status;
+            this.waitTime = waitTime;
         }
 
         private static String formatTime( final long startTime )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -44,9 +44,9 @@ public class QueryStatusResult
     public final String startTime;
     public final String elapsedTime;
     public final String connectionDetails;
-    public final long cpuTime;
+    public final long cpuTimeMicros;
     public final Map<String,Object> status;
-    public final long waitTime;
+    public final long waitTimeMillis;
     public final Map<String,Object> metaData;
 
     QueryStatusResult( ExecutingQuery q ) throws InvalidArgumentsException
@@ -57,12 +57,12 @@ public class QueryStatusResult
                 q.queryText(),
                 q.queryParameters(),
                 q.startTime(),
-                q.elapsedTime(),
+                q.elapsedTimeMillis(),
                 q.querySource(),
                 q.metaData(),
-                q.cpuTime(),
+                q.cpuTimeMicros(),
                 q.status(),
-                q.waitTime() );
+                q.waitTimeMillis() );
     }
 
     private QueryStatusResult(
@@ -74,9 +74,9 @@ public class QueryStatusResult
             long elapsedTime,
             QuerySource querySource,
             Map<String,Object> txMetaData,
-            long cpuTime,
+            long cpuTimeMicros,
             Map<String,Object> status,
-            long waitTime
+            long waitTimeMillis
     ) {
         this.queryId = queryId.toString();
         this.username = username;
@@ -86,9 +86,9 @@ public class QueryStatusResult
         this.elapsedTime = formatInterval( elapsedTime );
         this.connectionDetails = querySource.toString();
         this.metaData = txMetaData;
-        this.cpuTime = cpuTime;
+        this.cpuTimeMicros = cpuTimeMicros;
         this.status = status;
-        this.waitTime = waitTime;
+        this.waitTimeMillis = waitTimeMillis;
     }
 
     private static String formatTime( final long startTime )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.kernel.enterprise.builtinprocs;
 
 import java.time.Instant;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -1,0 +1,90 @@
+package org.neo4j.kernel.enterprise.builtinprocs;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+
+import org.neo4j.kernel.api.ExecutingQuery;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
+import org.neo4j.kernel.impl.query.QuerySource;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.neo4j.kernel.enterprise.builtinprocs.QueryId.ofInternalId;
+
+public class QueryStatusResult
+{
+    public final String queryId;
+    public final String username;
+    public final String query;
+    public final Map<String,Object> parameters;
+    public final String startTime;
+    public final String elapsedTime;
+    public final String connectionDetails;
+    public final long cpuTime;
+    public final Map<String,Object> status;
+    public final long waitTime;
+    public final Map<String,Object> metaData;
+
+    QueryStatusResult( ExecutingQuery q ) throws InvalidArgumentsException
+    {
+        this(
+                ofInternalId( q.internalQueryId() ),
+                q.username(),
+                q.queryText(),
+                q.queryParameters(),
+                q.startTime(),
+                q.elapsedTime(),
+                q.querySource(),
+                q.metaData(),
+                q.cpuTime(),
+                q.status(),
+                q.waitTime() );
+    }
+
+    private QueryStatusResult(
+            QueryId queryId,
+            String username,
+            String query,
+            Map<String,Object> parameters,
+            long startTime,
+            long elapsedTime,
+            QuerySource querySource,
+            Map<String,Object> txMetaData,
+            long cpuTime,
+            Map<String,Object> status,
+            long waitTime
+    ) {
+        this.queryId = queryId.toString();
+        this.username = username;
+        this.query = query;
+        this.parameters = parameters;
+        this.startTime = formatTime( startTime );
+        this.elapsedTime = formatInterval( elapsedTime );
+        this.connectionDetails = querySource.toString();
+        this.metaData = txMetaData;
+        this.cpuTime = cpuTime;
+        this.status = status;
+        this.waitTime = waitTime;
+    }
+
+    private static String formatTime( final long startTime )
+    {
+        return OffsetDateTime
+            .ofInstant( Instant.ofEpochMilli( startTime ), ZoneId.systemDefault() )
+            .format( ISO_OFFSET_DATE_TIME );
+    }
+
+    private static String formatInterval( final long l )
+    {
+        final long hr = MILLISECONDS.toHours( l );
+        final long min = MILLISECONDS.toMinutes( l - HOURS.toMillis( hr ) );
+        final long sec = MILLISECONDS.toSeconds( l - HOURS.toMillis( hr ) - MINUTES.toMillis( min ) );
+        final long ms = l - HOURS.toMillis( hr ) - MINUTES.toMillis( min ) - SECONDS.toMillis( sec );
+        return String.format( "%02d:%02d:%02d.%03d", hr, min, sec, ms );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -44,7 +44,7 @@ public class QueryStatusResult
     public final String startTime;
     public final String elapsedTime;
     public final String connectionDetails;
-    public final long cpuTimeMicros;
+    public final long cpuTimeMillis;
     public final Map<String,Object> status;
     public final long waitTimeMillis;
     public final Map<String,Object> metaData;
@@ -60,7 +60,7 @@ public class QueryStatusResult
                 q.elapsedTimeMillis(),
                 q.querySource(),
                 q.metaData(),
-                q.cpuTimeMicros(),
+                q.cpuTimeMillis(),
                 q.status(),
                 q.waitTimeMillis() );
     }
@@ -74,7 +74,7 @@ public class QueryStatusResult
             long elapsedTime,
             QuerySource querySource,
             Map<String,Object> txMetaData,
-            long cpuTimeMicros,
+            long cpuTimeMillis,
             Map<String,Object> status,
             long waitTimeMillis
     ) {
@@ -86,7 +86,7 @@ public class QueryStatusResult
         this.elapsedTime = formatInterval( elapsedTime );
         this.connectionDetails = querySource.toString();
         this.metaData = txMetaData;
-        this.cpuTimeMicros = cpuTimeMicros;
+        this.cpuTimeMillis = cpuTimeMillis;
         this.status = status;
         this.waitTimeMillis = waitTimeMillis;
     }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -288,7 +288,6 @@ public class ForsetiClient implements Locks.Client
                     continue;
                 }
 
-
                 Locks.WaitEvent waitEvent = null;
                 try
                 {
@@ -667,7 +666,6 @@ public class ForsetiClient implements Locks.Client
         ForsetiClient that = (ForsetiClient) o;
 
         return clientId == that.clientId;
-
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/ImpermanentEnterpriseDatabaseRule.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/ImpermanentEnterpriseDatabaseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/ImpermanentEnterpriseDatabaseRule.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/ImpermanentEnterpriseDatabaseRule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.enterprise;
+
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+public class ImpermanentEnterpriseDatabaseRule extends ImpermanentDatabaseRule
+{
+    @Override
+    protected GraphDatabaseFactory newFactory()
+    {
+        return maybeSetInternalLogProvider( maybeSetUserLogProvider( new TestEnterpriseGraphDatabaseFactory() ) );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -63,14 +63,6 @@ public class ListQueriesProcedureTest
         // then
         Map<String,Object> row = result.next();
         assertFalse( result.hasNext() );
-        //        Object queryId = row1.get( "queryId" );
-        //        Object username = row1.get( "username" );
-        //        Object query = row1.get( "query" );
-        //        Object parameters = row1.get( "parameters" );
-        //        Object startTime = row1.get( "startTime" );
-        //        Object elapsedTime = row1.get( "elapsedTime" );
-        //        Object connectionDetails = row1.get( "connectionDetails" );
-        //        Object metaData = row1.get( "metaData" );
         assertEquals( query, row.get( "query" ) );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -37,6 +37,7 @@ import org.neo4j.test.rule.concurrent.ThreadingRule;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -102,8 +103,8 @@ public class ListQueriesProcedureTest
             Map<String,Object> data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
 
             // then
-            assertTrue( "should contain a 'cpuTimeMicros' field", data.containsKey( "cpuTimeMicros" ) );
-            Object cpuTime1 = data.get( "cpuTimeMicros" );
+            assertTrue( "should contain a 'cpuTimeMillis' field", data.containsKey( "cpuTimeMillis" ) );
+            Object cpuTime1 = data.get( "cpuTimeMillis" );
             assertThat( cpuTime1, instanceOf( Long.class ) );
             assertTrue( "should contain a 'status' field", data.containsKey( "status" ) );
             Object status = data.get( "status" );
@@ -121,8 +122,8 @@ public class ListQueriesProcedureTest
             data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
 
             // then
-            Long cpuTime2 = (Long) data.get( "cpuTimeMicros" );
-            assertThat( cpuTime2, greaterThan( (Long) cpuTime1 ) );
+            Long cpuTime2 = (Long) data.get( "cpuTimeMillis" );
+            assertThat( cpuTime2, greaterThanOrEqualTo( (Long) cpuTime1 ) );
             Long waitTime2 = (Long) data.get( "waitTimeMillis" );
             assertThat( waitTime2, greaterThan( (Long) waitTime1 ) );
         }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.enterprise.builtinprocs;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.enterprise.ImpermanentEnterpriseDatabaseRule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.concurrent.ThreadingRule;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.test.rule.concurrent.ThreadingRule.waitingWhileIn;
+
+public class ListQueriesProcedureTest
+{
+    @Rule
+    public final DatabaseRule db = new ImpermanentEnterpriseDatabaseRule();
+    @Rule
+    public final ThreadingRule threads = new ThreadingRule();
+
+    @Test
+    public void shouldContainTheQueryItself() throws Exception
+    {
+        // given
+        String query = "CALL dbms.listQueries";
+
+        // when
+        Result result = db.execute( query );
+
+        // then
+        Map<String,Object> row = result.next();
+        assertFalse( result.hasNext() );
+        //        Object queryId = row1.get( "queryId" );
+        //        Object username = row1.get( "username" );
+        //        Object query = row1.get( "query" );
+        //        Object parameters = row1.get( "parameters" );
+        //        Object startTime = row1.get( "startTime" );
+        //        Object elapsedTime = row1.get( "elapsedTime" );
+        //        Object connectionDetails = row1.get( "connectionDetails" );
+        //        Object metaData = row1.get( "metaData" );
+        assertEquals( query, row.get( "query" ) );
+    }
+
+    @Test
+    public void shouldProvideElapsedCpuTime() throws Exception
+    {
+        // given
+        CountDownLatch nodeLocked = new CountDownLatch( 1 ), listQueriesLatch = new CountDownLatch( 1 );
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( "v", 1L );
+            tx.success();
+        }
+        threads.execute( parameter ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                tx.acquireWriteLock( node );
+                nodeLocked.countDown();
+                listQueriesLatch.await();
+            }
+            return null;
+        }, null );
+        nodeLocked.await();
+
+        threads.executeAndAwait( parameter ->
+        {
+            db.execute( "MATCH (n) SET n.v = n.v + 1" ).close();
+            return null;
+        }, null, waitingWhileIn( GraphDatabaseFacade.class, "execute" ), 5, SECONDS );
+
+        try
+        {
+            // when
+            Map<String,Object> data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
+
+            // then
+            assertTrue( "should contain a cpuTime field", data.containsKey( "cpuTime" ) );
+            Object cpuTime1 = data.get( "cpuTime" );
+            assertThat( cpuTime1, instanceOf( Long.class ) );
+
+            // when
+            data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
+
+            // then
+            Long cpuTime2 = (Long) data.get( "cpuTime" );
+            assertThat( cpuTime2, greaterThan( (Long) cpuTime1 ) );
+        }
+        finally
+        {
+            listQueriesLatch.countDown();
+        }
+    }
+
+    private Map<String,Object> getQueryListing( String query )
+    {
+        try ( Result rows = db.execute( "CALL dbms.listQueries" ) )
+        {
+            while ( rows.hasNext() )
+            {
+                Map<String,Object> row = rows.next();
+                if ( query.equals( row.get( "query" ) ) )
+                {
+                    return row;
+                }
+            }
+        }
+        throw new AssertionError( "query not active: " + query );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -102,8 +102,8 @@ public class ListQueriesProcedureTest
             Map<String,Object> data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
 
             // then
-            assertTrue( "should contain a 'cpuTime' field", data.containsKey( "cpuTime" ) );
-            Object cpuTime1 = data.get( "cpuTime" );
+            assertTrue( "should contain a 'cpuTimeMicros' field", data.containsKey( "cpuTimeMicros" ) );
+            Object cpuTime1 = data.get( "cpuTimeMicros" );
             assertThat( cpuTime1, instanceOf( Long.class ) );
             assertTrue( "should contain a 'status' field", data.containsKey( "status" ) );
             Object status = data.get( "status" );
@@ -113,17 +113,17 @@ public class ListQueriesProcedureTest
             assertEquals( "WAITING", statusMap.get( "state" ) );
             assertEquals( "NODE", statusMap.get( "resourceType" ) );
             assertArrayEquals( new long[]{node.getId()}, (long[]) statusMap.get( "resourceIds" ) );
-            assertTrue( "should contain a 'waitTime' field", data.containsKey( "waitTime" ) );
-            Object waitTime1 = data.get( "waitTime" );
+            assertTrue( "should contain a 'waitTimeMillis' field", data.containsKey( "waitTimeMillis" ) );
+            Object waitTime1 = data.get( "waitTimeMillis" );
             assertThat( waitTime1, instanceOf( Long.class ) );
 
             // when
             data = getQueryListing( "MATCH (n) SET n.v = n.v + 1" );
 
             // then
-            Long cpuTime2 = (Long) data.get( "cpuTime" );
+            Long cpuTime2 = (Long) data.get( "cpuTimeMicros" );
             assertThat( cpuTime2, greaterThan( (Long) cpuTime1 ) );
-            Long waitTime2 = (Long) data.get( "waitTime" );
+            Long waitTime2 = (Long) data.get( "waitTimeMillis" );
             assertThat( waitTime2, greaterThan( (Long) waitTime1 ) );
         }
         finally

--- a/integrationtests/src/test/java/org/neo4j/TransactionGuardIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionGuardIntegrationTest.java
@@ -83,6 +83,7 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.server.HTTP;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
+import org.neo4j.time.SystemNanoClock;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
@@ -587,7 +588,7 @@ public class TransactionGuardIntegrationTest
         {
             return new PlatformModule( storeDir, params, databaseInfo, dependencies, graphDatabaseFacade ) {
                 @Override
-                protected Clock createClock()
+                protected SystemNanoClock createClock()
                 {
                     return fakeClock;
                 }


### PR DESCRIPTION
Sample output from `CALL dbms.listQueries`:

```
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| queryId   | username | query                         | parameters | startTime                       | elapsedTime    | connectionDetails   | cpuTimeMillis | status                                                                                 | waitTimeMillis | metaData |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| "query-1" | ""       | "MATCH (n) SET n.v = n.v + 1" | {}         | "2017-01-03T16:38:29.213+01:00" | "00:00:01.507" | "embedded-session " | 856           | {waitTimeMillis -> 57, state -> "WAITING", resourceType -> "NODE", resourceIds -> [0]} | 57             | {}       |
| "query-4" | ""       | "CALL dbms.listQueries"       | {}         | "2017-01-03T16:38:30.719+01:00" | "00:00:00.001" | "embedded-session " | 1             | {state -> "RUNNING"}                                                                   | 0              | {}       |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```