### PR TITLE
Fix eagerness for labels() function

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/LabelsFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/LabelsFunction.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.commands.expressions
 
 import org.neo4j.cypher.internal.compiler.v3_0._
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsAnyLabel}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.ParameterWrongTypeException
@@ -46,4 +47,6 @@ case class LabelsFunction(nodeExpr: Expression) extends NullInNullOutExpression(
     nodeExpr.evaluateType(CTNode, symbols)
     CTList(CTString)
   }
+
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyLabel)
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/Effects.scala
@@ -178,7 +178,9 @@ sealed trait ReadsRelationshipProperty extends ReadEffect
 
 case class ReadsGivenRelationshipProperty(propertyName: String) extends ReadsRelationshipProperty
 
-object ReadsAnyRelationshipProperty extends ReadsRelationshipProperty
+case object ReadsAnyRelationshipProperty extends ReadsRelationshipProperty
+
+case object ReadsAnyLabel extends ReadEffect
 
 //-----------------------------------------------------------------------------
 // Write effects

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
@@ -206,6 +206,14 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
   }
 
   private def relationshipPropertiesConflict(from: Effects, to: Effects): Boolean = {
+    relationshipReadWriteProps(from, to) || relationshipWriteReadProps(from, to)
+  }
+
+  private def relationshipWriteReadProps(from: Effects, to: Effects) = {
+    relationshipReadWriteProps(to, from)
+  }
+
+  private def relationshipReadWriteProps(from: Effects, to: Effects): Boolean = {
     val propertyReads = from.effectsSet.collect {
       case property: ReadsRelationshipProperty => property
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/addEagernessIfNecessary.scala
@@ -56,7 +56,7 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
         relsCreateReadConflict(from, toWithoutLeafInfo) ||
         relsDeleteReadConflict(fromWithoutLeafInfo, toWithoutLeafInfo) ||
         relationshipPropertiesConflict(fromWithoutLeafInfo, toWithoutLeafInfo) ||
-        readsWritesLabels(fromWithoutLeafInfo, toWithoutLeafInfo) ||
+        readsWritesLabels(from, toWithoutLeafInfo) ||
         writesReadsLabels(fromWithoutLeafInfo, toWithoutLeafInfo)
     }
   }
@@ -81,7 +81,7 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     val relCreateReadConflict = relsCreateReadConflict(from, toWithoutLeafInfo)
     val relDeleteReadConflict = relsDeleteReadConflict(fromWithoutLeafInfo, toWithoutLeafInfo)
     val relPropConflict = relationshipPropertiesConflict(fromWithoutLeafInfo, toWithoutLeafInfo)
-    val readsWritesLabelConflict = readsWritesLabels(fromWithoutLeafInfo, toWithoutLeafInfo)
+    val readsWritesLabelConflict = readsWritesLabels(from, toWithoutLeafInfo)
     val writesReadsLabelsConflict = writesReadsLabels(fromWithoutLeafInfo, toWithoutLeafInfo)
 
     nodeNonLeafReadWriteConflict ||

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
@@ -159,7 +159,7 @@ trait UpdateGraph {
 
       setNodePropertyOverlap(propertiesReadInHorizon) || setRelPropertyOverlap(propertiesReadInHorizon)
     } || {
-      labelsToSet.nonEmpty &&
+      (labelsToSet.nonEmpty || removeLabelPatterns.nonEmpty) &&
         horizon.dependingExpressions.exists {
           case f: FunctionInvocation if f.function.get == Labels => true
           case _ => false

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
@@ -107,7 +107,7 @@ object Eagerness {
   def headWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                        (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    val conflictInHorizon = query.queryGraph.horizonOverlap(query.horizon)
+    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon)
     if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInHead(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else
@@ -117,7 +117,7 @@ object Eagerness {
   def tailWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                              (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    val conflictInHorizon = query.queryGraph.horizonOverlap(query.horizon)
+    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon)
     if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInTail(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
@@ -117,7 +117,8 @@ object Eagerness {
   def tailWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                              (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    if (alwaysEager || query.tail.isDefined && writeReadConflictInTail(query, query.tail.get))
+    val conflictInHorizon = query.queryGraph.horizonOverlap(query.horizon)
+    if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInTail(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else
       inputPlan

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -44,12 +44,30 @@ class EagerizationAcceptanceTest
 
   val EagerRegEx: Regex = "Eager(?!(Aggregation))".r
 
-  test("should be eager between property writes in QG and reads in horizon") {
+  test("should be eager between property writes in QG head and reads in horizon") {
     val n1 = createNode("val" -> 1)
     val n2 = createNode("val" -> 1)
     relate(n1, n2)
 
     val query = """MATCH (n)--(m)
+                  |SET n.val = n.val + 1
+                  |RETURN n.val AS nv, m.val AS mv
+                """.stripMargin
+
+    val result = updateWithBothPlanners(query)
+
+    result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
+                                    Map("nv" -> 2, "mv" -> 2)))
+    assertStats(result, propertiesWritten = 2)
+  }
+
+  test("should be eager between property writes in QG tail and reads in horizon") {
+    val n1 = createNode("val" -> 1)
+    val n2 = createNode("val" -> 1)
+    relate(n1, n2)
+
+    val query = """UNWIND [1] as i WITH *
+                  |MATCH (n)--(m)
                   |SET n.val = n.val + 1
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -44,7 +44,7 @@ class EagerizationAcceptanceTest
 
   val EagerRegEx: Regex = "Eager(?!(Aggregation))".r
 
-  test("should be eager between property writes in QG head and reads in horizon") {
+  test("should be eager between node property writes in QG head and reads in horizon") {
     val n1 = createNode("val" -> 1)
     val n2 = createNode("val" -> 1)
     relate(n1, n2)
@@ -61,7 +61,7 @@ class EagerizationAcceptanceTest
     assertStats(result, propertiesWritten = 2)
   }
 
-  test("should be eager between property writes in QG tail and reads in horizon") {
+  test("should be eager between node property writes in QG tail and reads in horizon") {
     val n1 = createNode("val" -> 1)
     val n2 = createNode("val" -> 1)
     relate(n1, n2)
@@ -76,6 +76,39 @@ class EagerizationAcceptanceTest
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
+    assertStats(result, propertiesWritten = 2)
+  }
+
+  test("should be eager between relationship property writes in QG head and reads in horizon") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2, ("val" -> 1))
+
+    val query = """MATCH (n)-[r]-(m)
+                  |SET r.val = r.val + 1
+                  |RETURN r.val AS rv
+                """.stripMargin
+
+    val result = updateWithBothPlanners(query)
+
+    result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
+    assertStats(result, propertiesWritten = 2)
+  }
+
+  test("should be eager between relationship property writes in QG tail and reads in horizon") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2, ("val" -> 1))
+
+    val query = """UNWIND [1] as i WITH *
+                  |MATCH (n)-[r]-(m)
+                  |SET r.val = r.val + 1
+                  |RETURN r.val AS rv
+                """.stripMargin
+
+    val result = updateWithBothPlanners(query)
+
+    result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
   }
 


### PR DESCRIPTION
We need to be eager when the use of labels() function in a query horizon
conflicts with a label write, which requires new conflict checks.

- For the rule planner a new read effect is introduced
- For read-write conflicts in the cost planner, a new location to plan eagerness
is introduced, with a dedicated check and pass, after planning the event horizon.
- For write-read conflicts in the cost planner, the check is added to the
existing passes.

Also fixes related eagerness bugs for property reads and extends testing.
