### PR TITLE
Implement new neo4j-admin backup surface

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/OutsideWorld.java
@@ -36,4 +36,6 @@ public interface OutsideWorld
     FileSystemAbstraction fileSystem();
 
     PrintStream errorStream();
+
+    PrintStream outStream();
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/RealOutsideWorld.java
@@ -63,4 +63,10 @@ public class RealOutsideWorld implements OutsideWorld
     {
         return System.err;
     }
+
+    @Override
+    public PrintStream outStream()
+    {
+        return System.out;
+    }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
@@ -26,9 +26,9 @@ import org.neo4j.commandline.arguments.MandatoryNamedArg;
 public class MandatoryCanonicalPath extends MandatoryNamedArg
 {
 
-    public MandatoryCanonicalPath( String name, String value, String description )
+    public MandatoryCanonicalPath( String name, String exampleValue, String description )
     {
-        super( name, value, description );
+        super( name, exampleValue, description );
     }
 
     private static String canonicalize( String path )

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
@@ -33,9 +33,9 @@ public class OptionalCanonicalPath extends OptionalNamedArg
 
     private static String canonicalize( String path )
     {
-        if ( path.isEmpty() )
+        if ( path == null || path.isEmpty() )
         {
-            return path;
+            return "";
         }
 
         return Util.canonicalPath( path ).toString();

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
@@ -26,9 +26,9 @@ import org.neo4j.commandline.arguments.OptionalNamedArg;
 public class OptionalCanonicalPath extends OptionalNamedArg
 {
 
-    public OptionalCanonicalPath( String name, String value, String defaultValue, String description )
+    public OptionalCanonicalPath( String name, String exampleValue, String defaultValue, String description )
     {
-        super( name, value, defaultValue, description );
+        super( name, exampleValue, defaultValue, description );
     }
 
     private static String canonicalize( String path )

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/NullOutsideWorld.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/NullOutsideWorld.java
@@ -56,4 +56,10 @@ public class NullOutsideWorld implements OutsideWorld
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
+
+    @Override
+    public PrintStream outStream()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -78,6 +78,8 @@ public class BackupTool
 
     public static void main( String[] args )
     {
+        System.err.println("WARNING: neo4j-backup is deprecated and support for it will be removed in a future\n" +
+                "version of Neo4j; please use neo4j-admin backup instead.\n");
         BackupTool tool = new BackupTool( new BackupService(), System.out );
         try
         {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -61,8 +61,8 @@ public class OnlineBackupCommand implements AdminCommand
             .withArgument( new OptionalNamedArg( "from", "address", "localhost:6362",
                     "Host and port of Neo4j." ) )
             .withArgument( new OptionalBooleanArg( "fallback-to-full", true,
-                    "If a failed incremental backup will move the old backup to <name>.err.<N> and fallback to a " +
-                            "full backup instead." ) )
+                    "If an incremental backup fails backup will move the old backup to <name>.err.<N> and " +
+                            "fallback to a full backup instead." ) )
             .withArgument( new OptionalBooleanArg( "check-consistency", true,
                     "If a consistency check should be made." ) )
             .withArgument( new OptionalCanonicalPath( "cc-report-dir", "directory", ".",

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandIT.java
@@ -19,14 +19,7 @@
  */
 package org.neo4j.backup;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,6 +28,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -53,9 +51,10 @@ import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith( Parameterized.class )
-public class BackupEmbeddedIT
+public class OnlineBackupCommandIT
 {
     @ClassRule
     public static final TestDirectory testDirectory = TestDirectory.testDirectory();
@@ -66,7 +65,7 @@ public class BackupEmbeddedIT
     public final RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( db );
 
     private static final String ip = "127.0.0.1";
-    private final File backupPath = testDirectory.directory( "backup-db" );
+    private final File backupDir = testDirectory.directory( "backups" );
 
     @Parameter
     public String recordFormat;
@@ -77,19 +76,9 @@ public class BackupEmbeddedIT
         return Arrays.asList( StandardV3_0.NAME, HighLimit.NAME );
     }
 
-    @Before
-    public void before() throws Exception
-    {
-        if ( SystemUtils.IS_OS_WINDOWS )
-        {
-            return;
-        }
-        FileUtils.deleteDirectory( backupPath );
-    }
-
     public static DbRepresentation createSomeData( GraphDatabaseService db )
     {
-        try (Transaction tx = db.beginTx())
+        try ( Transaction tx = db.beginTx() )
         {
             Node node = db.createNode();
             node.setProperty( "name", "Neo" );
@@ -102,53 +91,64 @@ public class BackupEmbeddedIT
     @Test
     public void makeSureBackupCanBePerformedWithDefaultPort() throws Exception
     {
-        if ( SystemUtils.IS_OS_WINDOWS ) return;
+        assumeFalse( SystemUtils.IS_OS_WINDOWS );
+
         startDb( null );
         assertEquals(
                 0,
                 runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
-                        "--to", backupPath.getPath() ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
+                        "cc-report-dir=" + backupDir,
+                        "--backup-dir=" + backupDir,
+                        "--name=defaultport" ) );
+        assertEquals( getDbRepresentation(), getBackupDbRepresentation( "defaultport" ) );
         createSomeData( db );
         assertEquals(
                 0,
                 runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
-                        "--to", backupPath.getPath() ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
+                        "cc-report-dir=" + backupDir,
+                        "--backup-dir=" + backupDir,
+                        "--name=defaultport" ) );
+        assertEquals( getDbRepresentation(), getBackupDbRepresentation( "defaultport" ) );
     }
 
     @Test
     public void makeSureBackupCanBePerformedWithCustomPort() throws Exception
     {
-        if ( SystemUtils.IS_OS_WINDOWS ) return;
+        assumeFalse( SystemUtils.IS_OS_WINDOWS );
+
         int port = 4445;
         startDb( "" + port );
         assertEquals(
                 1,
                 runBackupToolFromOtherJvmToGetExitCode( "--from", ip,
-                        "--to", backupPath.getPath() ) );
+                        "cc-report-dir=" + backupDir,
+                        "--backup-dir=" + backupDir,
+                        "--name=customport" ) );
         assertEquals(
                 0,
                 runBackupToolFromOtherJvmToGetExitCode( "--from",
                         ip + ":" + port,
-                        "--to", backupPath.getPath() ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
+                        "cc-report-dir=" + backupDir,
+                        "--backup-dir=" + backupDir,
+                        "--name=customport" ) );
+        assertEquals( getDbRepresentation(), getBackupDbRepresentation( "customport" ) );
         createSomeData( db );
         assertEquals(
                 0,
-                runBackupToolFromOtherJvmToGetExitCode( "--from", ip +":"
-                                 + port, "--to",
-                        backupPath.getPath() ) );
-        assertEquals( getDbRepresentation(), getBackupDbRepresentation() );
+                runBackupToolFromOtherJvmToGetExitCode( "--from", ip + ":" + port,
+                        "cc-report-dir=" + backupDir,
+                        "--backup-dir=" + backupDir,
+                        "--name=customport" ) );
+        assertEquals( getDbRepresentation(), getBackupDbRepresentation( "customport" ) );
     }
 
     private void startDb( String backupPort )
     {
         db.setConfig( GraphDatabaseSettings.record_format, recordFormat );
         db.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
-        if(backupPort != null)
+        if ( backupPort != null )
         {
-            db.setConfig( OnlineBackupSettings.online_backup_server, ip +":" + backupPort );
+            db.setConfig( OnlineBackupSettings.online_backup_server, ip + ":" + backupPort );
         }
         db.ensureStarted();
         createSomeData( db );
@@ -160,10 +160,10 @@ public class BackupEmbeddedIT
         List<String> allArgs = new ArrayList<>( Arrays.asList(
                 ProcessUtil.getJavaExecutable().toString(), "-cp", ProcessUtil.getClassPath(),
                 AdminTool.class.getName() ) );
-        allArgs.add("backup");
+        allArgs.add( "backup" );
         allArgs.addAll( Arrays.asList( args ) );
 
-        Process process = Runtime.getRuntime().exec( allArgs.toArray( new String[allArgs.size()] ));
+        Process process = Runtime.getRuntime().exec( allArgs.toArray( new String[allArgs.size()] ) );
         return new ProcessStreamHandler( process, false ).waitForResult();
     }
 
@@ -172,8 +172,8 @@ public class BackupEmbeddedIT
         return DbRepresentation.of( db );
     }
 
-    private DbRepresentation getBackupDbRepresentation()
+    private DbRepresentation getBackupDbRepresentation( String name )
     {
-        return DbRepresentation.of( backupPath );
+        return DbRepresentation.of( new File( backupDir, name ) );
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -560,10 +560,10 @@ public class OnlineBackupCommandTest
                             "                                           backup will be attempted.%n" +
                             "  --from=<address>                         Host and port of Neo4j.%n" +
                             "                                           [default:localhost:6362]%n" +
-                            "  --fallback-to-full=<true|false>          If a failed incremental backup will%n" +
-                            "                                           move the old backup to <name>.err.<N>%n" +
-                            "                                           and fallback to a full backup%n" +
-                            "                                           instead. [default:true]%n" +
+                            "  --fallback-to-full=<true|false>          If an incremental backup fails backup%n" +
+                            "                                           will move the old backup to%n" +
+                            "                                           <name>.err.<N> and fallback to a full%n" +
+                            "                                           backup instead. [default:true]%n" +
                             "  --check-consistency=<true|false>         If a consistency check should be%n" +
                             "                                           made. [default:true]%n" +
                             "  --cc-report-dir=<directory>              Directory where consistency report%n" +

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -22,6 +22,7 @@ package org.neo4j.backup;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
@@ -35,168 +36,410 @@ import java.nio.file.Paths;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.admin.Usage;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.HostnamePort;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.rule.TestDirectory;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.consistency.ConsistencyCheckService.Result.success;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.neo4j.backup.OnlineBackupCommand.MAX_OLD_BACKUPS;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cypher_planner;
 
 public class OnlineBackupCommandTest
 {
     @Rule
+    public ExpectedException expected = ExpectedException.none();
+    @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
-    private final BackupTool tool = mock( BackupTool.class );
+
+    private BackupService backupService = mock( BackupService.class );
+    private OutsideWorld outsideWorld = mock( OutsideWorld.class );
     private Path configDir;
-    private ConsistencyCheckService consistencyCheckService;
+    private ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
+    private ConsistencyCheckService.Result ccResult = mock( ConsistencyCheckService.Result.class );
+    private PrintStream out = mock( PrintStream.class );
+    private PrintStream err = mock( PrintStream.class );
+    private FileSystemAbstraction mockFs = mock( FileSystemAbstraction.class );
 
     @Before
     public void setUp() throws Exception
     {
+        when( outsideWorld.fileSystem() ).thenReturn( new DefaultFileSystemAbstraction() );
+        when( outsideWorld.errorStream() ).thenReturn( err );
+        when( outsideWorld.outStream() ).thenReturn( out );
+        when( ccResult.isSuccessful() ).thenReturn( true );
+        when( consistencyCheckService
+                .runFullConsistencyCheck( any(), any(), any(), any(), any(), anyBoolean(), any() ) )
+                .thenReturn( ccResult );
         configDir = testDirectory.directory( "config-dir" ).toPath();
     }
 
     @Test
     public void shouldNotRequestForensics() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool )
-                .executeBackup( any(), any(), any(), any(), anyLong(), eq( false ) );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), eq( false ) );
     }
 
     @Test
     public void shouldDefaultFromToDefaultBackupAddress()
             throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                eq( new HostnamePort( "localhost", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( eq( "localhost" ), eq( 6362 ), any(), any(), any(), anyLong(),
+                anyBoolean() );
     }
 
     @Test
     public void shouldDefaultPortAndPassHost() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--from=foo.bar.server", "--to=/" );
+        execute( "--from=foo.bar.server", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                eq( new HostnamePort( "foo.bar.server", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( eq( "foo.bar.server" ), eq( 6362 ), any(), any(), any(), anyLong(),
+                anyBoolean() );
     }
 
     @Test
-    public void shouldAcceptAHostWithATrailingColon() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldAcceptAHostWithATrailingColon()
+            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--from=foo.bar.server:", "--to=/" );
+        execute( "--from=foo.bar.server:", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                eq( new HostnamePort( "foo.bar.server", 6362 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( eq( "foo.bar.server" ), eq( 6362 ), any(), any(), any(), anyLong(),
+                anyBoolean() );
     }
 
     @Test
     public void shouldDefaultHostAndPassPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--from=:1234", "--to=/" );
+        execute( "--from=:1234", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                eq( new HostnamePort( "localhost", 1234 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( eq( "localhost" ), eq( 1234 ), any(), any(), any(), anyLong(),
+                anyBoolean() );
     }
 
     @Test
     public void shouldPassHostAndPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--from=foo.bar.server:1234", "--to=/" );
+        execute( "--from=foo.bar.server:1234", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                eq( new HostnamePort( "foo.bar.server", 1234 ) ), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( eq( "foo.bar.server" ), eq( 1234 ), any(), any(), any(), anyLong(),
+                anyBoolean() );
     }
 
     @Test
     public void shouldPassDestination() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--to=/some/path/or/other" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup(
-                any(), eq( new File( "/some/path/or/other" ) ), any(), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup(
+                any(), anyInt(), eq( new File( "/mybackup" ) ), any(), any(), anyLong(), anyBoolean() );
     }
 
     @Test
-    public void shouldTreatToArgumentAsMandatory() throws CommandFailed
+    public void nonExistingBackupDirThrows() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        try
-        {
-            execute();
-            fail( "exception expected" );
-        }
-        catch ( IncorrectUsage incorrectUsage )
-        {
-            assertThat( incorrectUsage.getMessage(), containsString( "to" ) );
-        }
+        expected.expect( CommandFailed.class );
+        expected.expectMessage( "Directory '/Idontexist/sasdfasdfa' does not exist." );
+        execute( "--backup-dir=/Idontexist/sasdfasdfa", "--name=mybackup" );
+    }
+
+    @Test
+    public void shouldTreatBackupDirArgumentAsMandatory() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "Missing argument 'backup-dir'" );
+        execute();
+    }
+
+    @Test
+    public void shouldTreatNameArgumentAsMandatory() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "Missing argument 'name'" );
+        execute( "--backup-dir=/" );
     }
 
     @Test
     public void shouldNotAskForConsistencyCheckIfNotSpecified()
             throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
-        execute( "--check-consistency=false", "--to=/" );
+        execute( "--check-consistency=false", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), eq( ConsistencyCheck.NONE ), any(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verifyNoMoreInteractions( consistencyCheckService );
     }
 
     @Test
     public void shouldAskForConsistencyCheckIfSpecified() throws Exception
 
     {
-        consistencyCheckService = mock( ConsistencyCheckService.class );
-        stub( consistencyCheckService.runFullConsistencyCheck( any(), any(), any(), any(), any(), any(), anyBoolean(),
-                any() ) ).toReturn( success( null ) );
-        ArgumentCaptor<ConsistencyCheck> captor = ArgumentCaptor.forClass( ConsistencyCheck.class );
-        stub( tool.executeBackup( any(), any(), captor.capture(), any(), anyLong(), anyBoolean() ) ).toReturn( null );
+        execute( "--check-consistency=true", "--backup-dir=/", "--name=mybackup" );
 
-        execute( "--check-consistency", "--to=/" );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(),
+                anyBoolean(), eq( new File( "." ).getCanonicalFile() ) );
+    }
 
