### PR TITLE
List all locks held by a transaction/query

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQuery.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.LongSupplier;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -107,6 +108,7 @@ public class ExecutingQuery
     /** Uses write barrier of {@link #status}. */
     private long planningDone;
     private final Thread threadExecutingTheQuery;
+    private final LongSupplier activeLockCount;
     private final SystemNanoClock clock;
     private final CpuClock cpuClock;
     private final long cpuTimeNanosWhenQueryStarted;
@@ -125,6 +127,7 @@ public class ExecutingQuery
             String queryText,
             Map<String,Object> queryParameters,
             Map<String,Object> metaData,
+            LongSupplier activeLockCount,
             Thread threadExecutingTheQuery,
             SystemNanoClock clock,
             CpuClock cpuClock )
@@ -134,6 +137,7 @@ public class ExecutingQuery
         this.username = username;
         this.queryText = queryText;
         this.queryParameters = queryParameters;
+        this.activeLockCount = activeLockCount;
         this.clock = clock;
         this.startTime = clock.millis();
         this.metaData = metaData;
@@ -253,6 +257,11 @@ public class ExecutingQuery
     public LockTracer lockTracer()
     {
         return lockTracer;
+    }
+
+    public long activeLockCount()
+    {
+        return activeLockCount.getAsLong();
     }
 
     public Map<String,Object> status()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutingQueryStatus.java
