### PR TITLE
Store migration support for block devices

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -30,7 +30,7 @@ import org.neo4j.io.pagecache.PageCursor;
  */
 public class DelegatingPageCursor extends PageCursor
 {
-    private final PageCursor delegate;
+    protected final PageCursor delegate;
 
     public byte getByte()
     {
@@ -220,6 +220,10 @@ public class DelegatingPageCursor extends PageCursor
     public boolean shouldRetry() throws IOException
     {
         return delegate.shouldRetry();
+    }
+
+    public PageCursor unwrap( ) {
+        return delegate;
     }
 
     public DelegatingPageCursor( PageCursor delegate )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -432,6 +432,12 @@ public class MuninnPageCache implements PageCache
             }
 
             @Override
+            public String toString()
+            {
+                return fileHandle.toString();
+            }
+
+            @Override
             public void delete() throws IOException
             {
                 synchronized ( MuninnPageCache.this )

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialReadPageCursor.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.neo4j.adversaries.Adversary;
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 /**
@@ -57,7 +58,7 @@ import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
  * See {@link org.neo4j.io.pagecache.PagedFile#PF_SHARED_READ_LOCK} flag.
  */
 @SuppressWarnings( "unchecked" )
-class AdversarialReadPageCursor extends PageCursor
+class AdversarialReadPageCursor extends DelegatingPageCursor
 {
     private static final boolean enableInconsistencyTracing = FeatureToggles.flag(
             AdversarialReadPageCursor.class, "enableInconsistencyTracing", false );
@@ -167,19 +168,18 @@ class AdversarialReadPageCursor extends PageCursor
         }
     }
 
-    private final PageCursor delegate;
     private AdversarialReadPageCursor linkedCursor;
     private State state;
 
     AdversarialReadPageCursor( PageCursor delegate, Adversary adversary )
     {
-        this.delegate = Objects.requireNonNull( delegate );
+        super( delegate );
         this.state = new State( Objects.requireNonNull( adversary ) );
     }
 
     private AdversarialReadPageCursor( PageCursor delegate, State state )
     {
-        this.delegate = Objects.requireNonNull( delegate );
+        super( delegate );
         this.state = state;
     }
 
@@ -413,7 +413,11 @@ class AdversarialReadPageCursor extends PageCursor
         state.injectFailure( IndexOutOfBoundsException.class );
         if ( !state.isInconsistent() )
         {
-            delegate.copyTo( sourceOffset, targetCursor, targetOffset, lengthInBytes );
+            while ( targetCursor instanceof DelegatingPageCursor )
+            {
+                targetCursor = ((DelegatingPageCursor) targetCursor).unwrap();
+            }
+            return delegate.copyTo( sourceOffset, targetCursor, targetOffset, lengthInBytes );
         }
         return lengthInBytes;
     }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialWritePageCursor.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import org.neo4j.adversaries.Adversary;
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
 
 /**
  * A write {@linkplain PageCursor page cursor} that wraps another page cursor and an {@linkplain Adversary adversary}
@@ -39,15 +40,14 @@ import org.neo4j.io.pagecache.PageCursor;
  * See {@link org.neo4j.io.pagecache.PagedFile#PF_SHARED_WRITE_LOCK} flag.
  */
 @SuppressWarnings( "unchecked" )
-class AdversarialWritePageCursor extends PageCursor
+class AdversarialWritePageCursor extends DelegatingPageCursor
 {
-    private final PageCursor delegate;
     private final Adversary adversary;
     private AdversarialWritePageCursor linkedCursor;
 
     AdversarialWritePageCursor( PageCursor delegate, Adversary adversary )
     {
-        this.delegate = Objects.requireNonNull( delegate );
+        super( delegate );
         this.adversary = Objects.requireNonNull( adversary );
     }
 
@@ -264,6 +264,10 @@ class AdversarialWritePageCursor extends PageCursor
     public int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes )
     {
         adversary.injectFailure( IndexOutOfBoundsException.class );
+        while ( targetCursor instanceof DelegatingPageCursor )
+        {
+            targetCursor = ((DelegatingPageCursor) targetCursor).unwrap();
+        }
         return delegate.copyTo( sourceOffset, targetCursor, targetOffset, lengthInBytes );
     }
 

--- a/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
@@ -220,13 +220,18 @@ public class TestDirectory implements TestRule
         {
             owningTest = description.getTestClass();
         }
-        evaluateClassBaseTestFolder();
         String test = description.getMethodName();
         if ( test == null )
         {
             test = "static";
         }
+        return prepareDirectoryForTest( test );
+    }
+
+    public File prepareDirectoryForTest( String test ) throws IOException
+    {
         String dir = Digests.md5Hex( test );
+        evaluateClassBaseTestFolder();
         register( test, dir );
         return cleanDirectory( dir );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormatSelector.java
@@ -262,7 +262,11 @@ public class RecordFormatSelector
         }
     }
 
-    private static Iterable<RecordFormats> allFormats()
+    /**
+     * Gets all {@link RecordFormats} that the selector is aware of.
+     * @return An iterable over all known record formats.
+     */
+    public static Iterable<RecordFormats> allFormats()
     {
         Iterable<RecordFormats.Factory> loadableFormatFactories = Service.load( RecordFormats.Factory.class );
         Iterable<RecordFormats> loadableFormats = map( RecordFormats.Factory::newInstance, loadableFormatFactories );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
@@ -84,7 +84,7 @@ public class DatabaseMigrator
         UpgradableDatabase upgradableDatabase =
                 new UpgradableDatabase( fs, new StoreVersionCheck( pageCache ), new LegacyStoreVersionCheck( fs ),
                         format );
-        StoreUpgrader storeUpgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, config, fs,
+        StoreUpgrader storeUpgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, config, fs, pageCache,
                 logProvider );
 
         StoreMigrationParticipant schemaMigrator = schemaIndexProvider.storeMigrationParticipant( fs, pageCache,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -32,7 +32,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor.Section;
-import org.neo4j.kernel.impl.util.CustomIOConfigValidator;
 import org.neo4j.kernel.internal.Version;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -116,7 +115,6 @@ public class StoreUpgrader
             throw new UpgradeNotAllowedByConfigurationException();
         }
 
-        CustomIOConfigValidator.assertCustomIOConfigNotUsed( config, CUSTOM_IO_EXCEPTION_MESSAGE );
 
         // One or more participants would like to do migration
         progressMonitor.started();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -24,7 +24,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -32,7 +31,6 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.FileHandle;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor.Section;
@@ -258,6 +256,8 @@ public class StoreUpgrader
 
     private void cleanMigrationDirectory( File migrationDirectory )
     {
+        // We use the page cache here to make sure that the migration directory is clean even if we are using a block
+        // device.
         try
         {
             Iterable<FileHandle> fileHandles = pageCache.streamFilesRecursive( migrationDirectory )::iterator;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -260,7 +260,7 @@ public class StoreUpgrader
     {
         try
         {
-            if ( migrationDirectory.exists() )
+            if ( fileSystem.fileExists( migrationDirectory ) )
             {
                 fileSystem.deleteRecursively( migrationDirectory );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogFilenames.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogFilenames.java
@@ -29,7 +29,7 @@ public class LegacyLogFilenames
     private static final String[] allLegacyLogFilesPatterns =
             {"active_tx_log", "tm_tx_log\\..*", "nioneo_logical\\.log\\..*"};
 
-    static final FilenameFilter versionedLegacyLogFilesFilter = new FilenameFilter()
+    public static final FilenameFilter versionedLegacyLogFilesFilter = new FilenameFilter()
     {
         @Override
         public boolean accept( File dir, String name )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -161,7 +161,7 @@ public class ParallelBatchImporter implements BatchImporter
         CountingStoreUpdateMonitor storeUpdateMonitor = new CountingStoreUpdateMonitor();
         try ( BatchingNeoStores neoStore = getBatchingNeoStores();
               CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(
-                      neoStore.getLastCommittedTransactionId() );
+                    neoStore.getLastCommittedTransactionId() );
               InputCache inputCache = new InputCache( fileSystem, storeDir, recordFormats, config ) )
         {
             Collector badCollector = input.badCollector();
@@ -256,11 +256,16 @@ public class ParallelBatchImporter implements BatchImporter
 
     private BatchingNeoStores getBatchingNeoStores()
     {
-        return (pageCache ==  null)
-              ? BatchingNeoStores.batchingNeoStores( fileSystem, storeDir, recordFormats, config, logService,
-                      additionalInitialIds, dbConfig )
-              : BatchingNeoStores.batchingNeoStoresWithExternalPageCache( fileSystem, pageCache, PageCacheTracer.NULL,
-                      storeDir, recordFormats, config, logService, additionalInitialIds, dbConfig );
+        if ( pageCache == null )
+        {
+            return BatchingNeoStores.batchingNeoStores( fileSystem, storeDir, recordFormats, config, logService,
+                    additionalInitialIds, dbConfig );
+        }
+        else
+        {
+            return BatchingNeoStores.batchingNeoStoresWithExternalPageCache( fileSystem, pageCache,
+                    PageCacheTracer.NULL, storeDir, recordFormats, config, logService, additionalInitialIds, dbConfig );
+        }
     }
 
     private long totalMemoryUsageOf( MemoryStatsVisitor.Visitable... users )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -87,7 +87,7 @@ public class RelationshipGroupDefragmenterTest
     @Before
     public void start()
     {
-        stores = new BatchingNeoStores( new DefaultFileSystemAbstraction(),
+        stores = BatchingNeoStores.batchingNeoStores( new DefaultFileSystemAbstraction(),
                 directory.absolutePath(), format, CONFIG, NullLogService.getInstance(),
                 AdditionalInitialIds.EMPTY, Config.defaults() );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
@@ -70,8 +70,8 @@ public class BatchingNeoStoresTest
         {
             RecordFormats recordFormats = RecordFormatSelector.selectForConfig( Config.empty(),
                     NullLogProvider.getInstance() );
-            BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT, NullLogService.getInstance(), EMPTY,
-                    Config.empty() );
+            BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT,
+                    NullLogService.getInstance(), EMPTY, Config.empty() );
             fail( "Should fail on existing data" );
         }
         catch ( IllegalStateException e )
@@ -93,8 +93,8 @@ public class BatchingNeoStoresTest
         // WHEN
         RecordFormats recordFormats = StandardV3_0.RECORD_FORMATS;
         int headerSize = recordFormats.dynamic().getRecordHeaderSize();
-        try ( BatchingNeoStores store = BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT,
-                NullLogService.getInstance(), EMPTY, config ) )
+        try ( BatchingNeoStores store = BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats,
+                DEFAULT, NullLogService.getInstance(), EMPTY, config ) )
         {
             // THEN
             assertEquals( size + headerSize, store.getPropertyStore().getArrayStore().getRecordSize() );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
@@ -70,7 +70,7 @@ public class BatchingNeoStoresTest
         {
             RecordFormats recordFormats = RecordFormatSelector.selectForConfig( Config.empty(),
                     NullLogProvider.getInstance() );
-            new BatchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT, NullLogService.getInstance(), EMPTY,
+            BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT, NullLogService.getInstance(), EMPTY,
                     Config.empty() );
             fail( "Should fail on existing data" );
         }
@@ -93,7 +93,7 @@ public class BatchingNeoStoresTest
         // WHEN
         RecordFormats recordFormats = StandardV3_0.RECORD_FORMATS;
         int headerSize = recordFormats.dynamic().getRecordHeaderSize();
-        try ( BatchingNeoStores store = new BatchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT,
+        try ( BatchingNeoStores store = BatchingNeoStores.batchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT,
                 NullLogService.getInstance(), EMPTY, config ) )
         {
             // THEN

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -30,6 +30,8 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_0;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_1;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -58,9 +60,29 @@ public class PlatformConstraintStoreUpgradeTest
     }
 
     @Test
-    public void shouldFailToStartWithCustomIOConfigurationTest() throws IOException
+    public void shouldFailToStartWithCustomIOConfigurationTest20() throws IOException
     {
-        prepareSampleLegacyDatabase( StandardV2_2.STORE_VERSION, fileSystem, workingDir, prepareDir );
+        String storeVersion = StandardV2_0.STORE_VERSION;
+        checkForStoreVersion( storeVersion );
+    }
+
+    @Test
+    public void shouldFailToStartWithCustomIOConfigurationTest21() throws IOException
+    {
+        String storeVersion = StandardV2_1.STORE_VERSION;
+        checkForStoreVersion( storeVersion );
+    }
+
+    @Test
+    public void shouldFailToStartWithCustomIOConfigurationTest22() throws IOException
+    {
+        String storeVersion = StandardV2_2.STORE_VERSION;
+        checkForStoreVersion( storeVersion );
+    }
+
+    protected void checkForStoreVersion( String storeVersion ) throws IOException
+    {
+        prepareSampleLegacyDatabase( storeVersion, fileSystem, workingDir, prepareDir );
         try
         {
             createGraphDatabaseService();

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -32,6 +32,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
+import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
@@ -68,7 +69,7 @@ public class PlatformConstraintStoreUpgradeTest
         }
         catch ( RuntimeException ex )
         {
-            assertEquals( StoreUpgrader.CUSTOM_IO_EXCEPTION_MESSAGE, ex.getCause().getCause().getMessage() );
+            assertEquals( StoreMigrator.CUSTOM_IO_EXCEPTION_MESSAGE, ex.getCause().getCause().getMessage() );
         }
     }
 

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
-import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -225,7 +225,7 @@ public class StoreUpgraderInterruptionTestIT
                 .allow_store_upgrade.name(), "true" ) );
 
         StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowUpgrade, fs,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance() );
         upgrader.addParticipant( indexMigrator );
         upgrader.addParticipant( migrator );
         return upgrader;

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -131,7 +131,7 @@ public class StoreUpgraderInterruptionTestIT
 
         try
         {
-            newUpgrader( upgradableDatabase, progressMonitor, createIndexMigrator(), failingStoreMigrator )
+            newUpgrader( upgradableDatabase, pageCache, progressMonitor, createIndexMigrator(), failingStoreMigrator )
                     .migrateIfNeeded( workingDirectory );
             fail( "Should throw exception" );
         }
@@ -146,7 +146,8 @@ public class StoreUpgraderInterruptionTestIT
         progressMonitor = new SilentMigrationProgressMonitor();
         StoreMigrator migrator = new StoreMigrator( fs, pageCache, CONFIG, logService, schemaIndexProvider );
         SchemaIndexMigrator indexMigrator = createIndexMigrator();
-        newUpgrader(upgradableDatabase, progressMonitor, indexMigrator, migrator ).migrateIfNeeded( workingDirectory );
+        newUpgrader(upgradableDatabase, pageCache, progressMonitor, indexMigrator, migrator ).migrateIfNeeded(
+                workingDirectory );
 
         assertTrue( checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
         assertTrue( allStoreFilesHaveNoTrailer( fs, workingDirectory ) );
@@ -190,7 +191,7 @@ public class StoreUpgraderInterruptionTestIT
 
         try
         {
-            newUpgrader( upgradableDatabase, progressMonitor, createIndexMigrator(), failingStoreMigrator )
+            newUpgrader( upgradableDatabase, pageCache, progressMonitor, createIndexMigrator(), failingStoreMigrator )
                     .migrateIfNeeded( workingDirectory );
             fail( "Should throw exception" );
         }
@@ -204,7 +205,7 @@ public class StoreUpgraderInterruptionTestIT
 
         progressMonitor = new SilentMigrationProgressMonitor();
         StoreMigrator migrator = new StoreMigrator( fs, pageCache, CONFIG, logService, schemaIndexProvider );
-        newUpgrader( upgradableDatabase, progressMonitor, createIndexMigrator(), migrator )
+        newUpgrader( upgradableDatabase, pageCache, progressMonitor, createIndexMigrator(), migrator )
                 .migrateIfNeeded( workingDirectory );
 
         assertTrue( checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
@@ -217,15 +218,13 @@ public class StoreUpgraderInterruptionTestIT
         assertConsistentStore( workingDirectory );
     }
 
-    private StoreUpgrader newUpgrader(UpgradableDatabase upgradableDatabase, MigrationProgressMonitor progressMonitor,
-            SchemaIndexMigrator indexMigrator,
-            StoreMigrator migrator )
+    private StoreUpgrader newUpgrader( UpgradableDatabase upgradableDatabase, PageCache pageCache,
+            MigrationProgressMonitor progressMonitor, SchemaIndexMigrator indexMigrator, StoreMigrator migrator )
     {
-        Config allowUpgrade = new Config( stringMap( GraphDatabaseSettings
-                .allow_store_upgrade.name(), "true" ) );
+        Config allowUpgrade = new Config( stringMap( GraphDatabaseSettings.allow_store_upgrade.name(), "true" ) );
 
-        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowUpgrade, fs,
-                pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance() );
+        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowUpgrade, fs, pageCache,
+                NullLogProvider.getInstance() );
         upgrader.addParticipant( indexMigrator );
         upgrader.addParticipant( migrator );
         return upgrader;

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -199,7 +199,7 @@ public class StoreUpgraderTest
         StoreMigrator defaultMigrator = new StoreMigrator( fs, pageCache, getTuningConfig(), NullLogService.getInstance(),
                 schemaIndexProvider );
         StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowMigrateConfig, fs,
-                NullLogProvider.getInstance() );
+                pageCache, NullLogProvider.getInstance() );
         upgrader.addParticipant( defaultMigrator );
 
         expectedException.expect( UnableToUpgradeException.class );