-        captor.getValue().runFull( null, null, null, null, null, null, false );
+    @Test
+    public void shouldAskForConsistencyCheckIfSpecifiedIncremental() throws Exception
 
-        verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(), any(),
-                anyBoolean(), eq( new File(".").getCanonicalFile()) );
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        assertTrue( new File( dir, "afile" ).createNewFile() );
+
+        execute( "--check-consistency=true", "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verifyNoMoreInteractions( backupService );
+        verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(),
+                anyBoolean(), eq( new File( "." ).getCanonicalFile() ) );
+    }
+
+    @Test
+    public void shouldNotAskForConsistencyCheckIfSpecifiedIncremental() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        assertTrue( new File( dir, "afile" ).createNewFile() );
+
+        execute( "--check-consistency=false", "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verifyNoMoreInteractions( backupService );
+        verifyNoMoreInteractions( consistencyCheckService );
+    }
+
+    @Test
+    public void failedCCIsReported() throws Exception
+
+    {
+        when( consistencyCheckService.runFullConsistencyCheck( any(), any(), any(), any(), any(),
+                anyBoolean(), eq( new File( "." ).getCanonicalFile() ) ) ).thenReturn(
+                ConsistencyCheckService.Result.failure( new File( "/foo/bar" ) ) );
+
+        expected.expect( CommandFailed.class );
+        expected.expectMessage( "Inconsistencies found. See '/foo/bar' for details." );
+        execute( "--check-consistency=true", "--backup-dir=/", "--name=mybackup" );
+    }
+
+    @Test
+    public void shouldDoFullIfDirectoryDoesNotExist() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccFull" );
+        assertTrue( dir.delete() );
+
+        execute( "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verify( outsideWorld ).stdOutLine( "Backup complete." );
+        verifyNoMoreInteractions( backupService );
+    }
+
+    @Test
+    public void shouldDoFullIfDirectoryEmpty() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccFull" );
+
+        execute( "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verifyNoMoreInteractions( backupService );
+    }
+
+    @Test
+    public void shouldDoIncrementalIfDirectoryNonEmpty() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        assertTrue( new File( dir, "afile" ).createNewFile() );
+
+        execute( "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
+        verifyNoMoreInteractions( backupService );
+    }
+
+    @Test
+    public void shouldFallbackToFullIfIncrementalFails() throws Exception
+
+    {
+        when( outsideWorld.fileSystem() ).thenReturn( mockFs );
+        File dir = testDirectory.directory( "ccInc" );
+        when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
+        when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{dir} );
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+                .thenThrow( new RuntimeException( "nah-ah" ) );
+
+        execute( "--cc-report-dir=" + dir.getParent(), "--backup-dir=" + dir.getParent(),
+                "--name=" + dir.getName() );
+
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
+        verify( outsideWorld ).stdErrLine( "Incremental backup failed: nah-ah" );
+        verify( outsideWorld ).stdErrLine( "Old backup renamed to 'ccInc.err.1'." );
+        verify( mockFs ).renameFile( eq( dir ), eq( testDirectory.directory( "ccInc.err.1" ) ) );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verifyNoMoreInteractions( backupService );
+    }
+
+    @Test
+    public void failToRenameIsReported() throws Exception
+    {
+        when( outsideWorld.fileSystem() ).thenReturn( mockFs );
+        File dir = testDirectory.directory( "ccInc" );
+        when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
+        when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{dir} );
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+                .thenThrow( new RuntimeException( "nah-ah" ) );
+
+        doThrow( new IOException( "kaboom" ) ).when( mockFs ).renameFile( any(), any() );
+
+        expected.expectMessage( "Failed to move old backup out of the way: kaboom" );
+        expected.expect( CommandFailed.class );
+
+        execute( "--cc-report-dir=" + dir.getParent(), "--backup-dir=" + dir.getParent(),
+                "--name=" + dir.getName() );
+    }
+
+    @Test
+    public void shouldNotFallbackToFullIfSpecified() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        assertTrue( new File( dir, "afile" ).createNewFile() );
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+                .thenThrow( new RuntimeException( "nah-ah" ) );
+
+        expected.expectMessage( "Backup failed: nah-ah" );
+        expected.expect( CommandFailed.class );
+
+        execute( "--fallback-to-full=false", "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+    }
+
+    @Test
+    public void renamingOldBackupIncrements() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        when( outsideWorld.fileSystem() ).thenReturn( mockFs );
+        when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
+        when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{dir} );
+        for ( int i = 1; i < 50; i++ )
+        {
+            when( mockFs.fileExists( eq( new File( dir.getParentFile(), "ccInc.err." + i ) ) ) ).thenReturn( true );
+        }
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+                .thenThrow( new RuntimeException( "nah-ah" ) );
+
+        execute( "--cc-report-dir=" + dir.getParent(), "--backup-dir=" + dir.getParent(),
+                "--name=" + dir.getName() );
+
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
+        verify( outsideWorld ).stdErrLine( "Incremental backup failed: nah-ah" );
+        verify( outsideWorld ).stdErrLine( "Old backup renamed to 'ccInc.err.50'." );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verifyNoMoreInteractions( backupService );
+    }
+
+    @Test
+    public void renamingOldBackupIncrementsOnlySoFar() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccInc" );
+        when( outsideWorld.fileSystem() ).thenReturn( mockFs );
+        when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
+        when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{dir} );
+        for ( int i = 1; i < MAX_OLD_BACKUPS; i++ )
+        {
+            when( mockFs.fileExists( eq( new File( dir.getParentFile(), "ccInc.err." + i ) ) ) ).thenReturn( true );
+        }
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+                .thenThrow( new RuntimeException( "nah-ah" ) );
+
+        expected.expect( CommandFailed.class );
+        expected.expectMessage( "ailed to move old backup out of the way: too many old backups." );
+        execute( "--cc-report-dir=" + dir.getParent(), "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
     }
 
     @Test
     public void shouldSpecifyReportDirIfSpecified() throws Exception
     {
-        consistencyCheckService = mock( ConsistencyCheckService.class );
-        stub( consistencyCheckService.runFullConsistencyCheck( any(), any(), any(), any(), any(), any(), anyBoolean(),
-                any() ) ).toReturn( success( null ) );
-        ArgumentCaptor<ConsistencyCheck> captor = ArgumentCaptor.forClass( ConsistencyCheck.class );
-        stub( tool.executeBackup( any(), any(), captor.capture(), any(), anyLong(), anyBoolean() ) ).toReturn( null );
+        File reportDir = testDirectory.directory( "ccreport" );
+        when( consistencyCheckService.runFullConsistencyCheck( any(), any(), any(), any(), any(), anyBoolean(),
+                any() ) ).thenReturn( ConsistencyCheckService.Result.success( null ) );
 
-        execute( "--check-consistency", "--to=/", "--cc-report-dir=" + Paths.get( "some", "dir" ) );
+        execute( "--check-consistency", "--backup-dir=/", "--name=mybackup",
+                "--cc-report-dir=" + reportDir );
 
-        captor.getValue().runFull( null, null, null, null, null, null, false );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
+        verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(),
+                anyBoolean(), eq( reportDir.getCanonicalFile() ) );
+    }
 
