### PR TITLE
Make bookmark await timeout configurable

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -140,23 +140,23 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
     @Override
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
-        final Config config = dependencies.config();
-        final GraphDatabaseService gdb = dependencies.db();
-        final GraphDatabaseAPI api = (GraphDatabaseAPI) gdb;
-        final LogService logService = dependencies.logService();
+        Config config = dependencies.config();
+        GraphDatabaseService gdb = dependencies.db();
+        GraphDatabaseAPI api = (GraphDatabaseAPI) gdb;
+        LogService logService = dependencies.logService();
         Clock clock = dependencies.clock();
-        final Log log = logService.getInternalLog( WorkerFactory.class );
+        Log log = logService.getInternalLog( WorkerFactory.class );
 
-        final LifeSupport life = new LifeSupport();
+        LifeSupport life = new LifeSupport();
 
-        final JobScheduler scheduler = dependencies.scheduler();
+        JobScheduler scheduler = dependencies.scheduler();
 
         InternalLoggerFactory.setDefaultFactory( new Netty4LoggerFactory( logService.getInternalLogProvider() ) );
 
         Authentication authentication = authentication( dependencies.authManager() );
 
         BoltFactory boltFactory = life.add( new LifecycleManagedBoltFactory( api, dependencies.usageData(),
-                logService, dependencies.txBridge(), authentication, dependencies.sessionTracker() ) );
+                logService, dependencies.txBridge(), authentication, dependencies.sessionTracker(), config ) );
         WorkerFactory workerFactory = createWorkerFactory( boltFactory, scheduler, dependencies, logService, clock );
 
         List<ProtocolInitializer> connectors = boltConnectors( config ).stream()

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
@@ -20,12 +20,15 @@
 package org.neo4j.bolt.v1.runtime;
 
 import java.time.Clock;
+import java.time.Duration;
 
 import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
@@ -44,6 +47,7 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
     private final Authentication authentication;
     private final BoltConnectionTracker connectionTracker;
     private final ThreadToStatementContextBridge txBridge;
+    private final Config config;
 
     private QueryExecutionEngine queryExecutionEngine;
     private GraphDatabaseQueryService queryService;
@@ -52,7 +56,7 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
 
     public LifecycleManagedBoltFactory( GraphDatabaseAPI gds, UsageData usageData, LogService logging,
             ThreadToStatementContextBridge txBridge, Authentication authentication,
-            BoltConnectionTracker connectionTracker )
+            BoltConnectionTracker connectionTracker, Config config )
     {
         this.gds = gds;
         this.usageData = usageData;
@@ -60,6 +64,7 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
         this.txBridge = txBridge;
         this.authentication = authentication;
         this.connectionTracker = connectionTracker;
+        this.config = config;
     }
 
     @Override
@@ -94,11 +99,18 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
     @Override
     public BoltStateMachine newMachine( String connectionDescriptor, Runnable onClose, Clock clock )
     {
-        TransactionStateMachine.SPI transactionSPI =
-                new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
-                        availabilityGuard, queryService, clock );
+        TransactionStateMachine.SPI transactionSPI = createTxSpi( clock );
         BoltStateMachine.SPI boltSPI = new BoltStateMachineSPI( connectionDescriptor, usageData,
                 logging, authentication, connectionTracker, transactionSPI );
         return new BoltStateMachine( boltSPI, onClose, clock );
+    }
+
+    private TransactionStateMachine.SPI createTxSpi( Clock clock )
+    {
+        long bookmarkAwaitTimeout = config.get( GraphDatabaseSettings.bookmark_await_timeout );
+        Duration txAwaitDuration = Duration.ofMillis( bookmarkAwaitTimeout );
+
+        return new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
+                availabilityGuard, queryService, txAwaitDuration, clock );
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
@@ -107,8 +107,8 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
 
     private TransactionStateMachine.SPI createTxSpi( Clock clock )
     {
-        long bookmarkAwaitTimeout = config.get( GraphDatabaseSettings.bookmark_await_timeout );
-        Duration txAwaitDuration = Duration.ofMillis( bookmarkAwaitTimeout );
+        long bookmarkReadyTimeout = config.get( GraphDatabaseSettings.bookmark_ready_timeout );
+        Duration txAwaitDuration = Duration.ofMillis( bookmarkReadyTimeout );
 
         return new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
                 availabilityGuard, queryService, txAwaitDuration, clock );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -20,7 +20,6 @@
 package org.neo4j.bolt.v1.runtime;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.util.Map;
 
 import org.neo4j.bolt.security.auth.AuthenticationResult;