@@ -510,7 +510,7 @@ public class StoreUpgraderTest
         SchemaIndexMigrator indexMigrator =
                 new SchemaIndexMigrator( fileSystem, schemaIndexProvider, labelScanStoreProvider );
 
-        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, config, fileSystem,
+        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, config, fileSystem, pageCache,
                 NullLogProvider.getInstance() );
         upgrader.addParticipant( indexMigrator );
         upgrader.addParticipant( defaultMigrator );

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -69,6 +69,7 @@ import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnableToUpgradeExcepti
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.UpgradableDatabase;
 import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
+import org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
@@ -168,14 +169,11 @@ public class StoreUpgraderTest
             @Override
             public File[] listFiles( File directory, FilenameFilter filter )
             {
-                sneakyThrow( new IOException( "Enforced IO Exception Fail to open file" ) );
+                if ( filter == LegacyLogFilenames.versionedLegacyLogFilesFilter )
+                {
+                    sneakyThrow( new IOException( "Enforced IO Exception Fail to open file" ) );
+                }
                 return super.listFiles( directory, filter );
-            }
-
-            @Override
-            public boolean fileExists( File fileName )
-            {
-                return true;
             }
         };
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFactory.java
@@ -27,7 +27,7 @@ public class HighLimitFactory extends RecordFormats.Factory
 {
     public HighLimitFactory()
     {
-        super( HighLimit.NAME );
+        super( HighLimit.NAME, HighLimit.STORE_VERSION );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitFactoryV3_0_0.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v300/HighLimitFactoryV3_0_0.java
@@ -27,7 +27,7 @@ public class HighLimitFactoryV3_0_0 extends RecordFormats.Factory
 {
     public HighLimitFactoryV3_0_0()
     {
-        super( HighLimitV3_0_0.NAME );
+        super( HighLimitV3_0_0.NAME, HighLimitV3_0_0.STORE_VERSION );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitFactoryV3_0_6.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/v306/HighLimitFactoryV3_0_6.java
@@ -27,7 +27,7 @@ public class HighLimitFactoryV3_0_6 extends RecordFormats.Factory
 {
     public HighLimitFactoryV3_0_6()
     {
-        super( HighLimitV3_0_6.NAME );
+        super( HighLimitV3_0_6.NAME, HighLimitV3_0_6.STORE_VERSION );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -25,11 +25,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -54,12 +57,10 @@ import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStoreVersionCheck;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
-import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -76,572 +77,25 @@ public class StoreMigrationIT
     @Rule
     public final TestDirectory testDir = TestDirectory.testDirectory( fileSystemRule.get() );
 
-    public static final String CREATE_QUERY =
-            "CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real " +
-            "World'})\n" +
-            "CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})\n" +
-            "CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})\n" +
-            "CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})\n" +
-            "CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})\n" +
-            "CREATE (AndyW:Person {name:'Andy Wachowski', born:1967})\n" +
-            "CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})\n" +
-            "CREATE (JoelS:Person {name:'Joel Silver', born:1952})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),\n" +
-            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),\n" +
-            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),\n" +
-            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),\n" +
-            "  (AndyW)-[:DIRECTED]->(TheMatrix),\n" +
-            "  (LanaW)-[:DIRECTED]->(TheMatrix),\n" +
-            "  (JoelS)-[:PRODUCED]->(TheMatrix)\n" +
-            "  \n" +
-            "CREATE (Emil:Person {name:\"Emil Eifrem\", born:1978})\n" +
-            "CREATE (Emil)-[:ACTED_IN {roles:[\"Emil\"]}]->(TheMatrix)\n" +
-            "\n" +
-            "CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free" +
-            " your mind'})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),\n" +
-            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),\n" +
-            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),\n" +
-            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),\n" +
-            "  (AndyW)-[:DIRECTED]->(TheMatrixReloaded),\n" +
-            "  (LanaW)-[:DIRECTED]->(TheMatrixReloaded),\n" +
-            "  (JoelS)-[:PRODUCED]->(TheMatrixReloaded)\n" +
-            "  \n" +
-            "CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, " +
-            "tagline:'Everything that has a beginning has an end'})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),\n" +
-            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),\n" +
-            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),\n" +
-            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),\n" +
-            "  (AndyW)-[:DIRECTED]->(TheMatrixRevolutions),\n" +
-            "  (LanaW)-[:DIRECTED]->(TheMatrixRevolutions),\n" +
-            "  (JoelS)-[:PRODUCED]->(TheMatrixRevolutions)\n" +
-            "  \n" +
-            "CREATE (TheDevilsAdvocate:Movie {title:\"The Devil's Advocate\", released:1997, " +
-            "tagline:'Evil has its winning ways'})\n" +
-            "CREATE (Charlize:Person {name:'Charlize Theron', born:1975})\n" +
-            "CREATE (Al:Person {name:'Al Pacino', born:1940})\n" +
-            "CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),\n" +
-            "  (Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),\n" +
-            "  (Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),\n" +
-            "  (Taylor)-[:DIRECTED]->(TheDevilsAdvocate)\n" +
-            "  \n" +
-            "CREATE (AFewGoodMen:Movie {title:\"A Few Good Men\", released:1992, tagline:\"In the heart" +
-            " of the nation's capital, in a courthouse of the U.S. government, one man will stop at " +
-            "nothing to keep his honor, and one will stop at nothing to find the truth.\"})\n" +
-            "CREATE (TomC:Person {name:'Tom Cruise', born:1962})\n" +
-            "CREATE (JackN:Person {name:'Jack Nicholson', born:1937})\n" +
-            "CREATE (DemiM:Person {name:'Demi Moore', born:1962})\n" +
-            "CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})\n" +
-            "CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})\n" +
-            "CREATE (NoahW:Person {name:'Noah Wyle', born:1971})\n" +
-            "CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})\n" +
-            "CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})\n" +
-            "CREATE (JTW:Person {name:'J.T. Walsh', born:1943})\n" +
-            "CREATE (JamesM:Person {name:'James Marshall', born:1967})\n" +
-            "CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})\n" +
-            "CREATE (RobR:Person {name:'Rob Reiner', born:1947})\n" +
-            "CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})\n" +
-            "CREATE\n" +
-            "  (TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),\n" +
-            "  (JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),\n" +
-            "  (DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),\n" +
-            "  (KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),\n" +
-            "  (KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),\n" +
-            "  (NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),\n" +
-            "  (CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),\n" +
-            "  (KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),\n" +
-            "  (JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),\n" +
-            "  (JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),\n" +
-            "  (ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),\n" +
-            "  (AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),\n" +
-            "  (RobR)-[:DIRECTED]->(AFewGoodMen),\n" +
-            "  (AaronS)-[:WROTE]->(AFewGoodMen)\n" +
-            "  \n" +
-            "CREATE (TopGun:Movie {title:\"Top Gun\", released:1986, tagline:'I feel the need, the need" +
-            " for speed.'})\n" +
-            "CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})\n" +
-            "CREATE (ValK:Person {name:'Val Kilmer', born:1959})\n" +
-            "CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})\n" +
-            "CREATE (TomS:Person {name:'Tom Skerritt', born:1933})\n" +
-            "CREATE (MegR:Person {name:'Meg Ryan', born:1961})\n" +
-            "CREATE (TonyS:Person {name:'Tony Scott', born:1944})\n" +
-            "CREATE (JimC:Person {name:'Jim Cash', born:1941})\n" +
-            "CREATE\n" +
-            "  (TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),\n" +
-            "  (KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),\n" +
-            "  (ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),\n" +
-            "  (AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),\n" +
-            "  (TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),\n" +
-            "  (MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),\n" +
-            "  (TonyS)-[:DIRECTED]->(TopGun),\n" +
-            "  (JimC)-[:WROTE]->(TopGun)\n" +
-            "  \n" +
-            "CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his" +
-            " life begins now.'})\n" +
-            "CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})\n" +
-            "CREATE (KellyP:Person {name:'Kelly Preston', born:1962})\n" +
-            "CREATE (JerryO:Person {name:\"Jerry O'Connell\", born:1974})\n" +
-            "CREATE (JayM:Person {name:'Jay Mohr', born:1970})\n" +
-            "CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})\n" +
-            "CREATE (ReginaK:Person {name:'Regina King', born:1971})\n" +
-            "CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})\n" +
-            "CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})\n" +
-            "CREATE\n" +
-            "  (TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),\n" +
-            "  (CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),\n" +
-            "  (ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),\n" +
-            "  (KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),\n" +
-            "  (JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),\n" +
-            "  (JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),\n" +
-            "  (BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),\n" +
-            "  (ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),\n" +
-            "  (JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),\n" +
-            "  (CameronC)-[:DIRECTED]->(JerryMaguire),\n" +
-            "  (CameronC)-[:PRODUCED]->(JerryMaguire),\n" +
-            "  (CameronC)-[:WROTE]->(JerryMaguire)\n" +
-            "  \n" +
-            "CREATE (StandByMe:Movie {title:\"Stand By Me\", released:1986, tagline:\"For some, it's " +
-            "the last real taste of innocence, and the first real taste of life. But for everyone, it's" +
-            " the time that memories are made of.\"})\n" +
-            "CREATE (RiverP:Person {name:'River Phoenix', born:1970})\n" +
-            "CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})\n" +
-            "CREATE (WilW:Person {name:'Wil Wheaton', born:1972})\n" +
-            "CREATE (JohnC:Person {name:'John Cusack', born:1966})\n" +
-            "CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})\n" +
-            "CREATE\n" +
-            "  (WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),\n" +
-            "  (RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),\n" +
-            "  (JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),\n" +
-            "  (CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),\n" +
-            "  (JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),\n" +
-            "  (KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),\n" +
-            "  (MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),\n" +
-            "  (RobR)-[:DIRECTED]->(StandByMe)\n" +
-            "  \n" +
-            "CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy" +
-            " from the heart that goes for the throat.'})\n" +
-            "CREATE (HelenH:Person {name:'Helen Hunt', born:1963})\n" +
-            "CREATE (GregK:Person {name:'Greg Kinnear', born:1963})\n" +
-            "CREATE (JamesB:Person {name:'James L. Brooks', born:1940})\n" +
-            "CREATE\n" +
-            "  (JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),\n" +
-            "  (HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),\n" +
-            "  (GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),\n" +
-            "  (CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),\n" +
-            "  (JamesB)-[:DIRECTED]->(AsGoodAsItGets)\n" +
-            "  \n" +
-            "CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, " +
-            "tagline:'After life there is more. The end is just the beginning.'})\n" +
-            "CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})\n" +
-            "CREATE (MaxS:Person {name:'Max von Sydow', born:1929})\n" +
-            "CREATE (WernerH:Person {name:'Werner Herzog', born:1942})\n" +
-            "CREATE (Robin:Person {name:'Robin Williams', born:1951})\n" +
-            "CREATE (VincentW:Person {name:'Vincent Ward', born:1956})\n" +
-            "CREATE\n" +
-            "  (Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),\n" +
-            "  (CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),\n" +
-            "  (AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),\n" +
-            "  (MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),\n" +
-            "  (WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),\n" +
-            "  (VincentW)-[:DIRECTED]->(WhatDreamsMayCome)\n" +
-            "  \n" +
-            "CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, " +
-            "tagline:'First loves last. Forever.'})\n" +
-            "CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})\n" +
-            "CREATE (RickY:Person {name:'Rick Yune', born:1971})\n" +
-            "CREATE (JamesC:Person {name:'James Cromwell', born:1940})\n" +
-            "CREATE (ScottH:Person {name:'Scott Hicks', born:1953})\n" +
-            "CREATE\n" +
-            "  (EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),\n" +
-            "  (RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),\n" +
-            "  (MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),\n" +
-            "  (JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),\n" +
-            "  (ScottH)-[:DIRECTED]->(SnowFallingonCedars)\n" +
-            "  \n" +
-            "CREATE (YouveGotMail:Movie {title:\"You've Got Mail\", released:1998, tagline:'At odds in " +
-            "life... in love on-line.'})\n" +
-            "CREATE (ParkerP:Person {name:'Parker Posey', born:1968})\n" +
-            "CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})\n" +
-            "CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})\n" +
-            "CREATE (TomH:Person {name:'Tom Hanks', born:1956})\n" +
-            "CREATE (NoraE:Person {name:'Nora Ephron', born:1941})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),\n" +
-            "  (MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),\n" +
-            "  (GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),\n" +
-            "  (ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),\n" +
-            "  (DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),\n" +
-            "  (SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),\n" +
-            "  (NoraE)-[:DIRECTED]->(YouveGotMail)\n" +
-            "  \n" +
-            "CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, " +
-            "tagline:'What if someone you never met, someone you never saw, someone you never knew was " +
-            "the only someone for you?'})\n" +
-            "CREATE (RitaW:Person {name:'Rita Wilson', born:1956})\n" +
-            "CREATE (BillPull:Person {name:'Bill Pullman', born:1953})\n" +
-            "CREATE (VictorG:Person {name:'Victor Garber', born:1949})\n" +
-            "CREATE (RosieO:Person {name:\"Rosie O'Donnell\", born:1962})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),\n" +
-            "  (MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),\n" +
-            "  (RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),\n" +
-            "  (BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),\n" +
-            "  (VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),\n" +
-            "  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),\n" +
-            "  (NoraE)-[:DIRECTED]->(SleeplessInSeattle)\n" +
-            "  \n" +
-            "CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, " +
-            "tagline:'A story of love, lava and burning desire.'})\n" +
-            "CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})\n" +
-            "CREATE (Nathan:Person {name:'Nathan Lane', born:1956})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),\n" +
-            "  (MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->" +
-            "(JoeVersustheVolcano),\n" +
-            "  (Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),\n" +
-            "  (JohnS)-[:DIRECTED]->(JoeVersustheVolcano)\n" +
-            "  \n" +
-            "CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'At " +
-            "odds in life... in love on-line.'})\n" +
-            "CREATE (BillyC:Person {name:'Billy Crystal', born:1948})\n" +
-            "CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})\n" +
-            "CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})\n" +
-            "CREATE\n" +
-            "  (BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),\n" +
-            "  (MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),\n" +
-            "  (CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),\n" +
-            "  (BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),\n" +
-            "  (RobR)-[:DIRECTED]->(WhenHarryMetSally),\n" +
-            "  (RobR)-[:PRODUCED]->(WhenHarryMetSally),\n" +
-            "  (NoraE)-[:PRODUCED]->(WhenHarryMetSally),\n" +
-            "  (NoraE)-[:WROTE]->(WhenHarryMetSally)\n" +
-            "  \n" +
-            "CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every " +
-            "life there comes a time when that thing you dream becomes that thing you do'})\n" +
-            "CREATE (LivT:Person {name:'Liv Tyler', born:1977})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),\n" +
-            "  (LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),\n" +
-            "  (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),\n" +
-            "  (TomH)-[:DIRECTED]->(ThatThingYouDo)\n" +
-            "  \n" +
-            "CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain " +
-            "heals, Chicks dig scars... Glory lasts forever'})\n" +
-            "CREATE (Brooke:Person {name:'Brooke Langton', born:1970})\n" +
-            "CREATE (Gene:Person {name:'Gene Hackman', born:1930})\n" +
-            "CREATE (Orlando:Person {name:'Orlando Jones', born:1968})\n" +
-            "CREATE (Howard:Person {name:'Howard Deutch', born:1950})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),\n" +
-            "  (Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),\n" +
-            "  (Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),\n" +
-            "  (Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),\n" +
-            "  (Howard)-[:DIRECTED]->(TheReplacements)\n" +
-            "  \n" +
-            "CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:\"Based on the " +
-            "extraordinary true story of one man's fight for freedom\"})\n" +
-            "CREATE (ChristianB:Person {name:'Christian Bale', born:1974})\n" +
-            "CREATE (ZachG:Person {name:'Zach Grenier', born:1954})\n" +
-            "CREATE\n" +
-            "  (MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),\n" +
-            "  (ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),\n" +
-            "  (ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),\n" +
-            "  (SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),\n" +
-            "  (WernerH)-[:DIRECTED]->(RescueDawn)\n" +
-            "  \n" +
-            "CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you " +
-            "are'})\n" +
-            "CREATE (MikeN:Person {name:'Mike Nichols', born:1931})\n" +
-            "CREATE\n" +
-            "  (Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),\n" +
-            "  (Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),\n" +
-            "  (Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),\n" +
-            "  (MikeN)-[:DIRECTED]->(TheBirdcage)\n" +
-            "  \n" +
-            "CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:\"It's a hell of a " +
-            "thing, killing a man\"})\n" +
-            "CREATE (RichardH:Person {name:'Richard Harris', born:1930})\n" +
-            "CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})\n" +
-            "CREATE\n" +
-            "  (RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),\n" +
-            "  (ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),\n" +
-            "  (Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),\n" +
-            "  (ClintE)-[:DIRECTED]->(Unforgiven)\n" +
-            "  \n" +
-            "CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest" +
-            " data on earth. In the coolest head in town'})\n" +
-            "CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})\n" +
-            "CREATE (Dina:Person {name:'Dina Meyer', born:1968})\n" +
-            "CREATE (IceT:Person {name:'Ice-T', born:1958})\n" +
-            "CREATE (RobertL:Person {name:'Robert Longo', born:1953})\n" +
-            "CREATE\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),\n" +
-            "  (Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),\n" +
-            "  (Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),\n" +
-            "  (IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),\n" +
-            "  (RobertL)-[:DIRECTED]->(JohnnyMnemonic)\n" +
-            "  \n" +
-            "CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is " +
-            "connected'})\n" +
-            "CREATE (HalleB:Person {name:'Halle Berry', born:1966})\n" +
-            "CREATE (JimB:Person {name:'Jim Broadbent', born:1949})\n" +
-            "CREATE (TomT:Person {name:'Tom Tykwer', born:1965})\n" +
-            "CREATE (DavidMitchell:Person {name:'David Mitchell', born:1969})\n" +
-            "CREATE (StefanArndt:Person {name:'Stefan Arndt', born:1961})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot " +
-            "Hoggins']}]->(CloudAtlas),\n" +
-            "  (Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse " +
-            "Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),\n" +
-            "  (HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->" +
-            "(CloudAtlas),\n" +
-            "  (JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->" +
-            "(CloudAtlas),\n" +
-            "  (TomT)-[:DIRECTED]->(CloudAtlas),\n" +
-            "  (AndyW)-[:DIRECTED]->(CloudAtlas),\n" +
-            "  (LanaW)-[:DIRECTED]->(CloudAtlas),\n" +
-            "  (DavidMitchell)-[:WROTE]->(CloudAtlas),\n" +
-            "  (StefanArndt)-[:PRODUCED]->(CloudAtlas)\n" +
-            "  \n" +
-            "CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The" +
-            " Codes'})\n" +
-            "CREATE (IanM:Person {name:'Ian McKellen', born:1939})\n" +
-            "CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})\n" +
-            "CREATE (PaulB:Person {name:'Paul Bettany', born:1971})\n" +
-            "CREATE (RonH:Person {name:'Ron Howard', born:1954})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),\n" +
-            "  (IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),\n" +
-            "  (AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),\n" +
-            "  (PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),\n" +
-            "  (RonH)-[:DIRECTED]->(TheDaVinciCode)\n" +
-            "  \n" +
-            "CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! " +
-            "Forever!'})\n" +
-            "CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})\n" +
-            "CREATE (StephenR:Person {name:'Stephen Rea', born:1946})\n" +
-            "CREATE (JohnH:Person {name:'John Hurt', born:1940})\n" +
-            "CREATE (BenM:Person {name: 'Ben Miles', born:1967})\n" +
-            "CREATE\n" +
-            "  (Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),\n" +
-            "  (NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),\n" +
-            "  (StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),\n" +
-            "  (JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),\n" +
-            "  (BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),\n" +
-            "  (JamesM)-[:DIRECTED]->(VforVendetta),\n" +
-            "  (AndyW)-[:PRODUCED]->(VforVendetta),\n" +
-            "  (LanaW)-[:PRODUCED]->(VforVendetta),\n" +
-            "  (JoelS)-[:PRODUCED]->(VforVendetta),\n" +
-            "  (AndyW)-[:WROTE]->(VforVendetta),\n" +
-            "  (LanaW)-[:WROTE]->(VforVendetta)\n" +
-            "  \n" +
-            "CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no " +
-            "limits'})\n" +
-            "CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})\n" +
-            "CREATE (JohnG:Person {name:'John Goodman', born:1960})\n" +
-            "CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})\n" +
-            "CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})\n" +
-            "CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})\n" +
-            "CREATE (Rain:Person {name:'Rain', born:1982})\n" +
-            "CREATE\n" +
-            "  (EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),\n" +
-            "  (JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),\n" +
-            "  (SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),\n" +
-            "  (MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),\n" +
-            "  (ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),\n" +
-            "  (Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),\n" +
-            "  (BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),\n" +
-            "  (AndyW)-[:DIRECTED]->(SpeedRacer),\n" +
-            "  (LanaW)-[:DIRECTED]->(SpeedRacer),\n" +
-            "  (AndyW)-[:WROTE]->(SpeedRacer),\n" +
-            "  (LanaW)-[:WROTE]->(SpeedRacer),\n" +
-            "  (JoelS)-[:PRODUCED]->(SpeedRacer)\n" +
-            "  \n" +
-            "CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to " +
-            "enter a secret world of assassins'})\n" +
-            "CREATE (NaomieH:Person {name:'Naomie Harris'})\n" +
-            "CREATE\n" +
-            "  (Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),\n" +
-            "  (NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),\n" +
-            "  (RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),\n" +
-            "  (BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),\n" +
-            "  (JamesM)-[:DIRECTED]->(NinjaAssassin),\n" +
-            "  (AndyW)-[:PRODUCED]->(NinjaAssassin),\n" +
-            "  (LanaW)-[:PRODUCED]->(NinjaAssassin),\n" +
-            "  (JoelS)-[:PRODUCED]->(NinjaAssassin)\n" +
-            "  \n" +
-            "CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:\"Walk a mile " +
-            "you'll never forget.\"})\n" +
-            "CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})\n" +
-            "CREATE (DavidM:Person {name:'David Morse', born:1953})\n" +
-            "CREATE (SamR:Person {name:'Sam Rockwell', born:1968})\n" +
-            "CREATE (GaryS:Person {name:'Gary Sinise', born:1955})\n" +
-            "CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})\n" +
-            "CREATE (FrankD:Person {name:'Frank Darabont', born:1959})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),\n" +
-            "  (MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),\n" +
-            "  (DavidM)-[:ACTED_IN {roles:['Brutus \"Brutal\" Howell']}]->(TheGreenMile),\n" +
-            "  (BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),\n" +
-            "  (JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),\n" +
-            "  (SamR)-[:ACTED_IN {roles:['\"Wild Bill\" Wharton']}]->(TheGreenMile),\n" +
-            "  (GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),\n" +
-            "  (PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),\n" +
-            "  (FrankD)-[:DIRECTED]->(TheGreenMile)\n" +
-            "  \n" +
-            "CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people " +
-            "were waiting for the truth.'})\n" +
-            "CREATE (FrankL:Person {name:'Frank Langella', born:1938})\n" +
-            "CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})\n" +
-            "CREATE (OliverP:Person {name:'Oliver Platt', born:1960})\n" +
-            "CREATE\n" +
-            "  (FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),\n" +
-            "  (MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),\n" +
-            "  (KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),\n" +
-            "  (OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),\n" +
-            "  (SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),\n" +
-            "  (RonH)-[:DIRECTED]->(FrostNixon)\n" +
-            "  \n" +
-            "CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:\"He didn't want law. He wanted" +
-            " justice.\"})\n" +
-            "CREATE (DannyD:Person {name:'Danny DeVito', born:1944})\n" +
-            "CREATE (JohnR:Person {name:'John C. Reilly', born:1965})\n" +
-            "CREATE\n" +
-            "  (JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),\n" +
-            "  (DannyD)-[:ACTED_IN {roles:['Robert \"Bobby\" Ciaro']}]->(Hoffa),\n" +
-            "  (JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),\n" +
-            "  (JohnR)-[:ACTED_IN {roles:['Peter \"Pete\" Connelly']}]->(Hoffa),\n" +
-            "  (DannyD)-[:DIRECTED]->(Hoffa)\n" +
-            "  \n" +
-            "CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a " +
-            "problem.'})\n" +
-            "CREATE (EdH:Person {name:'Ed Harris', born:1950})\n" +
-            "CREATE (BillPax:Person {name:'Bill Paxton', born:1955})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),\n" +
-            "  (KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),\n" +
-            "  (EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),\n" +
-            "  (BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),\n" +
-            "  (GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),\n" +
-            "  (RonH)-[:DIRECTED]->(Apollo13)\n" +
-            "  \n" +
-            "CREATE (Twister:Movie {title:'Twister', released:1996, tagline:\"Don't Breathe. Don't Look" +
-            " Back.\"})\n" +
-            "CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})\n" +
-            "CREATE (JanB:Person {name:'Jan de Bont', born:1943})\n" +
-            "CREATE\n" +
-            "  (BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),\n" +
-            "  (HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),\n" +
-            "  (ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),\n" +
-            "  (PhilipH)-[:ACTED_IN {roles:['Dustin \"Dusty\" Davis']}]->(Twister),\n" +
-            "  (JanB)-[:DIRECTED]->(Twister)\n" +
-            "  \n" +
-            "CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the " +
-            "world, his journey begins.'})\n" +
-            "CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),\n" +
-            "  (HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),\n" +
-            "  (RobertZ)-[:DIRECTED]->(CastAway)\n" +
-            "  \n" +
-            "CREATE (OneFlewOvertheCuckoosNest:Movie {title:\"One Flew Over the Cuckoo's Nest\", " +
-            "released:1975, tagline:\"If he's crazy, what does that make you?\"})\n" +
-            "CREATE (MilosF:Person {name:'Milos Forman', born:1932})\n" +
-            "CREATE\n" +
-            "  (JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),\n" +
-            "  (DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),\n" +
-            "  (MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)\n" +
-            "  \n" +
-            "CREATE (SomethingsGottaGive:Movie {title:\"Something's Gotta Give\", released:2003})\n" +
-            "CREATE (DianeK:Person {name:'Diane Keaton', born:1946})\n" +
-            "CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})\n" +
-            "CREATE\n" +
-            "  (JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),\n" +
-            "  (DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),\n" +
-            "  (Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),\n" +
-            "  (NancyM)-[:DIRECTED]->(SomethingsGottaGive),\n" +
-            "  (NancyM)-[:PRODUCED]->(SomethingsGottaGive),\n" +
-            "  (NancyM)-[:WROTE]->(SomethingsGottaGive)\n" +
-            "  \n" +
-            "CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:\"One " +
-            "robot's 200 year journey to become an ordinary man.\"})\n" +
-            "CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})\n" +
-            "CREATE\n" +
-            "  (Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),\n" +
-            "  (OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),\n" +
-            "  (ChrisC)-[:DIRECTED]->(BicentennialMan)\n" +
-            "  \n" +
-            "CREATE (CharlieWilsonsWar:Movie {title:\"Charlie Wilson's War\", released:2007, " +
-            "tagline:\"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring " +
-            "down the Soviet empire.\"})\n" +
-            "CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),\n" +
-            "  (JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),\n" +
-            "  (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),\n" +
-            "  (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)\n" +
-            "  \n" +
-            "CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This " +
-            "Holiday Season… Believe'})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa " +
-            "Claus']}]->(ThePolarExpress),\n" +
-            "  (RobertZ)-[:DIRECTED]->(ThePolarExpress)\n" +
-            "  \n" +
-            "CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, " +
-            "tagline:'Once in a lifetime you get a chance to do something different.'})\n" +
-            "CREATE (Madonna:Person {name:'Madonna', born:1954})\n" +
-            "CREATE (GeenaD:Person {name:'Geena Davis', born:1956})\n" +
-            "CREATE (LoriP:Person {name:'Lori Petty', born:1963})\n" +
-            "CREATE (PennyM:Person {name:'Penny Marshall', born:1943})\n" +
-            "CREATE\n" +
-            "  (TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),\n" +
-            "  (GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),\n" +
-            "  (LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),\n" +
-            "  (RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),\n" +
-            "  (Madonna)-[:ACTED_IN {roles:['\"All the Way\" Mae Mordabito']}]->(ALeagueofTheirOwn),\n" +
-            "  (BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),\n" +
-            "  (PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)\n" +
-            "  \n" +
-            "CREATE (PaulBlythe:Person {name:'Paul Blythe'})\n" +
-            "CREATE (AngelaScope:Person {name:'Angela Scope'})\n" +
-            "CREATE (JessicaThompson:Person {name:'Jessica Thompson'})\n" +
-            "CREATE (JamesThompson:Person {name:'James Thompson'})\n" +
-            "\n" +
-            "CREATE\n" +
-            "  (JamesThompson)-[:FOLLOWS]->(JessicaThompson),\n" +
-            "  (AngelaScope)-[:FOLLOWS]->(JessicaThompson),\n" +
-            "  (PaulBlythe)-[:FOLLOWS]->(AngelaScope)\n" +
-            "  \n" +
-            "CREATE\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements)," +
-            "\n" +
-            "  (JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->" +
-            "(TheReplacements),\n" +
-            "  (AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->" +
-            "(TheReplacements),\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven)," +
-            "\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:\"Slapstick redeemed only by the Robin Williams " +
-            "and Gene Hackman's stellar performances\", rating:45}]->(TheBirdcage),\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),\n" +
-            "  (JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->" +
-            "(TheDaVinciCode),\n" +
-            "  (JessicaThompson)-[:REVIEWED {summary:'You had me at Jerry', rating:92}]->(JerryMaguire)" +
-            "\n" +
-            "  \n" +
-            "WITH TomH as a\n" +
-            "MATCH (a)-[:ACTED_IN]->(m)<-[:DIRECTED]-(d) RETURN a,m,d LIMIT 10\n" +
-            ";";
-    protected final RecordFormats from;
-    protected final RecordFormats to;
+    public static final String CREATE_QUERY = readQuery();
+
+    private static String readQuery()
+    {
+        InputStream in = StoreMigrationIT.class.getClassLoader().getResourceAsStream( "store-migration-data.txt" );
+        String result = new BufferedReader( new InputStreamReader( in ) ).lines().collect( Collectors.joining( "\n" ) );
+        try
+        {
+            in.close();
+        }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    private final RecordFormats from;
+    private final RecordFormats to;
 
     @Parameterized.Parameters( name = "Migrate: {0}->{1}" )
     public static Iterable<Object[]> data() throws IOException
@@ -750,51 +204,42 @@ public class StoreMigrationIT
         database.execute( "CREATE INDEX ON :Person(born)" );
         database.execute( "CREATE CONSTRAINT ON (person:Person) ASSERT exists(person.name)" );
         database.execute( CREATE_QUERY );
-        int beforeNodes;
-        int beforeLabels;
-        int beforeKeys;
-        int beforeRels;
-        int beforeRelTypes;
-        int beforeIndexes;
-        int beforeConstraints;
-        String[] beforeIndexNames;
-        try ( Transaction tx = database.beginTx() )
+        long beforeNodes;
+        long beforeLabels;
+        long beforeKeys;
+        long beforeRels;
+        long beforeRelTypes;
+        long beforeIndexes;
+        long beforeConstraints;
+        try ( Transaction ignore = database.beginTx() )
         {
-            beforeNodes = database.getAllNodes().stream().mapToInt( ( n ) -> 1 ).sum();
-            beforeLabels = database.getAllLabels().stream().mapToInt( ( n ) -> 1 ).sum();
-            beforeKeys = database.getAllPropertyKeys().stream().mapToInt( ( n ) -> 1 ).sum();
-            beforeRels = database.getAllRelationships().stream().mapToInt( ( n ) -> 1 ).sum();
-            beforeRelTypes = database.getAllRelationshipTypes().stream().mapToInt( ( n ) -> 1 ).sum();
-            Stream<IndexDefinition> indexDefinitionStream = StreamSupport
-                    .stream( database.schema().getIndexes().spliterator(), false );
-            beforeIndexes = indexDefinitionStream.mapToInt( ( n ) -> 1 ).sum();
-            Stream<ConstraintDefinition> constraintStream = StreamSupport
-                    .stream( database.schema().getConstraints().spliterator(), false );
-            beforeConstraints = constraintStream.mapToInt( ( n ) -> 1 ).sum();
+            beforeNodes = database.getAllNodes().stream().count();
+            beforeLabels = database.getAllLabels().stream().count();
+            beforeKeys = database.getAllPropertyKeys().stream().count();
+            beforeRels = database.getAllRelationships().stream().count();
+            beforeRelTypes = database.getAllRelationshipTypes().stream().count();
+            beforeIndexes = stream( database.schema().getIndexes() ).count();
+            beforeConstraints = stream( database.schema().getConstraints() ).count();
         }
         database.shutdown();
 
         database = getGraphDatabaseService( db, to.storeVersion() );
-        int afterNodes;
-        int afterLabels;
-        int afterKeys;
-        int afterRels;
-        int afterRelTypes;
-        int afterIndexes;
-        int afterConstraints;
-        try ( Transaction tx = database.beginTx() )
+        long afterNodes;
+        long afterLabels;
+        long afterKeys;
+        long afterRels;
+        long afterRelTypes;
+        long afterIndexes;
+        long afterConstraints;
+        try ( Transaction ignore = database.beginTx() )
         {
-            afterNodes = database.getAllNodes().stream().mapToInt( ( n ) -> 1 ).sum();
-            afterLabels = database.getAllLabels().stream().mapToInt( ( n ) -> 1 ).sum();
-            afterKeys = database.getAllPropertyKeys().stream().mapToInt( ( n ) -> 1 ).sum();
-            afterRels = database.getAllRelationships().stream().mapToInt( ( n ) -> 1 ).sum();
-            afterRelTypes = database.getAllRelationshipTypes().stream().mapToInt( ( n ) -> 1 ).sum();
-            Stream<IndexDefinition> indexDefinitionStream = StreamSupport
-                    .stream( database.schema().getIndexes().spliterator(), false );
-            afterIndexes = indexDefinitionStream.mapToInt( ( n ) -> 1 ).sum();
-            Stream<ConstraintDefinition> constraintStream = StreamSupport
-                    .stream( database.schema().getConstraints().spliterator(), false );
-            afterConstraints = constraintStream.mapToInt( ( n ) -> 1 ).sum();
+            afterNodes = database.getAllNodes().stream().count();
+            afterLabels = database.getAllLabels().stream().count();
+            afterKeys = database.getAllPropertyKeys().stream().count();
+            afterRels = database.getAllRelationships().stream().count();
+            afterRelTypes = database.getAllRelationshipTypes().stream().count();
+            afterIndexes = stream( database.schema().getIndexes() ).count();
+            afterConstraints = stream( database.schema().getConstraints() ).count();
         }
         database.shutdown();
 
@@ -806,12 +251,17 @@ public class StoreMigrationIT
         assertEquals( beforeIndexes, afterIndexes ); //2
         assertEquals( beforeConstraints, afterConstraints ); //1
         ConsistencyCheckService consistencyCheckService = new ConsistencyCheckService( );
-        ConsistencyCheckService.Result result = runConsistencyChecker( db, fs, consistencyCheckService,
-                to.storeVersion() );
+        ConsistencyCheckService.Result result =
+                runConsistencyChecker( db, fs, consistencyCheckService, to.storeVersion() );
         if( !result.isSuccessful() )
         {
             fail( "Database is inconsistent after migration." );
         }
+    }
+
+    protected <T> Stream<T> stream( Iterable<T> iterable )
+    {
+        return StreamSupport.stream( iterable.spliterator(), false );
     }
 
     //This method is overridden by a blockdevice test.