-        verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(), any(),
-                anyBoolean(), eq( new File("some/dir").getCanonicalFile() ) );
+    @Test
+    public void fullFailureIsReported() throws Exception
+
+    {
+        File dir = testDirectory.directory( "ccFull" );
+
+        when( backupService.doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() ) )
+                .thenThrow( new RuntimeException( "nope" ) );
+
+        expected.expect( CommandFailed.class );
+        expected.expectMessage( "Backup failed: nope" );
+        execute( "--backup-dir=" + dir.getParent(), "--name=" + dir.getName() );
+    }
+
+    @Test
+    public void reportDirMustBeAPath() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "cc-report-dir must be a path" );
+        execute( "--check-consistency", "--backup-dir=/", "--name=mybackup",
+                "--cc-report-dir" );
+    }
+
+    @Test
+    public void reportDirMustExist() throws Exception
+    {
+        expected.expect( CommandFailed.class );
+        expected.expectMessage( "Directory '/aalivnmoimzlckmvPDK' does not exist." );
+        execute( "--check-consistency", "--backup-dir=/", "--name=mybackup",
+                "--cc-report-dir=/aalivnmoimzlckmvPDK" );
     }
 
     @Test
@@ -205,9 +448,10 @@ public class OnlineBackupCommandTest
     {
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
 
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), config.capture(), anyLong(),
+                anyBoolean() );
         assertThat( config.getValue().getSettingsClasses(), hasItem( GraphDatabaseSettings.class ) );
     }
 