@@ -56,12 +56,14 @@ abstract class ExecutingQueryStatus
 
     static class WaitingOnLock extends ExecutingQueryStatus
     {
+        private final String mode;
         private final ResourceType resourceType;
         private final long[] resourceIds;
         private final long startTimeNanos;
 
-        WaitingOnLock( ResourceType resourceType, long[] resourceIds, long startTimeNanos )
+        WaitingOnLock( String mode, ResourceType resourceType, long[] resourceIds, long startTimeNanos )
         {
+            this.mode = mode;
             this.resourceType = resourceType;
             this.resourceIds = resourceIds;
             this.startTimeNanos = startTimeNanos;
@@ -78,6 +80,7 @@ abstract class ExecutingQueryStatus
         {
             Map<String,Object> map = new HashMap<>();
             map.put( "state", "WAITING" );
+            map.put( "lockMode", mode );
             map.put( "waitTimeMillis", TimeUnit.NANOSECONDS.toMillis( waitTimeNanos( clock ) ) );
             map.put( "resourceType", resourceType.toString() );
             map.put( "resourceIds", resourceIds );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.kernel.api;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.Kernel;
+import org.neo4j.kernel.impl.locking.Locks;
 
 /**
  * View of a {@link KernelTransaction} that provides a limited set of actions against the transaction.
@@ -96,4 +98,9 @@ public interface KernelTransactionHandle
      * @return a list of all queries currently executing that use the underlying transaction
      */
     Stream<ExecutingQuery> executingQueries();
+
+    /**
+     * @return the lock requests granted for this transaction.
+     */
+    Collection<Locks.ActiveLock> activeLocks();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -19,14 +19,13 @@
  */
 package org.neo4j.kernel.api;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.Kernel;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ActiveLock;
 
 /**
  * View of a {@link KernelTransaction} that provides a limited set of actions against the transaction.
@@ -102,5 +101,5 @@ public interface KernelTransactionHandle
     /**
      * @return the lock requests granted for this transaction.
      */
-    Collection<Locks.ActiveLock> activeLocks();
+    Stream<? extends ActiveLock> activeLocks();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -793,6 +793,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         storageStatement.close();
     }
 
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        StatementLocks locks = this.statementLocks;
+        return locks == null ? Collections.emptyList() : locks.activeLocks();
+    }
+
     /**
      * It is not allowed for the same transaction to perform database writes as well as schema writes.
      * This enum tracks the current write transactionStatus of the transaction, allowing it to transition from

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -28,7 +27,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ActiveLock;
 
 /**
  * A {@link KernelTransactionHandle} that wraps the given {@link KernelTransactionImplementation}.
@@ -114,7 +113,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
         return tx.activeLocks();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -27,6 +28,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.impl.locking.Locks;
 
 /**
  * A {@link KernelTransactionHandle} that wraps the given {@link KernelTransactionImplementation}.
@@ -109,6 +111,12 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     public Stream<ExecutingQuery> executingQueries()
     {
         return executingQueries.queries();
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        return tx.activeLocks();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -31,7 +31,6 @@ import org.neo4j.time.SystemNanoClock;
 
 public class StackingQueryRegistrationOperations implements QueryRegistrationOperations
 {
-
     private final MonotonicCounter lastQueryId = MonotonicCounter.newAtomicMonotonicCounter();
     private final SystemNanoClock clock;
 
@@ -74,6 +73,5 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
     {
         statement.stopQueryExecution( executingQuery );
     }
-
 }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -63,7 +63,7 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
         Thread thread = Thread.currentThread();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, clientConnection, statement.username(), queryText, queryParameters,
-                        statement.getTransaction().getMetaData(), thread, clock, CpuClock.CPU_CLOCK );
+                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount, thread, clock, CpuClock.CPU_CLOCK );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ActiveLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ActiveLock.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import java.util.Objects;
+
+import org.neo4j.storageengine.api.lock.ResourceType;
+
+public interface ActiveLock
+{
+    String SHARED_MODE = "SHARED", EXCLUSIVE_MODE = "EXCLUSIVE";
+
+    String mode();
+
+    ResourceType resourceType();
+
+    long resourceId();
+
+    static ActiveLock exclusiveLock( ResourceType resourceType, long resourceId )
+    {
+        return new Implementation( resourceType, resourceId )
+        {
+            @Override
+            public String mode()
+            {
+                return EXCLUSIVE_MODE;
+            }
+        };
+    }
+
+    static ActiveLock sharedLock( ResourceType resourceType, long resourceId )
+    {
+        return new Implementation( resourceType, resourceId )
+        {
+            @Override
+            public String mode()
+            {
+                return SHARED_MODE;
+            }
+        };
+    }
+
+    interface Factory
+    {
+        Factory SHARED_LOCK = ActiveLock::sharedLock, EXCLUSIVE_LOCK = ActiveLock::exclusiveLock;
+
+        ActiveLock create( ResourceType resourceType, long resourceId );
+    }
+
+    abstract class Implementation implements ActiveLock
+    {
+        private final ResourceType resourceType;
+        private final long resourceId;
+
+        private Implementation( ResourceType resourceType, long resourceId )
+        {
+            this.resourceType = resourceType;
+            this.resourceId = resourceId;
+        }
+
+        @Override
+        public abstract String mode();
+
+        @Override
+        public ResourceType resourceType()
+        {
+            return resourceType;
+        }
+
+        @Override
+        public long resourceId()
+        {
+            return resourceId;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( !(o instanceof ActiveLock) )
+            {
+                return false;
+            }
+            ActiveLock that = (ActiveLock) o;
+            return resourceId == that.resourceId() &&
+                    Objects.equals( mode(), that.mode() ) &&
+                    Objects.equals( resourceType, that.resourceType() );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( resourceType, resourceId, mode() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/CombinedTracer.java
@@ -25,7 +25,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 
 /**
  * A {@link LockTracer} that combines multiple {@linkplain LockTracer tracers} into one, invoking each of them for
- * the {@linkplain #waitForLock(ResourceType, long...) wait events} received.
+ * the {@linkplain LockTracer#waitForLock(boolean, ResourceType, long...) wait events} received.
  * <p>
  * This is used for when there is a stack of queries in a transaction, or when a system-configured tracer combines with
  * the query specific tracers.
@@ -40,12 +40,12 @@ final class CombinedTracer implements LockTracer
     }
 
     @Override
-    public LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+    public LockWaitEvent waitForLock( boolean exclusive, ResourceType resourceType, long... resourceIds )
     {
         LockWaitEvent[] events = new LockWaitEvent[tracers.length];
         for ( int i = 0; i < events.length; i++ )
         {
-            events[i] = tracers[i].waitForLock( resourceType, resourceIds );
+            events[i] = tracers[i].waitForLock( exclusive, resourceType, resourceIds );
         }
         return new CombinedEvent( events );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockTracer.java
@@ -23,7 +23,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 
 public interface LockTracer
 {
-    LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds );
+    LockWaitEvent waitForLock( boolean exclusive, ResourceType resourceType, long... resourceIds );
 
     default LockTracer combine( LockTracer tracer )
     {
@@ -37,7 +37,7 @@ public interface LockTracer
     LockTracer NONE = new LockTracer()
     {
         @Override
-        public LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+        public LockWaitEvent waitForLock( boolean exclusive, ResourceType resourceType, long... resourceIds )
         {
             return LockWaitEvent.NONE;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -20,8 +20,7 @@
 package org.neo4j.kernel.impl.locking;
 
 import java.time.Clock;
-import java.util.Collection;
-import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.configuration.Config;
@@ -115,7 +114,7 @@ public interface Locks
         /** For slave transactions, this tracks an identifier for the lock session running on the master */
         int getLockSessionId();
 
-        Collection<ActiveLock> activeLocks();
+        Stream<? extends ActiveLock> activeLocks();
     }
 
     /**
@@ -130,67 +129,4 @@ public interface Locks
     void accept(Visitor visitor);
 
     void close();
-
-    abstract class ActiveLock
-    {
-        public final ResourceType resourceType;
-        public final long resourceId;
-
-        private ActiveLock( ResourceType resourceType, long resourceId )
-        {
-            this.resourceType = resourceType;
-            this.resourceId = resourceId;
-        }
-
-        @Override
-        public boolean equals( Object o )
-        {
-            if ( this == o )
-            {
-                return true;
-            }
-            if ( o.getClass() != this.getClass() )
-            {
-                return false;
-            }
-            ActiveLock activeLock = (ActiveLock) o;
-            return resourceId == activeLock.resourceId &&
-                    Objects.equals( resourceType, activeLock.resourceType );
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash( resourceType, resourceId );
-        }
-
-        public abstract String mode();
-    }
-
-    final class ActiveExclusiveLock extends ActiveLock
-    {
-        public ActiveExclusiveLock( ResourceType resourceType, long resourceId )
-        {
-            super( resourceType, resourceId );
-        }
-
-        @Override
-        public String mode()
-        {
-            return "EXCLUSIVE";
-        }
-    }
-    final class ActiveSharedLock extends ActiveLock
-    {
-        public ActiveSharedLock( ResourceType resourceType, long resourceId )
-        {
-            super( resourceType, resourceId );
-        }
-
-        @Override
-        public String mode()
-        {
-            return "SHARED";
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -115,6 +115,8 @@ public interface Locks
         int getLockSessionId();
 
         Stream<? extends ActiveLock> activeLocks();
+
+        long activeLockCount();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.locking;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.storageengine.api.lock.ResourceType;
 
@@ -70,5 +73,11 @@ public class NoOpClient implements Locks.Client
     public int getLockSessionId()
     {
         return -1;
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        return Collections.emptyList();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -19,8 +19,7 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.storageengine.api.lock.ResourceType;
@@ -76,8 +75,8 @@ public class NoOpClient implements Locks.Client
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
-        return Collections.emptyList();
+        return Stream.empty();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -79,4 +79,10 @@ public class NoOpClient implements Locks.Client
     {
         return Stream.empty();
     }
+
+    @Override
+    public long activeLockCount()
+    {
+        return 0;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * A {@link StatementLocks} implementation that uses given {@link Locks.Client} for both
@@ -65,7 +65,7 @@ public class SimpleStatementLocks implements StatementLocks
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
         return client.activeLocks();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.locking;
 
+import java.util.Collection;
+
 /**
  * A {@link StatementLocks} implementation that uses given {@link Locks.Client} for both
  * {@link #optimistic() optimistic} and {@link #pessimistic() pessimistic} locks.
@@ -60,5 +62,11 @@ public class SimpleStatementLocks implements StatementLocks
     public void close()
     {
         client.close();
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        return client.activeLocks();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -69,4 +69,10 @@ public class SimpleStatementLocks implements StatementLocks
     {
         return client.activeLocks();
     }
+
+    @Override
+    public long activeLockCount()
+    {
+        return client.activeLockCount();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.neo4j.kernel.impl.api.KernelStatement;
 
@@ -64,7 +64,9 @@ public interface StatementLocks extends AutoCloseable
     /**
      * List the locks held by this transaction.
      *
+     * This method is invoked by concurrent threads in order to inspect the lock state in this transaction.
+     *
      * @return the locks held by this transaction.
      */
