### PR TITLE
GBPTree - Backwards seek for SeekCursor

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/GBPTree.java
@@ -512,8 +512,6 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>
     @Override
     public RawCursor<Hit<KEY,VALUE>,IOException> seek( KEY fromInclusive, KEY toExclusive ) throws IOException
     {
-        KEY key = layout.newKey();
-        VALUE value = layout.newValue();
         long generation = this.generation;
         long stableGeneration = stableGeneration( generation );
         long unstableGeneration = unstableGeneration( generation );
@@ -522,7 +520,7 @@ public class GBPTree<KEY,VALUE> implements Index<KEY,VALUE>
         long rootGen = root.goTo( cursor );
 
         // Returns cursor which is now initiated with left-most leaf node for the specified range
-        return new SeekCursor<>( cursor, key, value, bTreeNode, fromInclusive, toExclusive, layout,
+        return new SeekCursor<>( cursor, bTreeNode, fromInclusive, toExclusive, layout,
                 stableGeneration, unstableGeneration, generationSupplier, rootCatchup, rootGen );
     }
 

--- a/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
@@ -28,7 +28,6 @@ import org.neo4j.index.Hit;
 import org.neo4j.io.pagecache.PageCursor;
 
 import static java.lang.Integer.max;
-
 import static org.neo4j.index.gbptree.PageCursorUtil.checkOutOfBounds;
 import static org.neo4j.index.gbptree.TreeNode.NODE_TYPE_TREE_NODE;
 
@@ -427,10 +426,10 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
             if ( !seekForward && pos >= keyCount )
             {
-                if ( goTo( prevSiblingId, prevSiblingGen, "prev sibling", true ) )
-                {
-                    continue; // in the read loop above so that we can continue reading from previous sibling
-                }
+                goTo( prevSiblingId, prevSiblingGen, "prev sibling", true );
+                // Continue in the read loop above so that we can continue reading from previous sibling
+                // or on next position
+                continue;
             }
 
             if ( (seekForward && pos >= keyCount) || (!seekForward && pos <= 0 && !insidePrevKey()) )

--- a/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/gbptree/SeekCursor.java
@@ -675,7 +675,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         int pos = KeySearch.positionOf( search );
 
         // Assuming unique keys
-        if ( seekForward && isInternal && KeySearch.isHit( search ) )
+        if ( isInternal && KeySearch.isHit( search ) )
         {
             pos++;
         }

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
@@ -33,7 +33,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -69,6 +72,7 @@ public class GBPTreeIT
 
     private final Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();
     private GBPTree<MutableLong,MutableLong> index;
+    private ExecutorService threadPool = Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() );
 
     private GBPTree<MutableLong,MutableLong> createIndex( int pageSize )
             throws IOException
@@ -94,6 +98,7 @@ public class GBPTreeIT
     @After
     public void consistencyCheck() throws IOException
     {
+        threadPool.shutdownNow();
         index.consistencyCheck();
     }
 
@@ -255,16 +260,13 @@ public class GBPTreeIT
         };
 
         // WHEN starting the readers
-        Thread[] readerThreads = new Thread[readers];
         for ( int i = 0; i < readers; i++ )
         {
-            readerThreads[i] = new Thread( reader );
-            readerThreads[i].start();
+            threadPool.submit( reader );
         }
 
         // and starting the checkpointer
-        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
-        checkpointer.start();
+        threadPool.submit( checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal ) );
 
         // and then starting the writer
         try
@@ -295,15 +297,12 @@ public class GBPTreeIT
             // number of successful reads. A successful read means that all results were ordered,
             // no holes and we saw all values that was inserted at the point of making the seek call.
             endSignal.set( true );
-            for ( Thread readerThread : readerThreads )
-            {
-                readerThread.join( SECONDS.toMillis( 10 ) );
-            }
+            threadPool.shutdown();
+            threadPool.awaitTermination( 10, TimeUnit.SECONDS );
             if ( readerError.get() != null )
             {
                 throw readerError.get();
             }
-            checkpointer.join();
         }
     }
 
@@ -342,17 +341,13 @@ public class GBPTreeIT
                 endSignal, failHalt, numberOfReads, readerError );
 
         // WHEN starting the readers