@@ -150,7 +149,7 @@ public class TransactionStateMachine implements StatementProcessor
                             if ( params.containsKey( "bookmark" ) )
                             {
                                 final Bookmark bookmark = Bookmark.fromString( params.get( "bookmark" ).toString() );
-                                spi.awaitUpToDate( bookmark.txId(), Duration.ofSeconds( 30 ) );
+                                spi.awaitUpToDate( bookmark.txId() );
                                 ctx.currentResult = new BookmarkResult( bookmark );
                             }
                             else
@@ -386,7 +385,7 @@ public class TransactionStateMachine implements StatementProcessor
 
     interface SPI
     {
-        void awaitUpToDate( long oldestAcceptableTxId, Duration timeout ) throws TransactionFailureException;
+        void awaitUpToDate( long oldestAcceptableTxId ) throws TransactionFailureException;
 
         long newestEncounteredTxId();
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -58,6 +58,7 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
     private static final PropertyContainerLocker locker = new PropertyContainerLocker();
     private final TransactionalContextFactory contextFactory;
     private final GraphDatabaseQueryService queryService;
+    private final Duration txAwaitDuration;
     private final Clock clock;
 
     TransactionStateMachineSPI( GraphDatabaseAPI db,
@@ -66,21 +67,23 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
                                 TransactionIdStore transactionIdStoreSupplier,
                                 AvailabilityGuard availabilityGuard,
                                 GraphDatabaseQueryService queryService,
+                                Duration txAwaitDuration,
                                 Clock clock )
     {
         this.db = db;
         this.txBridge = txBridge;
         this.queryExecutionEngine = queryExecutionEngine;
-        this.transactionIdTracker = new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard );
+        this.transactionIdTracker = new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard, clock );
         this.contextFactory = Neo4jTransactionalContextFactory.create( queryService, locker );
         this.queryService = queryService;
+        this.txAwaitDuration = txAwaitDuration;
         this.clock = clock;
     }
 
     @Override
-    public void awaitUpToDate( long oldestAcceptableTxId, Duration timeout ) throws TransactionFailureException
+    public void awaitUpToDate( long oldestAcceptableTxId ) throws TransactionFailureException
     {
-        transactionIdTracker.awaitUpToDate( oldestAcceptableTxId, timeout );
+        transactionIdTracker.awaitUpToDate( oldestAcceptableTxId, txAwaitDuration );
     }
 
     @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPITest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.GraphDatabaseQueryService;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.query.QueryExecutionEngine;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.NullLog;
+import org.neo4j.test.rule.concurrent.OtherThreadRule;
+import org.neo4j.time.FakeClock;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TransactionStateMachineSPITest
+{
+    @Rule
+    public final OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
+
+    @Test
+    public void throwsWhenTxAwaitDurationExpires() throws Exception
+    {
+        long lastClosedTransactionId = 100;
+        TransactionIdStore txIdStore = fixedTxIdStore( lastClosedTransactionId );
+        Duration txAwaitDuration = Duration.ofSeconds( 42 );
+        FakeClock clock = new FakeClock();
+
+        AvailabilityGuard availabilityGuard = spy( new AvailabilityGuard( clock, NullLog.getInstance() ) );
+        when( availabilityGuard.isAvailable() ).then( invocation ->
+        {
+            // move clock forward on the first availability check
+            // this check is executed on every tx id polling iteration
+            boolean available = (boolean) invocation.callRealMethod();
+            clock.forward( txAwaitDuration.getSeconds() + 1, SECONDS );
+            return available;
+        } );
+
+        TransactionStateMachineSPI txSpi = createTxSpi( txIdStore, txAwaitDuration, availabilityGuard, clock );
+
+        Future<Void> result = otherThread.execute( state ->
+        {
+            txSpi.awaitUpToDate( lastClosedTransactionId + 42 );
+            return null;
+        } );
+
+        try
+        {
+            result.get( 20, SECONDS );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( ExecutionException.class ) );
+            assertThat( e.getCause(), instanceOf( TransactionFailureException.class ) );
+        }
+    }
+
+    @Test
+    public void doesNotWaitWhenTxIdUpToDate() throws Exception
+    {
+        long lastClosedTransactionId = 100;
+        TransactionIdStore txIdStore = fixedTxIdStore( lastClosedTransactionId );
+
+        TransactionStateMachineSPI txSpi = createTxSpi( txIdStore, Duration.ZERO, Clock.systemUTC() );
+
+        Future<Void> result = otherThread.execute( state ->
+        {
+            txSpi.awaitUpToDate( lastClosedTransactionId - 42 );
+            return null;
+        } );
+
+        assertNull( result.get( 20, SECONDS ) );
+    }
+
+    private static TransactionIdStore fixedTxIdStore( long lastClosedTransactionId )
+    {
+        TransactionIdStore txIdStore = mock( TransactionIdStore.class );
+        when( txIdStore.getLastClosedTransactionId() ).thenReturn( lastClosedTransactionId );
+        return txIdStore;
+    }
+
+    private static TransactionStateMachineSPI createTxSpi( TransactionIdStore txIdStore, Duration txAwaitDuration,
+            Clock clock )
+    {
+        AvailabilityGuard availabilityGuard = new AvailabilityGuard( clock, NullLog.getInstance() );
+        return createTxSpi( txIdStore, txAwaitDuration, availabilityGuard, clock );
+    }
+
+    private static TransactionStateMachineSPI createTxSpi( TransactionIdStore txIdStore, Duration txAwaitDuration,
+            AvailabilityGuard availabilityGuard, Clock clock )
+    {
+        GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
+        when( queryService.getDependencyResolver() ).thenReturn( mock( DependencyResolver.class ) );
+
+        return new TransactionStateMachineSPI( mock( GraphDatabaseAPI.class ), new ThreadToStatementContextBridge(),
+                mock( QueryExecutionEngine.class ), txIdStore, availabilityGuard, queryService, txAwaitDuration,
+                clock );
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -41,6 +41,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.security.AuthManager;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -74,7 +75,8 @@ class SessionRule implements TestRule
                                         NullLogService.getInstance(),
                                         resolver.resolveDependency( ThreadToStatementContextBridge.class ),
                                         authentication,
-                                        BoltConnectionTracker.NOOP
+                                        BoltConnectionTracker.NOOP,
+                                        Config.defaults()
                                     );
                 boltFactory.start();
                 try