-    Collection<Locks.ActiveLock> activeLocks();
+    Stream<? extends ActiveLock> activeLocks();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -69,4 +69,14 @@ public interface StatementLocks extends AutoCloseable
      * @return the locks held by this transaction.
      */
     Stream<? extends ActiveLock> activeLocks();
+
+    /**
+     * Get the current number of active locks.
+     *
+     * Note that the value returned by this method might differ from the number of locks returned by
+     * {@link #activeLocks()}, since they would introspect the lock state at different points in time.
+     *
+     * @return the number of active locks in this transaction.
+     */
+    long activeLockCount();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.locking;
 
+import java.util.Collection;
+
 import org.neo4j.kernel.impl.api.KernelStatement;
 
 /**
@@ -58,4 +60,11 @@ public interface StatementLocks extends AutoCloseable
      */
     @Override
     void close();
+
+    /**
+     * List the locks held by this transaction.
+     *
+     * @return the locks held by this transaction.
+     */
+    Collection<Locks.ActiveLock> activeLocks();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -328,6 +328,28 @@ public class CommunityLockClient implements Locks.Client
         return locks.stream();
     }
 
+    @Override
+    public long activeLockCount()
+    {
+        LockCounter counter = new LockCounter();
+        exclusiveLocks.visitEntries( counter );
+        sharedLocks.visitEntries( counter );
+        return counter.locks;
+    }
+
+    private static class LockCounter
+            implements PrimitiveIntObjectVisitor<PrimitiveLongObjectMap<LockResource>,RuntimeException>
+    {
+        long locks;
+
+        @Override
+        public boolean visited( int key, PrimitiveLongObjectMap<LockResource> value )
+        {
+            locks += value.size();
+            return false;
+        }
+    }
+
     private static PrimitiveIntObjectVisitor<PrimitiveLongObjectMap<LockResource>,RuntimeException> collectActiveLocks(
             List<ActiveLock> locks, ActiveLock.Factory activeLock )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/RWLock.java
@@ -215,7 +215,7 @@ class RWLock
 
                 if ( waitEvent == null )
                 {
-                    waitEvent = tracer.waitForLock( resource.type(), resource.resourceId() );
+                    waitEvent = tracer.waitForLock( false, resource.type(), resource.resourceId() );
                 }
                 addLockRequest = waitUninterruptedly( lockAcquisitionTimeBoundary );
                 ragManager.stopWaitOn( this, tx );
@@ -403,7 +403,7 @@ class RWLock
 
                 if ( waitEvent == null )
                 {
-                    waitEvent = tracer.waitForLock( resource.type(), resource.resourceId() );
+                    waitEvent = tracer.waitForLock( true, resource.type(), resource.resourceId() );
                 }
                 addLockRequest = waitUninterruptedly( lockAcquisitionTimeBoundary );
                 ragManager.stopWaitOn( this, tx );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceType.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/lock/ResourceType.java
@@ -27,4 +27,7 @@ public interface ResourceType
 
     /** What to do if the lock cannot immediately be acquired. */
     WaitStrategy waitStrategy();
+
+    /** Must be unique among all existing resource types. */
+    String name();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.locking.ActiveLock;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
 
@@ -63,7 +64,11 @@ public class ExecutingQueryStatusTest
         // given
         long[] resourceIds = {17};
         ExecutingQueryStatus.WaitingOnLock status =
-                new ExecutingQueryStatus.WaitingOnLock( resourceType( "NODE" ), resourceIds, clock.nanos() );
+                new ExecutingQueryStatus.WaitingOnLock(
+                        ActiveLock.EXCLUSIVE_MODE,
+                        resourceType( "NODE" ),
+                        resourceIds,
+                        clock.nanos() );
         clock.forward( 17, TimeUnit.MILLISECONDS );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryStatusTest.java
@@ -78,6 +78,7 @@ public class ExecutingQueryStatusTest
         Map<String,Object> expected = new HashMap<>();
         expected.put( "state", "WAITING" );
         expected.put( "waitTimeMillis", 17L );
+        expected.put( "lockMode", "EXCLUSIVE" );
         expected.put( "resourceType", "NODE" );
         expected.put( "resourceIds", resourceIds );
         assertEquals( expected, statusMap );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -50,6 +50,7 @@ public class ExecutingQueryTest
 {
     private final FakeClock clock = Clocks.fakeClock( ZonedDateTime.parse( "2016-12-03T15:10:00+01:00" ) );
     private final FakeCpuClock cpuClock = new FakeCpuClock();
+    private long lockCount;
     private ExecutingQuery query = new ExecutingQuery(
             1,
             ClientConnectionInfo.EMBEDDED_CONNECTION,
@@ -57,7 +58,7 @@ public class ExecutingQueryTest
             "hello world",
             Collections.emptyMap(),
             Collections.emptyMap(),
-            Thread.currentThread(),
+            () -> lockCount, Thread.currentThread(),
             clock,
             cpuClock );
 
@@ -168,6 +169,22 @@ public class ExecutingQueryTest
 
         // then
         assertEquals( 60, cpuTime );
+    }
+
+    @Test
+    public void shouldReportLockCount() throws Exception
+    {
+        // given
+        lockCount = 11;
+
+        // then
+        assertEquals( 11, query.activeLockCount() );
+
+        // given
+        lockCount = 2;
+
+        // then
+        assertEquals( 2, query.activeLockCount() );
     }
 
     private LockWaitEvent lock( String resourceType, long resourceId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -175,14 +175,14 @@ public class ExecutingQueryTest
         return query.lockTracer().waitForLock( resourceType( resourceType ), resourceId );
     }
 
