### PR TITLE
Support UNWIND collection in compiled runtime

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -1,0 +1,118 @@
+#
+# Copyright (c) 2002-2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+Feature: UnwindAcceptance
+
+  Scenario: Flat type support in list literal
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A {prop: 'a'})-[:R {prop: 'r'}]->()
+      """
+    When executing query:
+      """
+      MATCH (n:A {prop: 'a'})-[r:R {prop: 'r'}]->()
+      WITH *
+      UNWIND [42, 0.7, true, 's', n, r] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i                 |
+      | 42                |
+      | 0.7               |
+      | true              |
+      | 's'               |
+      | (:A {prop: 'a'})  |
+      | [:R {prop: 'r'}]  |
+    And no side effects
+
+  Scenario: Nested type support in list literal
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A {prop: 'a'})-[:R {prop: 'r'}]->()
+      """
+    When executing query:
+      """
+      MATCH (n:A {prop: 'a'})-[r:R {prop: 'r'}]->()
+      WITH *
+      UNWIND [[42],[n],[r],[n,42],[r,42]] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i                      |
+      | [42]                   |
+      | [(:A {prop: 'a'})]     |
+      | [[:R {prop: 'r'}]]     |
+      | [(:A {prop: 'a'}), 42] |
+      | [[:R {prop: 'r'}], 42] |
+    And no side effects
+
+  Scenario: Nested type support in map literal
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A)-[:R]->()
+      """
+    When executing query:
+      """
+      MATCH (n:A)-[r:R]->()
+      WITH *
+      UNWIND [ {k: n},
+               {k: r},
+               {k: n, l: 42},
+               {k: r, l: 's'}
+             ] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i                 |
+      | {k: (:A)}         |
+      | {k: [:R]}         |
+      | {k: (:A), l: 42}  |
+      | {k: [:R], l: 's'} |
+    And no side effects
+
+  Scenario: Nested type support with mixed list and map literals
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A)-[:R]->()
+      """
+    When executing query:
+      """
+      MATCH (n:A)-[r:R]->()
+      WITH *
+      UNWIND [ {k: [n]},
+               {k: [r]},
+               {k: [n], l: 42},
+               {k: [r], l: 's'},
+               [ {k: [n]} ]
+             ] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i                   |
+      | {k: [(:A)]}         |
+      | {k: [(:R)]}         |
+      | {k: [(:A)], l: 42}  |
+      | {k: [(:R)], l: 's'} |
+      | [{k: [(:A)]}]       |
+    And no side effects

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -102,17 +102,45 @@ Feature: UnwindAcceptance
       WITH *
       UNWIND [ {k: [n]},
                {k: [r]},
-               {k: [n], l: 42},
+               {k: [n, r], l: 42},
                {k: [r], l: 's'},
-               [ {k: [n]} ]
+               [ {k: [n, r]} ]
              ] as i
       RETURN i
       """
     Then the result should be:
-      | i                   |
-      | {k: [(:A)]}         |
-      | {k: [[:R]]}         |
-      | {k: [(:A)], l: 42}  |
-      | {k: [[:R]], l: 's'} |
-      | [{k: [(:A)]}]       |
+      | i                        |
+      | {k: [(:A)]}              |
+      | {k: [[:R]]}              |
+      | {k: [(:A), [:R]], l: 42} |
+      | {k: [[:R]], l: 's'}      |
+      | [{k: [(:A), [:R]]}]      |
+    And no side effects
+
+  Scenario: Nested type support with mixed list and map literals with projection
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A)-[:R]->()
+      """
+    When executing query:
+      """
+      MATCH (n:A)-[r:R]->()
+      WITH *
+      UNWIND [ {k: [n]},
+               {k: [r]},
+               {k: [n, r], l: 42},
+               {k: [r], l: 's'},
+               [ {k: [n, r]} ]
+             ] as i
+      WITH i as j
+      RETURN j
+      """
+    Then the result should be:
+      | j                        |
+      | {k: [(:A)]}              |
+      | {k: [[:R]]}              |
+      | {k: [(:A), [:R]], l: 42} |
+      | {k: [[:R]], l: 's'}     |
+      | [{k: [(:A), [:R]]}]      |
     And no side effects

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -111,8 +111,8 @@ Feature: UnwindAcceptance
     Then the result should be:
       | i                   |
       | {k: [(:A)]}         |
-      | {k: [(:R)]}         |
+      | {k: [[:R]]}         |
       | {k: [(:A)], l: 42}  |
-      | {k: [(:R)], l: 's'} |
+      | {k: [[:R]], l: 's'} |
       | [{k: [(:A)]}]       |
     And no side effects

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -88,4 +88,22 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a:Person) WITH count(a) as c RETURN c")
     result.toList should equal(List(Map("c" -> 2L)))
   }
+
+  test("Count should work with projected node variable") {
+    val node1 = createLabeledNode("Person")
+    val node2 = createLabeledNode("Person")
+    val node3 = createNode()
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a:Person) WITH a as b WITH count(b) as c RETURN c")
+    result.toList should equal(List(Map("c" -> 2L)))
+  }
+
+  test("Count should work with projected relationship variable") {
+    val node1 = createLabeledNode("Person")
+    val node2 = createNode()
+    val node3 = createNode()
+    val r1 = relate(node1, node2)
+    val r2 = relate(node1, node3)
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a:Person)-[r]->() WITH r as s WITH count(s) as c RETURN c")
+    result.toList should equal(List(Map("c" -> 2L)))
+  }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
@@ -20,11 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v3_2.codegen
 
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.JoinData
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, ReferenceType}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.CodeGenType
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticTable
-import org.neo4j.cypher.internal.frontend.v3_2.symbols.{CTNode, CTRelationship}
 
 import scala.collection.mutable
 