@@ -821,9 +271,8 @@ public class StoreMigrationIT
     {
         Config config = Config.defaults();
         config.augment( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), storeVersion ) );
-        return consistencyCheckService
-                    .runFullConsistencyCheck( db, config, ProgressMonitorFactory.NONE,
-                            NullLogProvider.getInstance(), fs, false );
+        return consistencyCheckService.runFullConsistencyCheck( db, config, ProgressMonitorFactory.NONE,
+                NullLogProvider.getInstance(), fs, false );
     }
 
     //This method is overridden by a blockdevice test.

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
@@ -1,0 +1,765 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStoreVersionCheck;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith( Parameterized.class )
+public class StoreMigrationIT
+{
+    @ClassRule
+    public static final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @ClassRule
+    public static final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    //    @ClassRule
+//    public static final TestDirectory testDir = TestDirectory.testDirectory( fileSystemRule.get() );
+    public static final String CREATE_QUERY =
+            "CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real " +
+            "World'})\n" +
+            "CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})\n" +
+            "CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})\n" +
+            "CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})\n" +
+            "CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})\n" +
+            "CREATE (AndyW:Person {name:'Andy Wachowski', born:1967})\n" +
+            "CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})\n" +
+            "CREATE (JoelS:Person {name:'Joel Silver', born:1952})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),\n" +
+            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),\n" +
+            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),\n" +
+            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),\n" +
+            "  (AndyW)-[:DIRECTED]->(TheMatrix),\n" +
+            "  (LanaW)-[:DIRECTED]->(TheMatrix),\n" +
+            "  (JoelS)-[:PRODUCED]->(TheMatrix)\n" +
+            "  \n" +
+            "CREATE (Emil:Person {name:\"Emil Eifrem\", born:1978})\n" +
+            "CREATE (Emil)-[:ACTED_IN {roles:[\"Emil\"]}]->(TheMatrix)\n" +
+            "\n" +
+            "CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free" +
+            " your mind'})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),\n" +
+            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),\n" +
+            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),\n" +
+            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),\n" +
+            "  (AndyW)-[:DIRECTED]->(TheMatrixReloaded),\n" +
+            "  (LanaW)-[:DIRECTED]->(TheMatrixReloaded),\n" +
+            "  (JoelS)-[:PRODUCED]->(TheMatrixReloaded)\n" +
+            "  \n" +
+            "CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, " +
+            "tagline:'Everything that has a beginning has an end'})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),\n" +
+            "  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),\n" +
+            "  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),\n" +
+            "  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),\n" +
+            "  (AndyW)-[:DIRECTED]->(TheMatrixRevolutions),\n" +
+            "  (LanaW)-[:DIRECTED]->(TheMatrixRevolutions),\n" +
+            "  (JoelS)-[:PRODUCED]->(TheMatrixRevolutions)\n" +
+            "  \n" +
+            "CREATE (TheDevilsAdvocate:Movie {title:\"The Devil's Advocate\", released:1997, " +
+            "tagline:'Evil has its winning ways'})\n" +
+            "CREATE (Charlize:Person {name:'Charlize Theron', born:1975})\n" +
+            "CREATE (Al:Person {name:'Al Pacino', born:1940})\n" +
+            "CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),\n" +
+            "  (Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),\n" +
+            "  (Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),\n" +
+            "  (Taylor)-[:DIRECTED]->(TheDevilsAdvocate)\n" +
+            "  \n" +
+            "CREATE (AFewGoodMen:Movie {title:\"A Few Good Men\", released:1992, tagline:\"In the heart" +
+            " of the nation's capital, in a courthouse of the U.S. government, one man will stop at " +
+            "nothing to keep his honor, and one will stop at nothing to find the truth.\"})\n" +
+            "CREATE (TomC:Person {name:'Tom Cruise', born:1962})\n" +
+            "CREATE (JackN:Person {name:'Jack Nicholson', born:1937})\n" +
+            "CREATE (DemiM:Person {name:'Demi Moore', born:1962})\n" +
+            "CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})\n" +
+            "CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})\n" +
+            "CREATE (NoahW:Person {name:'Noah Wyle', born:1971})\n" +
+            "CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})\n" +
+            "CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})\n" +
+            "CREATE (JTW:Person {name:'J.T. Walsh', born:1943})\n" +
+            "CREATE (JamesM:Person {name:'James Marshall', born:1967})\n" +
+            "CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})\n" +
+            "CREATE (RobR:Person {name:'Rob Reiner', born:1947})\n" +
+            "CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})\n" +
+            "CREATE\n" +
+            "  (TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),\n" +
+            "  (JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),\n" +
+            "  (DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),\n" +
+            "  (KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),\n" +
+            "  (KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),\n" +
+            "  (NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),\n" +
+            "  (CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),\n" +
+            "  (KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),\n" +
+            "  (JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),\n" +
+            "  (JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),\n" +
+            "  (ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),\n" +
+            "  (AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),\n" +
+            "  (RobR)-[:DIRECTED]->(AFewGoodMen),\n" +
+            "  (AaronS)-[:WROTE]->(AFewGoodMen)\n" +
+            "  \n" +
+            "CREATE (TopGun:Movie {title:\"Top Gun\", released:1986, tagline:'I feel the need, the need" +
+            " for speed.'})\n" +
+            "CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})\n" +
+            "CREATE (ValK:Person {name:'Val Kilmer', born:1959})\n" +
+            "CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})\n" +
+            "CREATE (TomS:Person {name:'Tom Skerritt', born:1933})\n" +
+            "CREATE (MegR:Person {name:'Meg Ryan', born:1961})\n" +
+            "CREATE (TonyS:Person {name:'Tony Scott', born:1944})\n" +
+            "CREATE (JimC:Person {name:'Jim Cash', born:1941})\n" +
+            "CREATE\n" +
+            "  (TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),\n" +
+            "  (KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),\n" +
+            "  (ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),\n" +
+            "  (AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),\n" +
+            "  (TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),\n" +
+            "  (MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),\n" +
+            "  (TonyS)-[:DIRECTED]->(TopGun),\n" +
+            "  (JimC)-[:WROTE]->(TopGun)\n" +
+            "  \n" +
+            "CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his" +
+            " life begins now.'})\n" +
+            "CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})\n" +
+            "CREATE (KellyP:Person {name:'Kelly Preston', born:1962})\n" +
+            "CREATE (JerryO:Person {name:\"Jerry O'Connell\", born:1974})\n" +
+            "CREATE (JayM:Person {name:'Jay Mohr', born:1970})\n" +
+            "CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})\n" +
+            "CREATE (ReginaK:Person {name:'Regina King', born:1971})\n" +
+            "CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})\n" +
+            "CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})\n" +
+            "CREATE\n" +
+            "  (TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),\n" +
+            "  (CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),\n" +
+            "  (ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),\n" +
+            "  (KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),\n" +
+            "  (JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),\n" +
+            "  (JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),\n" +
+            "  (BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),\n" +
+            "  (ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),\n" +
+            "  (JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),\n" +
+            "  (CameronC)-[:DIRECTED]->(JerryMaguire),\n" +
+            "  (CameronC)-[:PRODUCED]->(JerryMaguire),\n" +
+            "  (CameronC)-[:WROTE]->(JerryMaguire)\n" +
+            "  \n" +
+            "CREATE (StandByMe:Movie {title:\"Stand By Me\", released:1986, tagline:\"For some, it's " +
+            "the last real taste of innocence, and the first real taste of life. But for everyone, it's" +
+            " the time that memories are made of.\"})\n" +
+            "CREATE (RiverP:Person {name:'River Phoenix', born:1970})\n" +
+            "CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})\n" +
+            "CREATE (WilW:Person {name:'Wil Wheaton', born:1972})\n" +
+            "CREATE (JohnC:Person {name:'John Cusack', born:1966})\n" +
+            "CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})\n" +
+            "CREATE\n" +
+            "  (WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),\n" +
+            "  (RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),\n" +
+            "  (JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),\n" +
+            "  (CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),\n" +
+            "  (JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),\n" +
+            "  (KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),\n" +
+            "  (MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),\n" +
+            "  (RobR)-[:DIRECTED]->(StandByMe)\n" +
+            "  \n" +
+            "CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy" +
+            " from the heart that goes for the throat.'})\n" +
+            "CREATE (HelenH:Person {name:'Helen Hunt', born:1963})\n" +
+            "CREATE (GregK:Person {name:'Greg Kinnear', born:1963})\n" +
+            "CREATE (JamesB:Person {name:'James L. Brooks', born:1940})\n" +
+            "CREATE\n" +
+            "  (JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),\n" +
+            "  (HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),\n" +
+            "  (GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),\n" +
+            "  (CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),\n" +
+            "  (JamesB)-[:DIRECTED]->(AsGoodAsItGets)\n" +
+            "  \n" +
+            "CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, " +
+            "tagline:'After life there is more. The end is just the beginning.'})\n" +
+            "CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})\n" +
+            "CREATE (MaxS:Person {name:'Max von Sydow', born:1929})\n" +
+            "CREATE (WernerH:Person {name:'Werner Herzog', born:1942})\n" +
+            "CREATE (Robin:Person {name:'Robin Williams', born:1951})\n" +
+            "CREATE (VincentW:Person {name:'Vincent Ward', born:1956})\n" +
+            "CREATE\n" +
+            "  (Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),\n" +
+            "  (CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),\n" +
+            "  (AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),\n" +
+            "  (MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),\n" +
+            "  (WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),\n" +
+            "  (VincentW)-[:DIRECTED]->(WhatDreamsMayCome)\n" +
+            "  \n" +
+            "CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, " +
+            "tagline:'First loves last. Forever.'})\n" +
+            "CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})\n" +
+            "CREATE (RickY:Person {name:'Rick Yune', born:1971})\n" +
+            "CREATE (JamesC:Person {name:'James Cromwell', born:1940})\n" +
+            "CREATE (ScottH:Person {name:'Scott Hicks', born:1953})\n" +
+            "CREATE\n" +
+            "  (EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),\n" +
+            "  (RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),\n" +
+            "  (MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),\n" +
+            "  (JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),\n" +
+            "  (ScottH)-[:DIRECTED]->(SnowFallingonCedars)\n" +
+            "  \n" +
+            "CREATE (YouveGotMail:Movie {title:\"You've Got Mail\", released:1998, tagline:'At odds in " +
+            "life... in love on-line.'})\n" +
+            "CREATE (ParkerP:Person {name:'Parker Posey', born:1968})\n" +
+            "CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})\n" +
+            "CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})\n" +
+            "CREATE (TomH:Person {name:'Tom Hanks', born:1956})\n" +
+            "CREATE (NoraE:Person {name:'Nora Ephron', born:1941})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),\n" +
+            "  (MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),\n" +
+            "  (GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),\n" +
+            "  (ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),\n" +
+            "  (DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),\n" +
+            "  (SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),\n" +
+            "  (NoraE)-[:DIRECTED]->(YouveGotMail)\n" +
+            "  \n" +
+            "CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, " +
+            "tagline:'What if someone you never met, someone you never saw, someone you never knew was " +
+            "the only someone for you?'})\n" +
+            "CREATE (RitaW:Person {name:'Rita Wilson', born:1956})\n" +
+            "CREATE (BillPull:Person {name:'Bill Pullman', born:1953})\n" +
+            "CREATE (VictorG:Person {name:'Victor Garber', born:1949})\n" +
+            "CREATE (RosieO:Person {name:\"Rosie O'Donnell\", born:1962})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),\n" +
+            "  (MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),\n" +
+            "  (RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),\n" +
+            "  (BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),\n" +
+            "  (VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),\n" +
+            "  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),\n" +
+            "  (NoraE)-[:DIRECTED]->(SleeplessInSeattle)\n" +
+            "  \n" +
+            "CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, " +
+            "tagline:'A story of love, lava and burning desire.'})\n" +
+            "CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})\n" +
+            "CREATE (Nathan:Person {name:'Nathan Lane', born:1956})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),\n" +
+            "  (MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->" +
+            "(JoeVersustheVolcano),\n" +
+            "  (Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),\n" +
+            "  (JohnS)-[:DIRECTED]->(JoeVersustheVolcano)\n" +
+            "  \n" +
+            "CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'At " +
+            "odds in life... in love on-line.'})\n" +
+            "CREATE (BillyC:Person {name:'Billy Crystal', born:1948})\n" +
+            "CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})\n" +
+            "CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})\n" +
+            "CREATE\n" +
+            "  (BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),\n" +
+            "  (MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),\n" +
+            "  (CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),\n" +
+            "  (BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),\n" +
+            "  (RobR)-[:DIRECTED]->(WhenHarryMetSally),\n" +
+            "  (RobR)-[:PRODUCED]->(WhenHarryMetSally),\n" +
+            "  (NoraE)-[:PRODUCED]->(WhenHarryMetSally),\n" +
+            "  (NoraE)-[:WROTE]->(WhenHarryMetSally)\n" +
+            "  \n" +
+            "CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every " +
+            "life there comes a time when that thing you dream becomes that thing you do'})\n" +
+            "CREATE (LivT:Person {name:'Liv Tyler', born:1977})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),\n" +
+            "  (LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),\n" +
+            "  (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),\n" +
+            "  (TomH)-[:DIRECTED]->(ThatThingYouDo)\n" +
+            "  \n" +
+            "CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain " +
+            "heals, Chicks dig scars... Glory lasts forever'})\n" +
+            "CREATE (Brooke:Person {name:'Brooke Langton', born:1970})\n" +
+            "CREATE (Gene:Person {name:'Gene Hackman', born:1930})\n" +
+            "CREATE (Orlando:Person {name:'Orlando Jones', born:1968})\n" +
+            "CREATE (Howard:Person {name:'Howard Deutch', born:1950})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),\n" +
+            "  (Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),\n" +
+            "  (Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),\n" +
+            "  (Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),\n" +
+            "  (Howard)-[:DIRECTED]->(TheReplacements)\n" +
+            "  \n" +
+            "CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:\"Based on the " +
+            "extraordinary true story of one man's fight for freedom\"})\n" +
+            "CREATE (ChristianB:Person {name:'Christian Bale', born:1974})\n" +
+            "CREATE (ZachG:Person {name:'Zach Grenier', born:1954})\n" +
+            "CREATE\n" +
+            "  (MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),\n" +
+            "  (ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),\n" +
+            "  (ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),\n" +
+            "  (SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),\n" +
+            "  (WernerH)-[:DIRECTED]->(RescueDawn)\n" +
+            "  \n" +
+            "CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you " +
+            "are'})\n" +
+            "CREATE (MikeN:Person {name:'Mike Nichols', born:1931})\n" +
+            "CREATE\n" +
+            "  (Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),\n" +
+            "  (Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),\n" +
+            "  (Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),\n" +
+            "  (MikeN)-[:DIRECTED]->(TheBirdcage)\n" +
+            "  \n" +
+            "CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:\"It's a hell of a " +
+            "thing, killing a man\"})\n" +
+            "CREATE (RichardH:Person {name:'Richard Harris', born:1930})\n" +
+            "CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})\n" +
+            "CREATE\n" +
+            "  (RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),\n" +
+            "  (ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),\n" +
+            "  (Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),\n" +
+            "  (ClintE)-[:DIRECTED]->(Unforgiven)\n" +
+            "  \n" +
+            "CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest" +
+            " data on earth. In the coolest head in town'})\n" +
+            "CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})\n" +
+            "CREATE (Dina:Person {name:'Dina Meyer', born:1968})\n" +
+            "CREATE (IceT:Person {name:'Ice-T', born:1958})\n" +
+            "CREATE (RobertL:Person {name:'Robert Longo', born:1953})\n" +
+            "CREATE\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),\n" +
+            "  (Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),\n" +
+            "  (Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),\n" +
+            "  (IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),\n" +
+            "  (RobertL)-[:DIRECTED]->(JohnnyMnemonic)\n" +
+            "  \n" +
+            "CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is " +
+            "connected'})\n" +
+            "CREATE (HalleB:Person {name:'Halle Berry', born:1966})\n" +
+            "CREATE (JimB:Person {name:'Jim Broadbent', born:1949})\n" +
+            "CREATE (TomT:Person {name:'Tom Tykwer', born:1965})\n" +
+            "CREATE (DavidMitchell:Person {name:'David Mitchell', born:1969})\n" +
+            "CREATE (StefanArndt:Person {name:'Stefan Arndt', born:1961})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot " +
+            "Hoggins']}]->(CloudAtlas),\n" +
+            "  (Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse " +
+            "Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),\n" +
+            "  (HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->" +
+            "(CloudAtlas),\n" +
+            "  (JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->" +
+            "(CloudAtlas),\n" +
+            "  (TomT)-[:DIRECTED]->(CloudAtlas),\n" +
+            "  (AndyW)-[:DIRECTED]->(CloudAtlas),\n" +
+            "  (LanaW)-[:DIRECTED]->(CloudAtlas),\n" +
+            "  (DavidMitchell)-[:WROTE]->(CloudAtlas),\n" +
+            "  (StefanArndt)-[:PRODUCED]->(CloudAtlas)\n" +
+            "  \n" +
+            "CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The" +
+            " Codes'})\n" +
+            "CREATE (IanM:Person {name:'Ian McKellen', born:1939})\n" +
+            "CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})\n" +
+            "CREATE (PaulB:Person {name:'Paul Bettany', born:1971})\n" +
+            "CREATE (RonH:Person {name:'Ron Howard', born:1954})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),\n" +
+            "  (IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),\n" +
+            "  (AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),\n" +
+            "  (PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),\n" +
+            "  (RonH)-[:DIRECTED]->(TheDaVinciCode)\n" +
+            "  \n" +
+            "CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! " +
+            "Forever!'})\n" +
+            "CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})\n" +
+            "CREATE (StephenR:Person {name:'Stephen Rea', born:1946})\n" +
+            "CREATE (JohnH:Person {name:'John Hurt', born:1940})\n" +
+            "CREATE (BenM:Person {name: 'Ben Miles', born:1967})\n" +
+            "CREATE\n" +
+            "  (Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),\n" +
+            "  (NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),\n" +
+            "  (StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),\n" +
+            "  (JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),\n" +
+            "  (BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),\n" +
+            "  (JamesM)-[:DIRECTED]->(VforVendetta),\n" +
+            "  (AndyW)-[:PRODUCED]->(VforVendetta),\n" +
+            "  (LanaW)-[:PRODUCED]->(VforVendetta),\n" +
+            "  (JoelS)-[:PRODUCED]->(VforVendetta),\n" +
+            "  (AndyW)-[:WROTE]->(VforVendetta),\n" +
+            "  (LanaW)-[:WROTE]->(VforVendetta)\n" +
+            "  \n" +
+            "CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no " +
+            "limits'})\n" +
+            "CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})\n" +
+            "CREATE (JohnG:Person {name:'John Goodman', born:1960})\n" +
+            "CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})\n" +
+            "CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})\n" +
+            "CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})\n" +
+            "CREATE (Rain:Person {name:'Rain', born:1982})\n" +
+            "CREATE\n" +
+            "  (EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),\n" +
+            "  (JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),\n" +
+            "  (SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),\n" +
+            "  (MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),\n" +
+            "  (ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),\n" +
+            "  (Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),\n" +
+            "  (BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),\n" +
+            "  (AndyW)-[:DIRECTED]->(SpeedRacer),\n" +
+            "  (LanaW)-[:DIRECTED]->(SpeedRacer),\n" +
+            "  (AndyW)-[:WROTE]->(SpeedRacer),\n" +
+            "  (LanaW)-[:WROTE]->(SpeedRacer),\n" +
+            "  (JoelS)-[:PRODUCED]->(SpeedRacer)\n" +
+            "  \n" +
+            "CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to " +
+            "enter a secret world of assassins'})\n" +
+            "CREATE (NaomieH:Person {name:'Naomie Harris'})\n" +
+            "CREATE\n" +
+            "  (Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),\n" +
+            "  (NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),\n" +
+            "  (RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),\n" +
+            "  (BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),\n" +
+            "  (JamesM)-[:DIRECTED]->(NinjaAssassin),\n" +
+            "  (AndyW)-[:PRODUCED]->(NinjaAssassin),\n" +
+            "  (LanaW)-[:PRODUCED]->(NinjaAssassin),\n" +
+            "  (JoelS)-[:PRODUCED]->(NinjaAssassin)\n" +
+            "  \n" +
+            "CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:\"Walk a mile " +
+            "you'll never forget.\"})\n" +
+            "CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})\n" +
+            "CREATE (DavidM:Person {name:'David Morse', born:1953})\n" +
+            "CREATE (SamR:Person {name:'Sam Rockwell', born:1968})\n" +
+            "CREATE (GaryS:Person {name:'Gary Sinise', born:1955})\n" +
+            "CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})\n" +
+            "CREATE (FrankD:Person {name:'Frank Darabont', born:1959})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),\n" +
+            "  (MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),\n" +
+            "  (DavidM)-[:ACTED_IN {roles:['Brutus \"Brutal\" Howell']}]->(TheGreenMile),\n" +
+            "  (BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),\n" +
+            "  (JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),\n" +
+            "  (SamR)-[:ACTED_IN {roles:['\"Wild Bill\" Wharton']}]->(TheGreenMile),\n" +
+            "  (GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),\n" +
+            "  (PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),\n" +
+            "  (FrankD)-[:DIRECTED]->(TheGreenMile)\n" +
+            "  \n" +
+            "CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people " +
+            "were waiting for the truth.'})\n" +
+            "CREATE (FrankL:Person {name:'Frank Langella', born:1938})\n" +
+            "CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})\n" +
+            "CREATE (OliverP:Person {name:'Oliver Platt', born:1960})\n" +
+            "CREATE\n" +
+            "  (FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),\n" +
+            "  (MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),\n" +
+            "  (KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),\n" +
+            "  (OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),\n" +
+            "  (SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),\n" +
+            "  (RonH)-[:DIRECTED]->(FrostNixon)\n" +
+            "  \n" +
+            "CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:\"He didn't want law. He wanted" +
+            " justice.\"})\n" +
+            "CREATE (DannyD:Person {name:'Danny DeVito', born:1944})\n" +
+            "CREATE (JohnR:Person {name:'John C. Reilly', born:1965})\n" +
+            "CREATE\n" +
+            "  (JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),\n" +
+            "  (DannyD)-[:ACTED_IN {roles:['Robert \"Bobby\" Ciaro']}]->(Hoffa),\n" +
+            "  (JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),\n" +
+            "  (JohnR)-[:ACTED_IN {roles:['Peter \"Pete\" Connelly']}]->(Hoffa),\n" +
+            "  (DannyD)-[:DIRECTED]->(Hoffa)\n" +
+            "  \n" +
+            "CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a " +
+            "problem.'})\n" +
+            "CREATE (EdH:Person {name:'Ed Harris', born:1950})\n" +
+            "CREATE (BillPax:Person {name:'Bill Paxton', born:1955})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),\n" +
+            "  (KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),\n" +
+            "  (EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),\n" +
+            "  (BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),\n" +
+            "  (GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),\n" +
+            "  (RonH)-[:DIRECTED]->(Apollo13)\n" +
+            "  \n" +
+            "CREATE (Twister:Movie {title:'Twister', released:1996, tagline:\"Don't Breathe. Don't Look" +
+            " Back.\"})\n" +
+            "CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})\n" +
+            "CREATE (JanB:Person {name:'Jan de Bont', born:1943})\n" +
+            "CREATE\n" +
+            "  (BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),\n" +
+            "  (HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),\n" +
+            "  (ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),\n" +
+            "  (PhilipH)-[:ACTED_IN {roles:['Dustin \"Dusty\" Davis']}]->(Twister),\n" +
+            "  (JanB)-[:DIRECTED]->(Twister)\n" +
+            "  \n" +
+            "CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the " +
+            "world, his journey begins.'})\n" +
+            "CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),\n" +
+            "  (HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),\n" +
+            "  (RobertZ)-[:DIRECTED]->(CastAway)\n" +
+            "  \n" +
+            "CREATE (OneFlewOvertheCuckoosNest:Movie {title:\"One Flew Over the Cuckoo's Nest\", " +
+            "released:1975, tagline:\"If he's crazy, what does that make you?\"})\n" +
+            "CREATE (MilosF:Person {name:'Milos Forman', born:1932})\n" +
+            "CREATE\n" +
+            "  (JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),\n" +
+            "  (DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),\n" +
+            "  (MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)\n" +
+            "  \n" +
+            "CREATE (SomethingsGottaGive:Movie {title:\"Something's Gotta Give\", released:2003})\n" +
+            "CREATE (DianeK:Person {name:'Diane Keaton', born:1946})\n" +
+            "CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})\n" +
+            "CREATE\n" +
+            "  (JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),\n" +
+            "  (DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),\n" +
+            "  (Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),\n" +
+            "  (NancyM)-[:DIRECTED]->(SomethingsGottaGive),\n" +
+            "  (NancyM)-[:PRODUCED]->(SomethingsGottaGive),\n" +
+            "  (NancyM)-[:WROTE]->(SomethingsGottaGive)\n" +
+            "  \n" +
+            "CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:\"One " +
+            "robot's 200 year journey to become an ordinary man.\"})\n" +
+            "CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})\n" +
+            "CREATE\n" +
+            "  (Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),\n" +
+            "  (OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),\n" +
+            "  (ChrisC)-[:DIRECTED]->(BicentennialMan)\n" +
+            "  \n" +
+            "CREATE (CharlieWilsonsWar:Movie {title:\"Charlie Wilson's War\", released:2007, " +
+            "tagline:\"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring " +
+            "down the Soviet empire.\"})\n" +
+            "CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),\n" +
+            "  (JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),\n" +
+            "  (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),\n" +
+            "  (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)\n" +
+            "  \n" +
+            "CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This " +
+            "Holiday Season… Believe'})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa " +
+            "Claus']}]->(ThePolarExpress),\n" +
+            "  (RobertZ)-[:DIRECTED]->(ThePolarExpress)\n" +
+            "  \n" +
+            "CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, " +
+            "tagline:'Once in a lifetime you get a chance to do something different.'})\n" +
+            "CREATE (Madonna:Person {name:'Madonna', born:1954})\n" +
+            "CREATE (GeenaD:Person {name:'Geena Davis', born:1956})\n" +
+            "CREATE (LoriP:Person {name:'Lori Petty', born:1963})\n" +
+            "CREATE (PennyM:Person {name:'Penny Marshall', born:1943})\n" +
+            "CREATE\n" +
+            "  (TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),\n" +
+            "  (GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),\n" +
+            "  (LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),\n" +
+            "  (RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),\n" +
+            "  (Madonna)-[:ACTED_IN {roles:['\"All the Way\" Mae Mordabito']}]->(ALeagueofTheirOwn),\n" +
+            "  (BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),\n" +
+            "  (PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)\n" +
+            "  \n" +
+            "CREATE (PaulBlythe:Person {name:'Paul Blythe'})\n" +
+            "CREATE (AngelaScope:Person {name:'Angela Scope'})\n" +
+            "CREATE (JessicaThompson:Person {name:'Jessica Thompson'})\n" +
+            "CREATE (JamesThompson:Person {name:'James Thompson'})\n" +
+            "\n" +
+            "CREATE\n" +
+            "  (JamesThompson)-[:FOLLOWS]->(JessicaThompson),\n" +
+            "  (AngelaScope)-[:FOLLOWS]->(JessicaThompson),\n" +
+            "  (PaulBlythe)-[:FOLLOWS]->(AngelaScope)\n" +
+            "  \n" +
+            "CREATE\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements)," +
+            "\n" +
+            "  (JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->" +
+            "(TheReplacements),\n" +
+            "  (AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->" +
+            "(TheReplacements),\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven)," +
+            "\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:\"Slapstick redeemed only by the Robin Williams " +
+            "and Gene Hackman's stellar performances\", rating:45}]->(TheBirdcage),\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),\n" +
+            "  (JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->" +
+            "(TheDaVinciCode),\n" +
+            "  (JessicaThompson)-[:REVIEWED {summary:'You had me at Jerry', rating:92}]->(JerryMaguire)" +
+            "\n" +
+            "  \n" +
+            "WITH TomH as a\n" +
+            "MATCH (a)-[:ACTED_IN]->(m)<-[:DIRECTED]-(d) RETURN a,m,d LIMIT 10\n" +
+            ";";
+    private final RecordFormats from;
+    private final RecordFormats to;
+
+    @Parameterized.Parameters( name = "Migrate: {0}->{1}" )
+    public static Iterable<Object[]> data() throws IOException
+    {
+        FileSystemAbstraction fs = fileSystemRule.get();
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        StoreVersionCheck storeVersionCheck = new StoreVersionCheck( pageCache );
+        LegacyStoreVersionCheck legacyStoreVersionCheck = new LegacyStoreVersionCheck( fs );
+        List<Object[]> data = new ArrayList<>();
+        ArrayList<RecordFormats> recordFormatses = new ArrayList<>();
+        RecordFormatSelector.allFormats().forEach( ( f ) -> addIfNotThere( f, recordFormatses ) );
+        for ( RecordFormats toFormat : recordFormatses )
+        {
+            UpgradableDatabase upgradableDatabase = new UpgradableDatabase( fs, storeVersionCheck,
+                    legacyStoreVersionCheck, toFormat );
+            for ( RecordFormats fromFormat : recordFormatses )
+            {
+                File db = new File( fromFormat.storeVersion() + toFormat.storeVersion() );
+                try
+                {
+                    createDb( fromFormat, pageCache, fs, db );
+                    if ( !upgradableDatabase.hasCurrentVersion( db ) )
+                    {
+                        upgradableDatabase.checkUpgradeable( db );
+                        data.add( new Object[]{fromFormat, toFormat} );
+                    }
+                }
+                catch ( Exception e )
+                {
+                    //This means that the combination is not migratable.
+                }
+                fs.deleteRecursively( db );
+            }
+        }
+
+        return data;
+    }
+
+    private static void addIfNotThere( RecordFormats f, ArrayList<RecordFormats> recordFormatses )
+    {
+        for ( RecordFormats format : recordFormatses )
+        {
+            if ( format.storeVersion().equals( f.storeVersion() ) )
+            {
+                return;
+            }
+        }
+        recordFormatses.add( f );
+    }
+
+    @Service.Implementation( RecordFormats.Factory.class )
+    public static class Standard23Factory extends RecordFormats.Factory
+    {
+        public Standard23Factory()
+        {
+            super( StandardV2_3.STORE_VERSION );
+        }
+
+        @Override
+        public RecordFormats newInstance()
+        {
+            return StandardV2_3.RECORD_FORMATS;
+        }
+    }
+
+    @Service.Implementation( RecordFormats.Factory.class )
+    public static class Standard30Factory extends RecordFormats.Factory
+    {
+        public Standard30Factory()
+        {
+            super( StandardV3_0.STORE_VERSION );
+        }
+
+        @Override
+        public RecordFormats newInstance()
+        {
+            return StandardV3_0.RECORD_FORMATS;
+        }
+    }
+
+    private static void createDb( RecordFormats recordFormat, PageCache pageCache, FileSystemAbstraction fs,
+            File storeDir ) throws IOException
+    {
+        GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.record_format, recordFormat.storeVersion() )
+                .newGraphDatabase();
+        database.shutdown();
+    }
+
+    public StoreMigrationIT( RecordFormats from, RecordFormats to )
+    {
+        this.from = from;
+        this.to = to;
+    }
+
+    @Test
+    public void shouldMigrate() throws Exception
+    {
+        File db = new File( from.toString() + to.toString() );
+        FileSystemAbstraction fs = fileSystemRule.get();
+        fs.deleteRecursively( db );
+
+        GraphDatabaseService database = getGraphDatabaseService( db, from.storeVersion() );
+        database.execute( CREATE_QUERY );
+        int beforeNodes;
+        int beforeRels;
+        try ( Transaction tx = database.beginTx() )
+        {
+            beforeNodes = database.getAllNodes().stream().mapToInt( ( n ) -> 1 ).sum();
+            beforeRels = database.getAllRelationships().stream().mapToInt( ( n ) -> 1 ).sum();
+        }
+        database.shutdown();
+
+        database = getGraphDatabaseService( db, to.storeVersion() );
+        int afterNodes;
+        int afterRels;
+        try ( Transaction tx = database.beginTx() )
+        {
+            afterNodes = database.getAllNodes().stream().mapToInt( ( n ) -> 1 ).sum();
+            afterRels = database.getAllRelationships().stream().mapToInt( ( n ) -> 1 ).sum();
+        }
+        database.shutdown();
+
+        assertEquals( beforeNodes, afterNodes );
+        assertEquals( beforeRels, afterRels );
+    }
+
+    //This method is overridden by a blockdevice test.
+
+    protected GraphDatabaseService getGraphDatabaseService( File db, String storeVersion )
+    {
+        return new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( db )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.record_format, storeVersion )
+                .newGraphDatabase();
+    }
+}