@@ -217,9 +461,10 @@ public class OnlineBackupCommandTest
     {
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
 
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), config.capture(), anyLong(),
+                anyBoolean() );
         assertThat( config.getValue().getSettingsClasses(), hasItem( ConsistencyCheckSettings.class ) );
     }
 
@@ -228,12 +473,13 @@ public class OnlineBackupCommandTest
             .ToolFailureException
 
     {
-        Files.write( configDir.resolve( "neo4j.conf" ), asList( cypher_planner.name() + "=RULE" ) );
+        Files.write( configDir.resolve( "neo4j.conf" ), singletonList( cypher_planner.name() + "=RULE" ) );
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
 
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), config.capture(), anyLong(),
+                anyBoolean() );
         assertThat( config.getValue().get( cypher_planner ), is( "RULE" ) );
     }
 
@@ -242,12 +488,13 @@ public class OnlineBackupCommandTest
             throws IOException, CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
     {
         Path extraConf = testDirectory.directory( "someOtherDir" ).toPath().resolve( "extra.conf" );
-        Files.write( extraConf, asList( cypher_planner.name() + "=RULE" ) );
+        Files.write( extraConf, singletonList( cypher_planner.name() + "=RULE" ) );
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
 
-        execute( "--additional-config=" + extraConf, "--to=/" );
+        execute( "--additional-config=" + extraConf, "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), config.capture(), anyLong(), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), config.capture(), anyLong(),
+                anyBoolean() );
         assertThat( config.getValue().get( cypher_planner ), is( "RULE" ) );
     }
 