-        Thread[] readerThreads = new Thread[readers];
         for ( int i = 0; i < readers; i++ )
         {
-            readerThreads[i] = new Thread( reader );
-            readerThreads[i].start();
+            threadPool.submit( reader );
         }
 
         // and starting the checkpointer
-        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
-        checkpointer.start();
-
+        threadPool.submit( checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal ) );
         // and then starting the writer
         try
         {
@@ -386,11 +381,8 @@ public class GBPTreeIT
             // number of successful reads. A successful read means that all results were ordered,
             // no holes and we saw all values that was inserted at the point of making the seek call.
             endSignal.set( true );
-            for ( Thread readerThread : readerThreads )
-            {
-                readerThread.join( SECONDS.toMillis( 10 ) );
-            }
-            checkpointer.join();
+            threadPool.shutdown();
+            threadPool.awaitTermination( 10, TimeUnit.SECONDS );
             if ( readerError.get() != null )
             {
                 throw readerError.get();
@@ -433,16 +425,13 @@ public class GBPTreeIT
                 endSignal, failHalt, numberOfReads, readerError );
 
         // WHEN starting the readers
-        Thread[] readerThreads = new Thread[readers];
         for ( int i = 0; i < readers; i++ )
         {
-            readerThreads[i] = new Thread( reader );
-            readerThreads[i].start();
+            threadPool.submit( reader );
         }
 
         // and starting the checkpointer
-        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
-        checkpointer.start();
+        threadPool.submit( checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal ) );
 
         // and then starting the writer
         try
@@ -477,11 +466,8 @@ public class GBPTreeIT
             // number of successful reads. A successful read means that all results were ordered,
             // no holes and we saw all values that was inserted at the point of making the seek call.
             endSignal.set( true );
-            for ( Thread readerThread : readerThreads )
-            {
-                readerThread.join( SECONDS.toMillis( 10 ) );
-            }
-            checkpointer.join();
+            threadPool.shutdown();
+            threadPool.awaitTermination( 10, TimeUnit.SECONDS );
             if ( readerError.get() != null )
             {
                 throw readerError.get();
@@ -526,16 +512,13 @@ public class GBPTreeIT
                 endSignal, failHalt, numberOfReads, readerError );
 
         // WHEN starting the readers
-        Thread[] readerThreads = new Thread[readers];
         for ( int i = 0; i < readers; i++ )
         {
-            readerThreads[i] = new Thread( reader );
-            readerThreads[i].start();
+            threadPool.submit( reader );
         }
 
         // and starting the checkpointer
-        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
-        checkpointer.start();
+        threadPool.submit( checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal ) );
 
         // and then starting the writer
         try
@@ -571,11 +554,8 @@ public class GBPTreeIT
             // number of successful reads. A successful read means that all results were ordered,
             // no holes and we saw all values that was inserted at the point of making the seek call.
             endSignal.set( true );
-            for ( Thread readerThread : readerThreads )
-            {
-                readerThread.join( SECONDS.toMillis( 10 ) );
-            }
-            checkpointer.join();
+            threadPool.shutdown();
+            threadPool.awaitTermination( 10, TimeUnit.SECONDS );
             if ( readerError.get() != null )
             {
                 throw readerError.get();
@@ -620,16 +600,13 @@ public class GBPTreeIT
                 endSignal, failHalt, numberOfReads, readerError );
 
         // WHEN starting the readers
-        Thread[] readerThreads = new Thread[readers];
         for ( int i = 0; i < readers; i++ )
         {
-            readerThreads[i] = new Thread( reader );
-            readerThreads[i].start();
+            threadPool.submit( reader );
         }
 
         // and starting the checkpointer
-        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
-        checkpointer.start();
+        threadPool.submit( checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal ) );
 
         // and then starting the writer
         try
@@ -665,11 +642,8 @@ public class GBPTreeIT
             // number of successful reads. A successful read means that all results were ordered,
             // no holes and we saw all values that was inserted at the point of making the seek call.
             endSignal.set( true );
-            for ( Thread readerThread : readerThreads )
-            {
-                readerThread.join( SECONDS.toMillis( 10 ) );
-            }
-            checkpointer.join();
+            threadPool.shutdown();
+            threadPool.awaitTermination( 10, TimeUnit.SECONDS );
             if ( readerError.get() != null )
             {
                 throw readerError.get();
@@ -696,9 +670,9 @@ public class GBPTreeIT
         }
     }
 