--- a/community/common/src/main/java/org/neo4j/time/FakeClock.java
+++ b/community/common/src/main/java/org/neo4j/time/FakeClock.java
@@ -32,11 +32,11 @@ public class FakeClock extends SystemNanoClock
 {
     private volatile long nanoTime = 0;
 
-    FakeClock()
+    public FakeClock()
     {
     }
 
-    FakeClock( long initialTime, TimeUnit unit )
+    public FakeClock( long initialTime, TimeUnit unit )
     {
         forward( initialTime, unit );
     }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -21,6 +21,7 @@ package org.neo4j.graphdb.factory;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.neo4j.graphdb.config.Setting;
@@ -495,6 +496,11 @@ public abstract class GraphDatabaseSettings
             "specify the +advertised_address+ property for the specific connector.")
     public static final Setting<String> default_advertised_address =
             setting( "dbms.connectors.default_advertised_address", STRING, "localhost" );
+
+    @Description( "The maximum amount of time to wait for the database state represented by the bookmark." )
+    public static final Setting<Long> bookmark_await_timeout = setting(
+            "dbms.transaction.bookmark_await_timeout", DURATION, "30s",
+            min( TimeUnit.SECONDS.toMillis( 1 ) ) );
 
     @Group("dbms.connector")
     public static class Connector

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -498,8 +498,8 @@ public abstract class GraphDatabaseSettings
             setting( "dbms.connectors.default_advertised_address", STRING, "localhost" );
 
     @Description( "The maximum amount of time to wait for the database state represented by the bookmark." )
