### PR TITLE
Avoids temp-arrays when modifying tree nodes

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -664,7 +664,6 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>
         private final StructurePropagation<KEY> structurePropagation;
         private PageCursor cursor;
         private IndexWriter.Options options;
-        private final byte[] tmp = new byte[0];
 
         // Writer can't live past a checkpoint because of the mutex with checkpoint,
         // therefore safe to locally cache these generation fields from the volatile generation in the tree
@@ -704,7 +703,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>
                 PageCursorUtil.goTo( cursor, "new root", newRootId );
 
                 bTreeNode.initializeInternal( cursor, stableGeneration, unstableGeneration );
-                bTreeNode.insertKeyAt( cursor, structurePropagation.primKey, 0, 0, tmp );
+                bTreeNode.insertKeyAt( cursor, structurePropagation.primKey, 0, 0 );
                 bTreeNode.setKeyCount( cursor, 1 );
                 bTreeNode.setChildAt( cursor, structurePropagation.left, 0, stableGeneration, unstableGeneration );
                 bTreeNode.setChildAt( cursor, structurePropagation.right, 1, stableGeneration, unstableGeneration );

--- a/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
@@ -79,9 +79,6 @@ class InternalTreeLogic<KEY,VALUE>
 {
     private final IdProvider idProvider;
     private final TreeNode<KEY,VALUE> bTreeNode;
-    private final byte[] tmpForKeys;
-    private final byte[] tmpForValues;
-    private final byte[] tmpForChildren;
     private final Layout<KEY,VALUE> layout;
     private final KEY primKeyPlaceHolder;
     private final KEY readKey;
@@ -93,9 +90,6 @@ class InternalTreeLogic<KEY,VALUE>
         this.bTreeNode = bTreeNode;
         this.layout = layout;
         int maxKeyCount = max( bTreeNode.internalMaxKeyCount(), bTreeNode.leafMaxKeyCount() );
-        this.tmpForKeys = new byte[(maxKeyCount + 1) * layout.keySize()];
-        this.tmpForValues = new byte[(maxKeyCount + 1) * layout.valueSize()];
-        this.tmpForChildren = new byte[(maxKeyCount + 2) * bTreeNode.childSize()];
         this.primKeyPlaceHolder = layout.newKey();
         this.readKey = layout.newKey();
         this.readValue = layout.newValue();

--- a/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/InternalTreeLogic.java
@@ -195,11 +195,10 @@ class InternalTreeLogic<KEY,VALUE>
             // No overflow
             int pos = positionOf( search( cursor, bTreeNode, primKey, readKey, keyCount ) );
 
-            bTreeNode.insertKeyAt( cursor, primKey, pos, keyCount, tmpForKeys );
+            bTreeNode.insertKeyAt( cursor, primKey, pos, keyCount );
             // NOTE pos+1 since we never insert a new child before child(0) because its key is really
             // the one from the parent.
-            bTreeNode.insertChildAt( cursor, rightChild, pos + 1, keyCount, tmpForChildren,
-                    stableGeneration, unstableGeneration );
+            bTreeNode.insertChildAt( cursor, rightChild, pos + 1, keyCount, stableGeneration, unstableGeneration );
 
             // Increase key count
             bTreeNode.setKeyCount( cursor, keyCount + 1 );
@@ -343,8 +342,8 @@ class InternalTreeLogic<KEY,VALUE>
         if ( keyCount < bTreeNode.leafMaxKeyCount() )
         {
             // No overflow, insert key and value
-            bTreeNode.insertKeyAt( cursor, key, pos, keyCount, tmpForKeys );
-            bTreeNode.insertValueAt( cursor, value, pos, keyCount, tmpForValues );
+            bTreeNode.insertKeyAt( cursor, key, pos, keyCount );
+            bTreeNode.insertValueAt( cursor, value, pos, keyCount );
             bTreeNode.setKeyCount( cursor, keyCount + 1 );
 
             return; // No split has occurred
@@ -580,9 +579,9 @@ class InternalTreeLogic<KEY,VALUE>
         // Remove key/value
         createUnstableVersionIfNeeded( cursor, structurePropagation, stableGeneration, unstableGeneration );
 
-        bTreeNode.removeKeyAt( cursor, pos, keyCount, tmpForKeys );
+        bTreeNode.removeKeyAt( cursor, pos, keyCount );
         bTreeNode.valueAt( cursor, into, pos );
-        bTreeNode.removeValueAt( cursor, pos, keyCount, tmpForValues );
+        bTreeNode.removeValueAt( cursor, pos, keyCount );
 
         // Decrease key count
         bTreeNode.setKeyCount( cursor, keyCount - 1 );

--- a/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/TreeNode.java
@@ -261,9 +261,9 @@ class TreeNode<KEY,VALUE>
      * Moves items (key/value/child) one step to the right, which means rewriting all items of the particular type
      * from pos - keyCount.
      */
-    private void insertSlotAt( PageCursor cursor, int pos, int toExcluding, int baseOffset, int itemSize )
+    private void insertSlotAt( PageCursor cursor, int pos, int keyCount, int baseOffset, int itemSize )
     {
-        for ( int posToMoveRight = toExcluding - 1, offset = baseOffset + posToMoveRight * itemSize;
+        for ( int posToMoveRight = keyCount - 1, offset = baseOffset + posToMoveRight * itemSize;
                 posToMoveRight >= pos; posToMoveRight--, offset -= itemSize )
         {
             cursor.copyTo( offset, cursor, offset + itemSize, itemSize );
@@ -335,7 +335,7 @@ class TreeNode<KEY,VALUE>
         return HEADER_LENGTH + pos * keySize;
     }
 
-    private int valueOffset( int pos )
+    int valueOffset( int pos )
     {
         return HEADER_LENGTH + leafMaxKeyCount * keySize + pos * valueSize;
     }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/ByteArrayPageCursor.java
@@ -28,10 +28,6 @@ import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
 
 /**
- * TODO: Adding another implementation of PageCursor (this implementation)
- * TODO: will mean Neo as a whole have three implementations in total.
- * TODO: This results in a slower method dispatch for ALL PageCursors. Is it worth it?
- * <p>
  * Wraps a byte array and present it as a PageCursor.
  * <p>
  * This class is bridging something which would otherwise make {@link InternalTreeLogic} code slightly more

--- a/community/index/src/test/java/org/neo4j/index/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/ConsistencyCheckerTest.java
@@ -100,7 +100,7 @@ public class ConsistencyCheckerTest
                 {
                     goTo( cursor, "new root", idProvider.acquireNewId( stableGeneration, unstableGeneration ) );
                     node.initializeInternal( cursor, stableGeneration, unstableGeneration );
-                    node.insertKeyAt( cursor, structure.primKey, 0, 0, new byte[0] );
+                    node.insertKeyAt( cursor, structure.primKey, 0, 0 );
                     node.setKeyCount( cursor, 1 );
                     node.setChildAt( cursor, structure.left, 0, stableGeneration, unstableGeneration );
                     node.setChildAt( cursor, structure.right, 1, stableGeneration, unstableGeneration );

--- a/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/InternalTreeLogicTest.java
@@ -1099,7 +1099,7 @@ public class InternalTreeLogicTest
         long rootId = id.acquireNewId( stableGen, unstableGen );
         goTo( cursor, rootId );
         node.initializeInternal( cursor, stableGen, unstableGen );
-        node.insertKeyAt( cursor, split.primKey, 0, 0, tmp );
+        node.insertKeyAt( cursor, split.primKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         node.setChildAt( cursor, split.left, 0, stableGen, unstableGen );
         node.setChildAt( cursor, split.right, 1, stableGen, unstableGen );

--- a/community/index/src/test/java/org/neo4j/index/gbptree/KeySearchTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/KeySearchTest.java
@@ -459,7 +459,7 @@ public class KeySearchTest
         {
             keys[i] = currentKey;
             key.setValue( currentKey );
-            node.insertKeyAt( cursor, key, i, i, tmp );
+            node.insertKeyAt( cursor, key, i, i );
             currentKey += random.nextInt( 100 ) + 10;
         }
         node.setKeyCount( cursor, keyCount );
@@ -510,7 +510,7 @@ public class KeySearchTest
     {
         insertKey.setValue( key );
         int keyCount = node.keyCount( cursor );
-        node.insertKeyAt( cursor, insertKey, keyCount, keyCount, tmp );
+        node.insertKeyAt( cursor, insertKey, keyCount, keyCount );
         node.setKeyCount( cursor, keyCount + 1 );
     }
 
@@ -528,7 +528,7 @@ public class KeySearchTest
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             key.setValue( key( i ) );
-            node.insertKeyAt( cursor, key, i, i, tmp );
+            node.insertKeyAt( cursor, key, i, i );
         }
         node.setKeyCount( cursor, KEY_COUNT );
     }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
@@ -1036,7 +1036,7 @@ public class SeekCursorTest
         node.initializeInternal( cursor, stableGen, unstableGen );
         long keyInRoot = 10L;
         insertKey.setValue( keyInRoot );
-        node.insertKeyAt( cursor, insertKey, 0, 0, tmp );
+        node.insertKeyAt( cursor, insertKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         // with old pointer to child (simulating reuse of child node)
         node.setChildAt( cursor, leftChild, 0, stableGen, unstableGen );
@@ -1112,7 +1112,7 @@ public class SeekCursorTest
         node.initializeInternal( cursor, stableGen - 1, unstableGen - 1 );
         long keyInRoot = 10L;
         insertKey.setValue( keyInRoot );
-        node.insertKeyAt( cursor, insertKey, 0, 0, tmp );
+        node.insertKeyAt( cursor, insertKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         // with old pointer to child (simulating reuse of internal node)
         node.setChildAt( cursor, leftChild, 0, stableGen, unstableGen );
@@ -1145,7 +1145,7 @@ public class SeekCursorTest
         long rootId = id.acquireNewId( stableGen, unstableGen );
         cursor.next( rootId );
         node.initializeInternal( cursor, stableGen, unstableGen );
-        node.insertKeyAt( cursor, split.primKey, 0, 0, tmp );
+        node.insertKeyAt( cursor, split.primKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         node.setChildAt( cursor, split.left, 0, stableGen, unstableGen );
         node.setChildAt( cursor, split.right, 1, stableGen, unstableGen );
@@ -1255,8 +1255,8 @@ public class SeekCursorTest
         int keyCount = node.keyCount( cursor );
         insertKey.setValue( k );
         insertValue.setValue( valueForKey( k ) );
-        node.insertKeyAt( cursor, insertKey, keyCount, keyCount, tmp );
-        node.insertValueAt( cursor, insertValue, keyCount, keyCount, tmp );
+        node.insertKeyAt( cursor, insertKey, keyCount, keyCount );
+        node.insertValueAt( cursor, insertValue, keyCount, keyCount );
         node.setKeyCount( cursor, keyCount + 1 );
     }
 
@@ -1269,16 +1269,16 @@ public class SeekCursorTest
         }
         insertKey.setValue( k );
         insertValue.setValue( valueForKey( k ) );
-        node.insertKeyAt( cursor, insertKey, pos, keyCount, tmp );
-        node.insertValueAt( cursor, insertValue, pos, keyCount, tmp );
+        node.insertKeyAt( cursor, insertKey, pos, keyCount );
+        node.insertValueAt( cursor, insertValue, pos, keyCount );
         node.setKeyCount( cursor, keyCount + 1 );
     }
 
     private void remove( int pos )
     {
         int keyCount = node.keyCount( cursor );
-        node.removeKeyAt( cursor, pos, keyCount, tmp );
-        node.removeValueAt( cursor, pos, keyCount, tmp );
+        node.removeKeyAt( cursor, pos, keyCount );
+        node.removeValueAt( cursor, pos, keyCount );
         node.setKeyCount( cursor, keyCount - 1 );
     }
 

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
@@ -376,8 +376,8 @@ public class TreeNodeTest
         node.insertKeyAt( cursor, key, 1, 1 );
 
         // WHEN
-        node.readKeysWithInsertRecordInPosition( cursor, c -> c.putLong( 2 ), 1, 3, tmp );
-        node.writeKeys( cursor, tmp, 0, 0, 3 );
+        key.setValue( 2 );
+        node.insertKeyAt( cursor, key, 1, 2 );
 
         // THEN
         assertEquals( 1, node.keyAt( cursor, key, 0 ).longValue() );
@@ -397,8 +397,8 @@ public class TreeNodeTest
         node.insertValueAt( cursor, value, 1, 1 );
 
         // WHEN
-        node.readValuesWithInsertRecordInPosition( cursor, c -> c.putLong( 2 ), 1, 3, tmp );
-        node.writeValues( cursor, tmp, 0, 0, 3 );
+        value.setValue( 2 );
+        node.insertValueAt( cursor, value, 1, 2 );
 
         // THEN
         assertEquals( 1, node.valueAt( cursor, value, 0 ).longValue() );
@@ -418,9 +418,7 @@ public class TreeNodeTest
         node.insertChildAt( cursor, thirdChild, 1, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
-        node.readChildrenWithInsertRecordInPosition( cursor,
-                c -> node.writeChild( c, secondChild, STABLE_GENERATION, UNSTABLE_GENERATION ), 1, 3, tmp );
-        node.writeChildren( cursor, tmp, 0, 0, 3 );
+        node.insertChildAt( cursor, secondChild, 1, 2, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
         assertEquals( firstChild, childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );

--- a/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/TreeNodeTest.java
@@ -151,11 +151,11 @@ public class TreeNodeTest
         // WHEN
         long firstKey = 10;
         key.setValue( firstKey );
-        node.insertKeyAt( cursor, key, 0, 0, tmp );
+        node.insertKeyAt( cursor, key, 0, 0 );
 
         long otherKey = 19;
         key.setValue( otherKey );
-        node.insertKeyAt( cursor, key, 1, 1, tmp );
+        node.insertKeyAt( cursor, key, 1, 1 );
 
         // THEN
         assertEquals( firstKey, node.keyAt( cursor, key, 0 ).longValue() );
@@ -188,16 +188,16 @@ public class TreeNodeTest
         MutableLong key = layout.newKey();
         long firstKey = 10;
         key.setValue( firstKey );
-        node.insertKeyAt( cursor, key, 0, 0, tmp );
+        node.insertKeyAt( cursor, key, 0, 0 );
         long otherKey = 19;
         key.setValue( otherKey );
-        node.insertKeyAt( cursor, key, 1, 1, tmp );
+        node.insertKeyAt( cursor, key, 1, 1 );
         long thirdKey = 123;
         key.setValue( thirdKey );
-        node.insertKeyAt( cursor, key, 2, 2, tmp );
+        node.insertKeyAt( cursor, key, 2, 2 );
 
         // WHEN
-        node.removeKeyAt( cursor, 1, 3, tmp );
+        node.removeKeyAt( cursor, 1, 3 );
 
         // THEN
         assertEquals( firstKey, node.keyAt( cursor, key, 0 ).longValue() );
@@ -234,11 +234,11 @@ public class TreeNodeTest
         // WHEN
         long firstValue = 123456789;
         value.setValue( firstValue );
-        node.insertValueAt( cursor, value, 0, 0, tmp );
+        node.insertValueAt( cursor, value, 0, 0 );
 
         long otherValue = 987654321;
         value.setValue( otherValue );
-        node.insertValueAt( cursor, value, 1, 1, tmp );
+        node.insertValueAt( cursor, value, 1, 1 );
 
         // THEN
         assertEquals( firstValue, node.valueAt( cursor, value, 0 ).longValue() );
@@ -253,16 +253,16 @@ public class TreeNodeTest
         MutableLong value = layout.newKey();
         long firstValue = 123456789;
         value.setValue( firstValue );
-        node.insertValueAt( cursor, value, 0, 0, tmp );
+        node.insertValueAt( cursor, value, 0, 0 );
         long otherValue = 987654321;
         value.setValue( otherValue );
-        node.insertValueAt( cursor, value, 1, 1, tmp );
+        node.insertValueAt( cursor, value, 1, 1 );
         long thirdValue = 49756;
         value.setValue( thirdValue );
-        node.insertValueAt( cursor, value, 2, 2, tmp );
+        node.insertValueAt( cursor, value, 2, 2 );
 
         // WHEN
-        node.removeValueAt( cursor, 1, 3, tmp );
+        node.removeValueAt( cursor, 1, 3 );
 
         // THEN
         assertEquals( firstValue, node.valueAt( cursor, value, 0 ).longValue() );
@@ -276,7 +276,7 @@ public class TreeNodeTest
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         MutableLong value = layout.newValue();
         value.setValue( 1 );
-        node.insertValueAt( cursor, value, 0, 0, tmp );
+        node.insertValueAt( cursor, value, 0, 0 );
 
         // WHEN
         long overwrittenValue = 2;
@@ -295,10 +295,10 @@ public class TreeNodeTest
 
         // WHEN
         long firstChild = 123456789;
-        node.insertChildAt( cursor, firstChild, 0, 0, tmp, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         long otherChild = 987654321;
-        node.insertChildAt( cursor, otherChild, 1, 1, tmp, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, otherChild, 1, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
         assertEquals( firstChild, childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );
@@ -311,7 +311,7 @@ public class TreeNodeTest
         // GIVEN
         long child = GenSafePointer.MIN_POINTER;
         node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, child, 0, 0, tmp, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, child, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
         long overwrittenChild = child + 1;
@@ -371,9 +371,9 @@ public class TreeNodeTest
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         MutableLong key = layout.newKey();
         key.setValue( 1 );
-        node.insertKeyAt( cursor, key, 0, 0, tmp );
+        node.insertKeyAt( cursor, key, 0, 0 );
         key.setValue( 3 );
-        node.insertKeyAt( cursor, key, 1, 1, tmp );
+        node.insertKeyAt( cursor, key, 1, 1 );
 
         // WHEN
         node.readKeysWithInsertRecordInPosition( cursor, c -> c.putLong( 2 ), 1, 3, tmp );
@@ -392,9 +392,9 @@ public class TreeNodeTest
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         MutableLong value = layout.newKey();
         value.setValue( 1 );
-        node.insertValueAt( cursor, value, 0, 0, tmp );
+        node.insertValueAt( cursor, value, 0, 0 );
         value.setValue( 3 );
-        node.insertValueAt( cursor, value, 1, 1, tmp );
+        node.insertValueAt( cursor, value, 1, 1 );
 
         // WHEN
         node.readValuesWithInsertRecordInPosition( cursor, c -> c.putLong( 2 ), 1, 3, tmp );
@@ -414,8 +414,8 @@ public class TreeNodeTest
         long secondChild = firstChild + 1;
         long thirdChild = secondChild + 1;
         node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, firstChild, 0, 0, tmp, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, thirdChild, 1, 1, tmp, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, thirdChild, 1, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
         node.readChildrenWithInsertRecordInPosition( cursor,
@@ -458,11 +458,11 @@ public class TreeNodeTest
                     }
                     while ( contains( expectedKeys, 0, expectedKeyCount, key.longValue() ) );
 
-                    node.insertKeyAt( cursor, key, position, expectedKeyCount, tmp );
+                    node.insertKeyAt( cursor, key, position, expectedKeyCount );
                     insert( expectedKeys, expectedKeyCount, key.longValue(), position );
 
                     value.setValue( random.nextLong() );
-                    node.insertValueAt( cursor, value, position, expectedKeyCount, tmp );
+                    node.insertValueAt( cursor, value, position, expectedKeyCount );
                     insert( expectedValues, expectedKeyCount, value.longValue(), position );
 
                     node.setKeyCount( cursor, ++expectedKeyCount );
@@ -474,12 +474,12 @@ public class TreeNodeTest
                 {   // there are things to remove
                     int position = random.nextInt( expectedKeyCount );
                     node.keyAt( cursor, key, position );
-                    node.removeKeyAt( cursor, position, expectedKeyCount, tmp );
+                    node.removeKeyAt( cursor, position, expectedKeyCount );
                     long expectedKey = remove( expectedKeys, expectedKeyCount, position );
                     assertEquals( expectedKey, key.longValue() );
 
                     node.valueAt( cursor, value, position );
-                    node.removeValueAt( cursor, position, expectedKeyCount, tmp );
+                    node.removeValueAt( cursor, position, expectedKeyCount );
                     long expectedValue = remove( expectedValues, expectedKeyCount, position );
                     assertEquals( expectedValue, value.longValue() );
 


### PR DESCRIPTION
Previously, when moving entries (keys / values / child-pointers) between nodes during split, all entries where read into a byte array together with the entry that should be inserted. To make this possible, an implementation of PageCursor that wrapped a byte buffer was needed.
This meant three different implementations of PageCursor would exist in production environment, making all callsites `megamorphic` instead of `bimorphic`.

This PR change this behaviour to instead copy directly between page cursors.