-    private Thread checkpointerThread( int minCheckpointInterval, int maxCheckpointInterval, AtomicBoolean endSignal )
+    private Runnable checkpointerThread( int minCheckpointInterval, int maxCheckpointInterval, AtomicBoolean endSignal )
     {
-        return new Thread( () ->
+        return () ->
         {
             while ( !endSignal.get() )
             {
@@ -713,7 +687,7 @@ public class GBPTreeIT
                     throw new RuntimeException( e );
                 }
             }
-        });
+        };
     }
 
     private int maxRange( int nbrOfGroups, int rangeWidth, int iteration )
@@ -832,6 +806,7 @@ public class GBPTreeIT
             catch ( Throwable e )
             {
                 readerError.set( e );
+                failHalt.set( true );
             }
             finally
             {

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
@@ -640,7 +640,7 @@ public class GBPTreeIT
                 }
                 iteration = currentWriteIteration.addAndGet( 2 );
                 // Sleep a little in between update groups (transactions, sort of)
-                MILLISECONDS.sleep( random.nextInt( 10 ) + 3 );
+                MILLISECONDS.sleep( random.nextInt( 3,13 ) );
             }
         }
         finally

--- a/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/GBPTreeIT.java
@@ -498,6 +498,196 @@ public class GBPTreeIT
     }
 
     @Test