@@ -255,27 +502,33 @@ public class OnlineBackupCommandTest
     public void shouldDefaultTimeoutToTwentyMinutes()
             throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
     {
-        execute( "--to=/" );
+        execute( "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), any(), eq( MINUTES.toMillis( 20 ) ), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(),
+                eq( MINUTES.toMillis( 20 ) ),
+                anyBoolean() );
     }
 
     @Test
     public void shouldInterpretAUnitlessTimeoutAsSeconds()
             throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
     {
-        execute( "--timeout=10", "--to=/" );
+        execute( "--timeout=10", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), any(), eq( SECONDS.toMillis( 10 ) ), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(),
+                eq( SECONDS.toMillis( 10 ) ),
+                anyBoolean() );
     }
 
     @Test
     public void shouldParseATimeoutWithUnits()
             throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
     {
-        execute( "--timeout=10h", "--to=/" );
+        execute( "--timeout=10h", "--backup-dir=/", "--name=mybackup" );
 
-        verify( tool ).executeBackup( any(), any(), any(), any(), eq( HOURS.toMillis( 10 ) ), anyBoolean() );
+        verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(),
+                eq( HOURS.toMillis( 10 ) ),
+                anyBoolean() );
     }
 
     @Test
@@ -288,26 +541,29 @@ public class OnlineBackupCommandTest
             Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
             usage.printUsageForCommand( new OnlineBackupCommand.Provider(), ps::println );
 