--- a/enterprise/kernel/src/test/resources/META-INF/services/org.neo4j.kernel.impl.store.format.RecordFormats$Factory
+++ b/enterprise/kernel/src/test/resources/META-INF/services/org.neo4j.kernel.impl.store.format.RecordFormats$Factory
@@ -1,0 +1,2 @@
+org.neo4j.kernel.impl.storemigration.StoreMigrationIT$Standard23Factory
+org.neo4j.kernel.impl.storemigration.StoreMigrationIT$Standard30Factory

--- a/enterprise/kernel/src/test/resources/store-migration-data.txt
+++ b/enterprise/kernel/src/test/resources/store-migration-data.txt
@@ -1,0 +1,506 @@
+CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real World'})
+CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})
+CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})
+CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})
+CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})
+CREATE (AndyW:Person {name:'Andy Wachowski', born:1967})
+CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})
+CREATE (JoelS:Person {name:'Joel Silver', born:1952})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),
+  (AndyW)-[:DIRECTED]->(TheMatrix),
+  (LanaW)-[:DIRECTED]->(TheMatrix),
+  (JoelS)-[:PRODUCED]->(TheMatrix)
+
+CREATE (Emil:Person {name:"Emil Eifrem", born:1978})
+CREATE (Emil)-[:ACTED_IN {roles:["Emil"]}]->(TheMatrix)
+
+CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free your mind'})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),
+  (AndyW)-[:DIRECTED]->(TheMatrixReloaded),
+  (LanaW)-[:DIRECTED]->(TheMatrixReloaded),
+  (JoelS)-[:PRODUCED]->(TheMatrixReloaded)
+
+CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, tagline:'Everything that has a beginning has an end'})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),
+  (AndyW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (LanaW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (JoelS)-[:PRODUCED]->(TheMatrixRevolutions)
+
+CREATE (TheDevilsAdvocate:Movie {title:"The Devil's Advocate", released:1997, tagline:'Evil has its winning ways'})
+CREATE (Charlize:Person {name:'Charlize Theron', born:1975})
+CREATE (Al:Person {name:'Al Pacino', born:1940})
+CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),
+  (Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),
+  (Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),
+  (Taylor)-[:DIRECTED]->(TheDevilsAdvocate)
+
+CREATE (AFewGoodMen:Movie {title:"A Few Good Men", released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth."})
+CREATE (TomC:Person {name:'Tom Cruise', born:1962})
+CREATE (JackN:Person {name:'Jack Nicholson', born:1937})
+CREATE (DemiM:Person {name:'Demi Moore', born:1962})
+CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})
+CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})
+CREATE (NoahW:Person {name:'Noah Wyle', born:1971})
+CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})
+CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})
+CREATE (JTW:Person {name:'J.T. Walsh', born:1943})
+CREATE (JamesM:Person {name:'James Marshall', born:1967})
+CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})
+CREATE (RobR:Person {name:'Rob Reiner', born:1947})
+CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),
+  (JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),
+  (DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),
+  (KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),
+  (KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),
+  (NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),
+  (CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),
+  (KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),
+  (JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),
+  (JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),
+  (ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),
+  (AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),
+  (RobR)-[:DIRECTED]->(AFewGoodMen),
+  (AaronS)-[:WROTE]->(AFewGoodMen)
+
+CREATE (TopGun:Movie {title:"Top Gun", released:1986, tagline:'I feel the need, the need for speed.'})
+CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})
+CREATE (ValK:Person {name:'Val Kilmer', born:1959})
+CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})
+CREATE (TomS:Person {name:'Tom Skerritt', born:1933})
+CREATE (MegR:Person {name:'Meg Ryan', born:1961})
+CREATE (TonyS:Person {name:'Tony Scott', born:1944})
+CREATE (JimC:Person {name:'Jim Cash', born:1941})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),
+  (KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),
+  (ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),
+  (AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),
+  (TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),
+  (MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),
+  (TonyS)-[:DIRECTED]->(TopGun),
+  (JimC)-[:WROTE]->(TopGun)
+
+CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his life begins now.'})
+CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})
+CREATE (KellyP:Person {name:'Kelly Preston', born:1962})
+CREATE (JerryO:Person {name:"Jerry O'Connell", born:1974})
+CREATE (JayM:Person {name:'Jay Mohr', born:1970})
+CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})
+CREATE (ReginaK:Person {name:'Regina King', born:1971})
+CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})
+CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})
+CREATE
+  (TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),
+  (CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),
+  (ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),
+  (KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),
+  (JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),
+  (JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),
+  (BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),
+  (ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),
+  (JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),
+  (CameronC)-[:DIRECTED]->(JerryMaguire),
+  (CameronC)-[:PRODUCED]->(JerryMaguire),
+  (CameronC)-[:WROTE]->(JerryMaguire)
+
+CREATE (StandByMe:Movie {title:"Stand By Me", released:1986, tagline:"For some, it's the last real taste of innocence, and the first real taste of life. But for everyone, it's the time that memories are made of."})
+CREATE (RiverP:Person {name:'River Phoenix', born:1970})
+CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})
+CREATE (WilW:Person {name:'Wil Wheaton', born:1972})
+CREATE (JohnC:Person {name:'John Cusack', born:1966})
+CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})
+CREATE
+  (WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),
+  (RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),
+  (JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),
+  (CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),
+  (JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),
+  (KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),
+  (MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),
+  (RobR)-[:DIRECTED]->(StandByMe)
+
+CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy from the heart that goes for the throat.'})
+CREATE (HelenH:Person {name:'Helen Hunt', born:1963})
+CREATE (GregK:Person {name:'Greg Kinnear', born:1963})
+CREATE (JamesB:Person {name:'James L. Brooks', born:1940})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),
+  (HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),
+  (GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),
+  (CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),
+  (JamesB)-[:DIRECTED]->(AsGoodAsItGets)
+
+CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, tagline:'After life there is more. The end is just the beginning.'})
+CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})
+CREATE (MaxS:Person {name:'Max von Sydow', born:1929})
+CREATE (WernerH:Person {name:'Werner Herzog', born:1942})
+CREATE (Robin:Person {name:'Robin Williams', born:1951})
+CREATE (VincentW:Person {name:'Vincent Ward', born:1956})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),
+  (CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),
+  (AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),
+  (MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),
+  (WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),
+  (VincentW)-[:DIRECTED]->(WhatDreamsMayCome)
+
+CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, tagline:'First loves last. Forever.'})
+CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})
+CREATE (RickY:Person {name:'Rick Yune', born:1971})
+CREATE (JamesC:Person {name:'James Cromwell', born:1940})
+CREATE (ScottH:Person {name:'Scott Hicks', born:1953})
+CREATE
+  (EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),
+  (RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),
+  (MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),
+  (JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),
+  (ScottH)-[:DIRECTED]->(SnowFallingonCedars)
+
+CREATE (YouveGotMail:Movie {title:"You've Got Mail", released:1998, tagline:'At odds in life... in love on-line.'})
+CREATE (ParkerP:Person {name:'Parker Posey', born:1968})
+CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})
+CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})
+CREATE (TomH:Person {name:'Tom Hanks', born:1956})
+CREATE (NoraE:Person {name:'Nora Ephron', born:1941})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),
+  (MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),
+  (GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),
+  (ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),
+  (DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),
+  (SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),
+  (NoraE)-[:DIRECTED]->(YouveGotMail)
+
+CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, tagline:'What if someone you never met, someone you never saw, someone you never knew was the only someone for you?'})
+CREATE (RitaW:Person {name:'Rita Wilson', born:1956})
+CREATE (BillPull:Person {name:'Bill Pullman', born:1953})
+CREATE (VictorG:Person {name:'Victor Garber', born:1949})
+CREATE (RosieO:Person {name:"Rosie O'Donnell", born:1962})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),
+  (MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),
+  (RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),
+  (BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),
+  (VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),
+  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),
+  (NoraE)-[:DIRECTED]->(SleeplessInSeattle)
+
+CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, tagline:'A story of love, lava and burning desire.'})
+CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})
+CREATE (Nathan:Person {name:'Nathan Lane', born:1956})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),
+  (MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->(JoeVersustheVolcano),
+  (Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),
+  (JohnS)-[:DIRECTED]->(JoeVersustheVolcano)
+
+CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'At odds in life... in love on-line.'})
+CREATE (BillyC:Person {name:'Billy Crystal', born:1948})
+CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})
+CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})
+CREATE
+  (BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),
+  (MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),
+  (CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),
+  (BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),
+  (RobR)-[:DIRECTED]->(WhenHarryMetSally),
+  (RobR)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:WROTE]->(WhenHarryMetSally)
+
+CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every life there comes a time when that thing you dream becomes that thing you do'})
+CREATE (LivT:Person {name:'Liv Tyler', born:1977})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),
+  (LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),
+  (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),
+  (TomH)-[:DIRECTED]->(ThatThingYouDo)
+
+CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain heals, Chicks dig scars... Glory lasts forever'})
+CREATE (Brooke:Person {name:'Brooke Langton', born:1970})
+CREATE (Gene:Person {name:'Gene Hackman', born:1930})
+CREATE (Orlando:Person {name:'Orlando Jones', born:1968})
+CREATE (Howard:Person {name:'Howard Deutch', born:1950})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),
+  (Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),
+  (Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),
+  (Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),
+  (Howard)-[:DIRECTED]->(TheReplacements)
+
+CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:"Based on the extraordinary true story of one man's fight for freedom"})
+CREATE (ChristianB:Person {name:'Christian Bale', born:1974})
+CREATE (ZachG:Person {name:'Zach Grenier', born:1954})
+CREATE
+  (MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),
+  (ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),
+  (ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),
+  (SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),
+  (WernerH)-[:DIRECTED]->(RescueDawn)
+
+CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you are'})
+CREATE (MikeN:Person {name:'Mike Nichols', born:1931})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),
+  (Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),
+  (Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),
+  (MikeN)-[:DIRECTED]->(TheBirdcage)
+
+CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:"It's a hell of a thing, killing a man"})
+CREATE (RichardH:Person {name:'Richard Harris', born:1930})
+CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})
+CREATE
+  (RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),
+  (ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),
+  (Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),
+  (ClintE)-[:DIRECTED]->(Unforgiven)
+
+CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest data on earth. In the coolest head in town'})
+CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})
+CREATE (Dina:Person {name:'Dina Meyer', born:1968})
+CREATE (IceT:Person {name:'Ice-T', born:1958})
+CREATE (RobertL:Person {name:'Robert Longo', born:1953})
+CREATE
+  (Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),
+  (Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),
+  (Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),
+  (IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),
+  (RobertL)-[:DIRECTED]->(JohnnyMnemonic)
+
+CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is connected'})
+CREATE (HalleB:Person {name:'Halle Berry', born:1966})
+CREATE (JimB:Person {name:'Jim Broadbent', born:1949})
+CREATE (TomT:Person {name:'Tom Tykwer', born:1965})
+CREATE (DavidMitchell:Person {name:'David Mitchell', born:1969})
+CREATE (StefanArndt:Person {name:'Stefan Arndt', born:1961})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas),
+  (Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),
+  (HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->(CloudAtlas),
+  (JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->(CloudAtlas),
+  (TomT)-[:DIRECTED]->(CloudAtlas),
+  (AndyW)-[:DIRECTED]->(CloudAtlas),
+  (LanaW)-[:DIRECTED]->(CloudAtlas),
+  (DavidMitchell)-[:WROTE]->(CloudAtlas),
+  (StefanArndt)-[:PRODUCED]->(CloudAtlas)
+
+CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The Codes'})
+CREATE (IanM:Person {name:'Ian McKellen', born:1939})
+CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})
+CREATE (PaulB:Person {name:'Paul Bettany', born:1971})
+CREATE (RonH:Person {name:'Ron Howard', born:1954})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),
+  (IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),
+  (AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),
+  (PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),
+  (RonH)-[:DIRECTED]->(TheDaVinciCode)
+
+CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! Forever!'})
+CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})
+CREATE (StephenR:Person {name:'Stephen Rea', born:1946})
+CREATE (JohnH:Person {name:'John Hurt', born:1940})
+CREATE (BenM:Person {name: 'Ben Miles', born:1967})
+CREATE
+  (Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),
+  (NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),
+  (StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),
+  (JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),
+  (BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),
+  (JamesM)-[:DIRECTED]->(VforVendetta),
+  (AndyW)-[:PRODUCED]->(VforVendetta),
+  (LanaW)-[:PRODUCED]->(VforVendetta),
+  (JoelS)-[:PRODUCED]->(VforVendetta),
+  (AndyW)-[:WROTE]->(VforVendetta),
+  (LanaW)-[:WROTE]->(VforVendetta)
+
+CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no limits'})
+CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})
+CREATE (JohnG:Person {name:'John Goodman', born:1960})
+CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})
+CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})
+CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})
+CREATE (Rain:Person {name:'Rain', born:1982})
+CREATE
+  (EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),
+  (JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),
+  (SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),
+  (MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),
+  (ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),
+  (Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),
+  (BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),
+  (AndyW)-[:DIRECTED]->(SpeedRacer),
+  (LanaW)-[:DIRECTED]->(SpeedRacer),
+  (AndyW)-[:WROTE]->(SpeedRacer),
+  (LanaW)-[:WROTE]->(SpeedRacer),
+  (JoelS)-[:PRODUCED]->(SpeedRacer)
+
+CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to enter a secret world of assassins'})
+CREATE (NaomieH:Person {name:'Naomie Harris'})
+CREATE
+  (Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),
+  (NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),
+  (RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),
+  (BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),
+  (JamesM)-[:DIRECTED]->(NinjaAssassin),
+  (AndyW)-[:PRODUCED]->(NinjaAssassin),
+  (LanaW)-[:PRODUCED]->(NinjaAssassin),
+  (JoelS)-[:PRODUCED]->(NinjaAssassin)
+
+CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:"Walk a mile you'll never forget."})
+CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})
+CREATE (DavidM:Person {name:'David Morse', born:1953})
+CREATE (SamR:Person {name:'Sam Rockwell', born:1968})
+CREATE (GaryS:Person {name:'Gary Sinise', born:1955})
+CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})
+CREATE (FrankD:Person {name:'Frank Darabont', born:1959})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),
+  (MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),
+  (DavidM)-[:ACTED_IN {roles:['Brutus "Brutal" Howell']}]->(TheGreenMile),
+  (BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),
+  (JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),
+  (SamR)-[:ACTED_IN {roles:['"Wild Bill" Wharton']}]->(TheGreenMile),
+  (GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),
+  (PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),
+  (FrankD)-[:DIRECTED]->(TheGreenMile)
+
+CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people were waiting for the truth.'})
+CREATE (FrankL:Person {name:'Frank Langella', born:1938})
+CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})
+CREATE (OliverP:Person {name:'Oliver Platt', born:1960})
+CREATE
+  (FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),
+  (MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),
+  (KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),
+  (OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),
+  (SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),
+  (RonH)-[:DIRECTED]->(FrostNixon)
+
+CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:"He didn't want law. He wanted justice."})
+CREATE (DannyD:Person {name:'Danny DeVito', born:1944})
+CREATE (JohnR:Person {name:'John C. Reilly', born:1965})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),
+  (DannyD)-[:ACTED_IN {roles:['Robert "Bobby" Ciaro']}]->(Hoffa),
+  (JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),
+  (JohnR)-[:ACTED_IN {roles:['Peter "Pete" Connelly']}]->(Hoffa),
+  (DannyD)-[:DIRECTED]->(Hoffa)
+
+CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a problem.'})
+CREATE (EdH:Person {name:'Ed Harris', born:1950})
+CREATE (BillPax:Person {name:'Bill Paxton', born:1955})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),
+  (KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),
+  (EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),
+  (BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),
+  (GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),
+  (RonH)-[:DIRECTED]->(Apollo13)
+
+CREATE (Twister:Movie {title:'Twister', released:1996, tagline:"Don't Breathe. Don't Look Back."})
+CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})
+CREATE (JanB:Person {name:'Jan de Bont', born:1943})
+CREATE
+  (BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),
+  (HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),
+  (ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),
+  (PhilipH)-[:ACTED_IN {roles:['Dustin "Dusty" Davis']}]->(Twister),
+  (JanB)-[:DIRECTED]->(Twister)
+
+CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the world, his journey begins.'})
+CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),
+  (HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),
+  (RobertZ)-[:DIRECTED]->(CastAway)
+
+CREATE (OneFlewOvertheCuckoosNest:Movie {title:"One Flew Over the Cuckoo's Nest", released:1975, tagline:"If he's crazy, what does that make you?"})
+CREATE (MilosF:Person {name:'Milos Forman', born:1932})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),
+  (DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),
+  (MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)
+
+CREATE (SomethingsGottaGive:Movie {title:"Something's Gotta Give", released:2003})
+CREATE (DianeK:Person {name:'Diane Keaton', born:1946})
+CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})
+CREATE
+  (JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),
+  (DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),
+  (Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),
+  (NancyM)-[:DIRECTED]->(SomethingsGottaGive),
+  (NancyM)-[:PRODUCED]->(SomethingsGottaGive),
+  (NancyM)-[:WROTE]->(SomethingsGottaGive)
+
+CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:"One robot's 200 year journey to become an ordinary man."})
+CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})
+CREATE
+  (Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),
+  (OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),
+  (ChrisC)-[:DIRECTED]->(BicentennialMan)
+
+CREATE (CharlieWilsonsWar:Movie {title:"Charlie Wilson's War", released:2007, tagline:"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring down the Soviet empire."})
+CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),
+  (JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),
+  (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),
+  (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)
+
+CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season… Believe'})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa Claus']}]->(ThePolarExpress),
+  (RobertZ)-[:DIRECTED]->(ThePolarExpress)
+
+CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, tagline:'Once in a lifetime you get a chance to do something different.'})
+CREATE (Madonna:Person {name:'Madonna', born:1954})
+CREATE (GeenaD:Person {name:'Geena Davis', born:1956})
+CREATE (LoriP:Person {name:'Lori Petty', born:1963})
+CREATE (PennyM:Person {name:'Penny Marshall', born:1943})
+CREATE
+  (TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),
+  (GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),
+  (LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),
+  (RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),
+  (Madonna)-[:ACTED_IN {roles:['"All the Way" Mae Mordabito']}]->(ALeagueofTheirOwn),
+  (BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),
+  (PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)
+
+CREATE (PaulBlythe:Person {name:'Paul Blythe'})
+CREATE (AngelaScope:Person {name:'Angela Scope'})
+CREATE (JessicaThompson:Person {name:'Jessica Thompson'})
+CREATE (JamesThompson:Person {name:'James Thompson'})
+
+CREATE
+  (JamesThompson)-[:FOLLOWS]->(JessicaThompson),
+  (AngelaScope)-[:FOLLOWS]->(JessicaThompson),
+  (PaulBlythe)-[:FOLLOWS]->(AngelaScope)
+
+CREATE
+  (JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),
+  (JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements),
+  (JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->(TheReplacements),
+  (AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->(TheReplacements),
+  (JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven),
+  (JessicaThompson)-[:REVIEWED {summary:"Slapstick redeemed only by the Robin Williams and Gene Hackman's stellar performances", rating:45}]->(TheBirdcage),
+  (JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),
+  (JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->(TheDaVinciCode),
+  (JessicaThompson)-[:REVIEWED {summary:'You had me at Jerry', rating:92}]->(JerryMaguire)
+;

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecordsFactory.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecordsFactory.java
@@ -27,7 +27,7 @@ public class HighLimitWithSmallRecordsFactory extends RecordFormats.Factory
 {
     public HighLimitWithSmallRecordsFactory()
     {
-        super( HighLimitWithSmallRecords.NAME );
+        super( HighLimitWithSmallRecords.NAME, HighLimitWithSmallRecords.STORE_VERSION );
     }
 
     @Override

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StoreMigratorFrom20IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StoreMigratorFrom20IT.java
@@ -243,7 +243,7 @@ public class StoreMigratorFrom20IT
     private StoreUpgrader upgrader( SchemaIndexMigrator indexMigrator, StoreMigrator storeMigrator )
     {
         Config config = getConfig().augment( stringMap( GraphDatabaseSettings.allow_store_upgrade.name(), "true" ) );
-        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, monitor, config, fs,
+        StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, monitor, config, fs, pageCache,
                 NullLogProvider.getInstance() );
         upgrader.addParticipant( indexMigrator );
         upgrader.addParticipant( storeMigrator );


### PR DESCRIPTION
Make store migration work for custom IO integrations, by accessing store files through the page cache. Including for file operations such as deletes, copying and moving files.

This work includes a new `StoreMigrationIT` test, which searches for all available store formats, and tests migration for all supported from-to format tuples. This test is used in the block device integration code to verify that migration works there as well.

The page cache based file operations only take effect for formats from 2.3 and onward.