+    public void shouldReadCorrectlyWhenConcurrentlyInsertingOutOfOrderAndSeekingBackwards() throws Throwable
+    {
+        // Checkpoint config
+        int minCheckpointInterval = 10;
+        int maxCheckpointInterval = 20;
+
+        // Write group config
+        int nbrOfGroups = 10;
+        int wantedRangeWidth = 1_000;
+        int rangeWidth = wantedRangeWidth - wantedRangeWidth % nbrOfGroups;
+        int wantedNbrOfReads = 10_000;
+
+        // Readers config
+        int readers = max( 1, Runtime.getRuntime().availableProcessors() - 1 );
+
+        // Thread communication
+        AtomicInteger currentWriteIteration = new AtomicInteger( 0 );
+        AtomicLong lastWrittenKey = new AtomicLong( -1 );
+        CountDownLatch readerReadySignal = new CountDownLatch( readers );
+        CountDownLatch startSignal = new CountDownLatch( 1 );
+        AtomicBoolean endSignal = new AtomicBoolean();
+        AtomicBoolean failHalt = new AtomicBoolean(); // Readers signal to writer that there is a failure
+        AtomicReference<Throwable> readerError = new AtomicReference<>();
+        AtomicInteger numberOfReads = new AtomicInteger();
+
+        // given
+        index = createIndex( 256 );
+
+        Runnable reader = () -> {
+            int numberOfLocalReads = 0;
+            try
+            {
+                readerReadySignal.countDown();
+                while ( currentWriteIteration.get() < 1 )
+                {
+                    startSignal.await( 5, SECONDS );
+                }
+
+                while ( !endSignal.get() && !failHalt.get() )
+                {
+                    // Read one go, we should see up to highId
+
+                    // Kept for SeekCursor life
+                    int iterationExpectedToSee = currentWriteIteration.get() - 1;
+                    int rangeModulus = iterationExpectedToSee % nbrOfGroups;
+                    long start = maxRange( nbrOfGroups, rangeWidth, iterationExpectedToSee );
+                    long end = minRange( nbrOfGroups, rangeWidth, iterationExpectedToSee );
+
+                    // Updated during SeekCursor life
+                    long lastSeenKey = -1;
+                    long nextToSeeBase = start;
+                    long nextToSeeDelta = 0;
+                    long nextToSee = nextToSeeBase - nextToSeeDelta;
+                    long lastWrittenBeforeStart;
+                    long lastWrittenWhenFinished;
+                    long lastWrittenBeforeTraversingTree;
+
+                    lastWrittenBeforeTraversingTree = lastWrittenKey.get();
+                    try ( RawCursor<Hit<MutableLong,MutableLong>,IOException> cursor =
+                                  index.seek( new MutableLong( start ), new MutableLong( end ) ) )
+                    {
+                        lastWrittenWhenFinished = lastWrittenKey.get();
+                        while ( cursor.next() )
+                        {
+                            lastWrittenBeforeStart = lastWrittenWhenFinished;
+                            lastWrittenWhenFinished = lastWrittenKey.get();
+
+                            lastSeenKey = cursor.get().key().longValue();
+                            long lastSeenValue = cursor.get().value().longValue();
+                            if ( lastSeenKey != lastSeenValue )
+                            {
+                                failHalt.set( true );
+                                fail( String.format( "Read mismatching key value pair, key=%d, value=%d%n",
+                                        lastSeenKey, lastSeenValue ) );
+                            }
+
+                            nextToSee = nextToSeeBase - nextToSeeDelta;
+                            if ( nextToSee == lastSeenKey )
+                            {
+                                if ( nextToSeeDelta < rangeModulus )
+                                {
+                                    nextToSeeDelta++;
+                                }
+                                else
+                                {
+                                    nextToSeeDelta = 0;
+                                    nextToSeeBase -= nbrOfGroups;
+                                }
+                            }
+                            else if ( lastSeenKey < nextToSee )
+                            {
+                                failHalt.set( true );
+                                fail( String.format( "Expected to see %d+%d=%d but went straight to %d, " +
+                                                "lastWrittenBeforeTraversingTree=%d, " +
+                                                "lastWrittenBeforeNext=%d, " +
+                                                "lastWrittenAfterNext=%d%n",
+                                        nextToSeeBase, nextToSeeDelta, nextToSee, lastSeenKey,
+                                        lastWrittenBeforeTraversingTree,
+                                        lastWrittenBeforeStart,
+                                        lastWrittenWhenFinished ) );
+                            }
+                        }
+                        long difference = Math.abs( end - nextToSee );
+                        boolean condition = difference <= nbrOfGroups;
+                        if ( !condition )
+                        {
+                            failHalt.set( true );
+                            fail( String.format( "Expected distance between end and nextToSee to be less " +
+                                            "than %d but was %d. lastSeenKey=%d, nextToSee=%d, start=%d%n",
+                                    nbrOfGroups, difference, lastSeenKey, nextToSee, start ) );
+                        }
+                    }
+
+                    // Keep a local counter and update the global one now and then, we don't want
+                    // out little statistic here to affect concurrency
+                    if ( ++numberOfLocalReads == 30 )
+                    {
+                        numberOfReads.addAndGet( numberOfLocalReads );
+                        numberOfLocalReads = 0;
+                    }
+                }
+            }
+            catch ( Throwable e )
+            {
+                readerError.set( e );
+            }
+            finally
+            {
+                numberOfReads.addAndGet( numberOfLocalReads );
+            }
+        };
+
+        // WHEN starting the readers
+        Thread[] readerThreads = new Thread[readers];
+        for ( int i = 0; i < readers; i++ )
+        {
+            readerThreads[i] = new Thread( reader );
+            readerThreads[i].start();
+        }
+
+        // and starting the checkpointer
+        Thread checkpointer = checkpointerThread( minCheckpointInterval, maxCheckpointInterval, endSignal );
+        checkpointer.start();
+
+        // and then starting the writer
+        try
+        {
+            assertTrue( readerReadySignal.await( 10, SECONDS ) );
+            startSignal.countDown();
+            int iteration = currentWriteIteration.get();
+            while ( !failHalt.get() && numberOfReads.get() < wantedNbrOfReads && readerError.get() == null )
+            {
+                try ( IndexWriter<MutableLong,MutableLong> writer = index.writer() )
+                {
+                    for ( long i = maxRange( nbrOfGroups, rangeWidth, iteration ) - iteration % nbrOfGroups;
+                          i > minRange( nbrOfGroups, rangeWidth, iteration ); i -= nbrOfGroups )
+                    {
+                        MutableLong thing = new MutableLong( i );
+                        writer.put( thing, thing );
+                        lastWrittenKey.set( i );
+                        if ( failHalt.get() )
+                        {
+                            break;
+                        }
+                    }
+                }
+                iteration = currentWriteIteration.incrementAndGet();
+                // Sleep a little in between update groups (transactions, sort of)
+                MILLISECONDS.sleep( random.nextInt( 10 ) + 3 );
+            }
+        }
+        finally
+        {
+            // THEN no reader should have failed and by this time there have been a certain
+            // number of successful reads. A successful read means that all results were ordered,
+            // no holes and we saw all values that was inserted at the point of making the seek call.
+            endSignal.set( true );
+            for ( Thread readerThread : readerThreads )
+            {
+                readerThread.join( SECONDS.toMillis( 10 ) );
+            }
+            checkpointer.join();
+            if ( readerError.get() != null )
+            {
+                throw readerError.get();
+            }
+        }
+    }
+
+    @Test
     public void shouldReadCorrectlyWhenConcurrentlyRemovingOutOfOrder() throws Throwable
     {
         // Checkpoint config

--- a/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/PageAwareByteArrayCursor.java
@@ -66,7 +66,7 @@ class PageAwareByteArrayCursor extends PageCursor
 
     PageAwareByteArrayCursor duplicate()
     {
-        return new PageAwareByteArrayCursor( pages, pageSize, nextPageId );
+        return new PageAwareByteArrayCursor( pages, pageSize, currentPageId );
     }
 
     PageAwareByteArrayCursor duplicate( long nextPageId )

--- a/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
@@ -451,6 +451,62 @@ public class SeekCursorTest
         assertEquals( expectedkey, -1 );
     }
 
