### PR TITLE
Double test timeout for CI

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/AcquisitionTimeoutCompatibility.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.fail;
 public class AcquisitionTimeoutCompatibility extends LockingCompatibilityTestSuite.Compatibility
 {
 
-    private final long TEST_TIMEOUT = 2000;
+    private final long TEST_TIMEOUT = 4000;
     private FakeClock clock;
     private Config customConfig;
     private Locks lockManager;

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLockTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLockTest.java
@@ -21,9 +21,9 @@ package org.neo4j.kernel.impl.enterprise.lock.forseti;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class SharedLockTest


### PR DESCRIPTION
Locally runs fine double test timeout to check with CI. Imports cleanup.