-    static ResourceType resourceType( String string )
+    static ResourceType resourceType( String name )
     {
         return new ResourceType()
         {
             @Override
             public String toString()
             {
-                return string;
+                return name();
             }
 
             @Override
@@ -195,6 +195,12 @@ public class ExecutingQueryTest
             public WaitStrategy waitStrategy()
             {
                 throw new UnsupportedOperationException( "not used" );
+            }
+
+            @Override
+            public String name()
+            {
+                return name;
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/ExecutingQueryTest.java
@@ -172,7 +172,7 @@ public class ExecutingQueryTest
 
     private LockWaitEvent lock( String resourceType, long resourceId )
     {
-        return query.lockTracer().waitForLock( resourceType( resourceType ), resourceId );
+        return query.lockTracer().waitForLock( false, resourceType( resourceType ), resourceId );
     }
 
     static ResourceType resourceType( String name )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -116,7 +116,7 @@ public class ExecutingQueryListTest
     private ExecutingQuery createExecutingQuery( int queryId, String query )
     {
         return new ExecutingQuery( queryId, ClientConnectionInfo.EMBEDDED_CONNECTION, "me", query,
-                Collections.emptyMap(), Collections.emptyMap(), Thread.currentThread(),
+                Collections.emptyMap(), Collections.emptyMap(), () -> 0, Thread.currentThread(),
                 Clocks.nanoClock(),
                 CpuClock.CPU_CLOCK
         );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -29,7 +28,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ActiveLock;
 
 /**
  * A test implementation of {@link KernelTransactionHandle} that simply wraps a given {@link KernelTransaction}.
@@ -99,7 +98,7 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
         throw new UnsupportedOperationException();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -28,6 +29,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.impl.locking.Locks;
 
 /**
  * A test implementation of {@link KernelTransactionHandle} that simply wraps a given {@link KernelTransaction}.
@@ -92,6 +94,12 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
 
     @Override
     public Stream<ExecutingQuery> executingQueries()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
     {
         throw new UnsupportedOperationException();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
@@ -19,13 +19,17 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Stream;
 
 import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.impl.locking.ActiveLock.exclusiveLock;
+import static org.neo4j.kernel.impl.locking.ActiveLock.sharedLock;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
 
 @Ignore( "Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite." )
@@ -44,17 +48,17 @@ public class ActiveLocksListingCompatibility extends LockingCompatibilityTestSui
         clientA.acquireShared( LockTracer.NONE, NODE, 3, 4, 5 );
 
         // when
-        Collection<Locks.ActiveLock> locks = clientA.activeLocks();
+        Stream<? extends ActiveLock> locks = clientA.activeLocks();
 
         // then
         assertEquals(
-                asList(
-                        new Locks.ActiveExclusiveLock( NODE, 1 ),
-                        new Locks.ActiveExclusiveLock( NODE, 2 ),
-                        new Locks.ActiveExclusiveLock( NODE, 3 ),
-                        new Locks.ActiveSharedLock( NODE, 3 ),
-                        new Locks.ActiveSharedLock( NODE, 4 ),
-                        new Locks.ActiveSharedLock( NODE, 5 ) ),
-                locks );
+                new HashSet<>( asList(
+                        exclusiveLock( NODE, 1 ),
+                        exclusiveLock( NODE, 2 ),
+                        exclusiveLock( NODE, 3 ),
+                        sharedLock( NODE, 3 ),
+                        sharedLock( NODE, 4 ),
+                        sharedLock( NODE, 5 ) ) ),
+                locks.collect( toSet() ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import java.util.Collection;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
+
+@Ignore( "Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite." )
+public class ActiveLocksListingCompatibility extends LockingCompatibilityTestSuite.Compatibility
+{
+    public ActiveLocksListingCompatibility( LockingCompatibilityTestSuite suite )
+    {
+        super( suite );
+    }
+
+    @Test
+    public void shouldListLocksHeldByTheCurrentClient() throws Exception
+    {
+        // given
+        clientA.acquireExclusive( LockTracer.NONE, NODE, 1, 2, 3 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 3, 4, 5 );
+
+        // when
+        Collection<Locks.ActiveLock> locks = clientA.activeLocks();
+
+        // then
+        assertEquals(
+                asList(
+                        new Locks.ActiveExclusiveLock( NODE, 1 ),
+                        new Locks.ActiveExclusiveLock( NODE, 2 ),
+                        new Locks.ActiveExclusiveLock( NODE, 3 ),
+                        new Locks.ActiveSharedLock( NODE, 3 ),
+                        new Locks.ActiveSharedLock( NODE, 4 ),
+                        new Locks.ActiveSharedLock( NODE, 5 ) ),
+                locks );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ActiveLocksListingCompatibility.java
@@ -31,6 +31,8 @@ import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.locking.ActiveLock.exclusiveLock;
 import static org.neo4j.kernel.impl.locking.ActiveLock.sharedLock;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.RELATIONSHIP;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.SCHEMA;
 
 @Ignore( "Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite." )
 public class ActiveLocksListingCompatibility extends LockingCompatibilityTestSuite.Compatibility
@@ -60,5 +62,20 @@ public class ActiveLocksListingCompatibility extends LockingCompatibilityTestSui
                         sharedLock( NODE, 4 ),
                         sharedLock( NODE, 5 ) ) ),
                 locks.collect( toSet() ) );
+    }
+
+    @Test
+    public void shouldCountNumberOfActiveLocks() throws Exception
+    {
+        // given
+        clientA.acquireShared( LockTracer.NONE, SCHEMA, 0 );
+        clientA.acquireShared( LockTracer.NONE, RELATIONSHIP, 17 );
+        clientA.acquireShared( LockTracer.NONE, NODE, 12 );
+
+        // when
+        long count = clientA.activeLockCount();
+
+        // then
+        assertEquals( 3, count );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -60,6 +60,7 @@ import static org.neo4j.test.rule.concurrent.OtherThreadRule.isWaiting;
         CloseCompatibility.class,
         AcquisitionTimeoutCompatibility.class,
         TracerCompatibility.class,
+        ActiveLocksListingCompatibility.class,
 })
 public abstract class LockingCompatibilityTestSuite
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/TracerCompatibility.java
@@ -96,7 +96,7 @@ public class TracerCompatibility extends LockingCompatibilityTestSuite.Compatibi
         final List<StackTraceElement[]> waitCalls = new ArrayList<>();
 
         @Override
-        public LockWaitEvent waitForLock( ResourceType resourceType, long... resourceIds )
+        public LockWaitEvent waitForLock( boolean exclusive, ResourceType resourceType, long... resourceIds )
         {
             waitCalls.add( Thread.currentThread().getStackTrace() );
             return this;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -265,5 +265,11 @@ public class LeaderOnlyLockManager implements Locks
         {
             return localClient.activeLocks();
         }
+
+        @Override
+        public long activeLockCount()
+        {
+            return localClient.activeLockCount();
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.causalclustering.core.state.machines.locks;
 
-import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.replication.Replicator;
 import org.neo4j.causalclustering.core.state.machines.tx.ReplicatedTransactionStateMachine;
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.kernel.impl.locking.ActiveLock;
 import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
@@ -260,9 +261,9 @@ public class LeaderOnlyLockManager implements Locks
         }
 
         @Override
-        public Collection<ActiveLock> activeLocks()
+        public Stream<? extends ActiveLock> activeLocks()
         {
-            throw new UnsupportedOperationException( "not implemented" );
+            return localClient.activeLocks();
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.core.state.machines.locks;
 
+import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -256,6 +257,12 @@ public class LeaderOnlyLockManager implements Locks
         public int getLockSessionId()
         {
             return lockTokenId;
+        }
+
+        @Override
+        public Collection<ActiveLock> activeLocks()
+        {
+            throw new UnsupportedOperationException( "not implemented" );
         }
     }
 }

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -19,11 +19,13 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import org.apache.commons.lang3.mutable.MutableInt;
-
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.mutable.MutableInt;
 
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
 import org.neo4j.storageengine.api.lock.ResourceType;
@@ -156,6 +158,15 @@ public class DeferringLockClient implements Locks.Client
     public int getLockSessionId()
     {
         return clientDelegate.getLockSessionId();
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        return locks.keySet().stream().map( ( unit ) -> unit.isExclusive()
+                ? new Locks.ActiveExclusiveLock( unit.resourceType(), unit.resourceId() )
+                : new Locks.ActiveSharedLock( unit.resourceType(), unit.resourceId() ) )
+                .collect( Collectors.toList() );
     }
 
     private void assertNotStopped()

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -20,10 +20,9 @@
 package org.neo4j.kernel.impl.locking;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 
@@ -161,12 +160,9 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
-        return locks.keySet().stream().map( ( unit ) -> unit.isExclusive()
-                ? new Locks.ActiveExclusiveLock( unit.resourceType(), unit.resourceId() )
-                : new Locks.ActiveSharedLock( unit.resourceType(), unit.resourceId() ) )
-                .collect( Collectors.toList() );
+        return locks.keySet().stream();
     }
 
     private void assertNotStopped()

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -165,6 +165,12 @@ public class DeferringLockClient implements Locks.Client
         return locks.keySet().stream();
     }
 
+    @Override
+    public long activeLockCount()
+    {
+        return locks.size();
+    }
+
     private void assertNotStopped()
     {
         if ( stopped )

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
@@ -71,4 +71,10 @@ public class DeferringStatementLocks implements StatementLocks
     {
         return Stream.concat( explicit.activeLocks(), implicit.activeLocks() );
     }
+
+    @Override
+    public long activeLockCount()
+    {
+        return explicit.activeLockCount() + implicit.activeLockCount();
+    }
 }

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A {@link StatementLocks} implementation that defers {@link #optimistic() optimistic}
@@ -69,28 +67,8 @@ public class DeferringStatementLocks implements StatementLocks
     }
 
     @Override
-    public Collection<Locks.ActiveLock> activeLocks()
+    public Stream<? extends ActiveLock> activeLocks()
     {
-        Collection<Locks.ActiveLock> explicit = this.explicit.activeLocks(), implicit = this.implicit.activeLocks();
-        // minimize (re-)allocation
-        if ( explicit instanceof ArrayList<?> && explicit.size() > implicit.size() )
-        {
-            List<Locks.ActiveLock> locks = (List<Locks.ActiveLock>) explicit;
-            locks.addAll( implicit );
-            return locks;
-        }
-        else if ( implicit instanceof ArrayList<?> && implicit.size() > explicit.size() )
-        {
-            List<Locks.ActiveLock> locks = (List<Locks.ActiveLock>) implicit;
-            locks.addAll( explicit );
-            return locks;
-        }
-        else
-        {
-            List<Locks.ActiveLock> locks = new ArrayList<>( explicit.size() + implicit.size() );
-            locks.addAll( explicit );
-            locks.addAll( implicit );
-            return locks;
-        }
+        return Stream.concat( explicit.activeLocks(), implicit.activeLocks() );
     }
 }

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/LockUnit.java
@@ -24,7 +24,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 /**
  * Description of a lock that was deferred to commit time.
  */
-public class LockUnit implements Comparable<LockUnit>
+public class LockUnit implements Comparable<LockUnit>, ActiveLock
 {
     private final ResourceType resourceType;
     private final long resourceId;
@@ -35,6 +35,12 @@ public class LockUnit implements Comparable<LockUnit>
         this.resourceType = resourceType;
         this.resourceId = resourceId;
         this.exclusive = exclusive;
+    }
+
+    @Override
+    public String mode()
+    {
+        return exclusive ? EXCLUSIVE_MODE : SHARED_MODE;
     }
 
     public ResourceType resourceType()

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -475,5 +475,11 @@ public class DeferringLockClientTest
         {
             return actualLockUnits.stream();
         }
+
+        @Override
+        public long activeLockCount()
+        {
+            return actualLockUnits.size();
+        }
     }
 }

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -20,12 +20,11 @@
 package org.neo4j.kernel.impl.locking;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -472,12 +471,9 @@ public class DeferringLockClientTest
         }
 
         @Override
-        public Collection<Locks.ActiveLock> activeLocks()
+        public Stream<? extends ActiveLock> activeLocks()
         {
-            return actualLockUnits.stream().map( lu -> lu.isExclusive()
-                    ? new Locks.ActiveExclusiveLock( lu.resourceType(), lu.resourceId() )
-                    : new Locks.ActiveSharedLock( lu.resourceType(), lu.resourceId() ) )
-                    .collect( Collectors.toList() );
+            return actualLockUnits.stream();
         }
     }
 }

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -19,14 +19,16 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.storageengine.api.lock.AcquireLockTimeoutException;
@@ -467,6 +469,15 @@ public class DeferringLockClientTest
         public int getLockSessionId()
         {
             return 0;
+        }
+
+        @Override
+        public Collection<Locks.ActiveLock> activeLocks()
+        {
+            return actualLockUnits.stream().map( lu -> lu.isExclusive()
+                    ? new Locks.ActiveExclusiveLock( lu.resourceType(), lu.resourceId() )
+                    : new Locks.ActiveSharedLock( lu.resourceType(), lu.resourceId() ) )
+                    .collect( Collectors.toList() );
         }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -116,7 +116,7 @@ class SlaveLocksClient implements Locks.Client
         long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
         if ( newResourceIds.length > 0 )
         {
-            try ( LockWaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
+            try ( LockWaitEvent event = tracer.waitForLock( false, resourceType, resourceIds ) )
             {
                 acquireSharedOnMaster( resourceType, newResourceIds );
             }
@@ -145,7 +145,7 @@ class SlaveLocksClient implements Locks.Client
         long[] newResourceIds = onlyFirstTimeLocks( lockMap, resourceIds );
         if ( newResourceIds.length > 0 )
         {
-            try ( LockWaitEvent event = tracer.waitForLock( resourceType, resourceIds ) )
+            try ( LockWaitEvent event = tracer.waitForLock( true, resourceType, resourceIds ) )
             {
                 acquireExclusiveOnMaster( resourceType, newResourceIds );
             }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -249,24 +249,13 @@ class SlaveLocksClient implements Locks.Client
     @Override
     public Stream<? extends ActiveLock> activeLocks()
     {
-        return Stream.concat( // TODO: do we need to make these maps of locks ConcurrentHashMaps?
-                exclusiveLocks.entrySet().stream().flatMap( EXCLUSIVE_ACTIVE_LOCKS ),
-                sharedLocks.entrySet().stream().flatMap( SHARED_ACTIVE_LOCKS ) );
+        return client.activeLocks();
     }
 
     @Override
     public long activeLockCount()
     {
-        long count = 0; // TODO: do we need to make these maps of locks ConcurrentHashMaps?
-        for ( Map<Long,AtomicInteger> locks : exclusiveLocks.values() )
-        {
-            count += locks.size();
-        }
-        for ( Map<Long,AtomicInteger> locks : sharedLocks.values() )
-        {
-            count += locks.size();
-        }
-        return count;
+        return client.activeLockCount();
     }
 
     private static Function<Map.Entry<ResourceType,Map<Long,AtomicInteger>>,Stream<? extends ActiveLock>> activeLocks(

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.ha.lock;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -238,6 +239,12 @@ class SlaveLocksClient implements Locks.Client
     {
         assertNotStopped();
         return initialized ? client.getLockSessionId() : -1;
+    }
+
+    @Override
+    public Collection<Locks.ActiveLock> activeLocks()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
     }
 
     private void stopLockSessionOnMaster()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -254,6 +254,21 @@ class SlaveLocksClient implements Locks.Client
                 sharedLocks.entrySet().stream().flatMap( SHARED_ACTIVE_LOCKS ) );
     }
 
+    @Override
+    public long activeLockCount()
+    {
+        long count = 0; // TODO: do we need to make these maps of locks ConcurrentHashMaps?
+        for ( Map<Long,AtomicInteger> locks : exclusiveLocks.values() )
+        {
+            count += locks.size();
+        }
+        for ( Map<Long,AtomicInteger> locks : sharedLocks.values() )
+        {
+            count += locks.size();
+        }
+        return count;
+    }
+
     private static Function<Map.Entry<ResourceType,Map<Long,AtomicInteger>>,Stream<? extends ActiveLock>> activeLocks(
             ActiveLock.Factory activeLock )
     {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksQueryResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksQueryResult.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.enterprise.builtinprocs;
 
-import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ActiveLock;
 
 public class ActiveLocksQueryResult
 {
@@ -27,10 +27,10 @@ public class ActiveLocksQueryResult
     public final String resourceType;
     public final long resourceId;
 
-    public ActiveLocksQueryResult( Locks.ActiveLock lock )
+    public ActiveLocksQueryResult( ActiveLock lock )
     {
         this.mode = lock.mode();
-        this.resourceType = lock.resourceType.toString();
-        this.resourceId = lock.resourceId;
+        this.resourceType = lock.resourceType().name();
+        this.resourceId = lock.resourceId();
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksQueryResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ActiveLocksQueryResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.enterprise.builtinprocs;
+
+import org.neo4j.kernel.impl.locking.Locks;
+
+public class ActiveLocksQueryResult
+{
+    public final String mode;
+    public final String resourceType;
+    public final long resourceId;
+
+    public ActiveLocksQueryResult( Locks.ActiveLock lock )
+    {
+        this.mode = lock.mode();
+        this.resourceType = lock.resourceType.toString();
+        this.resourceId = lock.resourceId;
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -245,6 +245,24 @@ public class EnterpriseBuiltInDbmsProcedures
         }
     }
 
+    @Description( "List the active lock requests granted for the transaction executing the query with the given query id." )
+    @Procedure( name = "dbms.listActiveLocks", mode = DBMS )
+    public Stream<ActiveLocksQueryResult> listActiveLocks( @Name( "queryId" ) String queryId )
+            throws InvalidArgumentsException
+    {
+        try
+        {
+            long id = fromExternalString( queryId ).kernelQueryId();
+            return getActiveTransactions( tx -> executingQueriesWithId( id, tx ) )
+                    .flatMap( pair -> pair.first().activeLocks().stream().map( ActiveLocksQueryResult::new ) );
+        }
+        catch ( UncaughtCheckedException uncaught )
+        {
+            throwIfPresent( uncaught.getCauseIfOfType( InvalidArgumentsException.class ) );
+            throw uncaught;
+        }
+    }
+
     @Description( "Kill all transactions executing the query with the given query id." )
     @Procedure( name = "dbms.killQuery", mode = DBMS )
     public Stream<QueryTerminationResult> killQuery( @Name( "id" ) String idText )
@@ -254,11 +272,7 @@ public class EnterpriseBuiltInDbmsProcedures
         {
             long queryId = fromExternalString( idText ).kernelQueryId();
 
-            Set<Pair<KernelTransactionHandle,ExecutingQuery>> executingQueries =
-                getActiveTransactions( tx -> executingQueriesWithId( queryId, tx ) );
-
-            return executingQueries
-                .stream()
+            return getActiveTransactions( tx -> executingQueriesWithId( queryId, tx ) )
                 .map( catchThrown( InvalidArgumentsException.class, this::killQueryTransaction ) );
          }
         catch ( UncaughtCheckedException uncaught )
@@ -281,11 +295,7 @@ public class EnterpriseBuiltInDbmsProcedures
                 .map( catchThrown( InvalidArgumentsException.class, QueryId::kernelQueryId ) )
                 .collect( toSet() );
 
-            Set<Pair<KernelTransactionHandle,ExecutingQuery>> executingQueries =
-                getActiveTransactions( tx -> executingQueriesWithIds( queryIds, tx ) );
-
-            return executingQueries
-                .stream()
+            return getActiveTransactions( tx -> executingQueriesWithIds( queryIds, tx ) )
                 .map( catchThrown( InvalidArgumentsException.class, this::killQueryTransaction ) );
         }
         catch ( UncaughtCheckedException uncaught )
@@ -295,14 +305,13 @@ public class EnterpriseBuiltInDbmsProcedures
         }
     }
 
-    private <T> Set<Pair<KernelTransactionHandle, T>> getActiveTransactions(
+    private <T> Stream<Pair<KernelTransactionHandle, T>> getActiveTransactions(
             Function<KernelTransactionHandle,Stream<T>> selector
     )
     {
         return getActiveTransactions( graph.getDependencyResolver() )
             .stream()
-            .flatMap( tx -> selector.apply( tx ).map( data -> Pair.of( tx, data ) ) )
-            .collect( toSet() );
+            .flatMap( tx -> selector.apply( tx ).map( data -> Pair.of( tx, data ) ) );
     }
 
     private Stream<ExecutingQuery> executingQueriesWithIds( Set<Long> ids, KernelTransactionHandle txHandle )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -254,7 +254,7 @@ public class EnterpriseBuiltInDbmsProcedures
         {
             long id = fromExternalString( queryId ).kernelQueryId();
             return getActiveTransactions( tx -> executingQueriesWithId( id, tx ) )
-                    .flatMap( pair -> pair.first().activeLocks().stream().map( ActiveLocksQueryResult::new ) );
+                    .flatMap( pair -> pair.first().activeLocks().map( ActiveLocksQueryResult::new ) );
         }
         catch ( UncaughtCheckedException uncaught )
         {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -62,6 +62,8 @@ public class QueryStatusResult
     /** EXPERIMENTAL: added in Neo4j 3.2 */
     public final Map<String,Object> status;
     /** EXPERIMENTAL: added in Neo4j 3.2 */
+    public final long activeLockCount;
+    /** EXPERIMENTAL: added in Neo4j 3.2 */
     public final long waitTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
     public final Map<String,Object> metaData;
     public final List<Map<String,String>> indexes;
@@ -78,6 +80,7 @@ public class QueryStatusResult
                 q.metaData(),
                 q.cpuTimeMillis(),
                 q.status(),
+                q.activeLockCount(),
                 q.waitTimeMillis() );
     }
 
@@ -91,6 +94,7 @@ public class QueryStatusResult
             Map<String,Object> txMetaData,
             long cpuTimeMillis,
             Map<String,Object> status,
+            long activeLockCount,
             long waitTimeMillis
     ) {
         this.queryId = queryId.toString();
@@ -107,6 +111,7 @@ public class QueryStatusResult
         this.metaData = txMetaData;
         this.cpuTimeMillis = cpuTimeMillis;
         this.status = status;
+        this.activeLockCount = activeLockCount;
         this.waitTimeMillis = waitTimeMillis;
         this.planner = query.planner;
         this.runtime = query.runtime;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -245,7 +245,7 @@ public class ForsetiClient implements Locks.Client
 
                         if ( waitEvent == null )
                         {
-                            waitEvent = tracer.waitForLock( resourceType, resourceId );
+                            waitEvent = tracer.waitForLock( false, resourceType, resourceId );
                         }
                         applyWaitStrategy( resourceType, tries++ );
 
@@ -322,7 +322,7 @@ public class ForsetiClient implements Locks.Client
 
                         if ( waitEvent == null )
                         {
-                            waitEvent = tracer.waitForLock( resourceType, resourceId );
+                            waitEvent = tracer.waitForLock( true, resourceType, resourceId );
                         }
                         applyWaitStrategy( resourceType, tries++ );
                         markAsWaitingFor( existingLock, resourceType, resourceId );
@@ -817,7 +817,7 @@ public class ForsetiClient implements Locks.Client
                     assertValid( waitStartMillis, resourceType, resourceId );
                     if ( waitEvent == null && priorEvent == null )
                     {
-                        waitEvent = tracer.waitForLock( resourceType, resourceId );
+                        waitEvent = tracer.waitForLock( true, resourceType, resourceId );
                     }
                     applyWaitStrategy( resourceType, tries++ );
                     markAsWaitingFor( sharedLock, resourceType, resourceId );

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -649,6 +649,12 @@ public class ForsetiClient implements Locks.Client
         return locks.stream();
     }
 