-    public static final Setting<Long> bookmark_await_timeout = setting(
-            "dbms.transaction.bookmark_await_timeout", DURATION, "30s",
+    public static final Setting<Long> bookmark_ready_timeout = setting(
+            "dbms.transaction.bookmark_ready_timeout", DURATION, "30s",
             min( TimeUnit.SECONDS.toMillis( 1 ) ) );
 
     @Group("dbms.connector")

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -224,8 +224,8 @@ public class GraphDatabaseSettingsTest
     public void hasDefaultBookmarkAwaitTimeout()
     {
         Config config = Config.defaults();
-        long bookmarkAwaitTimeoutMs = config.get( GraphDatabaseSettings.bookmark_await_timeout );
-        assertEquals( TimeUnit.SECONDS.toMillis( 30 ), bookmarkAwaitTimeoutMs );
+        long bookmarkReadyTimeoutMs = config.get( GraphDatabaseSettings.bookmark_ready_timeout );
+        assertEquals( TimeUnit.SECONDS.toMillis( 30 ), bookmarkReadyTimeoutMs );
     }
 
     @Test
@@ -236,10 +236,10 @@ public class GraphDatabaseSettingsTest
         for ( String value : illegalValues )
         {
             Config config = Config.defaults();
-            config.augment( stringMap( GraphDatabaseSettings.bookmark_await_timeout.name(), value ) );
+            config.augment( stringMap( GraphDatabaseSettings.bookmark_ready_timeout.name(), value ) );
             try
             {
-                config.get( GraphDatabaseSettings.bookmark_await_timeout );
+                config.get( GraphDatabaseSettings.bookmark_ready_timeout );
                 fail( "Exception expected for value '" + value + "'" );
             }
             catch ( Exception e )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
@@ -33,11 +34,13 @@ import org.neo4j.io.ByteUnit;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnectors;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -215,5 +218,34 @@ public class GraphDatabaseSettingsTest
         // then
         assertEquals( new ListenSocketAddress( "localhost", 8000 ), config.get( boltConnector1.listen_address ) );
         assertEquals( new ListenSocketAddress( "localhost", 9000 ), config.get( boltConnector2.listen_address ) );
+    }
+
+    @Test
+    public void hasDefaultBookmarkAwaitTimeout()
+    {
+        Config config = Config.defaults();
+        long bookmarkAwaitTimeoutMs = config.get( GraphDatabaseSettings.bookmark_await_timeout );
+        assertEquals( TimeUnit.SECONDS.toMillis( 30 ), bookmarkAwaitTimeoutMs );
+    }
+
+    @Test
+    public void throwsForIllegalBookmarkAwaitTimeout()
+    {
+        String[] illegalValues = {"0ms", "0s", "10ms", "99ms", "999ms", "42ms"};
+
+        for ( String value : illegalValues )
+        {
+            Config config = Config.defaults();
+            config.augment( stringMap( GraphDatabaseSettings.bookmark_await_timeout.name(), value ) );
+            try
+            {
+                config.get( GraphDatabaseSettings.bookmark_await_timeout );
+                fail( "Exception expected for value '" + value + "'" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( InvalidSettingException.class ) );
+            }
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.api.txtracking;
 
 import org.junit.Test;
 
+import java.time.Clock;
+
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -45,8 +47,7 @@ public class TransactionIdTrackerTest
         // given
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( -1L );
         when( availabilityGuard.isAvailable() ).thenReturn( true );
-        TransactionIdTracker transactionIdTracker =
-                new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        TransactionIdTracker transactionIdTracker = createTracker();
 
         // when
         transactionIdTracker.awaitUpToDate( BASE_TX_ID, ofSeconds( 5 ) );
@@ -61,8 +62,7 @@ public class TransactionIdTrackerTest
         long version = 5L;
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
         when( availabilityGuard.isAvailable() ).thenReturn( true );
-        TransactionIdTracker transactionIdTracker =
-                new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        TransactionIdTracker transactionIdTracker = createTracker();
 
         // when
         transactionIdTracker.awaitUpToDate( version, ofSeconds( 5 ) );
@@ -77,8 +77,7 @@ public class TransactionIdTrackerTest
         long version = 5L;
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
         when( availabilityGuard.isAvailable() ).thenReturn( true );
-        TransactionIdTracker transactionIdTracker =
-                new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        TransactionIdTracker transactionIdTracker = createTracker();
 
         // when
         try
@@ -100,7 +99,7 @@ public class TransactionIdTrackerTest
         long version = 5L;
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
         when( availabilityGuard.isAvailable() ).thenReturn( false );
-        TransactionIdTracker transactionIdTracker =  new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        TransactionIdTracker transactionIdTracker = createTracker();
 
         // when
         try
@@ -113,5 +112,10 @@ public class TransactionIdTrackerTest
             // then all good!
             assertEquals( Status.General.DatabaseUnavailable, ex.status() );
         }
+    }
+
+    private TransactionIdTracker createTracker()
+    {
+        return new TransactionIdTracker( transactionIdStore, availabilityGuard, Clock.systemUTC() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalConsistencyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalConsistencyIT.java
@@ -22,6 +22,8 @@ package org.neo4j.causalclustering.scenarios;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Clock;
+
 import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
@@ -102,6 +104,6 @@ public class CausalConsistencyIT
                 database.getDependencyResolver().resolveDependency( TransactionIdStore.class );
         AvailabilityGuard availabilityGuard =
                 database.getDependencyResolver().resolveDependency( AvailabilityGuard.class );
-        return new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        return new TransactionIdTracker( transactionIdStore, availabilityGuard, Clock.systemUTC() );
     }
 }


### PR DESCRIPTION
It was previously set to 30 seconds without a possibility to change this value. This PR makes it configurable via `dbms.transaction.bookmark_ready_timeout`. Setting is located in community `GraphDatabaseSettings` because bookmark is exposed in both single instance and Causal Cluster. In single instance bookmark is basically a no-op.