### PR TITLE
Improved error messages for unsupported auth tokens

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -238,8 +238,8 @@ public class BasicAuthenticationTest
         // Expect
         exception.expect( AuthenticationException.class );
         exception.expect( hasStatus( Status.Security.Unauthorized ) );
-        exception.expectMessage(
-                "The value associated with the key `principal` must be a String but was: SingletonList" );
+        exception.expectMessage( "Unsupported authentication token, the value associated with the key `principal` " +
+                "must be a String but was: SingletonList" );
 
         // When
         authentication

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -215,7 +215,8 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                "The value associated with the key `principal` must be a String but was: ArrayList" ) ) );
+                "Unsupported authentication token, the value associated with the key `principal` " +
+                        "must be a String but was: ArrayList" ) ) );
 
         assertThat( client, eventuallyDisconnects() );
     }
@@ -233,7 +234,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                "The value associated with the key `credentials` must be a String but was: null" ) ) );
+                "Unsupported authentication token, missing key `credentials`" ) ) );
 
         assertThat( client, eventuallyDisconnects() );
     }
@@ -251,7 +252,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                "The value associated with the key `scheme` must be a String but was: null" ) ) );
+                "Unsupported authentication token, missing key `scheme`" ) ) );
 
         assertThat( client, eventuallyDisconnects() );
     }
@@ -270,7 +271,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyReceives( msgFailure( Status.Security.Unauthorized,
-                "Unsupported authentication scheme 'unknown'." ) ) );
+                "Unsupported authentication token, scheme 'unknown' is not supported." ) ) );
 
         assertThat( client, eventuallyDisconnects() );
     }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -31,7 +31,7 @@ import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
 public class ShiroAuthToken implements AuthenticationToken
 {
-    private static final String VALUE_QOUTE = "'";
+    private static final String VALUE_DELIMITER = "'";
     private static final String PAIR_DELIMITER = ", ";
     private static final String KEY_VALUE_DELIMITER = "=";
 
@@ -106,6 +106,6 @@ public class ShiroAuthToken implements AuthenticationToken
     private String keyValueString( String key )
     {
         String valueString = ( key.equals( AuthToken.CREDENTIALS ) ? "******" : authToken.get( key ).toString() );
-        return key + KEY_VALUE_DELIMITER + VALUE_QOUTE + valueString + VALUE_QOUTE;
+        return key + KEY_VALUE_DELIMITER + VALUE_DELIMITER + valueString + VALUE_DELIMITER;
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -262,12 +262,30 @@ public class MultiRealmAuthManagerTest extends InitialUserTests
     {
         manager.start();
 
-        assertException( () -> manager.login( map( AuthToken.SCHEME_KEY, "supercool", AuthToken.PRINCIPAL, "neo4j" ) ),
-                InvalidAuthTokenException.class, "does not support authentication token" );
-        assertException( () -> manager.login( map( "key", "value" ) ),
-                InvalidAuthTokenException.class, "The value associated with the key `scheme` must be a String but was: null" );
-        assertException( () -> manager.login( map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, "neo4j" ) ),
-                InvalidAuthTokenException.class, "The value associated with the key `credentials` must be a String but was: null" );
+        assertException(
+                () -> manager.login( map( AuthToken.SCHEME_KEY, "supercool", AuthToken.PRINCIPAL, "neo4j" ) ),
+                InvalidAuthTokenException.class,
+                "Unsupported authentication token: { scheme='supercool', principal='neo4j' }" );
+
+        assertException(
+                () -> manager.login( map( AuthToken.SCHEME_KEY, "none" ) ),
+                InvalidAuthTokenException.class,
+                "Unsupported authentication token, scheme='none' only allowed when auth is disabled: { scheme='none' }" );
+
+        assertException(
+                () -> manager.login( map( "key", "value" ) ),
+                InvalidAuthTokenException.class,
+                "Unsupported authentication token, missing key `scheme`: { key='value' }" );
+
+        assertException(
+                () -> manager.login( map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, "neo4j" ) ),
+                InvalidAuthTokenException.class,
+                "Unsupported authentication token, missing key `credentials`: { scheme='basic', principal='neo4j' }" );
+
+        assertException(
+                () -> manager.login( map( AuthToken.SCHEME_KEY, "basic", AuthToken.CREDENTIALS, "very-secret" ) ),
+                InvalidAuthTokenException.class,
+                "Unsupported authentication token, missing key `principal`: { scheme='basic', credentials='******' }" );
     }
 
     @Test


### PR DESCRIPTION
This PR improves the coherency and quality of error messages for invalid auth tokens. In particular, the drivers `AuthToken.none()` will give a specific error message, and for example missing principals or credentials will yield specific error messages if the native auth provider is used.