+    @Override
+    public long activeLockCount()
+    {
+        return countLocks( exclusiveLockCounts ) + countLocks( sharedLockCounts );
+    }
+
     private static void collectActiveLocks(
             PrimitiveLongIntMap[] counts,
             List<ActiveLock> locks,
@@ -667,6 +673,19 @@ public class ForsetiClient implements Locks.Client
                 } );
             }
         }
+    }
+
+    private long countLocks( PrimitiveLongIntMap[] lockCounts )
+    {
+        long count = 0;
+        for ( PrimitiveLongIntMap lockCount : lockCounts )
+        {
+            if ( lockCount != null )
+            {
+                count += lockCount.size();
+            }
+        }
+        return count;
     }
 
     public int waitListSize()

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -90,11 +90,11 @@ public class ListQueriesProcedureTest
     public void shouldProvideElapsedCpuTime() throws Exception
     {
         // given
-        String QUERY = "MATCH (n) SET n.v = n.v + 1";
-        try ( Resource<Node> test = test( db::createNode, Transaction::acquireWriteLock, QUERY ) )
+        String query = "MATCH (n) SET n.v = n.v + 1";
+        try ( Resource<Node> test = test( db::createNode, Transaction::acquireWriteLock, query ) )
         {
             // when
-            Map<String,Object> data = getQueryListing( QUERY );
+            Map<String,Object> data = getQueryListing( query );
 
             // then
             assertThat( data, hasKey( "elapsedTimeMillis" ) );
@@ -116,7 +116,7 @@ public class ListQueriesProcedureTest
             assertThat( waitTime1, instanceOf( Long.class ) );
 
             // when
-            data = getQueryListing( QUERY );
+            data = getQueryListing( query );
 
             // then
             Long cpuTime2 = (Long) data.get( "cpuTimeMillis" );
@@ -148,7 +148,7 @@ public class ListQueriesProcedureTest
     public void shouldListActiveLocks() throws Exception
     {
         // given
-        String QUERY = "MATCH (x:X) SET x.v = 5 WITH count(x) AS num MATCH (y:Y) SET y.c = num";
+        String query = "MATCH (x:X) SET x.v = 5 WITH count(x) AS num MATCH (y:Y) SET y.c = num";
         Set<Long> locked = new HashSet<>();
         try ( Resource<Node> test = test( () ->
         {
@@ -157,13 +157,13 @@ public class ListQueriesProcedureTest
                 locked.add( db.createNode( label( "X" ) ).getId() );
             }
             return db.createNode( label( "Y" ) );
-        }, Transaction::acquireWriteLock, QUERY ) )
+        }, Transaction::acquireWriteLock, query ) )
         {
             // when
             try ( Result rows = db.execute( "CALL dbms.listQueries() YIELD query AS queryText, queryId "
                     + "WHERE queryText = $queryText "
                     + "CALL dbms.listActiveLocks(queryId) YIELD mode, resourceType, resourceId "
-                    + "RETURN *", singletonMap( "queryText", QUERY ) ) )
+                    + "RETURN *", singletonMap( "queryText", query ) ) )
             {
                 // then
                 Set<Long> ids = new HashSet<>();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -109,6 +109,7 @@ public class ListQueriesProcedureTest
             @SuppressWarnings( "unchecked" )
             Map<String,Object> statusMap = (Map<String,Object>) status;
             assertEquals( "WAITING", statusMap.get( "state" ) );
+            assertEquals( "EXCLUSIVE", statusMap.get( "lockMode" ) );
             assertEquals( "NODE", statusMap.get( "resourceType" ) );
             assertArrayEquals( new long[] {test.resource().getId()}, (long[]) statusMap.get( "resourceIds" ) );
             assertThat( data, hasKey( "waitTimeMillis" ) );

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -309,6 +309,7 @@ public class QueryLoggerTest
                 queryText,
                 params,
                 metaData,
+                () -> 0,
                 Thread.currentThread(),
                 clock,
                 CpuClock.CPU_CLOCK );


### PR DESCRIPTION
Adds a procedure called dbms.listActiveLocks(queryId) that lists all locks held by the transaction that executes the query with the given id.

Sample output from `CALL dbms.listQueries() YIELD queryId CALL dbms.listActiveLocks(queryId) YIELD mode, resourceType, resourceId RETURN *`:
```
+-----------------------------------------------------+
| mode        | queryId   | resourceId | resourceType |
+-----------------------------------------------------+
| "EXCLUSIVE" | "query-1" | 0          | "NODE"       |
| "EXCLUSIVE" | "query-1" | 1          | "NODE"       |
| "EXCLUSIVE" | "query-1" | 2          | "NODE"       |
| "EXCLUSIVE" | "query-1" | 3          | "NODE"       |
| "EXCLUSIVE" | "query-1" | 4          | "NODE"       |
| "SHARED"    | "query-1" | 0          | "SCHEMA"     |
| "SHARED"    | "query-3" | 0          | "SCHEMA"     |
+-----------------------------------------------------+
```