### PR TITLE
Separate LabelScanStore tests from actual label scan store implementation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -33,6 +33,54 @@ import org.neo4j.storageengine.api.schema.LabelScanReader;
  */
 public interface LabelScanStore extends Lifecycle
 {
+    interface Monitor
+    {
+        Monitor EMPTY = new Monitor()
+        {
+            @Override
+            public void init()
+            {
+            }
+
+            @Override
+            public void noIndex()
+            {
+            }
+
+            @Override
+            public void lockedIndex( Exception e )
+            {
+            }
+
+            @Override
+            public void notValidIndex()
+            {
+            }
+
+            @Override
+            public void rebuilding()
+            {
+            }
+
+            @Override
+            public void rebuilt( long roughNodeCount )
+            {
+            }
+        };
+
+        void init();
+
+        void noIndex();
+
+        void lockedIndex( Exception e );
+
+        void notValidIndex();
+
+        void rebuilding();
+
+        void rebuilt( long roughNodeCount );
+    }
+
     /**
      * From the point a {@link LabelScanReader} is created till it's {@link LabelScanReader#close() closed} the
      * contents it returns cannot change, i.e. it honors repeatable reads.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreChaosIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreChaosIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.Set;
+
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.RandomRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+/**
+ * Tests functionality around missing or corrupted lucene label scan store index, and that
+ * the database should repair (i.e. rebuild) that automatically and just work.
+ */
+public abstract class LabelScanStoreChaosIT
+{
+    private final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    protected final RandomRule randomRule = new RandomRule();
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( randomRule ).around( dbRule );
+
+    @Test
+    public void shouldRebuildDeletedLabelScanStoreOnStartup() throws Exception
+    {
+        // GIVEN
+        Node node1 = createLabeledNode( Labels.First );
+        Node node2 = createLabeledNode( Labels.First );
+        Node node3 = createLabeledNode( Labels.First );
+        deleteNode( node2 ); // just to create a hole in the store
+
+        // WHEN
+        dbRule.restartDatabase( deleteTheLabelScanStoreIndex() );
+
+        // THEN
+        assertEquals( asSet( node1, node3 ), getAllNodesWithLabel( Labels.First ) );
+    }
+
+    @Test
+    public void rebuildCorruptedLabelScanStoreToStartup() throws Exception
+    {
+        Node node = createLabeledNode( Labels.First );
+
+        dbRule.restartDatabase( corruptTheLabelScanStoreIndex() );
+
+        assertEquals( asSet( node ), getAllNodesWithLabel( Labels.First ) );
+    }
+
+    protected abstract DatabaseRule.RestartAction corruptTheLabelScanStoreIndex();
+
+    protected abstract DatabaseRule.RestartAction deleteTheLabelScanStoreIndex();
+
+    private Node createLabeledNode( Label... labels )
+    {
+        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        {
+            Node node = dbRule.getGraphDatabaseAPI().createNode( labels );
+            tx.success();
+            return node;
+        }
+    }
+
+    private Set<Node> getAllNodesWithLabel( Label label )
+    {
+        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        {
+            return asSet( dbRule.getGraphDatabaseAPI().findNodes( label ) );
+        }
+    }
+
+    private void deleteNode( Node node )
+    {
+        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        {
+            node.delete();
+            tx.success();
+        }
+    }
+
+    private enum Labels implements Label
+    {
+        First, Second, Third
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreStartupIT.java
@@ -45,7 +45,7 @@ import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-public class LuceneLabelScanStoreIT
+public abstract class LabelScanStoreStartupIT
 {
     @Rule
     public final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
@@ -54,7 +54,7 @@ public class LuceneLabelScanStoreIT
     public void scanStoreStartWithoutExistentIndex() throws IOException
     {
         NeoStoreDataSource dataSource = getDataSource();
-        LabelScanStore labelScanStore = getLabelScanStore();
+        LabelScanStore labelScanStore = getLabelScanStore( dbRule );
         labelScanStore.shutdown();
 
         File labelScanStoreDirectory = getLabelScanStoreDirectory( dataSource );
@@ -70,7 +70,7 @@ public class LuceneLabelScanStoreIT
     public void scanStoreRecreateCorruptedIndexOnStartup() throws IOException
     {
         NeoStoreDataSource dataSource = getDataSource();
-        LabelScanStore labelScanStore = getLabelScanStore();
+        LabelScanStore labelScanStore = getLabelScanStore( dbRule );
 
         Node node = createTestNode();
         long[] labels = readNodeLabels( labelScanStore, node );
@@ -97,7 +97,7 @@ public class LuceneLabelScanStoreIT
 
     private Node createTestNode()
     {
-        Node node = null;
+        Node node;
         try (Transaction transaction = dbRule.beginTx())
         {
             node = dbRule.createNode( Label.label( "testLabel" ));
@@ -132,11 +132,7 @@ public class LuceneLabelScanStoreIT
         return dataSourceManager.getDataSource();
     }
 
-    private LabelScanStore getLabelScanStore()
-    {
-        DependencyResolver dependencyResolver = dbRule.getDependencyResolver();
-        return dependencyResolver.resolveDependency( LabelScanStore.class );
-    }
+    protected abstract LabelScanStore getLabelScanStore( DatabaseRule dbRule );
 
     private void checkLabelScanStoreAccessible( LabelScanStore labelScanStore ) throws IOException
     {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreUpdateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreUpdateIT.java
@@ -43,7 +43,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.emptySetOf;
 import static org.neo4j.helpers.collection.Iterators.single;
 
-public class LabelScanStoreIT
+public class LabelScanStoreUpdateIT
 {
     @ClassRule
     public static final DatabaseRule dbRule = new ImpermanentDatabaseRule();

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.labelscan;
+
+import org.apache.lucene.index.IndexFileNames;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.BoundedIterable;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.LabelScanWriter;
+import org.neo4j.kernel.api.labelscan.NodeLabelRange;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.FullStoreChangeStream;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.storageengine.api.schema.LabelScanReader;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+import static org.neo4j.helpers.collection.Iterators.iterator;
+import static org.neo4j.helpers.collection.Iterators.single;
+import static org.neo4j.io.fs.FileUtils.deleteRecursively;
+import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
+
+public abstract class LabelScanStoreTest
+{
+    private final TestDirectory testDirectory = TestDirectory.testDirectory();
+    private final ExpectedException expectedException = ExpectedException.none();
+    private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    final RandomRule random = new RandomRule();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( random ).around( testDirectory ).around( expectedException )
+            .around( fileSystemRule );
+
+    private static final long[] NO_LABELS = new long[0];
+
+    private LifeSupport life;
+    private TrackingMonitor monitor;
+    private LabelScanStore store;
+    private File dir;
+
+    @Before
+    public void clearDir() throws IOException
+    {
+        dir = testDirectory.directory( "lucene" );
+        if ( dir.exists() )
+        {
+            deleteRecursively( dir );
+        }
+    }
+
+    @After
+    public void shutdown()
+    {
+        life.shutdown();
+    }
+
+    protected abstract LabelScanStore createLabelScanStore( FileSystemAbstraction fileSystemAbstraction,
+            File rootFolder, List<NodeLabelUpdate> existingData, boolean usePersistentStore, boolean readOnly,
+            LabelScanStore.Monitor monitor );
+
+    @Test
+    public void failToRetrieveWriterOnReadOnlyScanStore() throws IOException
+    {
+        createAndStartReadOnly();
+        expectedException.expect( UnsupportedOperationException.class );
+        store.newWriter();
+    }
+
+    @Test
+    public void forceShouldNotForceWriterOnReadOnlyScanStore()
+    {
+        createAndStartReadOnly();
+        store.force();
+    }
+
+    @Test
+    public void failToGetWriterOnReadOnlyScanStore() throws Exception
+    {
+        createAndStartReadOnly();
+        expectedException.expect( UnsupportedOperationException.class );
+        store.newWriter();
+    }
+
+    @Test
+    public void failToStartIfLabelScanStoreIndexDoesNotExistInReadOnlyMode()
+    {
+        expectedException.expectCause( Matchers.instanceOf( UnsupportedOperationException.class ) );
+        start( false, true );
+//        assertTrue( monitor.noIndexCalled );
+    }
+
+    @Test
+    public void snapshotReadOnlyLabelScanStore() throws IOException
+    {
+        prepareIndex();
+        createAndStartReadOnly();
+        try (ResourceIterator<File> indexFiles = store.snapshotStoreFiles())
+        {
+            List<String> filesNames = indexFiles.stream().map( File::getName ).collect( toList() );
+            assertThat( "Should have at least index segment file.", filesNames,
+                    hasItem( startsWith( IndexFileNames.SEGMENTS ) ) );
+        }
+    }
+
+    @Test
+    public void shouldUpdateIndexOnLabelChange() throws Exception
+    {
+        // GIVEN
+        int labelId = 1;
+        long nodeId = 10;
+        start();
+
+        // WHEN
+        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId} ) ) );
+
+        // THEN
+        assertNodesForLabel( labelId, nodeId );
+    }
+
+    @Test
+    public void shouldUpdateIndexOnAddedLabels() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 1, labelId2 = 2;
+        long nodeId = 10;
+        start();
+        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1} ) ) );
+        assertNodesForLabel( labelId2 );
+
+        // WHEN
+        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
+
+        // THEN
+        assertNodesForLabel( labelId1, nodeId );
+        assertNodesForLabel( labelId2, nodeId );
+    }
+
+    @Test
+    public void shouldUpdateIndexOnRemovedLabels() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 1, labelId2 = 2;
+        long nodeId = 10;
+        start();
+        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
+        assertNodesForLabel( labelId1, nodeId );
+        assertNodesForLabel( labelId2, nodeId );
+
+        // WHEN
+        write( iterator( labelChanges( nodeId, new long[]{labelId1, labelId2}, new long[]{labelId2} ) ) );
+
+        // THEN
+        assertNodesForLabel( labelId1 );
+        assertNodesForLabel( labelId2, nodeId );
+    }
+
+    @Test
+    public void shouldDeleteFromIndexWhenDeletedNode() throws Exception
+    {
+        // GIVEN
+        int labelId = 1;
+        long nodeId = 10;
+        start();
+        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId} ) ) );
+
+        // WHEN
+        write( iterator( labelChanges( nodeId, new long[]{labelId}, NO_LABELS ) ) );
+
+        // THEN
+        assertNodesForLabel( labelId );
+    }
+
+    @Test
+    public void shouldScanSingleRange() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 1, labelId2 = 2;
+        long nodeId1 = 10, nodeId2 = 11;
+        start( asList(
+                labelChanges( nodeId1, NO_LABELS, new long[]{labelId1} ),
+                labelChanges( nodeId2, NO_LABELS, new long[]{labelId1, labelId2} )
+        ) );
+
+        // WHEN
+        BoundedIterable<NodeLabelRange> reader = store.allNodeLabelRanges();
+        NodeLabelRange range = single( reader.iterator() );
+
+        // THEN
+        assertArrayEquals( new long[]{nodeId1, nodeId2}, sorted( range.nodes() ) );
+
+        assertArrayEquals( new long[]{labelId1}, sorted( range.labels( nodeId1 ) ) );
+        assertArrayEquals( new long[]{labelId1, labelId2}, sorted( range.labels( nodeId2 ) ) );
+    }
+
+    @Test
+    public void shouldScanMultipleRanges() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 1, labelId2 = 2;
+        long nodeId1 = 10, nodeId2 = 1280;
+        start( asList(
+                labelChanges( nodeId1, NO_LABELS, new long[]{labelId1} ),
+                labelChanges( nodeId2, NO_LABELS, new long[]{labelId1, labelId2} )
+        ) );
+
+        // WHEN
+        BoundedIterable<NodeLabelRange> reader = store.allNodeLabelRanges();
+        Iterator<NodeLabelRange> iterator = reader.iterator();
+        NodeLabelRange range1 = iterator.next();
+        NodeLabelRange range2 = iterator.next();
+        assertFalse( iterator.hasNext() );
+
+        // THEN
+        assertArrayEquals( new long[]{nodeId1}, sorted( range1.nodes() ) );
+        assertArrayEquals( new long[]{nodeId2}, sorted( range2.nodes() ) );
+
+        assertArrayEquals( new long[]{labelId1}, sorted( range1.labels( nodeId1 ) ) );
+
+        assertArrayEquals( new long[]{labelId1, labelId2}, sorted( range2.labels( nodeId2 ) ) );
+    }
+
+    @Test
+    public void shouldWorkWithAFullRange() throws Exception
+    {
+        // given
+        long labelId = 0;
+        List<NodeLabelUpdate> updates = new ArrayList<>();
+        for ( int i = 0; i < 34; i++ )
+        {
+            updates.add( NodeLabelUpdate.labelChanges( i, new long[]{}, new long[]{labelId} ) );
+        }
+
+        start( updates );
+
+        // when
+        LabelScanReader reader = store.newReader();
+        Set<Long> nodesWithLabel = PrimitiveLongCollections.toSet( reader.nodesWithLabel( (int) labelId ) );
+
+        // then
+        for ( long i = 0; i < 34; i++ )
+        {
+            assertThat( nodesWithLabel, hasItem( i ) );
+            Set<Long> labels = PrimitiveLongCollections.toSet( reader.labelsForNode( i ) );
+            assertThat( labels, hasItem( labelId ) );
+        }
+    }
+
+    @Test
+    public void shouldUpdateAFullRange() throws Exception
+    {
+        // given
+        long label0Id = 0;
+        List<NodeLabelUpdate> label0Updates = new ArrayList<>();
+        for ( int i = 0; i < 34; i++ )
+        {
+            label0Updates.add( NodeLabelUpdate.labelChanges( i, new long[]{}, new long[]{label0Id} ) );
+        }
+
+        start( label0Updates );
+
+        // when
+        write( Collections.emptyIterator() );
+
+        // then
+        LabelScanReader reader = store.newReader();
+        Set<Long> nodesWithLabel0 = PrimitiveLongCollections.toSet( reader.nodesWithLabel( (int) label0Id ) );
+        for ( long i = 0; i < 34; i++ )
+        {
+            assertThat( nodesWithLabel0, hasItem( i ) );
+            Set<Long> labels = PrimitiveLongCollections.toSet( reader.labelsForNode( i ) );
+            assertThat( labels, hasItem( label0Id ) );
+        }
+    }
+
+    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException
+    {
+        try ( LabelScanWriter writer = store.newWriter() )
+        {
+            while ( iterator.hasNext() )
+            {
+                writer.write( iterator.next() );
+            }
+        }
+    }
+
+    private long[] sorted( long[] input )
+    {
+        Arrays.sort( input );
+        return input;
+    }
+
+    @Test
+    public void shouldRebuildFromScratchIfIndexMissing() throws Exception
+    {
+        // GIVEN a start of the store with existing data in it
+        start( asList(
+                labelChanges( 1, NO_LABELS, new long[]{1} ),
+                labelChanges( 2, NO_LABELS, new long[]{1, 2} )
+        ) );
+
+        // THEN
+        assertTrue( "Didn't rebuild the store on startup",
+                monitor.noIndexCalled & monitor.rebuildingCalled & monitor.rebuiltCalled );
+        assertNodesForLabel( 1, 1, 2 );
+        assertNodesForLabel( 2, 2 );
+    }
+
+    @Test
+    public void rebuildCorruptedIndexIndexOnStartup() throws Exception
+    {
+        // GIVEN a start of the store with existing data in it
+        List<NodeLabelUpdate> data = asList(
+                labelChanges( 1, NO_LABELS, new long[]{1} ),
+                labelChanges( 2, NO_LABELS, new long[]{1, 2} ) );
+        start( data, true, false );
+
+        // WHEN the index is corrupted and then started again
+        scrambleIndexFilesAndRestart( data, true, false );
+
+        assertTrue( "Index corruption should be detected", monitor.corruptedIndex );
+        assertTrue( "Index should be rebuild", monitor.rebuildingCalled );
+    }
+
+    @Test
+    public void shouldFindDecentAmountOfNodesForALabel() throws Exception
+    {
+        // GIVEN
+        // 16 is the magic number of the page iterator
+        // 32 is the number of nodes in each lucene document
+        final int labelId = 1, nodeCount = 32 * 16 + 10;
+        start();
+        write( new PrefetchingIterator<NodeLabelUpdate>()
+        {
+            private int i = -1;
+
+            @Override
+            protected NodeLabelUpdate fetchNextOrNull()
+            {
+                return ++i < nodeCount ? labelChanges( i, NO_LABELS, new long[]{labelId} ) : null;
+            }
+        } );
+
+        // WHEN
+        Set<Long> nodeSet = new TreeSet<>();
+        LabelScanReader reader = store.newReader();
+        PrimitiveLongIterator nodes = reader.nodesWithLabel( labelId );
+        while ( nodes.hasNext() )
+        {
+            nodeSet.add( nodes.next() );
+        }
+        reader.close();
+
+        // THEN
+        assertEquals( "Found gaps in node id range: " + gaps( nodeSet, nodeCount ), nodeCount, nodeSet.size() );
+    }
+
+    @Test
+    public void shouldFindAllLabelsForGivenNode() throws Exception
+    {
+        // GIVEN
+        // 16 is the magic number of the page iterator
+        // 32 is the number of nodes in each lucene document
+        final long labelId1 = 1, labelId2 = 2, labelId3 = 87;
+        start();
+
+        int nodeId = 42;
+        write( Iterators.iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
+        write( Iterators.iterator( labelChanges( 41, NO_LABELS, new long[]{labelId3, labelId2} ) ) );
+
+        // WHEN
+        LabelScanReader reader = store.newReader();
+
+        // THEN
+        assertThat( PrimitiveLongCollections.toSet( reader.labelsForNode( nodeId ) ), hasItems( labelId1, labelId2 ) );
+        reader.close();
+    }
+
+    @Test
+    public void shouldFindNodesWithAnyOfGivenLabels() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 3, labelId2 = 5, labelId3 = 13;
+        start();
+
+        // WHEN
+        write( iterator(
+                labelChanges( 2, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2} ),
+                labelChanges( 1, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
+                labelChanges( 4, EMPTY_LONG_ARRAY, new long[] {labelId1,           labelId3} ),
+                labelChanges( 5, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2, labelId3} ),
+                labelChanges( 3, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
+                labelChanges( 7, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
+                labelChanges( 8, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ),
+                labelChanges( 6, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
+                labelChanges( 9, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ) ) );
+
+        // THEN
+        try ( LabelScanReader reader = store.newReader() )
+        {
+            assertArrayEquals(
+                    new long[] {1, 2, 3, 4, 5, 6, 7},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId2 ) ) );
+            assertArrayEquals(
+                    new long[] {1, 2, 3, 4, 5, 8, 9},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId3 ) ) );
+            assertArrayEquals(
+                    new long[] {1, 2, 3, 4, 5, 6, 7, 8, 9},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId2, labelId3 ) ) );
+        }
+    }
+
+    @Test
+    public void shouldFindNodesWithAllGivenLabels() throws Exception
+    {
+        // GIVEN
+        int labelId1 = 3, labelId2 = 5, labelId3 = 13;
+        start();
+
+        // WHEN
+        write( iterator(
+                labelChanges( 5, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2, labelId3} ),
+                labelChanges( 8, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ),
+                labelChanges( 3, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
+                labelChanges( 6, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
+                labelChanges( 1, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
+                labelChanges( 7, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
+                labelChanges( 4, EMPTY_LONG_ARRAY, new long[] {labelId1,           labelId3} ),
+                labelChanges( 2, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2} ),
+                labelChanges( 9, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ) ) );
+
+        // THEN
+        try ( LabelScanReader reader = store.newReader() )
+        {
+            assertArrayEquals(
+                    new long[] {2, 5},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId2 ) ) );
+            assertArrayEquals(
+                    new long[] {4, 5},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId3 ) ) );
+            assertArrayEquals(
+                    new long[] {5},
+                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId2, labelId3 ) ) );
+        }
+    }
+
+    private void prepareIndex() throws IOException
+    {
+        start();
+        try ( LabelScanWriter labelScanWriter = store.newWriter() )
+        {
+            labelScanWriter.write( NodeLabelUpdate.labelChanges( 1, new long[]{}, new long[]{1} ) );
+        }
+        store.shutdown();
+    }
+
+    private Set<Long> gaps( Set<Long> ids, int expectedCount )
+    {
+        Set<Long> gaps = new HashSet<>();
+        for ( long i = 0; i < expectedCount; i++ )
+        {
+            if ( !ids.contains( i ) )
+            {
+                gaps.add( i );
+            }
+        }
+        return gaps;
+    }
+
+    private void assertNodesForLabel( int labelId, long... expectedNodeIds )
+    {
+        Set<Long> nodeSet = new HashSet<>();
+        PrimitiveLongIterator nodes = store.newReader().nodesWithLabel( labelId );
+        while ( nodes.hasNext() )
+        {
+            nodeSet.add( nodes.next() );
+        }
+
+        for ( long expectedNodeId : expectedNodeIds )
+        {
+            assertTrue( "Expected node " + expectedNodeId + " not found in scan store",
+                    nodeSet.remove( expectedNodeId ) );
+        }
+        assertTrue( "Unexpected nodes in scan store " + nodeSet, nodeSet.isEmpty() );
+    }
+
+    private void createAndStartReadOnly()
+    {
+        // create label scan store and shutdown it
+        start();
+        life.shutdown();
+
+        start( false, true );
+    }
+
+    private void start()
+    {
+        start( false, false );
+    }
+
+    private void start( boolean usePersistentStore, boolean readOnly )
+    {
+        start( Collections.emptyList(), usePersistentStore, readOnly );
+    }
+
+    private void start( List<NodeLabelUpdate> existingData )
+    {
+        start( existingData, false, false );
+    }
+
+    private void start( List<NodeLabelUpdate> existingData, boolean usePersistentStore,
+            boolean readOnly )
+    {
+        life = new LifeSupport();
+        monitor = new TrackingMonitor();
+
+        store = createLabelScanStore( fileSystemRule.get(), dir, existingData, usePersistentStore, readOnly, monitor );
+        life.add( store );
+
+        life.start();
+        assertTrue( monitor.initCalled );
+    }
+
+    FullStoreChangeStream asStream( final List<NodeLabelUpdate> existingData )
+    {
+        return writer ->
+        {
+            long count = 0;
+            for ( NodeLabelUpdate update : existingData )
+            {
+                writer.write( update );
+                count++;
+            }
+            return count;
+        };
+    }
+
+    private void scrambleIndexFilesAndRestart( List<NodeLabelUpdate> data,
+            boolean usePersistentStore, boolean readOnly ) throws IOException
+    {
+        shutdown();
+        corruptIndex();
+        start( data, usePersistentStore, readOnly );
+    }
+
+    protected abstract void corruptIndex() throws IOException;
+
+    private static class TrackingMonitor implements LabelScanStore.Monitor
+    {
+        boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled;
+        boolean corruptedIndex = false;
+
+        @Override
+        public void noIndex()
+        {
+            noIndexCalled = true;
+        }
+
+        @Override
+        public void lockedIndex( Exception e )
+        {
+        }
+
+        @Override
+        public void notValidIndex()
+        {
+            corruptedIndex = true;
+        }
+
+        @Override
+        public void rebuilding()
+        {
+            rebuildingCalled = true;
+        }
+
+        @Override
+        public void rebuilt( long roughNodeCount )
+        {
+            rebuiltCalled = true;
+        }
+
+        @Override
+        public void init()
+        {
+            initCalled = true;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -127,19 +127,10 @@ public abstract class LabelScanStoreTest
     }
 
     @Test
-    public void failToGetWriterOnReadOnlyScanStore() throws Exception
-    {
-        createAndStartReadOnly();
-        expectedException.expect( UnsupportedOperationException.class );
-        store.newWriter();
-    }
-
-    @Test
     public void failToStartIfLabelScanStoreIndexDoesNotExistInReadOnlyMode()
     {
         expectedException.expectCause( Matchers.instanceOf( UnsupportedOperationException.class ) );
         start( false, true );
-//        assertTrue( monitor.noIndexCalled );
     }
 
     @Test

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
@@ -29,8 +29,6 @@ import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanIndexBuilder;
 import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
-import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.FullStoreChangeStream;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 
@@ -86,7 +84,7 @@ public class LuceneLabelScanStoreBuilder
                     .withOperationalMode( operationalMode )
                     .build();
             labelScanStore = new LuceneLabelScanStore( index, fullStoreLabelUpdateStream( storeViewSupplier ),
-                    logProvider, LuceneLabelScanStore.Monitor.EMPTY );
+                    logProvider, LabelScanStore.Monitor.EMPTY );
 
             try
             {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
@@ -43,54 +43,6 @@ public class LuceneLabelScanStore implements LabelScanStore
     private final Monitor monitor;
     private boolean needsRebuild;
 
-    public interface Monitor
-    {
-        Monitor EMPTY = new Monitor()
-        {
-            @Override
-            public void init()
-            {
-            }
-
-            @Override
-            public void noIndex()
-            {
-            }
-
-            @Override
-            public void lockedIndex( LockObtainFailedException e )
-            {
-            }
-
-            @Override
-            public void corruptedIndex()
-            {
-            }
-
-            @Override
-            public void rebuilding()
-            {
-            }
-
-            @Override
-            public void rebuilt( long roughNodeCount )
-            {
-            }
-        };
-
-        void init();
-
-        void noIndex();
-
-        void lockedIndex( LockObtainFailedException e );
-
-        void corruptedIndex();
-
-        void rebuilding();
-
-        void rebuilt( long roughNodeCount );
-    }
-
     public LuceneLabelScanStore( LabelScanIndex luceneIndex, FullStoreChangeStream fullStoreStream,
             LogProvider logProvider, Monitor monitor )
     {
@@ -151,7 +103,7 @@ public class LuceneLabelScanStore implements LabelScanStore
             else if ( !luceneIndex.isValid() )
             {
                 log.warn( "Lucene scan store index could not be read. Preparing to rebuild." );
-                monitor.corruptedIndex();
+                monitor.notValidIndex();
                 luceneIndex.drop();
                 luceneIndex.create();
                 needsRebuild = true;

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
-import static org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStore.Monitor;
+import static org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor;
 import static org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.fullStoreLabelUpdateStream;
 
 @Service.Implementation(KernelExtensionFactory.class)

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreStartupIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreStartupIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStore;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.test.rule.DatabaseRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class LuceneLabelScanStoreStartupIT extends LabelScanStoreStartupIT
+{
+    @Override
+    protected LabelScanStore getLabelScanStore( DatabaseRule dbRule )
+    {
+        DependencyResolver dependencyResolver = dbRule.getDependencyResolver();
+        LabelScanStore labelScanStore = dependencyResolver.resolveDependency( LabelScanStore.class );
+        assertThat( labelScanStore, instanceOf( LuceneLabelScanStore.class ) );
+        return labelScanStore;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
@@ -19,15 +19,6 @@
  */
 package org.neo4j.kernel.api.impl.labelscan;
 
-import org.apache.lucene.index.IndexFileNames;
-import org.apache.lucene.store.LockObtainFailedException;
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -36,69 +27,30 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
 
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.BoundedIterable;
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.storage.PartitionedIndexStorage;
 import org.neo4j.kernel.api.impl.labelscan.storestrategy.BitmapDocumentFormat;
-import org.neo4j.kernel.api.labelscan.LabelScanWriter;
-import org.neo4j.kernel.api.labelscan.NodeLabelRange;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider.FullStoreChangeStream;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.NullLogProvider;
-import org.neo4j.storageengine.api.schema.LabelScanReader;
-import org.neo4j.test.rule.TestDirectory;
-import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
-import static org.neo4j.helpers.collection.Iterators.iterator;
-import static org.neo4j.helpers.collection.Iterators.single;
-import static org.neo4j.io.fs.FileUtils.deleteRecursively;
-import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 
 @RunWith( Parameterized.class )
-public class LuceneLabelScanStoreTest
+public class LuceneLabelScanStoreTest extends LabelScanStoreTest
 {
-    private final TestDirectory testDirectory = TestDirectory.testDirectory();
-    private final ExpectedException expectedException = ExpectedException.none();
-    private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
-
-    @Rule
-    public final RuleChain ruleChain = RuleChain.outerRule( testDirectory ).around( expectedException )
-            .around( fileSystemRule );
-
-    private static final long[] NO_LABELS = new long[0];
-    private final BitmapDocumentFormat documentFormat;
+    @Parameterized.Parameter
+    public BitmapDocumentFormat documentFormat;
+    private final DirectoryFactory inMemoryDirectoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
+    private PartitionedIndexStorage indexStorage;
 
     @Parameterized.Parameters( name = "{0}" )
     public static List<BitmapDocumentFormat> parameterizedWithStrategies()
@@ -106,536 +58,32 @@ public class LuceneLabelScanStoreTest
         return asList( BitmapDocumentFormat._32, BitmapDocumentFormat._64 );
     }
 
-    private final Random random = new Random();
-    private DirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-    private LifeSupport life;
-    private TrackingMonitor monitor;
-    private PartitionedIndexStorage indexStorage;
-    private LuceneLabelScanStore store;
-    private File dir;
-
-    @Before
-    public void clearDir() throws IOException
+    @Override
+    protected LabelScanStore createLabelScanStore( FileSystemAbstraction fs, File rootFolder,
+            List<NodeLabelUpdate> existingData, boolean usePersistentStore, boolean readOnly,
+            LabelScanStore.Monitor monitor )
     {
-        dir = testDirectory.directory( "lucene" );
-        if ( dir.exists() )
-        {
-            deleteRecursively( dir );
-        }
-    }
+        DirectoryFactory directoryFactory = usePersistentStore ? DirectoryFactory.PERSISTENT : inMemoryDirectoryFactory;
 
-    @After
-    public void shutdown()
-    {
-        life.shutdown();
-    }
+        indexStorage = new PartitionedIndexStorage( directoryFactory, fs, rootFolder,
+                        LuceneLabelScanIndexBuilder.DEFAULT_INDEX_IDENTIFIER, false );
+        Config config = Config.defaults().with( MapUtil.stringMap(
+                GraphDatabaseSettings.read_only.name(), String.valueOf( readOnly ) ) );
 
-    @Test
-    public void failToRetrieveWriterOnReadOnlyScanStore() throws IOException
-    {
-        startReadOnlyLabelScanStore();
-        expectedException.expect( UnsupportedOperationException.class );
-        store.newWriter();
-    }
-
-    @Test
-    public void forceShouldNotForceWriterOnReadOnlyScanStore()
-    {
-        startReadOnlyLabelScanStore();
-        store.force();
-    }
-
-    @Test
-    public void failToGetWriterOnReadOnlyScanStore() throws Exception
-    {
-        startReadOnlyLabelScanStore();
-        expectedException.expect( UnsupportedOperationException.class );
-        store.newWriter();
-    }
-
-    @Test
-    public void failToStartIfLabelScanStoreIndexDoesNotExistInReadOnlyMode()
-    {
-        expectedException.expectCause( Matchers.instanceOf( UnsupportedOperationException.class ) );
-        startLabelScanStore( Config.empty().with( MapUtil.stringMap( GraphDatabaseSettings.read_only.name(), "true" ) ) );
-        assertTrue( monitor.noIndexCalled );
-    }
-
-    @Test
-    public void snapshotReadOnlyLabelScanStore() throws IOException
-    {
-        prepareIndex();
-        startReadOnlyLabelScanStore();
-        try (ResourceIterator<File> indexFiles = store.snapshotStoreFiles())
-        {
-            List<String> filesNames = indexFiles.stream().map( File::getName ).collect( toList() );
-            assertThat( "Should have at least index segment file.", filesNames,
-                    hasItem( startsWith( IndexFileNames.SEGMENTS ) ) );
-        }
-    }
-
-    @Test
-    public void shouldUpdateIndexOnLabelChange() throws Exception
-    {
-        // GIVEN
-        int labelId = 1;
-        long nodeId = 10;
-        start();
-
-        // WHEN
-        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId} ) ) );
-
-        // THEN
-        assertNodesForLabel( labelId, nodeId );
-    }
-
-    @Test
-    public void shouldUpdateIndexOnAddedLabels() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 1, labelId2 = 2;
-        long nodeId = 10;
-        start();
-        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1} ) ) );
-        assertNodesForLabel( labelId2 );
-
-        // WHEN
-        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
-
-        // THEN
-        assertNodesForLabel( labelId1, nodeId );
-        assertNodesForLabel( labelId2, nodeId );
-    }
-
-    @Test
-    public void shouldUpdateIndexOnRemovedLabels() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 1, labelId2 = 2;
-        long nodeId = 10;
-        start();
-        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
-        assertNodesForLabel( labelId1, nodeId );
-        assertNodesForLabel( labelId2, nodeId );
-
-        // WHEN
-        write( iterator( labelChanges( nodeId, new long[]{labelId1, labelId2}, new long[]{labelId2} ) ) );
-
-        // THEN
-        assertNodesForLabel( labelId1 );
-        assertNodesForLabel( labelId2, nodeId );
-    }
-
-    @Test
-    public void shouldDeleteFromIndexWhenDeletedNode() throws Exception
-    {
-        // GIVEN
-        int labelId = 1;
-        long nodeId = 10;
-        start();
-        write( iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId} ) ) );
-
-        // WHEN
-        write( iterator( labelChanges( nodeId, new long[]{labelId}, NO_LABELS ) ) );
-
-        // THEN
-        assertNodesForLabel( labelId );
-    }
-
-    @Test
-    public void shouldScanSingleRange() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 1, labelId2 = 2;
-        long nodeId1 = 10, nodeId2 = 11;
-        start( asList(
-                labelChanges( nodeId1, NO_LABELS, new long[]{labelId1} ),
-                labelChanges( nodeId2, NO_LABELS, new long[]{labelId1, labelId2} )
-        ) );
-
-        // WHEN
-        BoundedIterable<NodeLabelRange> reader = store.allNodeLabelRanges();
-        NodeLabelRange range = single( reader.iterator() );
-
-        // THEN
-        assertArrayEquals( new long[]{nodeId1, nodeId2}, sorted( range.nodes() ) );
-
-        assertArrayEquals( new long[]{labelId1}, sorted( range.labels( nodeId1 ) ) );
-        assertArrayEquals( new long[]{labelId1, labelId2}, sorted( range.labels( nodeId2 ) ) );
-    }
-
-    @Test
-    public void shouldScanMultipleRanges() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 1, labelId2 = 2;
-        long nodeId1 = 10, nodeId2 = 1280;
-        start( asList(
-                labelChanges( nodeId1, NO_LABELS, new long[]{labelId1} ),
-                labelChanges( nodeId2, NO_LABELS, new long[]{labelId1, labelId2} )
-        ) );
-
-        // WHEN
-        BoundedIterable<NodeLabelRange> reader = store.allNodeLabelRanges();
-        Iterator<NodeLabelRange> iterator = reader.iterator();
-        NodeLabelRange range1 = iterator.next();
-        NodeLabelRange range2 = iterator.next();
-        assertFalse( iterator.hasNext() );
-
-        // THEN
-        assertArrayEquals( new long[]{nodeId1}, sorted( range1.nodes() ) );
-        assertArrayEquals( new long[]{nodeId2}, sorted( range2.nodes() ) );
-
-        assertArrayEquals( new long[]{labelId1}, sorted( range1.labels( nodeId1 ) ) );
-
-        assertArrayEquals( new long[]{labelId1, labelId2}, sorted( range2.labels( nodeId2 ) ) );
-    }
-
-    @Test
-    public void shouldWorkWithAFullRange() throws Exception
-    {
-        // given
-        long labelId = 0;
-        List<NodeLabelUpdate> updates = new ArrayList<>();
-        for ( int i = 0; i < 34; i++ )
-        {
-            updates.add( NodeLabelUpdate.labelChanges( i, new long[]{}, new long[]{labelId} ) );
-        }
-
-        start( updates );
-
-        // when
-        LabelScanReader reader = store.newReader();
-        Set<Long> nodesWithLabel = PrimitiveLongCollections.toSet( reader.nodesWithLabel( (int) labelId ) );
-
-        // then
-        for ( long i = 0; i < 34; i++ )
-        {
-            assertThat( nodesWithLabel, hasItem( i ) );
-            Set<Long> labels = PrimitiveLongCollections.toSet( reader.labelsForNode( i ) );
-            assertThat( labels, hasItem( labelId ) );
-        }
-    }
-
-    @Test
-    public void shouldUpdateAFullRange() throws Exception
-    {
-        // given
-        long label0Id = 0;
-        List<NodeLabelUpdate> label0Updates = new ArrayList<>();
-        for ( int i = 0; i < 34; i++ )
-        {
-            label0Updates.add( NodeLabelUpdate.labelChanges( i, new long[]{}, new long[]{label0Id} ) );
-        }
-
-        start( label0Updates );
-
-        // when
-        write( Collections.emptyIterator() );
-
-        // then
-        LabelScanReader reader = store.newReader();
-        Set<Long> nodesWithLabel0 = PrimitiveLongCollections.toSet( reader.nodesWithLabel( (int) label0Id ) );
-        for ( long i = 0; i < 34; i++ )
-        {
-            assertThat( nodesWithLabel0, hasItem( i ) );
-            Set<Long> labels = PrimitiveLongCollections.toSet( reader.labelsForNode( i ) );
-            assertThat( labels, hasItem( label0Id ) );
-        }
-    }
-
-    private void write( Iterator<NodeLabelUpdate> iterator ) throws IOException
-    {
-        try ( LabelScanWriter writer = store.newWriter() )
-        {
-            while ( iterator.hasNext() )
-            {
-                writer.write( iterator.next() );
-            }
-        }
-    }
-
-    private long[] sorted( long[] input )
-    {
-        Arrays.sort( input );
-        return input;
-    }
-
-    @Test
-    public void shouldRebuildFromScratchIfIndexMissing() throws Exception
-    {
-        // GIVEN a start of the store with existing data in it
-        start( asList(
-                labelChanges( 1, NO_LABELS, new long[]{1} ),
-                labelChanges( 2, NO_LABELS, new long[]{1, 2} )
-        ) );
-
-        // THEN
-        assertTrue( "Didn't rebuild the store on startup",
-                monitor.noIndexCalled & monitor.rebuildingCalled & monitor.rebuiltCalled );
-        assertNodesForLabel( 1, 1, 2 );
-        assertNodesForLabel( 2, 2 );
-    }
-
-    @Test
-    public void rebuildCorruptedIndexIndexOnStartup() throws Exception
-    {
-        // GIVEN a start of the store with existing data in it
-        usePersistentDirectory();
-        List<NodeLabelUpdate> data = asList(
-                labelChanges( 1, NO_LABELS, new long[]{1} ),
-                labelChanges( 2, NO_LABELS, new long[]{1, 2} ) );
-        start( data );
-
-        // WHEN the index is corrupted and then started again
-        scrambleIndexFilesAndRestart( data );
-
-        assertTrue( "Index corruption should be detected", monitor.corruptedIndex );
-        assertTrue( "Index should be rebuild", monitor.rebuildingCalled );
-    }
-
-    @Test
-    public void shouldFindDecentAmountOfNodesForALabel() throws Exception
-    {
-        // GIVEN
-        // 16 is the magic number of the page iterator
-        // 32 is the number of nodes in each lucene document
-        final int labelId = 1, nodeCount = 32 * 16 + 10;
-        start();
-        write( new PrefetchingIterator<NodeLabelUpdate>()
-        {
-            private int i = -1;
-
-            @Override
-            protected NodeLabelUpdate fetchNextOrNull()
-            {
-                return ++i < nodeCount ? labelChanges( i, NO_LABELS, new long[]{labelId} ) : null;
-            }
-        } );
-
-        // WHEN
-        Set<Long> nodeSet = new TreeSet<>();
-        LabelScanReader reader = store.newReader();
-        PrimitiveLongIterator nodes = reader.nodesWithLabel( labelId );
-        while ( nodes.hasNext() )
-        {
-            nodeSet.add( nodes.next() );
-        }
-        reader.close();
-
-        // THEN
-        assertEquals( "Found gaps in node id range: " + gaps( nodeSet, nodeCount ), nodeCount, nodeSet.size() );
-    }
-
-    @Test
-    public void shouldFindAllLabelsForGivenNode() throws Exception
-    {
-        // GIVEN
-        // 16 is the magic number of the page iterator
-        // 32 is the number of nodes in each lucene document
-        final long labelId1 = 1, labelId2 = 2, labelId3 = 87;
-        start();
-
-        int nodeId = 42;
-        write( Iterators.iterator( labelChanges( nodeId, NO_LABELS, new long[]{labelId1, labelId2} ) ) );
-        write( Iterators.iterator( labelChanges( 41, NO_LABELS, new long[]{labelId3, labelId2} ) ) );
-
-        // WHEN
-        LabelScanReader reader = store.newReader();
-
-        // THEN
-        assertThat( PrimitiveLongCollections.toSet( reader.labelsForNode( nodeId ) ), hasItems( labelId1, labelId2 ) );
-        reader.close();
-    }
-
-    @Test
-    public void shouldFindNodesWithAnyOfGivenLabels() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 3, labelId2 = 5, labelId3 = 13;
-        start();
-
-        // WHEN
-        write( iterator(
-                labelChanges( 2, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2} ),
-                labelChanges( 1, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
-                labelChanges( 4, EMPTY_LONG_ARRAY, new long[] {labelId1,           labelId3} ),
-                labelChanges( 5, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2, labelId3} ),
-                labelChanges( 3, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
-                labelChanges( 7, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
-                labelChanges( 8, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ),
-                labelChanges( 6, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
-                labelChanges( 9, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ) ) );
-
-        // THEN
-        try ( LabelScanReader reader = store.newReader() )
-        {
-            assertArrayEquals(
-                    new long[] {1, 2, 3, 4, 5, 6, 7},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId2 ) ) );
-            assertArrayEquals(
-                    new long[] {1, 2, 3, 4, 5, 8, 9},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId3 ) ) );
-            assertArrayEquals(
-                    new long[] {1, 2, 3, 4, 5, 6, 7, 8, 9},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAnyOfLabels( labelId1, labelId2, labelId3 ) ) );
-        }
-    }
-
-    @Test
-    public void shouldFindNodesWithAllGivenLabels() throws Exception
-    {
-        // GIVEN
-        int labelId1 = 3, labelId2 = 5, labelId3 = 13;
-        start();
-
-        // WHEN
-        write( iterator(
-                labelChanges( 5, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2, labelId3} ),
-                labelChanges( 8, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ),
-                labelChanges( 3, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
-                labelChanges( 6, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
-                labelChanges( 1, EMPTY_LONG_ARRAY, new long[] {labelId1} ),
-                labelChanges( 7, EMPTY_LONG_ARRAY, new long[] {          labelId2} ),
-                labelChanges( 4, EMPTY_LONG_ARRAY, new long[] {labelId1,           labelId3} ),
-                labelChanges( 2, EMPTY_LONG_ARRAY, new long[] {labelId1, labelId2} ),
-                labelChanges( 9, EMPTY_LONG_ARRAY, new long[] {                    labelId3} ) ) );
-
-        // THEN
-        try ( LabelScanReader reader = store.newReader() )
-        {
-            assertArrayEquals(
-                    new long[] {2, 5},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId2 ) ) );
-            assertArrayEquals(
-                    new long[] {4, 5},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId3 ) ) );
-            assertArrayEquals(
-                    new long[] {5},
-                    PrimitiveLongCollections.asArray( reader.nodesWithAllLabels( labelId1, labelId2, labelId3 ) ) );
-        }
-    }
-
-    private void prepareIndex() throws IOException
-    {
-        start();
-        try ( LabelScanWriter labelScanWriter = store.newWriter() )
-        {
-            labelScanWriter.write( NodeLabelUpdate.labelChanges( 1, new long[]{}, new long[]{1} ) );
-        }
-        store.shutdown();
-    }
-
-    private Set<Long> gaps( Set<Long> ids, int expectedCount )
-    {
-        Set<Long> gaps = new HashSet<>();
-        for ( long i = 0; i < expectedCount; i++ )
-        {
-            if ( !ids.contains( i ) )
-            {
-                gaps.add( i );
-            }
-        }
-        return gaps;
-    }
-
-    public LuceneLabelScanStoreTest( BitmapDocumentFormat documentFormat )
-    {
-        this.documentFormat = documentFormat;
-    }
-
-    private void assertNodesForLabel( int labelId, long... expectedNodeIds )
-    {
-        Set<Long> nodeSet = new HashSet<>();
-        PrimitiveLongIterator nodes = store.newReader().nodesWithLabel( labelId );
-        while ( nodes.hasNext() )
-        {
-            nodeSet.add( nodes.next() );
-        }
-
-        for ( long expectedNodeId : expectedNodeIds )
-        {
-            assertTrue( "Expected node " + expectedNodeId + " not found in scan store",
-                    nodeSet.remove( expectedNodeId ) );
-        }
-        assertTrue( "Unexpected nodes in scan store " + nodeSet, nodeSet.isEmpty() );
-    }
-
-    private List<NodeLabelUpdate> noData()
-    {
-        return emptyList();
-    }
-
-    private void usePersistentDirectory()
-    {
-        directoryFactory = DirectoryFactory.PERSISTENT;
-    }
-
-    private void start()
-    {
-        start( noData() );
-    }
-
-    private void start( List<NodeLabelUpdate> existingData )
-    {
-        startLabelScanStore( existingData, Config.empty() );
-        assertTrue( monitor.initCalled );
-    }
-
-    private void startReadOnlyLabelScanStore()
-    {
-        // create label scan store and shutdown it
-        startLabelScanStore( Config.empty() );
-        life.shutdown();
-
-        Config config = Config.empty().with( MapUtil.stringMap( GraphDatabaseSettings.read_only.name(), "true" ) );
-        startLabelScanStore( config );
-    }
-
-    private void startLabelScanStore( Config config )
-    {
-        startLabelScanStore( Collections.emptyList(), config );
-    }
-
-    private void startLabelScanStore( List<NodeLabelUpdate> existingData, Config config )
-    {
-        life = new LifeSupport();
-        monitor = new TrackingMonitor();
-
-        indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(), dir,
-                LuceneLabelScanIndexBuilder.DEFAULT_INDEX_IDENTIFIER, false );
         LabelScanIndex index = LuceneLabelScanIndexBuilder.create()