-            assertEquals( String.format( "usage: neo4j-admin backup [--from=<address>] --to=<backup-path>%n" +
+            assertEquals(
+                    String.format( "usage: neo4j-admin backup --backup-dir=<backup-path> --name=<graph.db-backup>%n" +
+                            "                          [--from=<address>] [--fallback-to-full[=<true|false>]]%n" +
                             "                          [--check-consistency[=<true|false>]]%n" +
                             "                          [--cc-report-dir=<directory>]%n" +
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--timeout=<timeout>]%n" +
                             "%n" +
-                            "Perform a backup, over the network, from a running Neo4j server into a local%n" +
-                            "copy of the database store (the backup). Neo4j Server must be configured to run%n" +
-                            "a backup service. See http://neo4j.com/docs/operations-manual/current/backup/%n" +
-                            "for more details.%n" +
-                            "%n" +
-                            "WARNING: this command is experimental and subject to change.%n" +
+                            "Perform an online backup from a running Neo4j enterprise server. Neo4j's backup%n" +
+                            "service must have been configured on the server beforehand. See%n" +
+                            "http://neo4j.com/docs/operations-manual/current/backup/ for more details.%n" +
                             "%n" +
                             "options:%n" +
+                            "  --backup-dir=<backup-path>               Directory to place backup in.%n" +
+                            "  --name=<graph.db-backup>                 Name of backup. If a backup with this%n" +
+                            "                                           name already exists an incremental%n" +
+                            "                                           backup will be attempted.%n" +
                             "  --from=<address>                         Host and port of Neo4j.%n" +
                             "                                           [default:localhost:6362]%n" +
-                            "  --to=<backup-path>                       Directory where the backup will be%n" +
-                            "                                           made; if there is already a backup%n" +
-                            "                                           present an incremental backup will be%n" +
-                            "                                           attempted.%n" +
+                            "  --fallback-to-full=<true|false>          If a failed incremental backup will%n" +
+                            "                                           move the old backup to <name>.err.<N>%n" +
+                            "                                           and fallback to a full backup%n" +
+                            "                                           instead. [default:true]%n" +
                             "  --check-consistency=<true|false>         If a consistency check should be%n" +
                             "                                           made. [default:true]%n" +
                             "  --cc-report-dir=<directory>              Directory where consistency report%n" +
@@ -324,7 +580,7 @@ public class OnlineBackupCommandTest
 
     private void execute( String... args ) throws IncorrectUsage, CommandFailed
     {
-        new OnlineBackupCommand( tool, Paths.get( "/some/path" ), configDir, consistencyCheckService )
-                .execute( args );
+        new OnlineBackupCommand( backupService, Paths.get( "/some/path" ), configDir, consistencyCheckService,
+                outsideWorld ).execute( args );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
@@ -45,7 +44,7 @@ import org.neo4j.test.causalclustering.ClusterRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.neo4j.backup.BackupEmbeddedIT.runBackupToolFromOtherJvmToGetExitCode;
+import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
 import static org.neo4j.graphdb.Label.label;
 
 public class BackupCoreIT
@@ -73,15 +72,15 @@ public class BackupCoreIT
         {
             // Run backup
             DbRepresentation beforeChange = DbRepresentation.of( createSomeData( cluster ) );
-            File backupDir = new File( backupsDir, Integer.toString( db.serverId() ) );
-            String[] args = backupArguments( backupAddress( db.database() ), backupDir.getPath() );
+            String[] args = backupArguments( backupAddress( db.database() ), backupsDir, "" + db.serverId() );
             assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( args ) );
 
             // Add some new data
             DbRepresentation afterChange = DbRepresentation.of( createSomeData( cluster ) );
 
             // Verify that old data is back
-            DbRepresentation backupRepresentation = DbRepresentation.of( backupDir, getConfig() );
+            DbRepresentation backupRepresentation = DbRepresentation.of( new File( backupsDir, "" + db.serverId() ),
+                    getConfig() );
             assertEquals( beforeChange, backupRepresentation );
             assertNotEquals( backupRepresentation, afterChange );
         }
@@ -105,13 +104,13 @@ public class BackupCoreIT
         return inetSocketAddress.getHostName() + ":" + (inetSocketAddress.getPort() + 2000);
     }
 
-    static String[] backupArguments( String from, String to )
+    static String[] backupArguments( String from, File backupsDir, String name )
     {
         List<String> args = new ArrayList<>();
-        args.add( "-from" );
-        args.add( from );
-        args.add( "-to" );
-        args.add( to );
+        args.add( "--from=" + from );
+        args.add( "--cc-report-dir=" + backupsDir );
+        args.add( "--backup-dir=" + backupsDir );
+        args.add( "--name=" + name );
         return args.toArray( new String[args.size()] );
     }
 


### PR DESCRIPTION
New help text:

```
usage: neo4j-admin backup --backup-dir=<backup-path> --name=<graph.db-backup>
                          [--from=<address>] [--fallback-to-full[=<true|false>]]
                          [--check-consistency[=<true|false>]]
                          [--cc-report-dir=<directory>]
                          [--additional-config=<config-file-path>]
                          [--timeout=<timeout>]

Perform an online backup from a running Neo4j enterprise server. Neo4j's backup
service must have been configured on the server beforehand. See
http://neo4j.com/docs/operations-manual/current/backup/ for more details.

options:
  --backup-dir=<backup-path>               Directory to place backup in.
  --name=<graph.db-backup>                 Name of backup. If a backup with this
                                           name already exists an incremental
                                           backup will be attempted.
  --from=<address>                         Host and port of Neo4j.
                                           [default:localhost:6362]
  --fallback-to-full=<true|false>          If a failed incremental backup will
                                           move the old backup to <name>.err.<N>
                                           and fallback to a full backup
                                           instead. [default:true]
  --check-consistency=<true|false>         If a consistency check should be
                                           made. [default:true]
  --cc-report-dir=<directory>              Directory where consistency report
                                           will be written. [default:.]
  --additional-config=<config-file-path>   Configuration file to supply
                                           additional configuration in.
                                           [default:]
  --timeout=<timeout>                      Timeout in the form <time>[ms|s|m|h],
                                           where the default unit is seconds.
                                           [default:20m]

```

changelog 	
Implement new `neo4j-admin backup` surface

* consistency-check, if specified, is run for *both* full and
  incremental backup
* Exit with clear error messages on failures with exit code 1
* If incremental backup fails, the old backup is *moved*, and then it
  falls back to full backup
* fallback behavior can be disabled if desired, in which case failures
  are reported directly and old backup is *not* moved
