### PR TITLE
Added procedure to list currently active config

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.builtinprocs;
 import java.util.Comparator;
 import java.util.stream.Stream;
 
-import org.neo4j.configuration.ConfigValue;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.configuration.Config;
@@ -69,20 +68,6 @@ public class BuiltInDbmsProcedures
         return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllFunctions().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
                 .map( FunctionResult::new );
-    }
-
-    public static class ConfigResult
-    {
-        public final String name;
-        public final String description;
-        public final String value;
-
-        private ConfigResult( ConfigValue configValue )
-        {
-            this.name = configValue.name();
-            this.description = configValue.description().orElse( "" );
-            this.value = configValue.value().map( Object::toString ).orElse( "" );
-        }
     }
 
     public static class FunctionResult

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -43,14 +43,13 @@ public class BuiltInDbmsProcedures
 
     @Description( "List the currently active config of Neo4j." )
     @Procedure( name = "dbms.listConfig", mode = DBMS )
-    public Stream<ConfigResult> listConfig( @Name( value = "showHidden", defaultValue = "false" ) boolean showHidden,
-            @Name( value = "name", defaultValue = ".*" ) String namePattern )
+    public Stream<ConfigResult> listConfig( @Name( value = "namePrefix", defaultValue = "" ) String namePrefix )
     {
         Config config = graph.getDependencyResolver().resolveDependency( Config.class );
         return config.getConfigValues().values().stream()
                 .map( ConfigResult::new )
-                .filter( c -> showHidden || !c.name.startsWith( "unsupported" ) )
-                .filter( c -> c.name.matches( namePattern ) )
+                .filter( c -> !c.name.startsWith( "unsupported" ) )
+                .filter( c -> c.name.startsWith( namePrefix ) )
                 .sorted( Comparator.comparing( c -> c.name ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -43,12 +43,14 @@ public class BuiltInDbmsProcedures
 
     @Description( "List the currently active config of Neo4j." )
     @Procedure( name = "dbms.listConfig", mode = DBMS )
-    public Stream<ConfigResult> listConfig( @Name( value = "showHidden", defaultValue = "false" ) boolean showHidden )
+    public Stream<ConfigResult> listConfig( @Name( value = "showHidden", defaultValue = "false" ) boolean showHidden,
+            @Name( value = "name", defaultValue = ".*" ) String namePattern )
     {
         Config config = graph.getDependencyResolver().resolveDependency( Config.class );
         return config.getConfigValues().values().stream()
                 .map( ConfigResult::new )
                 .filter( c -> showHidden || !c.name.startsWith( "unsupported" ) )
+                .filter( c -> c.name.matches( namePattern ) )
                 .sorted( Comparator.comparing( c -> c.name ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ConfigResult.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ConfigResult.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import org.neo4j.configuration.ConfigValue;
+
+public class ConfigResult
+{
+    public final String name;
+    public final String description;
+    public final String value;
+
+    public ConfigResult( ConfigValue configValue )
+    {
+        this.name = configValue.name();
+        this.description = configValue.description().orElse( "" );
+        this.value = configValue.value().map( Object::toString ).orElse( "" );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.security.AnonymousContext;
+import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.collection.Iterators.asList;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
+
+public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
+{
+    @Test
+    public void listConfig() throws Exception
+    {
+        // When
+        RawIterator<Object[],ProcedureException> stream =
+                dbmsOperations().procedureCallDbms( procedureName( "dbms", "config" ),
+                        Collections.singletonList( false ).toArray(),
+                        AnonymousContext.none() );
+
+        // Then
+        List<Object[]> config = asList( stream );
+        List<String> names = config.stream()
+                .map( o -> o[0].toString() )
+                .collect( Collectors.toList() );
+
+        // The size of the config is not fixed so just make sure it's the right magnitude
+        assertTrue( names.size() > 10 );
+
+        assertThat( names, hasItem( GraphDatabaseSettings.record_format.name() ) );
+
+        // Should not contain "unsupported.*" configs
+        assertEquals( names.stream()
+                .filter( n -> n.startsWith( "unsupported" ) )
+                .count(), 0 );
+    }
+
+    @Test
+    public void listConfigWithUnsupported() throws Exception
+    {
+        // When
+        RawIterator<Object[],ProcedureException> stream =
+                dbmsOperations().procedureCallDbms( procedureName( "dbms", "config" ),
+                        Collections.singletonList( true ).toArray(),
+                        AnonymousContext.none() );
+
+        // Then
+        List<Object[]> config = asList( stream );
+        List<String> names = config.stream()
+                .map( o -> o[0].toString() )
+                .collect( Collectors.toList() );
+
+        // The size of the config is not fixed so just make sure it's the right magnitude
+        assertTrue( names.size() > 10 );
+
+        assertThat( names, hasItem( GraphDatabaseSettings.record_format.name() ) );
+
+        // Should contain "unsupported.*" configs, again the number is not fixed
+        assertTrue( names.stream()
+                .filter( n -> n.startsWith( "unsupported" ) )
+                .count() > 10 );
+
+        // Check a specific unsupported one
+        assertTrue( GraphDatabaseSettings.cypher_runtime.name().startsWith( "unsupported" ) );
+        assertThat( names, hasItem( GraphDatabaseSettings.cypher_runtime.name() ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
@@ -45,7 +45,7 @@ public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
     {
         // When
         RawIterator<Object[],ProcedureException> stream =
-                dbmsOperations().procedureCallDbms( procedureName( "dbms", "config" ),
+                dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
                         Collections.singletonList( false ).toArray(),
                         AnonymousContext.none() );
 
@@ -71,7 +71,7 @@ public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
     {
         // When
         RawIterator<Object[],ProcedureException> stream =
-                dbmsOperations().procedureCallDbms( procedureName( "dbms", "config" ),
+                dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
                         Collections.singletonList( true ).toArray(),
                         AnonymousContext.none() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
@@ -47,7 +47,7 @@ public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
         // When
         RawIterator<Object[],ProcedureException> stream =
                 dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
-                        Arrays.asList( false, ".*" ).toArray(),
+                        Arrays.asList( "" ).toArray(),
                         AnonymousContext.none() );
 
         // Then
@@ -68,42 +68,12 @@ public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
     }
 
     @Test
-    public void listConfigWithUnsupported() throws Exception
-    {
-        // When
-        RawIterator<Object[],ProcedureException> stream =
-                dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
-                        Arrays.asList( true, ".*" ).toArray(),
-                        AnonymousContext.none() );
-
-        // Then
-        List<Object[]> config = asList( stream );
-        List<String> names = config.stream()
-                .map( o -> o[0].toString() )
-                .collect( Collectors.toList() );
-
-        // The size of the config is not fixed so just make sure it's the right magnitude
-        assertTrue( names.size() > 10 );
-
-        assertThat( names, hasItem( GraphDatabaseSettings.record_format.name() ) );
-
-        // Should contain "unsupported.*" configs, again the number is not fixed
-        assertTrue( names.stream()
-                .filter( n -> n.startsWith( "unsupported" ) )
-                .count() > 10 );
-
-        // Check a specific unsupported one
-        assertTrue( GraphDatabaseSettings.cypher_runtime.name().startsWith( "unsupported" ) );
-        assertThat( names, hasItem( GraphDatabaseSettings.cypher_runtime.name() ) );
-    }
-
-    @Test
     public void listConfigWithASpecificConfigName() throws Exception
     {
         // When
         RawIterator<Object[],ProcedureException> stream =
                 dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
-                        Arrays.asList( true, GraphDatabaseSettings.strict_config_validation.name() ).toArray(),
+                        Arrays.asList( GraphDatabaseSettings.strict_config_validation.name() ).toArray(),
                         AnonymousContext.none() );
 
         // Then

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -51,12 +51,10 @@ import org.neo4j.kernel.impl.factory.Edition;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.proc.TypeMappers;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.kernel.internal.Version;
 import org.neo4j.storageengine.api.Token;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -65,9 +63,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.api.proc.Context.KERNEL_TRANSACTION;
-
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
@@ -184,8 +180,10 @@ public class BuiltInProceduresTest
     {
         // When/Then
         assertThat( call( "dbms.procedures" ), containsInAnyOrder(
-                record( "dbms.listConfig", "dbms.listConfig(showHidden = false :: BOOLEAN?) :: (name :: STRING?, " +
-                        "description :: STRING?, value :: STRING?)", "List the currently active config of Neo4j." ),
+                record( "dbms.listConfig",
+                        "dbms.listConfig(showHidden = false :: BOOLEAN?, name = .* :: STRING?) :: (name :: STRING?, " +
+                                "description :: STRING?, value :: STRING?)",
+                        "List the currently active config of Neo4j." ),
             record( "db.awaitIndex", "db.awaitIndex(index :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID", "Wait for an index to come online (for example: CALL db.awaitIndex(\":Person(name)\"))." ),
             record( "db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database." ),
             record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)", "List all indexes in the database." ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -184,6 +184,8 @@ public class BuiltInProceduresTest
     {
         // When/Then
         assertThat( call( "dbms.procedures" ), containsInAnyOrder(
+                record( "dbms.listConfig", "dbms.listConfig(showHidden = false :: BOOLEAN?) :: (name :: STRING?, " +
+                        "description :: STRING?, value :: STRING?)", "List the currently active config of Neo4j." ),
             record( "db.awaitIndex", "db.awaitIndex(index :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID", "Wait for an index to come online (for example: CALL db.awaitIndex(\":Person(name)\"))." ),
             record( "db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database." ),
             record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)", "List all indexes in the database." ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -181,8 +181,8 @@ public class BuiltInProceduresTest
         // When/Then
         assertThat( call( "dbms.procedures" ), containsInAnyOrder(
                 record( "dbms.listConfig",
-                        "dbms.listConfig(showHidden = false :: BOOLEAN?, name = .* :: STRING?) :: (name :: STRING?, " +
-                                "description :: STRING?, value :: STRING?)",
+                        "dbms.listConfig(namePrefix =  :: STRING?) :: (name :: STRING?, description :: STRING?, value" +
+                                " :: STRING?)",
                         "List the currently active config of Neo4j." ),
             record( "db.awaitIndex", "db.awaitIndex(index :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID", "Wait for an index to come online (for example: CALL db.awaitIndex(\":Person(name)\"))." ),
             record( "db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database." ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api.integrationtest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.DataWriteOperations;
@@ -106,8 +107,8 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         // Then
         assertThat( asList( stream ), containsInAnyOrder(
                 equalTo( new Object[]{ "dbms.listConfig",
-                        "dbms.listConfig(showHidden = false :: BOOLEAN?) :: (name :: STRING?, description :: STRING?," +
-                                " value :: STRING?)",
+                        "dbms.listConfig(showHidden = false :: BOOLEAN?, name = .* :: STRING?) :: (name :: STRING?, " +
+                                "description :: STRING?, value :: STRING?)",
                         "List the currently active config of Neo4j." } ),
                 equalTo( new Object[]{"db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database."} ),
                 equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)", "List all indexes in the database."} ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -107,8 +107,8 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         // Then
         assertThat( asList( stream ), containsInAnyOrder(
                 equalTo( new Object[]{ "dbms.listConfig",
-                        "dbms.listConfig(showHidden = false :: BOOLEAN?, name = .* :: STRING?) :: (name :: STRING?, " +
-                                "description :: STRING?, value :: STRING?)",
+                        "dbms.listConfig(namePrefix =  :: STRING?) :: (name :: STRING?, description :: STRING?, value" +
+                                " :: STRING?)",
                         "List the currently active config of Neo4j." } ),
                 equalTo( new Object[]{"db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database."} ),
                 equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)", "List all indexes in the database."} ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -105,6 +105,10 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
 
         // Then
         assertThat( asList( stream ), containsInAnyOrder(
+                equalTo( new Object[]{ "dbms.listConfig",
+                        "dbms.listConfig(showHidden = false :: BOOLEAN?) :: (name :: STRING?, description :: STRING?," +
+                                " value :: STRING?)",
+                        "List the currently active config of Neo4j." } ),
                 equalTo( new Object[]{"db.constraints", "db.constraints() :: (description :: STRING?)", "List all constraints in the database."} ),
                 equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)", "List all indexes in the database."} ),
                 equalTo( new Object[]{"db.awaitIndex", "db.awaitIndex(index :: STRING?, timeOutSeconds = 300 :: INTEGER?) :: VOID",


### PR DESCRIPTION
Example outputs:

- default output

![default output](https://cloud.githubusercontent.com/assets/223655/21807903/28a1d7c6-d741-11e6-9df9-92e30faed2af.png)

- with `showHidden=true` shows unsupported stuff (e.g. all of the config)

![includes unsupported settings when true](https://cloud.githubusercontent.com/assets/223655/21807909/2ad279ba-d741-11e6-9334-cfc355976a46.png)


changelog [procedures]