+    @Test
+    public void mustStartReadingFromCorrectLeafWhenRangeStartWithKeyEqualToPrimKey() throws Exception
+    {
+        // given
+        for ( int i = 0; i < maxKeyCount + 1; i++ )
+        {
+            insert( i );
+        }
+        MutableLong primKey = layout.newKey();
+        node.keyAt( cursor, primKey, 0 );
+        long expectedNext = primKey.longValue();
+        long rightChild = GenSafePointerPair.pointer( node.childAt( cursor, 1, stableGen, unstableGen ) );
+
+        // when
+        try ( SeekCursor<MutableLong, MutableLong> seek = seekCursor( expectedNext, maxKeyCount + 1 ) )
+        {
+            assertEquals( rightChild, cursor.getCurrentPageId() );
+            while ( seek.next() )
+            {
+                assertKeyAndValue( seek, expectedNext );
+                expectedNext++;
+            }
+        }
+
+        // then
+        assertEquals( maxKeyCount + 1, expectedNext );
+    }
+
+    @Test
+    public void mustStartReadingFromCorrectLeafWhenRangeStartWithKeyEqualToPrimKeyBackwards() throws Exception
+    {
+        // given
+        for ( int i = 0; i < maxKeyCount + 1; i++ )
+        {
+            insert( i );
+        }
+        MutableLong primKey = layout.newKey();
+        node.keyAt( cursor, primKey, 0 );
+        long expectedNext = primKey.longValue();
+        long rightChild = GenSafePointerPair.pointer( node.childAt( cursor, 1, stableGen, unstableGen ) );
+
+        // when
+        try ( SeekCursor<MutableLong, MutableLong> seek = seekCursor( expectedNext, -1 ) )
+        {
+            assertEquals( rightChild, cursor.getCurrentPageId() );
+            while ( seek.next() )
+            {
+                assertKeyAndValue( seek, expectedNext );
+                expectedNext--;
+            }
+        }
+
+        // then
+        assertEquals( -1, expectedNext );
+    }
+
     /* INSERT */
 
     @Test

--- a/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
@@ -69,8 +69,6 @@ public class SeekCursorTest
 
     private final MutableLong insertKey = layout.newKey();
     private final MutableLong insertValue = layout.newValue();
-    private final MutableLong readKey = layout.newKey();
-    private final MutableLong readValue = layout.newValue();
 
     private final MutableLong from = layout.newKey();
     private final MutableLong to = layout.newKey();
@@ -619,7 +617,7 @@ public class SeekCursorTest
         to.setValue( keyCount + 1 ); // +1 because we're adding one more down below
 
         // WHEN
