### PR TITLE
Trace causes of page cursor errors from file closed

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -71,6 +71,9 @@ final class MuninnPagedFile implements PagedFile
     // Guarded by the monitor lock on MuninnPageCache (map and unmap)
     private boolean deleteOnClose;
 
+    // Used to trace the causes of any exceptions from getLastPageId.
+    private volatile Exception closeStackTrace;
+
     /**
      * The header state includes both the reference count of the PagedFile – 15 bits – and the ID of the last page in
      * the file – 48 bits, plus an empty file marker bit. Because our pages are usually 2^13 bytes, this means that we
@@ -199,6 +202,10 @@ final class MuninnPagedFile implements PagedFile
 
     void closeSwapper() throws IOException
     {
+        // We don't set closeStackTrace in close(), because the reference count may keep the file open.
+        // But if we get here, to close the swapper, then we are definitely unmapping!
+        closeStackTrace = new Exception( "tracing paged file closing" );
+
         if ( !deleteOnClose )
         {
             swapper.close();
@@ -377,7 +384,14 @@ final class MuninnPagedFile implements PagedFile
         long state = getHeaderState();
         if ( refCountOf( state ) == 0 )
         {
-            throw new IllegalStateException( "File has been unmapped: " + file().getPath() );
+            String msg = "File has been unmapped: " + file().getPath();
+            IllegalStateException exception = new IllegalStateException( msg );
+            Exception closedBy = closeStackTrace;
+            if ( closedBy != null )
+            {
+                exception.addSuppressed( closedBy );
+            }
+            throw exception;
         }
         return state & headerStateLastPageIdMask;
     }


### PR DESCRIPTION
Closing a paged file will now record its stack trace in an exception, and if
a page cursor runs into trouble because it is operating on a file that has been
unmapped, then the IllegalStateException will now also contain the file closed
trace exception as a suppressed exception. This allows us to see where and why
a file was closed, and give us clues as to why we still have a cursor on such
a file.