### PR TITLE
Fix a bug in the schema index partitioning (maxDoc vs. numDocs)

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -23,7 +23,6 @@ import org.apache.lucene.document.Document;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
 
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -65,11 +64,9 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
     {
         // Lucene documents stored in a ThreadLocal and reused so we can't create an eager collection of documents here
         // That is why we create a lazy Iterator and then Iterable
-        Iterator<Document> documents = updates.stream()
+        writer.addDocuments( updates.size(), () -> updates.stream()
                 .map( LuceneIndexPopulator::updateAsDocument )
-                .iterator();
-
-        writer.addDocuments( updates.size(), () -> documents );
+                .iterator() );
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -69,7 +69,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
                 .map( LuceneIndexPopulator::updateAsDocument )
                 .iterator();
 
-        writer.addDocuments( () -> documents );
+        writer.addDocuments( updates.size(), () -> documents );
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/LuceneIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/LuceneIndexWriter.java
@@ -33,7 +33,7 @@ public interface LuceneIndexWriter
 {
     void addDocument( Document document ) throws IOException;
 
-    void addDocuments( Iterable<Document> document ) throws IOException;
+    void addDocuments( int numDocs, Iterable<Document> document ) throws IOException;
 
     void updateDocument( Term term, Document document ) throws IOException;
 


### PR DESCRIPTION
There is a bug in the schema index partitioning that could lead to problems adding/updating Lucene documents. The problem is the following:

Lucene's docIds are 32 bits (so we need partitioning) and those are assigned using the IndexReader's maxDoc() property. maxDoc() is generally larger than numDocs() which takes deleted documents into account. As deleted documents are not removed asap (it may take very long time until they are deleted, sometimes they are never deleted, especially because you are using the "outdated" LogByteSizeMergePolicy, which never removes deletes from huge segments unless they get merged by other reasons!!! -> TieredMergePolicy merges segments once they have > 10% deletes).

The problem is that a document addition or document update (delete + add) consumes one document ID, so IndexReaders/IndexWriter's maxDoc raises by one. Once maxDoc() reaches IndexWriter.MAX_DOC (slightly smaller than Integer.MAX_VALUE), indexing will break and stop with IllegalState/IllegalArgumentException.

The partitioning code currently uses numDocs() to find a segment with enough space. This is wrong, because it does not count deleted documents, which also consume document IDs. The bug does not affect most users, because there is a buffer of 10% included, but once a segment has more than 10% deletes, the whole thing will break.

This PR uses IndexWriter.maxDoc() for the calculation. It also changes the getIndexWriter() method to require the number of documents to be added (generally 1, but for bulk updates there are more required). 

For concurrency reason it still adds the buffer of 10%, because of incomplete synchronization: At the time when a thread requests an IndexWriter that is able to accept the number of document adds/updates to write, it does not "reserve those document ids", so another thread could do the same and then on addDocument/updateDocument it will break. So I left the buffer of 10%. To fix this correctly (and allow the partitions to get maximum size), one would need to completely synchronize addition of documents (bad idea), or use some AtomicInteger for each partition to "reserve" document ids before the actual document is added.

I figured out that the labelscan index seems to have the same problem, but I don't understand the partitioning there. It also has not 10% buffer, so i don't understand why it did not break at some point. Maybe because it never does deletes or updates (although it uses IndexWriter.updateDocument)?

Further steps would be to use TieredMergePolicy instead of outdated LogByteSizeMergePolicy - but this is unrelated to this issue.