-        try ( SeekCursor<MutableLong,MutableLong> cursor = new SeekCursor<>( this.cursor, insertKey, insertValue,
+        try ( SeekCursor<MutableLong,MutableLong> cursor = new SeekCursor<>( this.cursor,
                 node, from, to, layout, stableGen, unstableGen, () -> 0L, failingRootCatchup, unstableGen ) )
         {
             // reading a couple of keys
@@ -999,8 +997,8 @@ public class SeekCursorTest
         };
 
         // when
-        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, readKey, readValue, node, from, to,
-                layout, stableGen, unstableGen, generationSupplier, rootCatchup, gen - 1 ) )
+        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
+                stableGen, unstableGen, generationSupplier, rootCatchup, gen - 1 ) )
         {
             // do nothing
         }
@@ -1055,8 +1053,8 @@ public class SeekCursorTest
         // when
         from.setValue( 1L );
         to.setValue( 2L );
-        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, readKey, readValue, node, from, to,
-                layout, stableGen, unstableGen, generationSupplier, rootCatchup, unstableGen ) )
+        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
+                stableGen, unstableGen, generationSupplier, rootCatchup, unstableGen ) )
         {
             // do nothing
         }
@@ -1110,8 +1108,8 @@ public class SeekCursorTest
         // when
         from.setValue( 1L );
         to.setValue( 20L );