@@ -33,20 +32,13 @@ case class Variable(name: String, codeGenType: CodeGenType, nullable: Boolean = 
 class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, Id], val namer: Namer = Namer()) {
 
   private val variables: mutable.Map[String, Variable] = mutable.Map()
-  private val internalVariables: mutable.Map[String, Variable] = mutable.Map()
   private val probeTables: mutable.Map[CodeGenPlan, JoinData] = mutable.Map()
   private val parents: mutable.Stack[CodeGenPlan] = mutable.Stack()
   val operatorIds: mutable.Map[Id, String] = mutable.Map()
 
   def addVariable(queryVariable: String, variable: Variable) {
-    if (variable.codeGenType != CodeGenType(CTNode, ReferenceType) &&
-      variable.codeGenType != CodeGenType(CTRelationship, ReferenceType)) {
-      internalVariables.put(queryVariable, variable)
-    }
     variables.put(queryVariable, variable)
   }
-
-  def getInternalVariable(queryVariable: String): Variable = internalVariables(queryVariable)
 
   def getVariable(queryVariable: String): Variable = variables(queryVariable)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -81,9 +81,8 @@ object LogicalPlanConverter {
 
     override def consume(context: CodeGenContext, child: CodeGenPlan) = {
       val projectionOpName = context.registerOperator(projection)
-      // TODO: Remove intermediate materialization of values
       val columns = immutableMapValues(projection.expressions,
-                                       (e: ast.Expression) => ExpressionConverter.createProjection(e)(context))
+                                       (e: ast.Expression) => ExpressionConverter.createExpression(e)(context))
       val vars = columns.map {
         case (name, expr) =>
           val variable = Variable(context.namer.newVarName(), CodeGenType(expr.codeGenType(context).ct, ReferenceType),
@@ -109,7 +108,7 @@ object LogicalPlanConverter {
     override def consume(context: CodeGenContext, child: CodeGenPlan) = {
       val produceResultOpName = context.registerOperator(produceResults)
       val projections = produceResults.columns.map(c =>
-        c -> ExpressionConverter.createExpressionForVariable(c)(context)).toMap
+        c -> ExpressionConverter.createMaterializeExpressionForVariable(c)(context)).toMap
 
       (None, List(AcceptVisitor(produceResultOpName, projections)))
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -44,7 +44,7 @@ object LogicalPlanConverter {
     case p: NodeByIdSeek => nodeByIdSeekAsCodeGenPlan(p)
     case p: NodeUniqueIndexSeek => nodeUniqueIndexSeekAsCodeGen(p)
     case p: Expand => expandAsCodeGenPlan(p)
-    case p: OptionalExpand => optExpandAsCodeGenPlan(p)
+    case p: OptionalExpand => optionalExpandAsCodeGenPlan(p)
     case p: NodeHashJoin => nodeHashJoinAsCodeGenPlan(p)
     case p: CartesianProduct => cartesianProductAsCodeGenPlan(p)
     case p: Selection => selectionAsCodeGenPlan(p)
@@ -336,7 +336,7 @@ object LogicalPlanConverter {
     }
   }
 
-  private def optExpandAsCodeGenPlan(optionalExpand: OptionalExpand) = new CodeGenPlan {
+  private def optionalExpandAsCodeGenPlan(optionalExpand: OptionalExpand) = new CodeGenPlan {
 
     override val logicalPlan: LogicalPlan = optionalExpand
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -85,8 +85,7 @@ object LogicalPlanConverter {
                                        (e: ast.Expression) => ExpressionConverter.createExpression(e)(context))
       val vars = columns.map {
         case (name, expr) =>
-          val variable = Variable(context.namer.newVarName(), CodeGenType(expr.codeGenType(context).ct, ReferenceType),
-                                  expr.nullable(context))
+          val variable = Variable(context.namer.newVarName(), expr.codeGenType(context), expr.nullable(context))
           context.addVariable(name, variable)
           variable -> expr
       }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/AcceptVisitor.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/AcceptVisitor.scala
@@ -30,7 +30,7 @@ case class AcceptVisitor(produceResultOpName: String, columns: Map[String, CodeG
     generator.trace(produceResultOpName) { body =>
       body.incrementRows()
       columns.foreach { case (k, v) =>
-        body.setInRow(k, generator.box(v.generateExpression(body)))
+        body.setInRow(k, generator.box(v.generateExpression(body), v.codeGenType))
       }
       body.visitorAccept()
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
 
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.CodeGenExpression
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, CodeGenExpression}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 
@@ -38,7 +38,11 @@ case class Projection(projectionOpName: String, variables: Map[Variable, CodeGen
       body.incrementRows()
       variables.foreach {
         case (variable, expr) =>
-          body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
+          if (variable.codeGenType.isPrimitive)
+            body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
+          else
+            // Declare the variable with a non-specific Object type for non-primitive types to avoid casting
+            body.assign(variable.name, CodeGenType.Any, expr.generateExpression(body))
       }
       action.body(body)
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
@@ -38,11 +38,15 @@ case class Projection(projectionOpName: String, variables: Map[Variable, CodeGen
       body.incrementRows()
       variables.foreach {
         case (variable, expr) =>
-          if (variable.codeGenType.isPrimitive)
+          if (variable.codeGenType.isPrimitive) {
+            body.declare(variable.name, variable.codeGenType)
             body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
-          else
+          }
+          else {
             // Declare the variable with a non-specific Object type for non-primitive types to avoid casting
+            body.declare(variable.name, CodeGenType.Any)
             body.assign(variable.name, CodeGenType.Any, expr.generateExpression(body))
+          }
       }
       action.body(body)
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
@@ -37,8 +37,8 @@ case class Projection(projectionOpName: String, variables: Map[Variable, CodeGen
     generator.trace(projectionOpName) { body =>
       body.incrementRows()
       variables.foreach {
-        case (variable, expr) => body.projectVariable(variable.name,
-                                                      generator.box(expr.generateExpression(body)))
+        case (variable, expr) =>
+          body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
       }
       action.body(body)
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/AggregateExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/AggregateExpression.scala
@@ -47,9 +47,7 @@ abstract class BaseAggregateExpression(expression: CodeGenExpression, distinct: 
                           (implicit context: CodeGenContext) = {
     expression match {
       case NodeExpression(v) => primitiveIfNot(v, structure)(block(_))
-      case NodeProjection(v) => primitiveIfNot(v, structure)(block(_))
       case RelationshipExpression(v) => primitiveIfNot(v, structure)(block(_))
-      case RelationshipProjection(v) => primitiveIfNot(v, structure)(block(_))
       case _ =>
         val tmpName = context.namer.newVarName()
         structure.assign(tmpName, expression.codeGenType, expression.generateExpression(structure))
@@ -62,24 +60,6 @@ abstract class BaseAggregateExpression(expression: CodeGenExpression, distinct: 
           else block(body)
         }
     }
-  }
-
-  protected def internalExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext): E = {
-    expression match {
-      case NodeExpression(v) => structure.loadVariable(v.name)
-      case NodeProjection(v) => structure.loadVariable(v.name)
-      case RelationshipExpression(v) => structure.loadVariable(v.name)
-      case RelationshipProjection(v) => structure.loadVariable(v.name)
-      case _ => expression.generateExpression(structure)
-    }
-  }
-
-  protected def internalExpressionType(implicit context: CodeGenContext) = expression match {
-    case NodeExpression(v) => CodeGenType.primitiveNode
-    case NodeProjection(v) => CodeGenType.primitiveNode
-    case RelationshipExpression(v) => CodeGenType.primitiveRel
-    case RelationshipProjection(v) => CodeGenType.primitiveRel
-    case _ => expression.codeGenType
   }
 
   private def primitiveIfNot[E](v: Variable, structure: MethodStructure[E])(block: MethodStructure[E] => Unit)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/DynamicCount.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/DynamicCount.scala
@@ -40,7 +40,7 @@ class DynamicCount(opName: String, variable: Variable, expression: CodeGenExpres
     val key = groupingKey.map(_.codeGenType).toIndexedSeq
     generator.newAggregationMap(mapName, key)
     if (distinct) {
-      generator.newMapOfSets(seenSet, key, internalExpressionType)
+      generator.newMapOfSets(seenSet, key, expression.codeGenType)
     }
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/SimpleCount.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/SimpleCount.scala
@@ -34,7 +34,7 @@ case class SimpleCount(variable: Variable, expression: CodeGenExpression, distin
     expression.init(generator)
     generator.assign(variable.name, CodeGenType.primitiveInt, generator.constantExpression(Long.box(0L)))
     if (distinct) {
-      generator.newDistinctSet(setName(variable), Seq(internalExpressionType))
+      generator.newDistinctSet(setName(variable), Seq(expression.codeGenType))
     }
   }
 
@@ -49,7 +49,7 @@ case class SimpleCount(variable: Variable, expression: CodeGenExpression, distin
                           (implicit context: CodeGenContext) = {
 
     structure.distinctSetIfNotContains(
-      setName(variable), Map(typeName(variable) ->(internalExpressionType -> internalExpression(structure))))(block)
+      setName(variable), Map(typeName(variable) -> (expression.codeGenType -> expression.generateExpression(structure))))(block)
   }
 
   private def setName(variable: Variable) = variable.name + "Set"

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/AnyProjection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/AnyProjection.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen._
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+
+case class AnyProjection(variable: Variable) extends CodeGenExpression {
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
+
+  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) ={
+    structure.materializeAny(variable.name)
+  }
+
+  override def nullable(implicit context: CodeGenContext): Boolean = variable.nullable
+
+  override def codeGenType(implicit context: CodeGenContext) = variable.codeGenType
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Equals.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Equals.scala
@@ -48,8 +48,8 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
    *   semantics
    */
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
-    if (nullable) structure.threeValuedEqualsExpression(structure.box(lhs.generateExpression(structure)),
-                                                        structure.box(rhs.generateExpression(structure)))
+    if (nullable) structure.threeValuedEqualsExpression(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
+                                                        structure.box(rhs.generateExpression(structure), rhs.codeGenType))
     else (lhs, rhs) match {
       case (NodeExpression(v1), NodeExpression(v2)) =>
         structure.equalityExpression(structure.loadVariable(v1.name), structure.loadVariable(v2.name), CodeGenType.primitiveNode)
@@ -79,7 +79,8 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
         structure.equalityExpression(lhs.generateExpression(structure), rhs.generateExpression(structure), t1.codeGenType)
       case _ =>
         structure.unbox(
-          structure.threeValuedEqualsExpression(structure.box(lhs.generateExpression(structure)), structure.box(rhs.generateExpression(structure))),
+          structure.threeValuedEqualsExpression(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
+                                                structure.box(rhs.generateExpression(structure), rhs.codeGenType)),
           CodeGenType(CTBoolean, ReferenceType))
       }
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Equals.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/Equals.scala
@@ -49,12 +49,17 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
    */
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     (lhs, rhs, nullable) match {
-      // it does not matter to equals if node and relationship expressions are nullable or not
-      case (NodeExpression(v1), NodeExpression(v2), _) =>
+      case (NodeExpression(v1), NodeExpression(v2), false) =>
         structure.equalityExpression(structure.loadVariable(v1.name), structure.loadVariable(v2.name), CodeGenType.primitiveNode)
-      case (RelationshipExpression(v1), RelationshipExpression(v2), _) =>
+      case (NodeExpression(v1), NodeExpression(v2), true) =>
+        structure.threeValuedPrimitiveEqualsExpression(structure.loadVariable(v1.name), structure.loadVariable(v2.name),
+                                                       CodeGenType.primitiveNode)
+      case (RelationshipExpression(v1), RelationshipExpression(v2), false) =>
         structure.equalityExpression(structure.loadVariable(v1.name), structure.loadVariable(v2.name),
                                      CodeGenType.primitiveRel)
+      case (RelationshipExpression(v1), RelationshipExpression(v2), true) =>
+        structure.threeValuedPrimitiveEqualsExpression(structure.loadVariable(v1.name), structure.loadVariable(v2.name),
+                                                       CodeGenType.primitiveRel)
       case (NodeExpression(_), RelationshipExpression(_), _) => throw new
           IncomparableValuesException(symbols.CTNode.toString, symbols.CTRelationship.toString)
       case (RelationshipExpression(_), NodeExpression(_), _) => throw new

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -96,18 +96,18 @@ object ExpressionConverter {
 
     expression match {
       case node@ast.Variable(name) if context.semanticTable.isNode(node) =>
-        NodeExpression(context.getInternalVariable(name))
+        NodeExpression(context.getVariable(name))
 
       case rel@ast.Variable(name) if context.semanticTable.isRelationship(rel) =>
-        RelationshipExpression(context.getInternalVariable(name))
+        RelationshipExpression(context.getVariable(name))
 
       case ast.Property(node@ast.Variable(name), propKey) if context.semanticTable.isNode(node) =>
         val token = propKey.id(context.semanticTable).map(_.id)
-        NodeProperty(token, propKey.name, context.getInternalVariable(name), context.namer.newVarName())
+        NodeProperty(token, propKey.name, context.getVariable(name), context.namer.newVarName())
 
       case ast.Property(rel@ast.Variable(name), propKey) if context.semanticTable.isRelationship(rel) =>
         val token = propKey.id(context.semanticTable).map(_.id)
-        RelProperty(token, propKey.name, context.getInternalVariable(name), context.namer.newVarName())
+        RelProperty(token, propKey.name, context.getVariable(name), context.namer.newVarName())
 
       case ast.Parameter(name, _) => expressions.Parameter(name, context.namer.newVarName())
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -75,26 +75,8 @@ object ExpressionConverter {
   def createExpression(expression: ast.Expression)
                       (implicit context: CodeGenContext): CodeGenExpression = expressionConverter(expression, createExpression)
 
-  def createProjection(expression: ast.Expression)
-                      (implicit context: CodeGenContext): CodeGenExpression = {
-
-    expression match {
-      case node@ast.Variable(name) if context.semanticTable.isNode(node) =>
-        val variable = context.getVariable(name)
-        if (variable.codeGenType.isPrimitive) NodeProjection(variable)
-        else LoadVariable(variable)
-
-      case rel@ast.Variable(name) if context.semanticTable.isRelationship(rel) =>
-        val variable = context.getVariable(name)
-        if (variable.codeGenType.isPrimitive) RelationshipProjection(variable)
-        else LoadVariable(variable)
-
-      case e => expressionConverter(e, createProjection)
-    }
-  }
-
-  def createExpressionForVariable(variableQueryVariable: String)
-                                 (implicit context: CodeGenContext): CodeGenExpression = {
+  def createMaterializeExpressionForVariable(variableQueryVariable: String)
+                                            (implicit context: CodeGenContext): CodeGenExpression = {
 
     val variable = context.getVariable(variableQueryVariable)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -84,9 +84,10 @@ object ExpressionConverter {
       case CTNode => NodeProjection(variable)
       case CTRelationship => RelationshipProjection(variable)
       case CTString | CTBoolean | CTInteger | CTFloat => LoadVariable(variable)
+      case ListType(CTString) | ListType(CTBoolean) | ListType(CTInteger) | ListType(CTFloat) => LoadVariable(variable)
       case CTAny => AnyProjection(variable)
       case CTMap => AnyProjection(variable)
-      case ListType(_) => AnyProjection(variable) // TODO: We could have a more specialized projection when the inner type is known
+      case ListType(_) => AnyProjection(variable) // TODO: We could have a more specialized projection when the inner type is known to be node or relationship
       case _ => throw new CantCompileQueryException(s"The compiled runtime cannot handle results of type ${variable.codeGenType.ct}")
     }
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
@@ -31,7 +31,7 @@ case class ListLiteral(expressions: Seq[CodeGenExpression]) extends CodeGenExpre
     }
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.asList(expressions.map(e => structure.box(e.generateExpression(structure))))
+    structure.asList(expressions.map(e => structure.box(e.generateExpression(structure), e.codeGenType)))
 
   override def nullable(implicit context: CodeGenContext) = false
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
@@ -31,12 +31,16 @@ case class ListLiteral(expressions: Seq[CodeGenExpression]) extends CodeGenExpre
     }
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.asList(expressions.map(_.generateExpression(structure)))
+    structure.asList(expressions.map(e => structure.box(e.generateExpression(structure))))
 
   override def nullable(implicit context: CodeGenContext) = false
 
   override def codeGenType(implicit context: CodeGenContext) = {
-    val commonType = expressions.map(_.codeGenType.ct).reduce[CypherType](_ leastUpperBound _)
+    val commonType =
+      if (expressions.nonEmpty)
+        expressions.map(_.codeGenType.ct).reduce[CypherType](_ leastUpperBound _)
+      else
+        CTAny
 
     CodeGenType(CTList(commonType), ReferenceType)
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MyMap.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MyMap.scala
@@ -32,7 +32,7 @@ case class MyMap(instructions: Map[String, CodeGenExpression]) extends CodeGenEx
     }
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.asMap(instructions.mapValues(_.generateExpression(structure)))
+    structure.asMap(instructions.mapValues(e => structure.box(e.generateExpression(structure))))
 
   override def nullable(implicit context: CodeGenContext) = false
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MyMap.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MyMap.scala
@@ -32,7 +32,7 @@ case class MyMap(instructions: Map[String, CodeGenExpression]) extends CodeGenEx
     }
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
-    structure.asMap(instructions.mapValues(e => structure.box(e.generateExpression(structure))))
+    structure.asMap(instructions.mapValues(e => structure.box(e.generateExpression(structure), e.codeGenType)))
 
   override def nullable(implicit context: CodeGenContext) = false
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
@@ -30,9 +30,11 @@ case class NodeExpression(nodeIdVar: Variable) extends CodeGenExpression {
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
-    if (nodeIdVar.nullable)
-      structure.nullableReference(nodeIdVar.name, CodeGenType.primitiveNode,
+    // Nullable primitive variables already have their nullValue (-1L) in the same domain as their possible values and do not need a null check
+    if (nodeIdVar.nullable && !nodeIdVar.codeGenType.isPrimitive) {
+      structure.nullableReference(nodeIdVar.name, nodeIdVar.codeGenType,
         structure.node(nodeIdVar.name, nodeIdVar.codeGenType))
+    }
     else
       structure.node(nodeIdVar.name, nodeIdVar.codeGenType)
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
@@ -22,7 +22,6 @@ package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols
-import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class NodeExpression(nodeIdVar: Variable) extends CodeGenExpression {
 
@@ -32,12 +31,13 @@ case class NodeExpression(nodeIdVar: Variable) extends CodeGenExpression {
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     if (nodeIdVar.nullable)
-      structure.nullableReference(nodeIdVar.name, CodeGenType.primitiveNode, structure.node(nodeIdVar.name))
+      structure.nullableReference(nodeIdVar.name, CodeGenType.primitiveNode,
+        structure.node(nodeIdVar.name, nodeIdVar.codeGenType))
     else
-      structure.node(nodeIdVar.name)
+      structure.node(nodeIdVar.name, nodeIdVar.codeGenType)
   }
 
   override def nullable(implicit context: CodeGenContext) = nodeIdVar.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTNode, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = nodeIdVar.codeGenType
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeExpression.scala
@@ -21,23 +21,16 @@ package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
 
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
-import org.neo4j.cypher.internal.frontend.v3_2.symbols
 
 case class NodeExpression(nodeIdVar: Variable) extends CodeGenExpression {
 
-  assert(nodeIdVar.codeGenType.ct == symbols.CTNode)
+  assert(nodeIdVar.codeGenType == CodeGenType.primitiveNode)
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
-  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
     // Nullable primitive variables already have their nullValue (-1L) in the same domain as their possible values and do not need a null check
-    if (nodeIdVar.nullable && !nodeIdVar.codeGenType.isPrimitive) {
-      structure.nullableReference(nodeIdVar.name, nodeIdVar.codeGenType,
-        structure.node(nodeIdVar.name, nodeIdVar.codeGenType))
-    }
-    else
-      structure.node(nodeIdVar.name, nodeIdVar.codeGenType)
-  }
+    structure.node(nodeIdVar.name, nodeIdVar.codeGenType)
 
   override def nullable(implicit context: CodeGenContext) = nodeIdVar.nullable
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeProjection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/NodeProjection.scala
@@ -31,9 +31,10 @@ case class NodeProjection(nodeIdVar: Variable) extends CodeGenExpression {
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) ={
     if (nodeIdVar.nullable)
-      structure.nullableReference(nodeIdVar.name, CodeGenType.primitiveNode, structure.materializeNode(nodeIdVar.name))
+      structure.nullableReference(nodeIdVar.name, CodeGenType.primitiveNode,
+        structure.materializeNode(nodeIdVar.name, nodeIdVar.codeGenType))
     else
-      structure.materializeNode(nodeIdVar.name)
+      structure.materializeNode(nodeIdVar.name, nodeIdVar.codeGenType)
   }
 
   override def nullable(implicit context: CodeGenContext) = nodeIdVar.nullable

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
@@ -29,12 +29,13 @@ case class RelationshipExpression(relId: Variable) extends CodeGenExpression {
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
-    if (relId.nullable)
-      structure.nullableReference(relId.name, CodeGenType.primitiveRel,
+    // Nullable primitive variables already have their nullValue (-1L) in the same domain as their possible values and do not need a null check
+    if (relId.nullable && !relId.codeGenType.isPrimitive) {
+      structure.nullableReference(relId.name, relId.codeGenType,
         structure.relationship(relId.name, relId.codeGenType))
+    }
     else
       structure.relationship(relId.name, relId.codeGenType)
-
   }
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
@@ -21,22 +21,15 @@ package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
 
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
-import org.neo4j.cypher.internal.frontend.v3_2.symbols
 
 case class RelationshipExpression(relId: Variable) extends CodeGenExpression {
-  assert(relId.codeGenType.ct == symbols.CTRelationship)
+  assert(relId.codeGenType == CodeGenType.primitiveRel)
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
-  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
     // Nullable primitive variables already have their nullValue (-1L) in the same domain as their possible values and do not need a null check
-    if (relId.nullable && !relId.codeGenType.isPrimitive) {
-      structure.nullableReference(relId.name, relId.codeGenType,
-        structure.relationship(relId.name, relId.codeGenType))
-    }
-    else
-      structure.relationship(relId.name, relId.codeGenType)
-  }
+    structure.relationship(relId.name, relId.codeGenType)
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipExpression.scala
@@ -22,7 +22,6 @@ package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols
-import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class RelationshipExpression(relId: Variable) extends CodeGenExpression {
   assert(relId.codeGenType.ct == symbols.CTRelationship)
@@ -31,13 +30,14 @@ case class RelationshipExpression(relId: Variable) extends CodeGenExpression {
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     if (relId.nullable)
-      structure.nullableReference(relId.name, CodeGenType.primitiveRel, structure.relationship(relId.name))
+      structure.nullableReference(relId.name, CodeGenType.primitiveRel,
+        structure.relationship(relId.name, relId.codeGenType))
     else
-      structure.relationship(relId.name)
+      structure.relationship(relId.name, relId.codeGenType)
 
   }
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTRelationship, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = relId.codeGenType
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipProjection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RelationshipProjection.scala
@@ -31,9 +31,10 @@ case class RelationshipProjection(relId: Variable) extends CodeGenExpression {
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) ={
     if (relId.nullable)
-      structure.nullableReference(relId.name, CodeGenType.primitiveRel, structure.materializeRelationship(relId.name))
+      structure.nullableReference(relId.name, CodeGenType.primitiveRel,
+        structure.materializeRelationship(relId.name, relId.codeGenType))
     else
-      structure.materializeRelationship(relId.name)
+      structure.materializeRelationship(relId.name, relId.codeGenType)
   }
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/TypeOf.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/TypeOf.scala
@@ -30,7 +30,7 @@ case class TypeOf(relId: Variable)
 
   def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     val typeName = context.namer.newVarName()
-    structure.declare(typeName, CodeGenType(CTString, ReferenceType))
+    structure.declareAndInitialize(typeName, CodeGenType(CTString, ReferenceType))
     if (nullable) {
       structure.ifNotStatement(structure.isNull(relId.name, CodeGenType.primitiveRel)) { body =>
         body.relType(relId.name, typeName)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -157,6 +157,7 @@ trait MethodStructure[E] {
   def node(nodeIdVar: String): E
   def materializeRelationship(relIdVar: String): E
   def relationship(relIdVar: String): E
+  def materializeAny(variable: String): E
   /** Feed single row to the given visitor */
   def visitorAccept(): Unit
   def setInRow(column: String, value: E): Unit

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -154,9 +154,9 @@ trait MethodStructure[E] {
 
   // results
   def materializeNode(nodeIdVar: String, codeGenType: CodeGenType): E
-  def node(nodeIdVar: String): E
+  def node(nodeIdVar: String, codeGenType: CodeGenType): E
   def materializeRelationship(relIdVar: String, codeGenType: CodeGenType): E
-  def relationship(relIdVar: String): E
+  def relationship(relIdVar: String, codeGenType: CodeGenType): E
   def materializeAny(variable: String): E
   /** Feed single row to the given visitor */
   def visitorAccept(): Unit

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -38,7 +38,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
   */
 trait MethodStructure[E] {
   // misc
-  def projectVariable(variableName: String, value: E)
   def declareFlag(name: String, initialValue: Boolean)
   def updateFlag(name: String, newValue: Boolean)
   def declarePredicate(name: String): Unit
@@ -91,6 +90,7 @@ trait MethodStructure[E] {
   def threeValuedNotExpression(value: E): E
   def notExpression(value: E): E
   def threeValuedEqualsExpression(lhs: E, rhs: E): E
+  def threeValuedPrimitiveEqualsExpression(lhs: E, rhs: E, codeGenType: CodeGenType): E
   def equalityExpression(lhs: E, rhs: E, codeGenType: CodeGenType): E
   def orExpression(lhs: E, rhs: E): E
   def threeValuedOrExpression(lhs: E, rhs: E): E

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -100,7 +100,7 @@ trait MethodStructure[E] {
   def nullableReference(varName: String, codeGenType: CodeGenType, onSuccess: E): E
   def isNull(name: String, codeGenType: CodeGenType): E
   def notNull(name: String, codeGenType: CodeGenType): E
-  def box(expression:E): E
+  def box(expression:E, codeGenType: CodeGenType = CodeGenType.Any): E
   def unbox(expression:E, codeGenType: CodeGenType): E
   def toFloat(expression:E): E
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -153,9 +153,9 @@ trait MethodStructure[E] {
   def returnSuccessfully(): Unit
 
   // results
-  def materializeNode(nodeIdVar: String): E
+  def materializeNode(nodeIdVar: String, codeGenType: CodeGenType): E
   def node(nodeIdVar: String): E
-  def materializeRelationship(relIdVar: String): E
+  def materializeRelationship(relIdVar: String, codeGenType: CodeGenType): E
   def relationship(relIdVar: String): E
   def materializeAny(variable: String): E
   /** Feed single row to the given visitor */

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -43,6 +43,7 @@ trait MethodStructure[E] {
   def updateFlag(name: String, newValue: Boolean)
   def declarePredicate(name: String): Unit
   def assign(varName: String, codeGenType: CodeGenType, value: E): Unit
+  def declareAndInitialize(varName: String, codeGenType: CodeGenType): Unit
   def declare(varName: String, codeGenType: CodeGenType): Unit
   def declareProperty(name: String): Unit
   def declareCounter(name: String, initialValue: E): Unit

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -246,8 +246,8 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
       case Sort(_, orderBy) =>
         PlanDescriptionImpl(id, "Sort", children, Seq(KeyNames(orderBy.map(_.id.name))), variables)
 
-      case _: UnwindCollection =>
-        PlanDescriptionImpl(id, "Unwind", children, Seq(), variables)
+      case UnwindCollection(_, _, expression) =>
+        PlanDescriptionImpl(id, "Unwind", children, Seq(Expression(expression)), variables)
 
       case VarExpand(_, IdName(fromName), dir, _, types, IdName(toName), IdName(relName), length, mode, predicates) =>
         val expandDescription = ExpandExpression(fromName, relName, types.map(_.name), toName, dir, minLength = length.min, maxLength = length.max)

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -197,10 +197,6 @@ public abstract class CompiledConversionUtils
             ((Map) anyValue).replaceAll( (k, v) -> materializeAnyResult( nodeManager, v ) );
             return anyValue;
         }
-        else if ( anyValue instanceof JavaListWrapper )
-        {
-            throw new IllegalStateException( "JavaListWrapper should not leak into compiled runtime" );
-        }
         else
         {
             return anyValue;

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -187,11 +187,6 @@ public abstract class CompiledConversionUtils
         {
             return nodeManager.newRelationshipProxyById( ((RelationshipIdWrapper) anyValue).id() );
         }
-        else if ( anyValue instanceof JavaListWrapper )
-        {
-            return ((JavaListWrapper) anyValue).inner().stream()
-                    .map( v -> materializeAnyResult( nodeManager, v ) ).collect( Collectors.toList() );
-        }
         else if ( anyValue instanceof List )
         {
             return ((List) anyValue).stream()
@@ -201,6 +196,10 @@ public abstract class CompiledConversionUtils
         {
             ((Map) anyValue).replaceAll( (k, v) -> materializeAnyResult( nodeManager, v ) );
             return anyValue;
+        }
+        else if ( anyValue instanceof JavaListWrapper )
+        {
+            throw new IllegalStateException( "JavaListWrapper should not leak into compiled runtime" );
         }
         else
         {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -258,8 +258,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   }
 
 
-  override def materializeNode(nodeIdVar: String) =
-    invoke(nodeManager, newNodeProxyById, generator.load(nodeIdVar))
+  override def materializeNode(nodeIdVar: String, codeGenType: CodeGenType) =
+    if (codeGenType.isPrimitive)
+      invoke(nodeManager, newNodeProxyById, generator.load(nodeIdVar))
+    else
+      invoke(nodeManager, newNodeProxyById,
+        invoke(cast(typeRef[NodeIdWrapper], generator.load(nodeIdVar)), nodeId))
 
   override def node(nodeIdVar: String) = createNewInstance(typeRef[NodeIdWrapper],
                                                            (typeRef[Long], generator.load(nodeIdVar)))
@@ -282,14 +286,17 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     case _ => ternaryOnNull(generator.load(varName), constant(null), onSuccess)
   }
 
-  override def materializeRelationship(relIdVar: String) =
-    invoke(nodeManager, newRelationshipProxyById, generator.load(relIdVar))
+  override def materializeRelationship(relIdVar: String, codeGenType: CodeGenType) =
+    if (codeGenType.isPrimitive)
+      invoke(nodeManager, newRelationshipProxyById, generator.load(relIdVar))
+    else
+      invoke(nodeManager, newRelationshipProxyById,
+        invoke(cast(typeRef[RelationshipIdWrapper], generator.load(relIdVar)), relId))
 
   override def relationship(relIdVar: String) = createNewInstance(typeRef[RelationshipIdWrapper],
                                                                   (typeRef[Long], generator.load(relIdVar)))
 
   override def materializeAny(variable: String) =
-    // TODO: Generate code directly instead of helper method call
     invoke(materializeAnyResult, nodeManager, generator.load(variable))
 
   override def trace[V](planStepId: String)(block: MethodStructure[Expression] => V) = if (!tracing) block(this)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1033,7 +1033,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       case CodeGenType(symbols.CTInteger, IntType) => constant(0L)
       case CodeGenType(symbols.CTFloat, FloatType) => constant(0.0)
       case CodeGenType(symbols.CTBoolean, BoolType) => constant(false)
-      case CodeGenType(symbols.CTInteger, _) => constant(0L)
       case _ => generator.assign(localVariable, nullValue(codeGenType))
     }
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -265,8 +265,11 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       invoke(nodeManager, newNodeProxyById,
         invoke(cast(typeRef[NodeIdWrapper], generator.load(nodeIdVar)), nodeId))
 
-  override def node(nodeIdVar: String) = createNewInstance(typeRef[NodeIdWrapper],
-                                                           (typeRef[Long], generator.load(nodeIdVar)))
+  override def node(nodeIdVar: String, codeGenType: CodeGenType) =
+    if (codeGenType.isPrimitive)
+      generator.load(nodeIdVar)
+    else
+      createNewInstance(typeRef[NodeIdWrapper], (typeRef[Long], generator.load(nodeIdVar)))
 
   override def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
@@ -293,8 +296,11 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       invoke(nodeManager, newRelationshipProxyById,
         invoke(cast(typeRef[RelationshipIdWrapper], generator.load(relIdVar)), relId))
 
-  override def relationship(relIdVar: String) = createNewInstance(typeRef[RelationshipIdWrapper],
-                                                                  (typeRef[Long], generator.load(relIdVar)))
+  override def relationship(relIdVar: String, codeGenType: CodeGenType) =
+    if (codeGenType.isPrimitive)
+      generator.load(relIdVar)
+    else
+      createNewInstance(typeRef[RelationshipIdWrapper], (typeRef[Long], generator.load(relIdVar)))
 
   override def materializeAny(variable: String) =
     invoke(materializeAnyResult, nodeManager, generator.load(variable))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -30,9 +30,8 @@ import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.CompositeKey
 import org.neo4j.cypher.internal.codegen._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{Parameter => _, _}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, IntType, Parameter => _, ReferenceType}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, IntType, ReferenceType}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.{CTNode, CTRelationship}
@@ -288,6 +287,10 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def relationship(relIdVar: String) = createNewInstance(typeRef[RelationshipIdWrapper],
                                                                   (typeRef[Long], generator.load(relIdVar)))
+
+  override def materializeAny(variable: String) =
+    // TODO: Generate code directly instead of helper method call
+    invoke(materializeAnyResult, nodeManager, generator.load(variable))
 
   override def trace[V](planStepId: String)(block: MethodStructure[Expression] => V) = if (!tracing) block(this)
   else {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -366,9 +366,15 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def notNull(varName: String, codeGenType: CodeGenType) = not(isNull(varName, codeGenType))
 
-  override def box(expression: Expression) = Expression.box(expression)
+  override def box(expression: Expression, codeGenType: CodeGenType) = codeGenType match {
+    case CodeGenType(symbols.CTNode, IntType) =>
+      createNewInstance(typeRef[NodeIdWrapper], (typeRef[Long], expression))
+    case CodeGenType(symbols.CTRelationship, IntType) =>
+      createNewInstance(typeRef[RelationshipIdWrapper], (typeRef[Long], expression))
+    case _ => Expression.box(expression)
+  }
 
-  override def unbox(expression: Expression, cType: CodeGenType) = cType match {
+  override def unbox(expression: Expression, codeGenType: CodeGenType) = codeGenType match {
     case c if c.isPrimitive => expression
     case CodeGenType(symbols.CTNode, ReferenceType) => invoke(expression, Methods.unboxNode)
     case CodeGenType(symbols.CTRelationship, ReferenceType) => invoke(expression, Methods.unboxRel)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -343,6 +343,17 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def threeValuedEqualsExpression(lhs: Expression, rhs: Expression) = invoke(Methods.ternaryEquals, lhs, rhs)
 
+  override def threeValuedPrimitiveEqualsExpression(lhs: Expression, rhs: Expression, codeGenType: CodeGenType) = {
+    // This is only for primitive nodes and relationships
+    assert(codeGenType == CodeGenType.primitiveNode || codeGenType == CodeGenType.primitiveRel)
+    ternary(
+      or(equal(nullValue(codeGenType), lhs),
+         equal(nullValue(codeGenType), rhs)),
+      constant(null),
+      box(equal(lhs, rhs))
+    )
+  }
+
   override def equalityExpression(lhs: Expression, rhs: Expression, codeGenType: CodeGenType) =
     if (codeGenType.isPrimitive) equal(lhs, rhs)
     else invoke(lhs, Methods.equals, rhs)
@@ -1064,13 +1075,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       inner.assign(variable, res)
       generator.load(variable.name())
     }
-  }
-
-  override def projectVariable(variableName: String, expression: Expression) = {
-    // java.lang.Object is an ok type for result variables because we only put them into result row
-    val resultType = typeRef[Object]
-    val localVariable = generator.declare(resultType, variableName)
-    generator.assign(localVariable, expression)
   }
 
   override def declareFlag(name: String, initialValue: Boolean) = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.CompositeKey
 import org.neo4j.cypher.internal.codegen._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, IntType, Parameter => _, ReferenceType}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{BoolType, CodeGenType, FloatType, IntType, Parameter => _, ReferenceType}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
@@ -1026,10 +1026,21 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     generator.assign(localVariable, constant(null))
   }
 
+  override def declareAndInitialize(varName: String, codeGenType: CodeGenType) = {
+    val localVariable = generator.declare(lowerType(codeGenType), varName)
+    locals += (varName -> localVariable)
+    codeGenType match {
+      case CodeGenType(symbols.CTInteger, IntType) => constant(0L)
+      case CodeGenType(symbols.CTFloat, FloatType) => constant(0.0)
+      case CodeGenType(symbols.CTBoolean, BoolType) => constant(false)
+      case CodeGenType(symbols.CTInteger, _) => constant(0L)
+      case _ => generator.assign(localVariable, nullValue(codeGenType))
+    }
+  }
+
   override def declare(varName: String, codeGenType: CodeGenType) = {
     val localVariable = generator.declare(lowerType(codeGenType), varName)
     locals += (varName -> localVariable)
-    generator.assign(localVariable, nullValue(codeGenType))
   }
 
   override def assign(varName: String, codeGenType: CodeGenType, expression: Expression) = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -266,10 +266,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
         invoke(cast(typeRef[NodeIdWrapper], generator.load(nodeIdVar)), nodeId))
 
   override def node(nodeIdVar: String, codeGenType: CodeGenType) =
-    if (codeGenType.isPrimitive)
-      generator.load(nodeIdVar)
-    else
-      createNewInstance(typeRef[NodeIdWrapper], (typeRef[Long], generator.load(nodeIdVar)))
+    generator.load(nodeIdVar)
 
   override def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CodeGenType(CTNode, IntType) | CodeGenType(CTRelationship, IntType) =>
@@ -297,10 +294,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
         invoke(cast(typeRef[RelationshipIdWrapper], generator.load(relIdVar)), relId))
 
   override def relationship(relIdVar: String, codeGenType: CodeGenType) =
-    if (codeGenType.isPrimitive)
-      generator.load(relIdVar)
-    else
-      createNewInstance(typeRef[RelationshipIdWrapper], (typeRef[Long], generator.load(relIdVar)))
+    generator.load(relIdVar)
 
   override def materializeAny(variable: String) =
     invoke(materializeAnyResult, nodeManager, generator.load(variable))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -25,9 +25,9 @@ import java.util
 import org.neo4j.codegen.CodeGeneratorOption._
 import org.neo4j.codegen.TypeReference._
 import org.neo4j.codegen.source.{SourceCode, SourceVisitor}
-import org.neo4j.codegen.{CodeGenerator, _}
+import org.neo4j.codegen.{CodeGenerator, Parameter, _}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, FloatType, IntType, ReferenceType}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{BoolType, CodeGenType, FloatType, IntType, ReferenceType}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.{CodeStructure, CodeStructureResult, MethodStructure}
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers._
@@ -189,6 +189,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     case CodeGenType(symbols.CTRelationship, IntType) => typeRef[Long]
     case CodeGenType(symbols.CTInteger, IntType) => typeRef[Long]
     case CodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
+    case CodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
     case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String]
     case _ => typeRef[Object]
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
@@ -93,6 +93,7 @@ object Methods {
   val fetchNextRelationship = method[RelationshipIterator, Long]("next")
   val newNodeProxyById = method[NodeManager, NodeProxy]("newNodeProxyById", typeRef[Long])
   val newRelationshipProxyById = method[NodeManager, RelationshipProxy]("newRelationshipProxyById", typeRef[Long])
+  val materializeAnyResult = method[CompiledConversionUtils, Object]("materializeAnyResult", typeRef[NodeManager], typeRef[Object])
   val nodeId = method[NodeIdWrapper, Long]("id")
   val relId = method[RelationshipIdWrapper, Long]("id")
   val set = method[ResultRowImpl, Unit]("set", typeRef[String], typeRef[Object])

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
@@ -56,7 +56,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         }),
         Operation("load node from parameters", m => {
           m.declare("a", CodeGenType.primitiveNode)
-          m.generator.assign(typeRef[Object], "node", m.node("a"))
+          m.generator.assign(typeRef[Object], "node", m.node("a", CodeGenType.primitiveNode))
         }),
         Operation("nullable node", m => {
           m.declare("foo", CodeGenType.primitiveNode)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
@@ -56,7 +56,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         }),
         Operation("load node from parameters", m => {
           m.declare("a", CodeGenType.primitiveNode)
-          m.generator.assign(typeRef[Object], "node", m.node("a", CodeGenType.primitiveNode))
+          m.generator.assign(typeRef[Long], "node", m.node("a", CodeGenType.primitiveNode))
         }),
         Operation("nullable node", m => {
           m.declare("foo", CodeGenType.primitiveNode)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
@@ -49,17 +49,17 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
   val ops = Seq(
         Operation("create rel extractor", _.createRelExtractor("foo")),
         Operation("nullable object", m => {
-          m.declare("foo", CodeGenType.Any)
+          m.declareAndInitialize("foo", CodeGenType.Any)
           m.generator.assign(typeRef[Object], "bar",
                              m.nullablePrimitive("foo", CodeGenType.Any, Expression.constant("hello")))
 
         }),
         Operation("load node from parameters", m => {
-          m.declare("a", CodeGenType.primitiveNode)
+          m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.generator.assign(typeRef[Long], "node", m.node("a", CodeGenType.primitiveNode))
         }),
         Operation("nullable node", m => {
-          m.declare("foo", CodeGenType.primitiveNode)
+          m.declareAndInitialize("foo", CodeGenType.primitiveNode)
           m.generator.assign(typeRef[Long], "bar",
                              m.nullablePrimitive("foo", CodeGenType.primitiveNode, m.loadVariable("foo")))
 
@@ -74,7 +74,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           }
         }),
         Operation("use a LongsToCount probe table", m => {
-          m.declare("a", CodeGenType.primitiveNode)
+          m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.allocateProbeTable("table", LongsToCountTable)
           m.updateProbeTableCount("table", LongsToCountTable, Seq("a"))
           m.probe("table", LongsToCountTable, Seq("a")) { inner =>
@@ -82,7 +82,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           }
         }),
        Operation("use a LongToCount key probe table", m => {
-          m.declare("a", CodeGenType.primitiveNode)
+          m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.allocateProbeTable("table", LongToCountTable)
           m.updateProbeTableCount("table", LongToCountTable, Seq("a"))
           m.probe("table", LongToCountTable, Seq("a")) { inner =>
@@ -91,7 +91,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         }),
        Operation("use a LongToList probe table", m => {
          val table: LongToListTable = LongToListTable(Map("a" -> CodeGenType.primitiveNode), Map("b" -> "a"))
-         m.declare("a", CodeGenType.primitiveNode)
+         m.declareAndInitialize("a", CodeGenType.primitiveNode)
          m.allocateProbeTable("table", table)
          val value: Expression = m.newTableValue("value", table.structure)
          m.updateProbeTable(table.structure, "table", table, Seq("a"), value)
@@ -102,8 +102,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
        Operation("use a LongsToList probe table", m => {
          val table: LongsToListTable = LongsToListTable(Map("a" -> CodeGenType.primitiveNode, "b" -> CodeGenType.primitiveNode),
                                                         Map("aa" -> "a", "bb" -> "b"))
-         m.declare("a", CodeGenType.primitiveNode)
-         m.declare("b", CodeGenType.primitiveNode)
+         m.declareAndInitialize("a", CodeGenType.primitiveNode)
+         m.declareAndInitialize("b", CodeGenType.primitiveNode)
          m.allocateProbeTable("table", table)
          val value: Expression = m.newTableValue("value", table.structure)
          m.updateProbeTable(table.structure, "table", table, Seq("a", "b"), value)
@@ -118,57 +118,57 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         }),
         Operation("look up rel type", _.lookupRelationshipTypeId("foo", "bar")),
         Operation("all relationships for node", (m) => {
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.nodeGetAllRelationships("foo", "node", SemanticDirection.OUTGOING)
         }),
         Operation("has label", m => {
           m.lookupLabelId("label", "A")
           m.declarePredicate("predVar")
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.hasLabel("node", "label", "predVar")
         }),
         Operation("property by name for node", m => {
           m.lookupPropertyKey("prop", "prop")
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
           m.nodeGetPropertyForVar("node", "prop", "propVar")
         }),
         Operation("property by id for node", m => {
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
           m.nodeGetPropertyById("node", 13, "propVar")
         }),
         Operation("property by name for relationship", m => {
           m.lookupPropertyKey("prop", "prop")
-          m.declare("rel", CodeGenType.primitiveRel)
+          m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
           m.relationshipGetPropertyForVar("rel", "prop", "propVar")
         }),
         Operation("property by id for relationship", m => {
-          m.declare("rel", CodeGenType.primitiveRel)
+          m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
           m.nodeGetPropertyById("rel", 13, "propVar")
         }),
         Operation("rel type", m => {
           m.createRelExtractor("bar")
-          m.declare("foo", CodeGenType(symbols.CTString, ReferenceType))
+          m.declareAndInitialize("foo", CodeGenType(symbols.CTString, ReferenceType))
           m.relType("bar", "foo")
         }),
         Operation("all relationships for node and types", (m) => {
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.lookupRelationshipTypeId("a", "A")
           m.lookupRelationshipTypeId("b", "B")
           m.nodeGetRelationships("foo", "node", SemanticDirection.OUTGOING, Seq("a", "b"))
         }),
         Operation("next relationship", (m) => {
           m.createRelExtractor("r")
-          m.declare("node", CodeGenType.primitiveNode)
+          m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.nodeGetAllRelationships("foo", "node", SemanticDirection.OUTGOING)
           m.nextRelationshipAndNode("nextNode", "foo", SemanticDirection.OUTGOING, "node", "r")
         }),
     Operation("expand into", (m) => {
-      m.declare("from", CodeGenType.primitiveNode)
-      m.declare("to", CodeGenType.primitiveNode)
+      m.declareAndInitialize("from", CodeGenType.primitiveNode)
+      m.declareAndInitialize("to", CodeGenType.primitiveNode)
       val local = m.generator.declare(typeRef[RelationshipIterator], "iter")
       Templates.handleKernelExceptions(m.generator, m.fields.ro, m.finalizers) { body =>
         body.assign(local, Expression.invoke(Methods.allConnectingRelationships,
@@ -178,8 +178,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       }
     }),
     Operation("expand into with types", (m) => {
-      m.declare("from", CodeGenType.primitiveNode)
-      m.declare("to", CodeGenType.primitiveNode)
+      m.declareAndInitialize("from", CodeGenType.primitiveNode)
+      m.declareAndInitialize("to", CodeGenType.primitiveNode)
       val local = m.generator.declare(typeRef[RelationshipIterator], "iter")
       Templates.handleKernelExceptions(m.generator, m.fields.ro, m.finalizers) { body =>
         body.assign(local, Expression.invoke(Methods.connectingRelationships,

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
@@ -41,4 +41,10 @@ trait AstConstructionTestSupport extends CypherTestSupport {
 
   def literalInt(intValue: Int): SignedDecimalIntegerLiteral =
     SignedDecimalIntegerLiteral(intValue.toString)(pos)
+
+  def literalList(expressions: Expression*): ListLiteral =
+    ListLiteral(expressions.toSeq)(pos)
+
+  def literalIntList(intValues: Int*): ListLiteral =
+    ListLiteral(intValues.toSeq.map(literalInt))(pos)
 }

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
@@ -230,7 +230,7 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
     case Failure(e) =>
       tx.failure()
       tx.close()
-      fail(s"Expected successful result, but got error: $e")
+      fail(s"Expected successful result, but got error: $e", e)
   }
 
   private def initEmpty() =


### PR DESCRIPTION
- Basic support for UNWIND collection
- Use only primitive node and relationship types internally, and materialize results only as the final step in `ProduceResult`.
- Basic support for runtime materialization of type `Any`. This will materialize nodes and relationships within results where the type is not known at compile time, including when it is nested within `List` and `Map`. 
- Still missing support for UNWIND of `null` and `range`, but it will fallback on interpreted runtime for those cases.
