### PR TITLE
Remove wrapping by ConstantScoreQuery, because all MultiTermQuery ins…

### DIFF
--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
@@ -164,9 +164,7 @@ public class LuceneDocumentStructureTest
     public void shouldBuildRangeSeekByStringQueryForStrings() throws Exception
     {
         // given
-        ConstantScoreQuery constantQuery =
-                (ConstantScoreQuery) LuceneDocumentStructure.newRangeSeekByStringQuery( "foo", false, null, true );
-        TermRangeQuery query = (TermRangeQuery) constantQuery.getQuery();
+        TermRangeQuery query = (TermRangeQuery) LuceneDocumentStructure.newRangeSeekByStringQuery( "foo", false, null, true );
 
         // then
         assertEquals( "string", query.getField() );
@@ -190,8 +188,7 @@ public class LuceneDocumentStructureTest
     public void shouldBuildRangeSeekByPrefixQueryForStrings() throws Exception
     {
         // given
-        ConstantScoreQuery query = (ConstantScoreQuery) LuceneDocumentStructure.newRangeSeekByPrefixQuery( "Prefix" );
-        MultiTermQuery prefixQuery = (MultiTermQuery) query.getQuery();
+        MultiTermQuery prefixQuery = (MultiTermQuery) LuceneDocumentStructure.newRangeSeekByPrefixQuery( "Prefix" );
 
         // then
         assertThat("Should contain term value", prefixQuery.toString(), containsString( "Prefix" ) );


### PR DESCRIPTION
…tances are constant score by default. Refactor DocWithId a bit (and use simpler ThreadLocal).

This is just a small optimization. I am still not sure what the strange handling of the empty strings in newRangeSeekByStringQuery should do. There is also no test for it! I just changed this to be ConstantScore, too (to be correct). All inner clauses are now Occur.FILTER and Occur.MUST_NOT (but Lucene would rewrite this anyways).