### PR TITLE
Close network channel on Bolt handshake failure

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.bolt.v1.runtime;
 
-import org.neo4j.kernel.monitoring.Monitors;
-
 import java.time.Clock;
+
+import org.neo4j.kernel.monitoring.Monitors;
 
 /**
  * Thin wrapper around {@link WorkerFactory} that adds monitoring capabilities, which
@@ -65,6 +65,8 @@ public class MonitoredWorkerFactory implements WorkerFactory
             this.monitor = monitor;
             this.delegate = delegate;
             this.clock = clock;
+
+            this.monitor.sessionStarted();
         }
 
         @Override
@@ -100,6 +102,11 @@ public class MonitoredWorkerFactory implements WorkerFactory
      */
     public interface SessionMonitor
     {
+        /**
+         * Called when a new Bolt session (backed by a {@link BoltWorker}) is started.
+         */
+        void sessionStarted();
+
         /**
          * Called whenever a request is received. This happens after a request is
          * deserialized, but before it is queued pending processing.

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
@@ -46,6 +46,7 @@ import static org.neo4j.metrics.MetricsTestHelper.readLongValue;
 import static org.neo4j.metrics.source.db.BoltMetrics.MESSAGES_DONE;
 import static org.neo4j.metrics.source.db.BoltMetrics.MESSAGES_RECIEVED;
 import static org.neo4j.metrics.source.db.BoltMetrics.MESSAGES_STARTED;
+import static org.neo4j.metrics.source.db.BoltMetrics.SESSIONS_STARTED;
 import static org.neo4j.metrics.source.db.BoltMetrics.TOTAL_PROCESSING_TIME;
 import static org.neo4j.metrics.source.db.BoltMetrics.TOTAL_QUEUE_TIME;
 import static org.neo4j.test.assertion.Assert.assertEventually;
@@ -82,6 +83,8 @@ public class BoltMetricsIT
                         map("scheme", "basic", "principal", "neo4j", "credentials", "neo4j") ) ) );
 
         // Then
+        assertEventually( "session shows up as started",
+                () -> readLongValue( metricsCsv( metricsFolder, SESSIONS_STARTED ) ), equalTo( 1L ), 5, SECONDS );
         assertEventually( "init request shows up as received",
                 () -> readLongValue( metricsCsv( metricsFolder, MESSAGES_RECIEVED ) ), equalTo( 1L ), 5, SECONDS );
         assertEventually( "init request shows up as started",

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -172,6 +172,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.neo4j.driver</groupId>
       <artifactId>neo4j-java-driver</artifactId>
     </dependency>

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.bolt.v1.runtime.BoltFactory;
+import org.neo4j.bolt.v1.runtime.WorkerFactory;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+
+public class BoltFailuresIT
+{
+    @Rule
+    public final TestDirectory dir = TestDirectory.testDirectory();
+
+    private GraphDatabaseService db;
+
+    @After
+    public void shutdownDb()
+    {
+        if ( db != null )
+        {
+            db.shutdown();
+        }
+    }
+
+    @Test( timeout = 20_000 )
+    public void throwsWhenSessionCreationFails()
+    {
+        WorkerFactory workerFactory = mock( WorkerFactory.class );
+        when( workerFactory.newWorker( anyString(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
+
+        db = newDbFactory( new BoltKernelExtensionWithWorkerFactory( workerFactory ) );
+
+        try ( Driver driver = GraphDatabase.driver( "bolt://localhost" ) )
+        {
+            driver.session();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( ConnectionFailureException.class ) );
+        }
+    }
+
+    private GraphDatabaseService newDbFactory( BoltKernelExtension boltKernelExtension )
+    {
+        return new GraphDatabaseFactoryWithCustomBoltKernelExtension( boltKernelExtension )
+                .newEmbeddedDatabaseBuilder( dir.graphDbDir() )
+                .setConfig( boltConnector( "0" ).type, BOLT.name() )
+                .setConfig( boltConnector( "0" ).enabled, TRUE )
+                .setConfig( GraphDatabaseSettings.auth_enabled, FALSE )
+                .newGraphDatabase();
+    }
+
+    private static class BoltKernelExtensionWithWorkerFactory extends BoltKernelExtension
+    {
+        final WorkerFactory workerFactory;
+
+        BoltKernelExtensionWithWorkerFactory( WorkerFactory workerFactory )
+        {
+            this.workerFactory = workerFactory;
+        }
+
+        @Override
+        protected WorkerFactory createWorkerFactory( BoltFactory boltFactory, JobScheduler scheduler,
+                Dependencies dependencies, LogService logService )
+        {
+            return workerFactory;
+        }
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -23,15 +23,22 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.function.Consumer;
+
 import org.neo4j.bolt.v1.runtime.BoltFactory;
+import org.neo4j.bolt.v1.runtime.MonitoredWorkerFactory.SessionMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.ConnectionFailureException;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -40,6 +47,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
@@ -48,10 +56,13 @@ import static org.neo4j.kernel.configuration.Settings.TRUE;
 
 public class BoltFailuresIT
 {
+    private static final int TEST_TIMEOUT = 20_000;
+
     @Rule
     public final TestDirectory dir = TestDirectory.testDirectory();
 
     private GraphDatabaseService db;
+    private Driver driver;
 
     @After
     public void shutdownDb()
@@ -60,17 +71,21 @@ public class BoltFailuresIT
         {
             db.shutdown();
         }
+        IOUtils.closeAllSilently( driver );
     }
 
-    @Test( timeout = 20_000 )
-    public void throwsWhenSessionCreationFails()
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenWorkerCreationFails()
     {
         WorkerFactory workerFactory = mock( WorkerFactory.class );
         when( workerFactory.newWorker( anyString(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
 
-        db = newDbFactory( new BoltKernelExtensionWithWorkerFactory( workerFactory ) );
+        BoltKernelExtension extension = new BoltKernelExtensionWithWorkerFactory( workerFactory );
 
-        try ( Driver driver = GraphDatabase.driver( "bolt://localhost" ) )
+        db = startDbWithBolt( new GraphDatabaseFactoryWithCustomBoltKernelExtension( extension ) );
+        driver = createDriver();
+
+        try
         {
             driver.session();
             fail( "Exception expected" );
@@ -81,14 +96,140 @@ public class BoltFailuresIT
         }
     }
 
-    private GraphDatabaseService newDbFactory( BoltKernelExtension boltKernelExtension )
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenMonitoredWorkerCreationFails()
     {
-        return new GraphDatabaseFactoryWithCustomBoltKernelExtension( boltKernelExtension )
-                .newEmbeddedDatabaseBuilder( dir.graphDbDir() )
+        ThrowingSessionMonitor sessionMonitor = new ThrowingSessionMonitor();
+        sessionMonitor.throwInSessionStarted();
+        Monitors monitors = newMonitorsSpy( sessionMonitor );
+
+        db = startDbWithBolt( new GraphDatabaseFactory().setMonitors( monitors ) );
+        driver = createDriver();
+
+        try
+        {
+            driver.session();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( ConnectionFailureException.class ) );
+        }
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenInitMessageReceiveFails()
+    {
+        throwsWhenInitMessageFails( ThrowingSessionMonitor::throwInMessageReceived, false );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenInitMessageProcessingFailsToStart()
+    {
+        throwsWhenInitMessageFails( ThrowingSessionMonitor::throwInProcessingStarted, false );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenInitMessageProcessingFailsToComplete()
+    {
+        throwsWhenInitMessageFails( ThrowingSessionMonitor::throwInProcessingDone, true );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenRunMessageReceiveFails()
+    {
+        throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInMessageReceived );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenRunMessageProcessingFailsToStart()
+    {
+        throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInProcessingStarted );
+    }
+
+    @Test( timeout = TEST_TIMEOUT )
+    public void throwsWhenRunMessageProcessingFailsToComplete()
+    {
+        throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInProcessingDone );
+    }
+
+    private void throwsWhenInitMessageFails( Consumer<ThrowingSessionMonitor> monitorSetup,
+            boolean shouldBeAbleToGetSession )
+    {
+        ThrowingSessionMonitor sessionMonitor = new ThrowingSessionMonitor();
+        monitorSetup.accept( sessionMonitor );
+        Monitors monitors = newMonitorsSpy( sessionMonitor );
+
+        db = startTestDb( monitors );
+        driver = createDriver();
+
+        try
+        {
+            Session session = driver.session();
+            if ( shouldBeAbleToGetSession )
+            {
+                session.run( "CREATE ()" ).consume();
+            }
+            else
+            {
+                fail( "Exception expected" );
+            }
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( ConnectionFailureException.class ) );
+        }
+    }
+
+    private void throwsWhenRunMessageFails( Consumer<ThrowingSessionMonitor> monitorSetup )
+    {
+        ThrowingSessionMonitor sessionMonitor = new ThrowingSessionMonitor();
+        Monitors monitors = newMonitorsSpy( sessionMonitor );
+
+        db = startTestDb( monitors );
+        driver = createDriver();
+
+        Session session = driver.session();
+        session.run( "CREATE ()" );
+        try
+        {
+            monitorSetup.accept( sessionMonitor );
+            session.close();
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( ConnectionFailureException.class ) );
+        }
+    }
+
+    private GraphDatabaseService startTestDb( Monitors monitors )
+    {
+        return startDbWithBolt( new GraphDatabaseFactory().setMonitors( monitors ) );
+    }
+
+    private GraphDatabaseService startDbWithBolt( GraphDatabaseFactory dbFactory )
+    {
+        return dbFactory.newEmbeddedDatabaseBuilder( dir.graphDbDir() )
                 .setConfig( boltConnector( "0" ).type, BOLT.name() )
                 .setConfig( boltConnector( "0" ).enabled, TRUE )
                 .setConfig( GraphDatabaseSettings.auth_enabled, FALSE )
                 .newGraphDatabase();
+    }
+
+    private static Driver createDriver()
+    {
+        return GraphDatabase.driver( "bolt://localhost" );
+    }
+
+    private static Monitors newMonitorsSpy( ThrowingSessionMonitor sessionMonitor )
+    {
+        Monitors monitors = spy( new Monitors() );
+        // it is not allowed to throw exceptions from monitors
+        // make the given sessionMonitor be returned as is, without any proxying
+        when( monitors.newMonitor( SessionMonitor.class ) ).thenReturn( sessionMonitor );
+        when( monitors.hasListeners( SessionMonitor.class ) ).thenReturn( true );
+        return monitors;
     }
 
     private static class BoltKernelExtensionWithWorkerFactory extends BoltKernelExtension
@@ -105,6 +246,66 @@ public class BoltFailuresIT
                 Dependencies dependencies, LogService logService )
         {
             return workerFactory;
+        }
+    }
+
+    private static class ThrowingSessionMonitor implements SessionMonitor
+    {
+        volatile boolean throwInSessionStarted;
+        volatile boolean throwInMessageReceived;
+        volatile boolean throwInProcessingStarted;
+        volatile boolean throwInProcessingDone;
+
+        @Override
+        public void sessionStarted()
+        {
+            throwIfNeeded( throwInSessionStarted );
+        }
+
+        @Override
+        public void messageReceived()
+        {
+            throwIfNeeded( throwInMessageReceived );
+        }
+
+        @Override
+        public void processingStarted( long queueTime )
+        {
+            throwIfNeeded( throwInProcessingStarted );
+        }
+
+        @Override
+        public void processingDone( long processingTime )
+        {
+            throwIfNeeded( throwInProcessingDone );
+        }
+
+        void throwInSessionStarted()
+        {
+            throwInSessionStarted = true;
+        }
+
+        void throwInMessageReceived()
+        {
+            throwInMessageReceived = true;
+        }
+
+        void throwInProcessingStarted()
+        {
+            throwInProcessingStarted = true;
+        }
+
+        void throwInProcessingDone()
+        {
+            throwInProcessingDone = true;
+        }
+
+        void throwIfNeeded( boolean shouldThrow )
+        {
+            if ( shouldThrow )
+            {
+                throw new RuntimeException();
+            }
         }
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/GraphDatabaseFactoryWithCustomBoltKernelExtension.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.security.URLAccessRule;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.extension.KernelExtensions;
+import org.neo4j.kernel.impl.enterprise.EnterpriseEditionModule;
+import org.neo4j.kernel.impl.factory.DatabaseInfo;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.query.QueryEngineProvider;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.LogProvider;
+
+import static java.util.stream.Collectors.toList;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies;
+
+public class GraphDatabaseFactoryWithCustomBoltKernelExtension extends GraphDatabaseFactory
+{
+    private final BoltKernelExtension customExtension;
+
+    public GraphDatabaseFactoryWithCustomBoltKernelExtension( BoltKernelExtension customExtension )
+    {
+        this.customExtension = customExtension;
+    }
+
+    @Override
+    protected GraphDatabaseService newDatabase( File storeDir, Map<String,String> config, Dependencies dependencies )
+    {
+        GraphDatabaseFacadeFactory factory = new CustomBoltKernelExtensionFacadeFactory( customExtension );
+        return factory.newFacade( storeDir, config, dependencies );
+    }
+
+    private static class CustomBoltKernelExtensionFacadeFactory extends GraphDatabaseFacadeFactory
+    {
+        final BoltKernelExtension customExtension;
+
+        CustomBoltKernelExtensionFacadeFactory( BoltKernelExtension customExtension )
+        {
+            super( DatabaseInfo.ENTERPRISE, EnterpriseEditionModule::new );
+            this.customExtension = customExtension;
+        }
+
+        @Override
+        protected PlatformModule createPlatform( File storeDir, Map<String,String> params,
+                Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
+        {
+            Dependencies newDependencies = new CustomBoltKernelExtensionDependencies( customExtension, dependencies );
+            return new PlatformModule( storeDir, params, databaseInfo, newDependencies, graphDatabaseFacade );
+        }
+    }
+
+    private static class CustomBoltKernelExtensionDependencies implements Dependencies
+    {
+        final BoltKernelExtension customExtension;
+        final Dependencies delegate;
+
+        CustomBoltKernelExtensionDependencies( BoltKernelExtension customExtension, Dependencies delegate )
+        {
+            this.customExtension = customExtension;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Monitors monitors()
+        {
+            return delegate.monitors();
+        }
+
+        @Override
+        public LogProvider userLogProvider()
+        {
+            return delegate.userLogProvider();
+        }
+
+        @Override
+        public Iterable<Class<?>> settingsClasses()
+        {
+            return delegate.settingsClasses();
+        }
+
+        @Override
+        public Iterable<KernelExtensionFactory<?>> kernelExtensions()
+        {
+            return Iterables.stream( delegate.kernelExtensions() )
+                    .map( this::replaceBoltKernelExtensionFactory )
+                    .collect( toList() );
+        }
+
+        @Override
+        public Map<String,URLAccessRule> urlAccessRules()
+        {
+            return delegate.urlAccessRules();
+        }
+
+        @Override
+        public Iterable<QueryEngineProvider> executionEngines()
+        {
+            return delegate.executionEngines();
+        }
+
+        KernelExtensionFactory<?> replaceBoltKernelExtensionFactory( KernelExtensionFactory<?> factory )
+        {
+            if ( factory instanceof BoltKernelExtension )
+            {
+                return new CustomBoltKernelExtension( customExtension );
+            }
+            return factory;
+        }
+    }
+
+    /**
+     * Each kernel extension factory is expected to extend {@link KernelExtensionFactory} and have some dependencies
+     * as it's type parameter. That is why we can't use given custom extension as is, it can extend a real
+     * {@link BoltKernelExtension}. So this wrapper delegates to the given extension and has same superclass as the
+     * real {@link BoltKernelExtension}.
+     *
+     * @see KernelExtensions#getKernelExtensionDependencies(KernelExtensionFactory)
+     */
+    private static class CustomBoltKernelExtension extends KernelExtensionFactory<BoltKernelExtension.Dependencies>
+    {
+        final BoltKernelExtension customExtension;
+
+        CustomBoltKernelExtension( BoltKernelExtension customExtension )
+        {
+            super( "custom-bolt-server" );
+            this.customExtension = customExtension;
+        }
+
+        @Override
+        public Lifecycle newInstance( KernelContext context, BoltKernelExtension.Dependencies dependencies )
+                throws Throwable
+        {
+            return customExtension.newInstance( context, dependencies );
+        }
+    }
+}


### PR DESCRIPTION
PR consists of 3 commits:

* Added monitor and metric for number of started Bolt sessions
 New metric is exposed with name `neo4j.bolt.sessions_started`.

* Close Netty channel on Bolt handshake failure
 Bolt protocol executes a handshake before establishing new session. New worker is started for each session after protocol negotiation and handshake complete. Creation of a worker can potentially fail with a runtime exception. In this case corresponding Netty channel would just remain open and client (driver) would hang waiting for a response.
 This commit makes code close channels even when handshake fails.

* More ITs for Bolt failures
 Added tests to check that driver does not hang when message processing fails with exception. They are mostly to make sure that network resources (like Netty channels) are properly closed in case of failure.

It fixes a problem discovered while investigating https://github.com/neo4j/neo4j-javascript-driver/issues/148