-                                .withDirectoryFactory( directoryFactory )
-                                .withIndexStorage( indexStorage )
-                                .withOperationalMode( OperationalMode.single )
-                                .withConfig( config )
-                                .withDocumentFormat( documentFormat )
-                                .build();
+                .withDirectoryFactory( directoryFactory )
+                .withIndexStorage( indexStorage )
+                .withOperationalMode( OperationalMode.single )
+                .withConfig( config )
+                .withDocumentFormat( documentFormat )
+                .build();
 
-        store = new LuceneLabelScanStore( index, asStream( existingData ), NullLogProvider.getInstance(), monitor );
-        life.add( store );
-
-        life.start();
-        assertTrue( monitor.initCalled );
+        return new LuceneLabelScanStore( index, asStream( existingData ), NullLogProvider.getInstance(), monitor );
     }
 
-    private FullStoreChangeStream asStream( final List<NodeLabelUpdate> existingData )
+    @Override
+    protected void corruptIndex() throws IOException
     {
-        return writer ->
-        {
-            long count = 0;
-            for ( NodeLabelUpdate update : existingData )
-            {
-                writer.write( update );
-                count++;
-            }
-            return count;
-        };
-    }
-
-    private void scrambleIndexFilesAndRestart( List<NodeLabelUpdate> data ) throws IOException
-    {
-        shutdown();
         List<File> indexPartitions = indexStorage.listFolders();
         for ( File partition : indexPartitions )
         {
@@ -648,9 +96,7 @@ public class LuceneLabelScanStoreTest
                 }
             }
         }