-        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, readKey, readValue, node, from, to,
-                layout, stableGen - 1, unstableGen - 1, generationSupplier, rootCatchup, unstableGen ) )
+        try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
+                stableGen - 1, unstableGen - 1, generationSupplier, rootCatchup, unstableGen ) )
         {
             while ( seek.next() )
             {
@@ -1193,8 +1191,8 @@ public class SeekCursorTest
     {
         from.setValue( fromInclusive );
         to.setValue( toExclusive );
-        return new SeekCursor<>( pageCursor, readKey, readValue, node, from,
-                to, layout, stableGen, unstableGen, generationSupplier, failingRootCatchup, unstableGen );
+        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGen, unstableGen, generationSupplier,
+                failingRootCatchup, unstableGen );
     }
 
     /**

--- a/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/gbptree/SeekCursorTest.java
@@ -363,6 +363,94 @@ public class SeekCursorTest
         assertFalse( "Cursor continued to next leaf even though end of range is within first leaf", nextCalled.get() );
     }
 
+    @Test
+    public void mustFindKeysWhenGivenRangeStartingOutsideStartOfData() throws Exception
+    {
+        // Given
+        // [ 0 1... maxKeyCount-1]
+        for ( int i = 0; i < maxKeyCount; i++ )
+        {
+            insert( i );
+        }
+
+        long expectedkey = 0;
+        try ( SeekCursor<MutableLong, MutableLong> seekCursor = seekCursor( -1, maxKeyCount - 1 ) )
+        {
+            while ( seekCursor.next() )
+            {
+                assertKeyAndValue( seekCursor, expectedkey );
+                expectedkey++;
+            }
+        }
+        assertEquals( expectedkey, maxKeyCount - 1 );
+    }
+
+    @Test
+    public void mustFindKeysWhenGivenRangeStartingOutsideStartOfDataBackwards() throws Exception
+    {
+        // Given
+        // [ 0 1... maxKeyCount-1]
+        for ( int i = 0; i < maxKeyCount; i++ )
+        {
+            insert( i );
+        }
+
+        long expectedkey = maxKeyCount - 1;
+        try ( SeekCursor<MutableLong, MutableLong> seekCursor = seekCursor( maxKeyCount, 0 ) )
+        {
+            while ( seekCursor.next() )
+            {
+                assertKeyAndValue( seekCursor, expectedkey );
+                expectedkey--;
+            }
+        }
+        assertEquals( expectedkey, 0 );
+    }
+
+    @Test
+    public void mustFindKeysWhenGivenRangeEndingOutsideEndOfData() throws Exception
+    {
+        // Given
+        // [ 0 1... maxKeyCount-1]
+        for ( int i = 0; i < maxKeyCount; i++ )
+        {
+            insert( i );
+        }
+
+        long expectedkey = 0;
+        try ( SeekCursor<MutableLong, MutableLong> seekCursor = seekCursor( 0, maxKeyCount + 1 ) )
+        {
+            while ( seekCursor.next() )
+            {
+                assertKeyAndValue( seekCursor, expectedkey );
+                expectedkey++;
+            }
+        }
+        assertEquals( expectedkey, maxKeyCount );
+    }
+
+    @Test
+    public void mustFindKeysWhenGivenRangeEndingOutsideEndOfDataBackwards() throws Exception
+    {
+        // Given
+        // [ 0 1... maxKeyCount-1]
+        for ( int i = 0; i < maxKeyCount; i++ )
+        {
+            insert( i );
+        }
+
+        long expectedkey = maxKeyCount - 1;
+        try ( SeekCursor<MutableLong, MutableLong> seekCursor = seekCursor( maxKeyCount - 1 , -2 ) )
+        {
+            while ( seekCursor.next() )
+            {
+                assertKeyAndValue( seekCursor, expectedkey );
+                expectedkey--;
+            }
+        }
+        assertEquals( expectedkey, -1 );
+    }
+
     /* INSERT */
 
     @Test


### PR DESCRIPTION
Introduce backwards seek in SeekCursor. This makes it possible to scan index built on top of GBPTree in descending order.

**Why is this so complicated?**

*General*
To allow for lock free concurrency control the GBPTree agree to only move keys between nodes in 'forward' direction, from left to right. This means when we do normal forward seek we never risk having keys moved 'passed' us and therefore we can always be sure that we never miss any keys when traversing the leaf nodes or end up in the middle of the range when traversing down the internal nodes.
This assumption, of course, does not hold when seeking backwards.

There are two complicated cases where we risk missing keys.
Case 1 - Split in current node
Case 2 - Split in next node while seeker is moving to that node

**Case 1 - Split in current node**
*Forward seek*
Here, the seeker is seeking forward and has read `K0, K1, K2` and is about to read `K3`.
Then `K4` is suddenly inserted and a split happens.
Seeker will now wake up and find that he is now outside the range of `(previously returned key, end of range)`. But he knows that he can continue to read forward until he hits the previously returned key, which is `K2` and then continue to return the next key, `K3`.
```
FORWARD
    Seeker->
       v  
[K0 K1 K2 K3]

    Seeker->
       v  
[K0 K1 __ __]<->[K2 K3 K4 __]
```

*Backward seek*
Here, the seeking is seeking backwards and has only read `K3` and is about to read `K2`.
Again, `K4` is inserted, causing the same split as above.
Seeker now wakes up and find that the next key he can return is `K1`. What he do not see is that `K2` has been moved to the previous sibling and so, because he can not find the previously returned key, `K3`, in the current node and because the next to return, `K1`, is located to the far right in the current node he need to jump back to the previous sibling to find where to start again.
```
BACKWARD
     <-Seeker
          v  
[K0 K1 K2 K3]

     <-Seeker (WRONG)
          v  
[K0 K1 __ __]<->[K2 K3 K4 __]

               <-Seeker (RIGHT)
                    v  
[K0 K1 __ __]<->[K2 K3 K4 __]
```

**Case 2 - Split in next node while seeker is moving to that node**
*Forward seek*
Seeker has read `K0, K1` on node 1  and has just moved to right sibling, node 2.
Now, `K6` is inserted and a split  happens in node 2, right sibling of node 1.
Seeker wakes up and continues to read on node 2. Everything is fine.
```
FORWARD
                  Seeker->
                     v  
1:[K0 K1 __ __]<->2:[K2 K3 K4 K5]

                  Seeker->
                     v  
1:[K0 K1 __ __]<->2:[K2 K3 __ __]<->3:[K4 K5 K6 __]
```
*Backward seek*
Seeker has read `K4, K5` and has just moved to left sibling, node 1.
Insert `K6`, split in node 2. Note that keys are move to node 3, passed our seeker.
Seeker wakes up and see `K1` as next key but misses `K3` and `K2`.
```
BACKWARD
                      <--Seeker
                            v  
                1:[K0 K1 K2 K3]<->2:[K4 K5 __ __]

       <-Seeker
            v  
1:[K0 K1 __ __]<->3:[K2 K3 K4 __]<->2:[K5 K6 __ __]
```
To guard for this, seeker 'scout' next sibling before moving there and read first key that he expect to see, `K3` in this case. By using a linked cursor to 'scout' we create a consistent read over the node gap. If there us suddenly another key when he goes there he knows that he could have missed some keys and he needs to go back until he find the place where he left off, `K4`.