### PR TITLE
Fix erroneous LDAP authorization cache expiry in multi-provider setup

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -246,7 +246,7 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
     {
         if ( authorizationEnabled )
         {
-            String username = (String) getAvailablePrincipal( principals );
+            String username = getUsername( principals );
             if ( username == null )
             {
                 return null;
@@ -287,6 +287,21 @@ public class LdapRealm extends JndiLdapRealm implements RealmLifecycle, ShiroAut
             }
         }
         return null;
+    }
+
+    private String getUsername( PrincipalCollection principals )
+    {
+        String username = null;
+        Collection ldapPrincipals = principals.fromRealm( getName() );
+        if ( !ldapPrincipals.isEmpty() )
+        {
+            username = (String) ldapPrincipals.iterator().next();
+        }
+        else if ( useSystemAccountForAuthorization )
+        {
+            username = (String) principals.getPrimaryPrincipal();
+        }
+        return username;
     }
 
     private LdapContext getSystemLdapContextUsingStartTls( LdapContextFactory ldapContextFactory )


### PR DESCRIPTION
This PR fixes a bug that could occur in the LDAP auth provider when it was part of a mult-provider setup with the system account disabled. In this configuration, the LDAP provider would fail all queries with an Authorization Info Expired message, for users that did not authenticate using the LDAP provider.