-        start( data );
     }
-
     private void scrambleFile( File file ) throws IOException
     {
         try ( RandomAccessFile fileAccess = new RandomAccessFile( file, "rw" );
@@ -658,59 +104,18 @@ public class LuceneLabelScanStoreTest
         {
             // The files will be small, so OK to allocate a buffer for the full size
             byte[] bytes = new byte[(int) channel.size()];
-            putRandomBytes( bytes );
+            putRandomBytes( random.random(), bytes );
             ByteBuffer buffer = ByteBuffer.wrap( bytes );
             channel.position( 0 );
             channel.write( buffer );
         }
     }
 
-    private void putRandomBytes( byte[] bytes )
+    private void putRandomBytes( Random random, byte[] bytes )
     {
         for ( int i = 0; i < bytes.length; i++ )
         {
             bytes[i] = (byte) random.nextInt();
-        }
-    }
-
-    private static class TrackingMonitor implements LuceneLabelScanStore.Monitor
-    {
-        boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled;
-        boolean corruptedIndex = false;
-
-        @Override
-        public void noIndex()
-        {
-            noIndexCalled = true;
-        }
-
-        @Override
-        public void lockedIndex( LockObtainFailedException e )
-        {
-        }
-
-        @Override
-        public void corruptedIndex()
-        {
-            corruptedIndex = true;
-        }
-
-        @Override
-        public void rebuilding()
-        {
-            rebuildingCalled = true;
-        }
-
-        @Override
-        public void rebuilt( long roughNodeCount )
-        {
-            rebuiltCalled = true;
-        }
-
-        @Override
-        public void init()
-        {
-            initCalled = true;
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
@@ -44,7 +44,7 @@ import static org.neo4j.helpers.collection.Iterators.count;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allAvailabilityGuardsReleased;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 
-public class LabelScanStoreHaIT
+public abstract class LabelScanStoreHaIT
 {
     @Test
     public void shouldCopyLabelScanStoreToNewSlaves() throws Exception
@@ -107,7 +107,7 @@ public class LabelScanStoreHaIT
     @Before
     public void setUp()
     {
-        KernelExtensionFactory<?> testExtension = new LuceneLabelScanStoreExtension( 100, monitor );
+        KernelExtensionFactory<?> testExtension = labelScanStoreExtension( monitor );
         TestHighlyAvailableGraphDatabaseFactory factory = new TestHighlyAvailableGraphDatabaseFactory();
         factory.addKernelExtensions( Collections.singletonList( testExtension ) );
         ClusterManager clusterManager = new ClusterManager.Builder( testDirectory.directory( "root" ) )
@@ -137,6 +137,8 @@ public class LabelScanStoreHaIT
         cluster.await( allSeesAllAsAvailable() );
         cluster.await( allAvailabilityGuardsReleased() );
     }
+
+    protected abstract KernelExtensionFactory<?> labelScanStoreExtension( LabelScanStore.Monitor monitor );
 
     @After
     public void tearDown()

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
@@ -19,18 +19,18 @@
  */
 package org.neo4j.kernel.api.impl.labelscan;
 
-import org.apache.lucene.store.LockObtainFailedException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
@@ -95,7 +95,7 @@ public class LabelScanStoreHaIT
     private enum Labels implements Label
     {
         First,
-        Second;
+        Second
     }
 
     @Rule
@@ -109,7 +109,7 @@ public class LabelScanStoreHaIT
     {
         KernelExtensionFactory<?> testExtension = new LuceneLabelScanStoreExtension( 100, monitor );
         TestHighlyAvailableGraphDatabaseFactory factory = new TestHighlyAvailableGraphDatabaseFactory();
-        factory.addKernelExtensions( Arrays.asList( testExtension ) );
+        factory.addKernelExtensions( Collections.singletonList( testExtension ) );
         ClusterManager clusterManager = new ClusterManager.Builder( testDirectory.directory( "root" ) )
                 .withDbFactory( factory )
                 .withStoreDirInitializer( ( serverId, storeDir ) -> {
@@ -144,7 +144,7 @@ public class LabelScanStoreHaIT
         life.shutdown();
     }
 
-    private static class TestMonitor implements LuceneLabelScanStore.Monitor
+    private static class TestMonitor implements LabelScanStore.Monitor
     {
         private volatile int callsTo_init;
         private volatile int timesRebuiltWithData;
@@ -161,12 +161,12 @@ public class LabelScanStoreHaIT
         }
 
         @Override
-        public void lockedIndex( LockObtainFailedException e )
+        public void lockedIndex( Exception e )
         {
         }
 
         @Override
-        public void corruptedIndex()
+        public void notValidIndex()
         {
         }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreHaIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.labelscan;
+
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+
+public class LuceneLabelScanStoreHaIT extends LabelScanStoreHaIT
+{
+    @Override
+    protected KernelExtensionFactory<?> labelScanStoreExtension( LabelScanStore.Monitor monitor )
+    {
+        return new LuceneLabelScanStoreExtension( 100, monitor );
+    }
+}


### PR DESCRIPTION
This is preparation for letting native lss use same tests as current implementation.