### PR TITLE
Restructure TCK implementation

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -1,1 +1,132 @@
-
+Case should handle mixed number types
+Case should handle mixed types
+Returning a CASE expression into pattern expression
+Returning a CASE expression into integer
+Returning a CASE expression with label predicates
+Using a CASE expression in a WITH, positive case
+Using a CASE expression in a WITH, negative case
+Using a CASE expression with label predicates in a WITH
+Using a CASE expression in a WHERE, positive case
+Using a CASE expression in a WHERE, negative case
+Using a CASE expression in a WHERE, with relationship predicate
+Using a CASE expression in a WHERE, with label predicate
+Returning a CASE expression with a pattern expression alternative
+Merge node with prop and label and unique index
+Merge node with prop and label and unique index when no match
+Merge using unique constraint should update existing node
+Merge using unique constraint should create missing node
+Should match on merge using multiple unique indexes if only found single node for both indexes
+Should match on merge using multiple unique indexes and labels if only found single node for both indexes
+Should match on merge using multiple unique indexes using same key if only found single node for both indexes
+Should create on merge using multiple unique indexes if found no nodes
+Should create on merge using multiple unique indexes and labels if found no nodes
+Should fail on merge using multiple unique indexes using same key if found different nodes
+Should fail on merge using multiple unique indexes if found different nodes
+Should fail on merge using multiple unique indexes if it found a node matching single property only
+Should fail on merge using multiple unique indexes if it found a node matching single property only flipped order
+Should fail on merge using multiple unique indexes and labels if found different nodes
+Merge with uniqueness constraints must properly handle multiple labels
+Unrelated nodes with same property should not clash
+Works fine with index and constraint
+Works with property repeated in literal map in set
+Works with property in map that gets set
+Failing when creation would violate constraint
+Explanation of in-query procedure call
+Add labels inside FOREACH
+Merging inside a FOREACH using a previously matched node
+Merging inside a FOREACH using a previously matched node and a previously merged node
+Merging inside a FOREACH using two previously merged nodes
+Merging inside a FOREACH using two previously merged nodes that also depend on WITH
+Inside nested FOREACH
+Inside nested FOREACH, nodes inlined
+Should handle running merge inside a foreach loop
+Merge inside foreach should see variables introduced by update actions outside foreach
+Handling numerical literal on the left when using an index
+Handling numerical literal on the right when using an index
+Works fine with index
+Works with indexed and unindexed property
+Works with two indexed properties
+Should be able to merge using property from match with index
+Merge with an index must properly handle multiple labels
+Filter on path nodes
+Using a single bound node
+Using a longer pattern
+Using bound nodes in mid-pattern
+Using bound nodes in mid-pattern when pattern partly matches
+Introduce named paths
+Unbound pattern
+Returning an `extract()` expression
+Using an `extract()` expression in a WITH
+Using an `extract()` expression in a WHERE
+Using a pattern expression and a CASE expression in a WHERE
+Pattern expressions and ORDER BY
+Returning a pattern expression
+Returning a pattern expression with label predicate
+Returning a pattern expression with bound nodes
+Using a pattern expression in a WITH
+Using a variable-length pattern expression in a WITH
+Using pattern expression in RETURN
+Aggregating on pattern expression
+Using `length()` on outgoing pattern expression
+Using `length()` on incoming pattern expression
+Using `length()` on undirected pattern expression
+Using `length()` on pattern expression with complex relationship predicate
+Returning pattern expression in `exists()`
+Pattern expression inside list comprehension
+Get node degree via length of pattern expression
+Get node degree via length of pattern expression that specifies a relationship type
+Get node degree via length of pattern expression that specifies multiple relationship types
+Filter relationships with properties using pattern predicate
+Filter using negated pattern predicate
+Filter using a variable length relationship pattern predicate with properties
+Filter using a pattern predicate that is a logical OR between an expression and a subquery
+Filter using a pattern predicate that is a logical OR between two expressions and a subquery
+Filter using a pattern predicate that is a logical OR between one expression and a negated subquery
+Filter using a pattern predicate that is a logical OR between one subquery and a negated subquery
+Filter using a pattern predicate that is a logical OR between one negated subquery and a subquery
+Filter using a pattern predicate that is a logical OR between two subqueries
+Filter using a pattern predicate that is a logical OR between one negated subquery, a subquery, and an equality expression
+Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression
+Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression 2
+Using a pattern predicate after aggregation 1
+Using a pattern predicate after aggregation 2
+Returning a relationship from a pattern predicate
+Pattern predicate should uphold the relationship uniqueness constraint
+Using pattern predicate
+Matching using pattern predicate with multiple relationship types
+Matching using pattern predicate
+Pattern predicates on missing optionally matched nodes should simply evaluate to false
+Pattern predicates and parametrised predicate
+Matching with complex composite pattern predicate
+Handling pattern predicates without matches
+Handling pattern predicates
+Matching named path with variable length pattern and pattern predicates
+In-query call to procedure that takes no arguments
+Calling the same procedure twice using the same outputs in each call
+In-query call to VOID procedure that takes no arguments
+In-query call to VOID procedure does not consume rows
+In-query call to procedure with explicit arguments
+In-query call to procedure with argument of type NUMBER accepts value of type INTEGER
+In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
+In-query call to procedure with argument of type FLOAT accepts value of type INTEGER
+In-query call to procedure with null argument
+Filter should work
+Find a shortest path among paths that fulfill a predicate on all nodes
+Find a shortest path among paths that fulfill a predicate on all relationships
+Find a shortest path among paths that fulfill a predicate on all relationships 2
+Find a shortest path among paths that fulfill a predicate
+Find a shortest path without loosing context information at runtime
+Find a shortest path in an expression context
+Find a shortest path among paths that fulfill a predicate on all relationships
+Finds shortest path
+Optionally finds shortest path
+Optionally finds shortest path using previously bound nodes
+Returns null when not finding a shortest path during an OPTIONAL MATCH
+Find relationships of a shortest path
+Find no shortest path when a length limit prunes all candidates
+Find no shortest path when the start node is null
+Find all shortest paths
+Find a shortest path among paths of length 1
+Find a shortest path of length 1 if requested to
+Find a shortest path among paths matched using a non-variable length pattern
+Find a combination of a shortest path and a pattern expression

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/rule.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/rule.txt
@@ -1,29 +1,17 @@
-// BuiltInProcedureAcceptance.feature
-Getting all labels
-
 // ProcedureCallAcceptance.feature
-Standalone call to procedure that takes no arguments
   In-query call to procedure that takes no arguments
 Calling the same procedure twice using the same outputs in each call
-Standalone call to VOID procedure that takes no arguments
   In-query call to VOID procedure that takes no arguments
   In-query call to VOID procedure does not consume rows
-Standalone call to VOID procedure that takes no arguments, called with implicit arguments
 Standalone call to procedure that takes no arguments and yields no results
   In-query call to procedure that takes no arguments and yields no results
-Standalone call to procedure that takes no arguments and yields no results, called with implicit arguments
-Standalone call to procedure with explicit arguments
   In-query call to procedure with explicit arguments
 Standalone call to procedure with implicit arguments
-Standalone call to procedure with argument of type NUMBER  accepts value of type INTEGER
   In-query call to procedure with argument of type NUMBER  accepts value of type INTEGER
-Standalone call to procedure with argument of type NUMBER  accepts value of type FLOAT
   In-query call to procedure with argument of type NUMBER  accepts value of type FLOAT
 Standalone call to procedure with argument of type INTEGER accepts value of type FLOAT
   In-query call to procedure with argument of type INTEGER accepts value of type FLOAT
-Standalone call to procedure with argument of type FLOAT   accepts value of type INTEGER
   In-query call to procedure with argument of type FLOAT   accepts value of type INTEGER
-Standalone call to procedure with null argument
   In-query call to procedure with null argument
 Standalone call to procedure should fail if input type is wrong
   In-query call to procedure should fail if input type is wrong
@@ -41,5 +29,4 @@ In-query call to procedure that has outputs fails if no outputs are yielded
 In-query call to procedure that both takes arguments and has outputs fails if the arguments are passed implicitly and no outputs are yielded
 
 //ExplainAcceptance.feature
-Explanation of standalone procedure call
 Explanation of   in-query procedure call

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -65,7 +65,6 @@ Failing when performing property access on a non-map 1
 `percentileDisc()` failing on bad arguments
 `percentileDisc()` failing in more involved query
 Fail when adding new label predicate on a node that is already bound 5
-Null-setting one property with ON CREATE
 Fail when imposing new predicates on a variable that is already bound
 Ignore null when setting properties using an appending map
 Ignore null when setting properties using an overriding map

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -61,7 +61,6 @@ Failing when performing property access on a non-map 1
 `min()` should aggregate strings
 
 // other
-Combine MATCH, WITH and CREATE
 `percentileCont()` failing on bad arguments
 `percentileDisc()` failing on bad arguments
 `percentileDisc()` failing in more involved query

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-30.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-30.txt
@@ -76,9 +76,3 @@ Fail when comparing parameters to nodes
 Comparing nodes to properties
 Fail when comparing nodes to relationships
 Fail when comparing relationships to nodes
-
-// bugs, 3.0 dependency not updated
-IN should work with nested list subscripting
-IN should work with nested literal list subscripting
-IN should work with list slices
-IN should work with literal list slices

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -1,3 +1,702 @@
+Return an integer
+Support multiple divisions in aggregate function
+Support column renaming for aggregates as well
+Aggregates inside normal functions
+Handle aggregates inside non-aggregate expressions
+Count nodes
+Sort on aggregate function and normal property
+Aggregate on property
+Count non-null values
+Sum non-null values
+Handle aggregation on functions
+Distinct on unbound node
+Distinct on null
+Collect distinct nulls
+Collect distinct values mixed with nulls
+Aggregate on list values
+Aggregates in aggregates
+Aggregates with arithmetics
+Aggregates ordered by arithmetics
+Multiple aggregates on same variable
+Simple counting of nodes
+Aggregation of named paths
+Aggregation with `min()`
+Handle subexpression in aggregation also occurring as standalone expression with nested aggregation in a literal map
+Projection during aggregation in WITH before MERGE and after WITH with predicate
+No overflow during summation
+Counting with loops
+`max()` should aggregate strings
+`min()` should aggregate strings
+Keeping used expression 1
+Keeping used expression 2
+Keeping used expression 3
+Keeping used expression 4
+Handling numerical ranges 1
+Handling numerical ranges 2
+Handling numerical ranges 3
+Handling numerical ranges 4
+Handling string ranges 1
+Handling string ranges 2
+Handling string ranges 3
+Handling string ranges 4
+Handling empty range
+Handling long chains of operators
+Number-typed integer comparison
+Number-typed float comparison
+Any-typed string comparison
+Comparing nodes to nodes
+Comparing relationships to relationships
+IN should work with nested list subscripting
+IN should work with nested literal list subscripting
+IN should work with list slices
+IN should work with literal list slices
+Execute n[0]
+Execute n['name'] in read queries
+Execute n['name'] in update queries
+Use dynamic property lookup based on parameters when there is no type information
+Use dynamic property lookup based on parameters when there is lhs type information
+Use dynamic property lookup based on parameters when there is rhs type information
+Use collection lookup based on parameters when there is no type information
+Use collection lookup based on parameters when there is lhs type information
+Use collection lookup based on parameters when there is rhs type information
+Fail at runtime when attempting to index with an Int into a Map
+Fail at runtime when trying to index into a map with a non-string
+Fail at runtime when attempting to index with a String into a Collection
+Fail at runtime when trying to index into a list with a list
+Fail at runtime when trying to index something which is not a map or collection
+Run coalesce
+Functions should return null if they get path containing unbound
+`split()`
+`properties()` on a node
+`properties()` on a relationship
+`properties()` on a map
+`properties()` on null
+`reverse()`
+`exists()` with dynamic property lookup
+`exists()` with literal maps
+IS NOT NULL with literal maps
+`percentileDisc()`
+`percentileCont()`
+`percentileCont()` failing on bad arguments
+`percentileDisc()` failing on bad arguments
+`percentileDisc()` failing in more involved query
+`type()`
+`type()` on two relationships
+`type()` on null relationship
+`type()` on mixed null and non-null relationships
+`type()` handling Any type
+`type()` failing on invalid arguments
+`labels()` should accept type Any
+`labels()` should accept type Any
+`labels()` should accept type Any
+`exists()` is case insensitive
+Find friends of others
+Should only join when matching
+Using `keys()` on a single node, non-empty result
+Using `keys()` on multiple nodes, non-empty result
+Using `keys()` on a single node, empty result
+Using `keys()` on an optionally matched node
+Using `keys()` on a relationship, non-empty result
+Using `keys()` on a relationship, empty result
+Using `keys()` on an optionally matched relationship
+Using `keys()` on a literal map
+Using `keys()` on a parameter map
+Adding a single label
+Ignore space before colon
+Adding multiple labels
+Ignoring intermediate whitespace 1
+Ignoring intermediate whitespace 2
+Creating node without label
+Creating node with two labels
+Ignore space when creating node with labels
+Create node with label in pattern
+Using `labels()` in return clauses
+Removing a label
+Removing a non-existent label
+Does not lose precision
+Handling inlined equality of large integer
+Handling explicit equality of large integer
+Handling inlined equality of large integer, non-equal values
+Handling explicit equality of large integer, non-equal values
+Returning a list comprehension
+Using a list comprehension in a WITH
+Using a list comprehension in a WHERE
+Path query should return results in written order
+Longer path query should return results in written order
+Use multiple MATCH clauses to do a Cartesian product
+Filter out based on node prop name
+Honour the column name for RETURN items
+Filter based on rel prop name
+Cope with shadowed variables
+Get neighbours
+Get two related nodes
+Get related to related to
+Handle comparison between node properties
+Return two subgraphs with bound undirected relationship
+Return two subgraphs with bound undirected relationship and optional relationship
+Rel type function works as expected
+Walk alternative relationships
+Handle OR in the WHERE clause
+Return a simple path
+Return a three node path
+Do not return anything because path length does not match
+Pass the path length test
+Return relationships by fetching them from the path - starting from the end
+Return relationships by fetching them from the path
+Return relationships by collecting them as a list - wrong way
+Return relationships by collecting them as a list - undirected
+Return relationships by collecting them as a list
+Return a var length path
+Return a var length path of length zero
+Return a named var length path of length zero
+Do not fail when evaluating predicates with illegal operations if the AND'ed predicate evaluates to false
+Do not fail when evaluating predicates with illegal operations if the OR'd predicate evaluates to true
+Fail when comparing strings and integers using > in an AND'd predicate
+Fail when comparing strings and integers using > in a OR'd predicate
+Aggregation with named paths
+Zero-length variable length pattern in the middle of the pattern
+Simple variable length pattern
+Variable length relationship without lower bound
+Variable length relationship without bounds
+Returning bound nodes that are not part of the pattern
+Two bound nodes pointing to the same node
+Three bound nodes pointing to the same node
+Three bound nodes pointing to the same node with extra connections
+MATCH with OPTIONAL MATCH in longer pattern
+Optionally matching named paths
+Optionally matching named paths with single and variable length patterns
+Optionally matching named paths with variable length patterns
+Matching variable length patterns from a bound node
+Excluding connected nodes
+Do not fail when predicates on optionally matched and missed nodes are invalid
+MATCH and OPTIONAL MATCH on same pattern
+Matching using an undirected pattern
+Matching all nodes
+Comparing nodes for equality
+Matching using self-referencing pattern returns no result
+Variable length relationship in OPTIONAL MATCH
+Matching using relationship predicate with multiples of the same type
+ORDER BY with LIMIT
+Simple node property predicate
+Handling direction of named paths
+Simple OPTIONAL MATCH on empty graph
+OPTIONAL MATCH with previously bound nodes
+`collect()` filtering nulls
+Multiple anonymous nodes in a pattern
+Matching a relationship pattern using a label predicate
+Matching a relationship pattern using a label predicate on both sides
+Matching nodes using multiple labels
+Returning label predicate expression
+Returning label predicate expression
+Matching using a simple pattern with label predicate
+Matching disconnected patterns
+Non-optional matches should not return nulls
+Handling cyclic patterns
+Handling cyclic patterns when separated into two parts
+Handling fixed-length variable length pattern
+Matching from null nodes should return no results owing to finding no matches
+Matching from null nodes should return no results owing to matches being filtered out
+Optionally matching from null nodes should return null
+OPTIONAL MATCH returns null
+Zero-length named path
+Variable-length named path
+Matching with aggregation
+Matching using a relationship that is already bound
+Matching using a relationship that is already bound, in conjunction with aggregation
+Matching using a relationship that is already bound, in conjunction with aggregation and ORDER BY
+Matching with LIMIT and optionally matching using a relationship that is already bound
+Matching with LIMIT and optionally matching using a relationship and node that are both already bound
+Matching with LIMIT, then matching again using a relationship and node that are both already bound along with an additional predicate
+Matching with LIMIT and predicates, then matching again using a relationship and node that are both already bound along with a duplicate predicate
+Matching twice with conflicting relationship types on same relationship
+Matching twice with duplicate relationship types on same relationship
+Matching relationships into a list and matching variable length using the list
+Matching relationships into a list and matching variable length using the list, with bound nodes
+Matching relationships into a list and matching variable length using the list, with bound nodes, wrong direction
+Matching and optionally matching with bound nodes in reverse direction
+Matching and optionally matching with unbound nodes and equality predicate in reverse direction
+Fail when using property access on primitive type
+Matching and returning ordered results, with LIMIT
+Counting an empty graph
+Matching variable length pattern with property predicate
+Variable length pattern checking labels on endnodes
+Variable length pattern with label predicate on both sides
+Undirected named path
+Named path with WITH
+Named path with alternating directed/undirected relationships
+Named path with multiple alternating directed/undirected relationships
+Named path with undirected fixed variable length pattern
+Returning a node property value
+Returning a relationship property value
+Projecting nodes and relationships
+Missing node property should become null
+Missing relationship property should become null
+Returning multiple node property values
+Adding a property and a literal in projection
+Adding list properties in projection
+Variable length relationship variables are lists of relationships
+Variable length patterns and nulls
+Projecting a list of nodes and relationships
+Projecting a map of nodes and relationships
+Respecting direction when matching existing path
+Respecting direction when matching non-existent path
+Respecting direction when matching non-existent path with multiple directions
+Matching path with both directions should respect other directions
+Matching path with multiple bidirectional relationships
+Matching nodes with many labels
+Matching longer variable length paths
+Counting rows after MATCH, MERGE, OPTIONAL MATCH
+Matching a self-loop
+Failing on merging relationship with null property
+Failing on merging node with null property
+Failing when setting a list of maps as a property
+Ignore null when setting property
+Ignore null when removing property
+Ignore null when setting properties using an appending map
+Ignore null when setting properties using an overriding map
+Ignore null when setting label
+Ignore null when removing label
+Ignore null when deleting node
+Ignore null when deleting relationship
+Satisfies the open world assumption, relationships between same nodes
+Satisfies the open world assumption, single relationship
+Satisfies the open world assumption, relationships between different nodes
+Return null when no matches due to inline label predicate
+Return null when no matches due to label predicate in WHERE
+Respect predicates on the OPTIONAL MATCH
+Returning label predicate on null node
+MATCH after OPTIONAL MATCH
+WITH after OPTIONAL MATCH
+Named paths in optional matches
+OPTIONAL MATCH and bound nodes
+OPTIONAL MATCH with labels on the optional end node
+Named paths inside optional matches with node predicates
+Variable length optional relationships
+Variable length optional relationships with length predicates
+Optionally matching self-loops
+Optionally matching self-loops without matches
+Variable length optional relationships with bound nodes
+Variable length optional relationships with bound nodes, no matches
+Longer pattern with bound nodes
+Longer pattern with bound nodes without matches
+Handling correlated optional matches; first does not match implies second does not match
+Handling optional matches between optionally matched entities
+Handling optional matches between nulls
+OPTIONAL MATCH and `collect()`
+ORDER BY should return results in ascending order
+ORDER BY DESC should return results in descending order
+ORDER BY of a column introduced in RETURN should return salient results in ascending order
+Renaming columns before ORDER BY should return results in ascending order
+Handle projections with ORDER BY - GH#4937
+ORDER BY should order booleans in the expected order
+ORDER BY DESC should order booleans in the expected order
+ORDER BY should order strings in the expected order
+ORDER BY DESC should order strings in the expected order
+ORDER BY should order ints in the expected order
+ORDER BY DESC should order ints in the expected order
+ORDER BY should order floats in the expected order
+ORDER BY DESC should order floats in the expected order
+Handle ORDER BY with LIMIT 1
+ORDER BY with LIMIT 0 should not generate errors
+ORDER BY with negative parameter for LIMIT should not generate errors
+ORDER BY with a negative LIMIT should fail with a syntax exception
+Pattern comprehension and ORDER BY
+Returning a pattern comprehension
+Returning a pattern comprehension with label predicate
+Returning a pattern comprehension with bound nodes
+Using a pattern comprehension in a WITH
+Using a variable-length pattern comprehension in a WITH
+Using pattern comprehension in RETURN
+Aggregating on pattern comprehension
+Using pattern comprehension to test existence
+Pattern comprehension inside list comprehension
+Get node degree via size of pattern comprehension
+Get node degree via size of pattern comprehension that specifies a relationship type
+Get node degree via size of pattern comprehension that specifies multiple relationship types
+Introducing new node variable in pattern comprehension
+Introducing new relationship variable in pattern comprehension
+Should ignore nulls
+Remove a single label
+Remove multiple labels
+Remove a single node property
+Remove multiple node properties
+Remove a single relationship property
+Remove a single relationship property
+Remove multiple relationship properties
+Remove a missing property should be a valid operation
+Allow addition
+Limit to two hits
+Start the result from the second row
+Start the result from the second row by param
+Get rows in the middle
+Get rows in the middle by param
+Sort on aggregated function
+Support sort and distinct
+Support column renaming
+Support ordering by a property after being distinct-ified
+Count star should count everything in scope
+Absolute function
+Return collection size
+Fail when returning properties of deleted nodes
+Fail when returning labels of deleted nodes
+Fail when returning properties of deleted relationships
+Do not fail when returning type of deleted relationships
+LIMIT 0 should return an empty result
+Fail when sorting on variable removed by DISTINCT
+Fail when ordering nodes
+Ordering with aggregation
+DISTINCT on nullable values
+Return all variables
+Setting and returning the size of a list property
+Setting and returning the size of a list property
+`sqrt()` returning float values
+Arithmetic expressions inside aggregation
+Matching and disregarding output, then matching again
+Returning a list property
+Returning a projected map
+Returning an expression
+Concatenating and returning the size of literal lists
+Concatenating and returning the size of literal lists
+Limiting amount of rows when there are fewer left than the LIMIT argument
+`substring()` with default second argument
+Returning all variables with ordering
+Using aliased DISTINCT expression in ORDER BY
+Returned columns do not change from using ORDER BY
+Arithmetic expressions should propagate null values
+Indexing into nested literal lists
+Aliasing expressions
+Projecting an arithmetic expression with aggregation
+Multiple aliasing and backreferencing
+Aggregating by a list property has a correct definition of equality
+Reusing variable names
+DISTINCT inside aggregation should work with lists in maps
+Handling DISTINCT with lists in maps
+DISTINCT inside aggregation should work with nested lists in maps
+DISTINCT inside aggregation should work with nested lists of maps in maps
+Handling property access on the Any type
+Failing when performing property access on a non-map 1
+Failing when performing property access on a non-map 2
+Bad arguments for `range()`
+SKIP with an expression that does not depend on variables
+LIMIT with an expression that does not depend on variables
+Find all nodes
+Find labelled nodes
+Find nodes by property
+Finding exact matches
+Finding beginning of string
+Finding end of string 1
+Finding end of string 2
+Finding middle of string
+Finding the empty string
+Finding when the middle is known
+Finding strings starting with whitespace
+Finding strings starting with newline
+Finding strings ending with newline
+Finding strings ending with whitespace
+Finding strings containing whitespace
+Finding strings containing newline
+No string starts with null
+No string does not start with null
+No string ends with null
+No string does not end with null
+No string contains null
+No string does not contain null
+Combining string operators
+NOT with CONTAINS
+Using `rand()` in aggregations
+A literal null IS null
+A literal null is not IS NOT null
+Using null in AND
+Using null in OR
+Using null in XOR
+Using null in IN
+Handling triadic friend of a friend
+Handling triadic friend of a friend that is not a friend
+Handling triadic friend of a friend that is not a friend with different relationship type
+Handling triadic friend of a friend that is not a friend with superset of relationship type
+Handling triadic friend of a friend that is not a friend with implicit subset of relationship type
+Handling triadic friend of a friend that is not a friend with explicit subset of relationship type
+Handling triadic friend of a friend that is not a friend with same labels
+Handling triadic friend of a friend that is not a friend with different labels
+Handling triadic friend of a friend that is not a friend with implicit subset of labels
+Handling triadic friend of a friend that is not a friend with implicit superset of labels
+Handling triadic friend of a friend that is a friend
+Handling triadic friend of a friend that is a friend with different relationship type
+Handling triadic friend of a friend that is a friend with superset of relationship type
+Handling triadic friend of a friend that is a friend with implicit subset of relationship type
+Handling triadic friend of a friend that is a friend with explicit subset of relationship type
+Handling triadic friend of a friend that is a friend with same labels
+Handling triadic friend of a friend that is a friend with different labels
+Handling triadic friend of a friend that is a friend with implicit subset of labels
+Handling triadic friend of a friend that is a friend with implicit superset of labels
+`toBoolean()` on valid literal string
+`toBoolean()` on booleans
+`toBoolean()` on variables with valid string values
+`toBoolean()` on invalid strings
+`toBoolean()` on invalid types
+`toInteger()`
+`toInteger()` on float
+`toInteger()` returning null on non-numerical string
+`toInteger()` handling mixed number types
+`toInteger()` handling Any type
+`toInteger()` on a list of strings
+`toInteger()` on a complex-typed expression
+`toInteger()` failing on invalid arguments
+`toFloat()`
+`toFloat()` on mixed number types
+`toFloat()` returning null on non-numerical string
+`toFloat()` handling Any type
+`toFloat()` on a list of strings
+`toFloat()` failing on invalid arguments
+`toString()`
+`toString()` handling boolean properties
+`toString()` handling inlined boolean
+`toString()` handling boolean literal
+`toString()` should work on Any type
+`toString()` on a list of integers
+`toString()` failing on invalid arguments
+`toString()` should accept potentially correct types 1
+`toString()` should accept potentially correct types 2
+Should be able to create text output from union queries
+Two elements, both unique, not distinct
+Two elements, both unique, distinct
+Three elements, two unique, distinct
+Three elements, two unique, not distinct
+Unwinding a list
+Unwinding a range
+Unwinding a concatenation of lists
+Unwinding a collected unwound expression
+Unwinding a collected expression
+Creating nodes from an unwound parameter list
+Double unwinding a list of lists
+Unwinding the empty list
+Unwinding null
+Unwinding list with duplicates
+Unwind does not prune context
+Unwind does not remove variables from scope
+Multiple unwinds after each other
+Handling unbounded variable length match
+Handling explicitly unbounded variable length match
+Fail when asterisk operator is missing
+Handling single bounded variable length match 1
+Handling single bounded variable length match 2
+Handling single bounded variable length match 3
+Handling upper and lower bounded variable length match 1
+Handling upper and lower bounded variable length match 2
+Handling symmetrically bounded variable length match, bounds are zero
+Handling symmetrically bounded variable length match, bounds are one
+Handling symmetrically bounded variable length match, bounds are two
+Fail on negative bound
+Handling upper and lower bounded variable length match, empty interval 1
+Handling upper and lower bounded variable length match, empty interval 2
+Handling upper bounded variable length match, empty interval
+Handling upper bounded variable length match 1
+Handling upper bounded variable length match 2
+Handling lower bounded variable length match 1
+Handling lower bounded variable length match 2
+Handling lower bounded variable length match 3
+Handling a variable length relationship and a standard relationship in chain, zero length 1
+Handling a variable length relationship and a standard relationship in chain, zero length 2
+Handling a variable length relationship and a standard relationship in chain, single length 1
+Handling a variable length relationship and a standard relationship in chain, single length 2
+Handling a variable length relationship and a standard relationship in chain, longer 1
+Handling a variable length relationship and a standard relationship in chain, longer 2
+Handling a variable length relationship and a standard relationship in chain, longer 3
+Handling mixed relationship patterns and directions 1
+Handling mixed relationship patterns and directions 2
+Handling mixed relationship patterns 1
+Handling mixed relationship patterns 2
+Handling relationships that are already bound in variable length paths
+NOT and false
+Fail when trying to compare strings and numbers
+Passing on pattern nodes
+ORDER BY and LIMIT can be used
+No dependencies between the query parts
+Aliasing
+Handle dependencies across WITH
+Handle dependencies across WITH with SKIP
+WHERE after WITH should filter results
+WHERE after WITH can filter on top of an aggregation
+ORDER BY on an aggregating key
+ORDER BY a DISTINCT column
+WHERE on a DISTINCT column
+A simple pattern with one bound endpoint
+Null handling
+Nested maps
+Connected components succeeding WITH
+Single WITH using a predicate and aggregation
+Multiple WITHs using a predicate and aggregation
+Fail at compile time when attempting to index with a non-integer into a list
+`properties()` failing on an integer literal
+`properties()` failing on a string literal
+`properties()` failing on a list of booleans
+Fail when adding a new label predicate on a node that is already bound 1
+Fail when adding new label predicate on a node that is already bound 2
+Fail when adding new label predicate on a node that is already bound 3
+Fail when adding new label predicate on a node that is already bound 4
+Fail when adding new label predicate on a node that is already bound 5
+Return a float
+Return a float in exponent form
+Return a boolean
+Return a single-quoted string
+Return a double-quoted string
+Return null
+Return an empty list
+Return a nonempty list
+Return an empty map
+Return a nonempty map
+Accept skip zero
+Do not return non-existent nodes
+Do not return non-existent relationships
+Failing on incorrect unicode literal
+Failing on aggregation in WHERE
+Failing on aggregation in ORDER BY after RETURN
+Failing on aggregation in ORDER BY after WITH
+Failing when not aliasing expressions in WITH
+Failing when using undefined variable in pattern
+Failing when using undefined variable in SET
+Failing when using undefined variable in DELETE
+Failing when using a variable that is already bound in CREATE
+
+// Updating queries
+Fail when imposing new predicates on a variable that is already bound
+Creating a node
+Creating two nodes
+Creating two nodes and a relationship
+Creating a node with a label
+Creating a node with a property
+Create a single node with multiple labels
+Combine MATCH and CREATE
+Combine MATCH, WITH and CREATE
+Newly-created nodes not visible to preceding MATCH
+Create a single node with properties
+Creating a node with null properties should not return those properties
+Creating a relationship with null properties should not return those properties
+Create a simple pattern
+Create a self loop
+Create a self loop using MATCH
+Create nodes and relationships
+Create a relationship with a property
+Create a relationship with the correct direction
+Create a relationship and an end node from a matched starting node
+Create a single node after a WITH
+Create a relationship with a reversed direction
+Create a pattern with multiple hops
+Create a pattern with multiple hops in the reverse direction
+Create a pattern with multiple hops in varying directions
+Create a pattern with multiple hops with multiple types and varying directions
+Nodes are not created when aliases are applied to variable names
+Only a single node is created when an alias is applied to a variable name
+Nodes are not created when aliases are applied to variable names multiple times
+Only a single node is created when an alias is applied to a variable name multiple times
+A bound node should be recognized after projection with WITH + WITH
+A bound node should be recognized after projection with WITH + UNWIND
+A bound node should be recognized after projection with WITH + MERGE node
+A bound node should be recognized after projection with WITH + MERGE pattern
+Creating a pattern with multiple hops and changing directions
+Delete nodes
+Detach delete node
+Delete relationships
+Deleting connected nodes
+Detach deleting connected nodes and relationships
+Detach deleting paths
+Undirected expand followed by delete and count
+Undirected variable length expand followed by delete and count
+Create and delete in same query
+Delete optionally matched relationship
+Delete on null node
+Detach delete on null node
+Delete on null path
+Delete node from a list
+Delete node from a list
+Delete relationship from a list
+Delete nodes from a map
+Delete relationships from a map
+Detach delete nodes from nested map/list
+Delete relationships from nested map/list
+Delete paths from nested map/list
+Delete relationship with bidirectional matching
+Generate the movie graph correctly
+Updating one property with ON CREATE
+Null-setting one property with ON CREATE
+Copying properties from node with ON CREATE
+Copying properties from node with ON MATCH
+Copying properties from literal map with ON CREATE
+Copying properties from literal map with ON MATCH
+Merge node when no nodes exist
+Merge node with label
+Merge node with label add label on create
+Merge node with label add property on create
+Merge node with label when it exists
+Merge node should create when it doesn't match, properties
+Merge node should create when it doesn't match, properties and label
+Merge node with prop and label
+Merge node with label add label on match when it exists
+Merge node with label add property on update when it exists
+Merge node and set property on match
+Should work when finding multiple elements
+Should handle argument properly
+Should handle arguments properly with only write clauses
+Should be able to merge using property from match
+Should be able to use properties from match in ON CREATE
+Should be able to use properties from match in ON MATCH
+Should be able to use properties from match in ON MATCH and ON CREATE
+Should be able to set labels on match
+Should be able to set labels on match and on create
+Should support updates while merging
+Merge must properly handle multiple labels
+Merge followed by multiple creates
+Unwind combined with merge
+Merges should not be able to match on deleted nodes
+ON CREATE on created nodes
+Creating a relationship
+Matching a relationship
+Matching two relationships
+Filtering relationships
+Creating relationship when all matches filtered out
+Matching incoming relationship
+Creating relationship with property
+Using ON CREATE on a node
+Using ON CREATE on a relationship
+Using ON MATCH on created node
+Using ON MATCH on created relationship
+Using ON MATCH on a relationship
+Using ON CREATE and ON MATCH
+Creating relationship using merged nodes
+Mixing MERGE with CREATE
+Introduce named paths 1
+Introduce named paths 2
+Use outgoing direction when unspecified
+Match outgoing relationship when direction unspecified
+Match both incoming and outgoing relationships when direction unspecified
+Using list properties via variable
+Matching using list property
+Using bound variables from other updating clause
+UNWIND with multiple merges
+Do not match on deleted entities
+Do not match on deleted relationships
+Aliasing of existing nodes 1
+Aliasing of existing nodes 2
+Double aliasing of existing nodes 1
+Double aliasing of existing nodes 2
+Setting a node property to null removes the existing property
+Setting a relationship property to null removes the existing property
+Set a property
+Set a property to an expression
+Set a property by selecting the node using a simple expression
+Set a property by selecting the relationship using a simple expression
+Setting a property to null removes the property
+Add a label to a node
+Adding a list property
+Concatenate elements onto a list property
+Concatenate elements in reverse onto a list property
+Overwrite values when using +=
+Retain old values when using +=
+Explicit null values in a map remove old values
+Non-existent values in a property map are removed with SET =
+Unwind with merge
+Fail when trying to create using an undirected relationship pattern
+
 Many CREATE clauses
 
 // unsupported comparability

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -1,4 +1,3 @@
-Return an integer
 Support multiple divisions in aggregate function
 Support column renaming for aggregates as well
 Aggregates inside normal functions
@@ -80,10 +79,6 @@ IS NOT NULL with literal maps
 `percentileCont()` failing on bad arguments
 `percentileDisc()` failing on bad arguments
 `percentileDisc()` failing in more involved query
-`type()`
-`type()` on two relationships
-`type()` on null relationship
-`type()` on mixed null and non-null relationships
 `type()` handling Any type
 `type()` failing on invalid arguments
 `labels()` should accept type Any
@@ -113,28 +108,13 @@ Create node with label in pattern
 Using `labels()` in return clauses
 Removing a label
 Removing a non-existent label
-Does not lose precision
-Handling inlined equality of large integer
-Handling explicit equality of large integer
-Handling inlined equality of large integer, non-equal values
-Handling explicit equality of large integer, non-equal values
 Returning a list comprehension
 Using a list comprehension in a WITH
 Using a list comprehension in a WHERE
 Path query should return results in written order
 Longer path query should return results in written order
-Use multiple MATCH clauses to do a Cartesian product
-Filter out based on node prop name
 Honour the column name for RETURN items
-Filter based on rel prop name
 Cope with shadowed variables
-Get neighbours
-Get two related nodes
-Get related to related to
-Handle comparison between node properties
-Return two subgraphs with bound undirected relationship
-Return two subgraphs with bound undirected relationship and optional relationship
-Rel type function works as expected
 Walk alternative relationships
 Handle OR in the WHERE clause
 Return a simple path
@@ -158,41 +138,17 @@ Zero-length variable length pattern in the middle of the pattern
 Simple variable length pattern
 Variable length relationship without lower bound
 Variable length relationship without bounds
-Returning bound nodes that are not part of the pattern
-Two bound nodes pointing to the same node
-Three bound nodes pointing to the same node
-Three bound nodes pointing to the same node with extra connections
 MATCH with OPTIONAL MATCH in longer pattern
 Optionally matching named paths
 Optionally matching named paths with single and variable length patterns
 Optionally matching named paths with variable length patterns
 Matching variable length patterns from a bound node
 Excluding connected nodes
-Do not fail when predicates on optionally matched and missed nodes are invalid
-MATCH and OPTIONAL MATCH on same pattern
-Matching using an undirected pattern
-Matching all nodes
-Comparing nodes for equality
-Matching using self-referencing pattern returns no result
 Variable length relationship in OPTIONAL MATCH
-Matching using relationship predicate with multiples of the same type
 ORDER BY with LIMIT
-Simple node property predicate
 Handling direction of named paths
 Simple OPTIONAL MATCH on empty graph
-OPTIONAL MATCH with previously bound nodes
 `collect()` filtering nulls
-Multiple anonymous nodes in a pattern
-Matching a relationship pattern using a label predicate
-Matching a relationship pattern using a label predicate on both sides
-Matching nodes using multiple labels
-Returning label predicate expression
-Returning label predicate expression
-Matching using a simple pattern with label predicate
-Matching disconnected patterns
-Non-optional matches should not return nulls
-Handling cyclic patterns
-Handling cyclic patterns when separated into two parts
 Handling fixed-length variable length pattern
 Matching from null nodes should return no results owing to finding no matches
 Matching from null nodes should return no results owing to matches being filtered out
@@ -226,27 +182,15 @@ Named path with WITH
 Named path with alternating directed/undirected relationships
 Named path with multiple alternating directed/undirected relationships
 Named path with undirected fixed variable length pattern
-Returning a node property value
-Returning a relationship property value
-Projecting nodes and relationships
-Missing node property should become null
-Missing relationship property should become null
-Returning multiple node property values
-Adding a property and a literal in projection
-Adding list properties in projection
 Variable length relationship variables are lists of relationships
 Variable length patterns and nulls
-Projecting a list of nodes and relationships
-Projecting a map of nodes and relationships
 Respecting direction when matching existing path
 Respecting direction when matching non-existent path
 Respecting direction when matching non-existent path with multiple directions
 Matching path with both directions should respect other directions
 Matching path with multiple bidirectional relationships
-Matching nodes with many labels
 Matching longer variable length paths
 Counting rows after MATCH, MERGE, OPTIONAL MATCH
-Matching a self-loop
 Failing on merging relationship with null property
 Failing on merging node with null property
 Failing when setting a list of maps as a property
@@ -263,23 +207,16 @@ Satisfies the open world assumption, single relationship
 Satisfies the open world assumption, relationships between different nodes
 Return null when no matches due to inline label predicate
 Return null when no matches due to label predicate in WHERE
-Respect predicates on the OPTIONAL MATCH
-Returning label predicate on null node
 MATCH after OPTIONAL MATCH
 WITH after OPTIONAL MATCH
 Named paths in optional matches
-OPTIONAL MATCH and bound nodes
-OPTIONAL MATCH with labels on the optional end node
 Named paths inside optional matches with node predicates
 Variable length optional relationships
 Variable length optional relationships with length predicates
-Optionally matching self-loops
-Optionally matching self-loops without matches
 Variable length optional relationships with bound nodes
 Variable length optional relationships with bound nodes, no matches
 Longer pattern with bound nodes
 Longer pattern with bound nodes without matches
-Handling correlated optional matches; first does not match implies second does not match
 Handling optional matches between optionally matched entities
 Handling optional matches between nulls
 OPTIONAL MATCH and `collect()`
@@ -324,15 +261,12 @@ Remove a single relationship property
 Remove a single relationship property
 Remove multiple relationship properties
 Remove a missing property should be a valid operation
-Allow addition
-Limit to two hits
 Start the result from the second row
 Start the result from the second row by param
 Get rows in the middle
 Get rows in the middle by param
 Sort on aggregated function
 Support sort and distinct
-Support column renaming
 Support ordering by a property after being distinct-ified
 Count star should count everything in scope
 Absolute function
@@ -341,7 +275,6 @@ Fail when returning properties of deleted nodes
 Fail when returning labels of deleted nodes
 Fail when returning properties of deleted relationships
 Do not fail when returning type of deleted relationships
-LIMIT 0 should return an empty result
 Fail when sorting on variable removed by DISTINCT
 Fail when ordering nodes
 Ordering with aggregation
@@ -352,8 +285,6 @@ Setting and returning the size of a list property
 `sqrt()` returning float values
 Arithmetic expressions inside aggregation
 Matching and disregarding output, then matching again
-Returning a list property
-Returning a projected map
 Returning an expression
 Concatenating and returning the size of literal lists
 Concatenating and returning the size of literal lists
@@ -364,7 +295,6 @@ Using aliased DISTINCT expression in ORDER BY
 Returned columns do not change from using ORDER BY
 Arithmetic expressions should propagate null values
 Indexing into nested literal lists
-Aliasing expressions
 Projecting an arithmetic expression with aggregation
 Multiple aliasing and backreferencing
 Aggregating by a list property has a correct definition of equality
@@ -379,9 +309,6 @@ Failing when performing property access on a non-map 2
 Bad arguments for `range()`
 SKIP with an expression that does not depend on variables
 LIMIT with an expression that does not depend on variables
-Find all nodes
-Find labelled nodes
-Find nodes by property
 Finding exact matches
 Finding beginning of string
 Finding end of string 1
@@ -410,7 +337,6 @@ Using null in AND
 Using null in OR
 Using null in XOR
 Using null in IN
-Handling triadic friend of a friend
 Handling triadic friend of a friend that is not a friend
 Handling triadic friend of a friend that is not a friend with different relationship type
 Handling triadic friend of a friend that is not a friend with superset of relationship type
@@ -509,9 +435,7 @@ Handling mixed relationship patterns 2
 Handling relationships that are already bound in variable length paths
 NOT and false
 Fail when trying to compare strings and numbers
-Passing on pattern nodes
 ORDER BY and LIMIT can be used
-No dependencies between the query parts
 Aliasing
 Handle dependencies across WITH
 Handle dependencies across WITH with SKIP
@@ -535,19 +459,6 @@ Fail when adding new label predicate on a node that is already bound 2
 Fail when adding new label predicate on a node that is already bound 3
 Fail when adding new label predicate on a node that is already bound 4
 Fail when adding new label predicate on a node that is already bound 5
-Return a float
-Return a float in exponent form
-Return a boolean
-Return a single-quoted string
-Return a double-quoted string
-Return null
-Return an empty list
-Return a nonempty list
-Return an empty map
-Return a nonempty map
-Accept skip zero
-Do not return non-existent nodes
-Do not return non-existent relationships
 Failing on incorrect unicode literal
 Failing on aggregation in WHERE
 Failing on aggregation in ORDER BY after RETURN

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/rule.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/rule.txt
@@ -1,7 +1,6 @@
 // misc bugs
 Fail when adding new label predicate on a node that is already bound 5
 Matching relationships into a list and matching variable length using the list
-Null-setting one property with ON CREATE
 Fail when imposing new predicates on a variable that is already bound
 
 // pattern comprehension

--- a/community/cypher/spec-suite-tools/src/main/scala/cypher/cucumber/db/GraphArchiveImporter.scala
+++ b/community/cypher/spec-suite-tools/src/main/scala/cypher/cucumber/db/GraphArchiveImporter.scala
@@ -64,7 +64,7 @@ abstract class GraphArchiveImporter {
 
         while (iterator.hasNext) {
           val statement = iterator.next()
-          val result = executor.execute(statement, java.util.Collections.emptyMap())
+          val result = executor.execute(s"CYPHER runtime=interpreted $statement", java.util.Collections.emptyMap())
           try {
             while (result.hasNext) result.next()
           } finally {

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/ScenarioExecutionBuilder.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/ScenarioExecutionBuilder.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cypher.feature.steps
+
+import java.util
+
+import cypher.cucumber.BlacklistPlugin.blacklisted
+import org.neo4j.graphdb.{QueryStatistics, Result, Transaction}
+import org.neo4j.kernel.internal.GraphDatabaseAPI
+
+import scala.util.{Failure, Success, Try}
+
+class ScenarioExecutionBuilder {
+
+  var skip: Boolean = _
+  var name: String = _
+  def register(name: String, skip: Boolean): Unit = {
+    this.name = name
+    this.skip = skip
+  }
+
+  var db: GraphDatabaseAPI = _
+  def setDb(db: GraphDatabaseAPI): Unit = this.db = db
+
+  var params: util.Map[String, AnyRef] = _
+  def setParams(params: util.Map[String, AnyRef]): Unit = this.params = params
+
+  var initF: (GraphDatabaseAPI) => Unit = _
+  def init(f: (GraphDatabaseAPI) => Unit): Unit = initF = f
+
+  var procReg: (GraphDatabaseAPI) => Unit = _
+  def procedureRegistration(f: (GraphDatabaseAPI) => Unit): Unit = procReg = f
+
+  var executions: Seq[(GraphDatabaseAPI, util.Map[String, Object]) => Result] = Seq.empty
+  def exec(function: (GraphDatabaseAPI, util.Map[String, Object]) => Result) = executions = executions :+ function
+
+  var expectations: Seq[(Result) => Unit] = Seq.empty
+  def expect(expectation: (Result) => Unit): Unit = expectations = expectations :+ expectation
+
+  var expectedError: (Try[Result], Transaction) => Unit = _
+  def expectError(function: (Try[Result], Transaction) => Unit) = expectedError = function
+
+  var sideEffects: (QueryStatistics) => Unit = _
+  def sideEffects(f: (QueryStatistics) => Unit): Unit = sideEffects = f
+
+  def build(): ScenarioExecution = {
+    if (skip) {
+      SkippedScenario(name)
+    } else if (expectedError != null) {
+      NegativeScenario(name, blacklisted(name.toLowerCase), db, params, Option(initF), Option(procReg), executions.head, expectedError)
+    } else {
+      RegularScenario(name, blacklisted(name.toLowerCase), db, params, Option(initF), Option(procReg), executions, expectations, sideEffects)
+    }
+  }
+}
+
+trait ScenarioExecution {
+  def run(): Unit
+  def name(): String
+}
+
+case class SkippedScenario(name: String) extends ScenarioExecution {
+  override def run(): Unit = () // skip
+}
+
+case class NegativeScenario(name: String, blacklisted: Boolean, db: GraphDatabaseAPI, params: util.Map[String, Object],
+                            init: Option[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
+                            execution: (GraphDatabaseAPI, util.Map[String, Object]) => Result,
+                            errorExpectation: (Try[Result], Transaction) => Unit
+                           ) extends ScenarioExecution {
+  override def run(): Unit = {
+    if (blacklisted) {
+      // TODO: Report when a blacklisted negative scenario does fail with the expected error
+    } else {
+      init.foreach(f => f(db))
+      procedureRegistration.foreach(f => f(db))
+
+      val tx = db.beginTx()
+      val attempt = Try(execution(db, params))
+      try {
+        errorExpectation(attempt, tx)
+      } finally {
+        tx.close()
+      }
+    }
+  }
+}
+
+case class RegularScenario(name: String, blacklisted: Boolean,
+                           db: GraphDatabaseAPI, params: util.Map[String, Object],
+                           init: Option[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
+                           executions: Seq[(GraphDatabaseAPI, util.Map[String, Object]) => Result],
+                           expectations: Seq[(Result) => Unit], sideEffects: (QueryStatistics) => Unit
+                          ) extends ScenarioExecution {
+  override def run(): Unit = {
+    if (name.equals("Many CREATE clauses") && blacklisted) {
+      // TODO: This scenario causes StackOverflowException in the compiled runtime ... not sure how to handle
+      return
+    }
+
+    init.foreach(f => f(db))
+    procedureRegistration.foreach(f => f(db))
+
+    executions.zip(expectations).foreach {
+      case (execute, expect) =>
+        val tx = db.beginTx()
+        try {
+          Try(execute(db, params)) match {
+            case Success(result) =>
+              if (!blacklisted) {
+                expect(result)
+                tx.success()
+              } else {
+
+                Try(while (result.hasNext) result.next()) match {
+                  case Success(_) =>
+                    throw new ScenarioFailedException(s"Scenario '$name' was blacklisted, but succeeded", null)
+                  case _ =>
+                }
+              }
+            case Failure(throwable) =>
+              if(!blacklisted)
+                throw new ScenarioFailedException(s"Scenario '$name' failed with ${throwable.getMessage}", throwable)
+          }
+        } catch {
+          case e: Error => if (!blacklisted) throw new ScenarioFailedException(s"Scenario '$name' failed with ${e.getMessage}", e)
+        } finally {
+          tx.close()
+        }
+    }
+  }
+}
+
+class ScenarioFailedException(message: String, cause: Throwable) extends Throwable(message, cause)

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/ScenarioExecutionBuilder.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/ScenarioExecutionBuilder.scala
@@ -29,6 +29,8 @@ import scala.util.{Failure, Success, Try}
 
 class ScenarioExecutionBuilder {
 
+  import scala.collection.JavaConverters._
+
   var skip: Boolean = _
   var name: String = _
   def register(name: String, skip: Boolean): Unit = {
@@ -39,11 +41,11 @@ class ScenarioExecutionBuilder {
   var db: GraphDatabaseAPI = _
   def setDb(db: GraphDatabaseAPI): Unit = this.db = db
 
-  var params: util.Map[String, AnyRef] = _
+  var params: util.Map[String, AnyRef] = Map.empty[String, AnyRef].asJava
   def setParams(params: util.Map[String, AnyRef]): Unit = this.params = params
 
-  var initF: (GraphDatabaseAPI) => Unit = _
-  def init(f: (GraphDatabaseAPI) => Unit): Unit = initF = f
+  var initF: Seq[(GraphDatabaseAPI) => Unit] = Seq.empty
+  def init(f: (GraphDatabaseAPI) => Unit): Unit = initF = initF :+ f
 
   var procReg: (GraphDatabaseAPI) => Unit = _
   def procedureRegistration(f: (GraphDatabaseAPI) => Unit): Unit = procReg = f
@@ -64,9 +66,9 @@ class ScenarioExecutionBuilder {
     if (skip) {
       SkippedScenario(name)
     } else if (expectedError != null) {
-      NegativeScenario(name, blacklisted(name.toLowerCase), db, params, Option(initF), Option(procReg), executions.head, expectedError)
+      NegativeScenario(name, blacklisted(name.toLowerCase), db, params, initF, Option(procReg), executions.head, expectedError)
     } else {
-      RegularScenario(name, blacklisted(name.toLowerCase), db, params, Option(initF), Option(procReg), executions, expectations, sideEffects)
+      RegularScenario(name, blacklisted(name.toLowerCase), db, params, initF, Option(procReg), executions, expectations, sideEffects)
     }
   }
 }
@@ -81,7 +83,7 @@ case class SkippedScenario(name: String) extends ScenarioExecution {
 }
 
 case class NegativeScenario(name: String, blacklisted: Boolean, db: GraphDatabaseAPI, params: util.Map[String, Object],
-                            init: Option[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
+                            init: Seq[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
                             execution: (GraphDatabaseAPI, util.Map[String, Object]) => Result,
                             errorExpectation: (Try[Result], Transaction) => Unit
                            ) extends ScenarioExecution {
@@ -98,6 +100,7 @@ case class NegativeScenario(name: String, blacklisted: Boolean, db: GraphDatabas
         errorExpectation(attempt, tx)
       } finally {
         tx.close()
+        db.shutdown()
       }
     }
   }
@@ -105,7 +108,7 @@ case class NegativeScenario(name: String, blacklisted: Boolean, db: GraphDatabas
 
 case class RegularScenario(name: String, blacklisted: Boolean,
                            db: GraphDatabaseAPI, params: util.Map[String, Object],
-                           init: Option[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
+                           init: Seq[(GraphDatabaseAPI) => Unit], procedureRegistration: Option[(GraphDatabaseAPI) => Unit],
                            executions: Seq[(GraphDatabaseAPI, util.Map[String, Object]) => Result],
                            expectations: Seq[(Result) => Unit], sideEffects: (QueryStatistics) => Unit
                           ) extends ScenarioExecution {
@@ -115,37 +118,48 @@ case class RegularScenario(name: String, blacklisted: Boolean,
       return
     }
 
+    if (name.equals("Concatenating and returning the size of literal lists") && blacklisted) {
+      // TODO: There are two scenarios with this name, one that works and one that doesn't - fixed by updating TCK later
+      return
+    }
+
     init.foreach(f => f(db))
     procedureRegistration.foreach(f => f(db))
 
-    executions.zip(expectations).foreach {
-      case (execute, expect) =>
-        val tx = db.beginTx()
-        try {
-          Try(execute(db, params)) match {
-            case Success(result) =>
-              if (!blacklisted) {
-                expect(result)
-                tx.success()
-              } else {
-
-                Try(while (result.hasNext) result.next()) match {
-                  case Success(_) =>
-                    throw new ScenarioFailedException(s"Scenario '$name' was blacklisted, but succeeded", null)
-                  case _ =>
+    try {
+      executions.zip(expectations).foreach {
+        case (execute, expect) =>
+          val tx = db.beginTx()
+          try {
+            Try(execute(db, params)) match {
+              case Success(result) =>
+                if (!blacklisted) {
+                  expect(result)
+                  tx.success()
+                } else {
+                  Try(expect(result)) match {
+                    case Success(_) =>
+                      throw new BlacklistException(s"Scenario '$name' was blacklisted, but succeeded")
+                    case _ => // failure is expected
+                  }
                 }
-              }
-            case Failure(throwable) =>
-              if(!blacklisted)
-                throw new ScenarioFailedException(s"Scenario '$name' failed with ${throwable.getMessage}", throwable)
+              case Failure(throwable) =>
+                if (!blacklisted)
+                  throw new ScenarioFailedException(s"Scenario '$name' failed with ${throwable.getMessage}", throwable)
+            }
+          } catch {
+            case e: Error =>
+              if (!blacklisted)
+                throw new ScenarioFailedException(s"Scenario '$name' failed with ${e.getMessage}", e)
+          } finally {
+            tx.close()
           }
-        } catch {
-          case e: Error => if (!blacklisted) throw new ScenarioFailedException(s"Scenario '$name' failed with ${e.getMessage}", e)
-        } finally {
-          tx.close()
-        }
+      }
+    } finally {
+      db.shutdown()
     }
   }
 }
 
-class ScenarioFailedException(message: String, cause: Throwable) extends Throwable(message, cause)
+class ScenarioFailedException(message: String, cause: Throwable) extends Exception(message, cause)
+class BlacklistException(message: String) extends Exception(message)

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
@@ -62,7 +62,9 @@ case class SpecSuiteErrorHandler(typ: String, phase: String, detail: String) ext
 
     result match {
       case Failure(e: QueryExecutionException) =>
-        s"Neo.ClientError.$statusType.$statusDetail" should equal(e.getStatusCode)
+        withClue(e.getMessage) {
+          s"Neo.ClientError.$statusType.$statusDetail" should equal(e.getStatusCode)
+        }
 
         if (!msgHandler(e.getMessage)) fail(s"Unknown $phase error: $e", e)
 

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
@@ -21,17 +21,15 @@ package cypher.feature.steps
 
 import java.util
 
-import cucumber.api.{PendingException, DataTable}
+import cucumber.api.DataTable
 import cypher.SpecSuiteResources
-import cypher.cucumber.BlacklistPlugin
 import cypher.cucumber.db.DatabaseConfigProvider._
 import cypher.cucumber.db.{GraphArchive, GraphArchiveImporter, GraphArchiveLibrary, GraphFileRepository}
 import cypher.feature.parser._
-import cypher.feature.parser.matchers.ResultWrapper
 import org.neo4j.collection.RawIterator
 import org.neo4j.cypher.internal.frontend.v3_1.symbols.{CypherType, _}
 import org.neo4j.graphdb.factory.{GraphDatabaseFactory, GraphDatabaseSettings}
-import org.neo4j.graphdb.{GraphDatabaseService, Result, Transaction}
+import org.neo4j.graphdb.{GraphDatabaseService, QueryStatistics, Result, Transaction}
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
@@ -44,7 +42,7 @@ import org.scalatest.{FunSuiteLike, Matchers}
 
 import scala.collection.JavaConverters._
 import scala.reflect.io.Path
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate with MatcherMatchingSupport {
 
@@ -55,190 +53,121 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   lazy val graphArchiveLibrary = new GraphArchiveLibrary(new GraphFileRepository(Path(SpecSuiteResources.targetDirectory(specSuiteClass, "graphs"))))
   lazy val requiredScenarioName = specSuiteClass.getField( "SCENARIO_NAME_REQUIRED" ).get( null ).toString.trim.toLowerCase
 
-  // Stateful
-
-  var graph: GraphDatabaseAPI = null
-  var result: Try[Result] = null
-  var tx: Transaction = null
-  var params: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef]()
-  var currentScenarioName: String = ""
+  var scenarioBuilder: ScenarioExecutionBuilder = _
 
   // Steps
 
-  After() { _ =>
-    ifEnabled {
-      // TODO: postpone this till the last scenario
-      graph.shutdown()
-    }
+  Before() { scenario =>
+    val currentScenarioName = scenario.getName.toLowerCase
+    val skip = requiredScenarioName.nonEmpty && !currentScenarioName.contains(requiredScenarioName)
+    scenarioBuilder = new ScenarioExecutionBuilder
+    scenarioBuilder.register(scenario.getName, skip)
   }
 
-  Before() { scenario =>
-    currentScenarioName = scenario.getName.toLowerCase
+  After() { _ =>
+    scenarioBuilder.build().run()
   }
 
   Background(BACKGROUND) {
     // do nothing, but necessary for the scala match
   }
 
-  private val PENDING = """^this scenario is pending on: (.+)$"""
-  And(PENDING) { (reason: String) =>
-    ifEnabled {
-      throw new PendingException(s"Scenario '${currentScenarioName.replace("'", "\\'")}' is pending on: $reason")
-    }
-  }
-
   Given(NAMED_GRAPH) { (dbName: String) =>
-    ifEnabled {
-      lendForReadOnlyUse(dbName)
-    }
+    scenarioBuilder.setDb(lendForReadOnlyUse(dbName))
   }
 
   Given(ANY_GRAPH) {
-    ifEnabled {
-      // We could do something fancy here, like randomising a state,
-      // in order to guarantee that we aren't implicitly relying on an empty db.
-      initEmpty()
-    }
+    // We could do something fancy here, like randomising a state,
+    // in order to guarantee that we aren't implicitly relying on an empty db.
+    scenarioBuilder.setDb(DbBuilder.initEmpty(currentDatabaseConfig("8m")))
   }
 
   Given(EMPTY_GRAPH) {
-    ifEnabled {
-      initEmpty()
-    }
+    scenarioBuilder.setDb(DbBuilder.initEmpty(currentDatabaseConfig("8m")))
   }
 
   And(INIT_QUERY) { (query: String) =>
-    ifEnabled {
+    scenarioBuilder.init { g: GraphDatabaseAPI =>
       // side effects are necessary for setting up graph state
-      graph.execute(query)
+      g.execute(s"CYPHER runtime=interpreted $query")
     }
   }
 
   And(PARAMETERS) { (values: DataTable) =>
-    ifEnabled {
-      params = parseParameters(values)
-    }
+    scenarioBuilder.setParams(parseParameters(values))
   }
 
   private val INSTALLED_PROCEDURE = """^there exists a procedure (.+):$"""
   And(INSTALLED_PROCEDURE){ (signatureText: String, values: DataTable) =>
-    ifEnabled {
+    scenarioBuilder.procedureRegistration { g: GraphDatabaseAPI =>
       val parsedSignature = ProcedureSignature.parse(signatureText)
-      val kernelProcedure= buildProcedure(parsedSignature, values)
-      kernelAPI.registerProcedure(kernelProcedure)
+      val kernelProcedure = buildProcedure(parsedSignature, values)
+      g.getDependencyResolver.resolveDependency(classOf[KernelAPI]).registerProcedure(kernelProcedure)
     }
   }
 
   When(EXECUTING_QUERY) { (query: String) =>
-    ifEnabled {
-      tx = graph.beginTx()
-      result = Try {
-        graph.execute(query, params)
-      }
+    scenarioBuilder.exec { (g: GraphDatabaseAPI, params: util.Map[String, Object]) =>
+      g.execute(query, params)
     }
   }
 
   Then(EXPECT_RESULT) { (expectedTable: DataTable) =>
-    ifEnabled {
+    scenarioBuilder.expect { r: Result =>
       val matcher = constructResultMatcher(expectedTable)
 
-      val assertedSuccessful = successful(result)
-      tryAndClose {
-        matcher should accept(assertedSuccessful)
-      }
+      matcher should accept(r)
     }
   }
 
   Then(EXPECT_RESULT_UNORDERED_LISTS) { (expectedTable: DataTable) =>
-    ifEnabled {
+    scenarioBuilder.expect { r: Result =>
       val matcher = constructResultMatcher(expectedTable, unorderedLists = true)
 
-      val assertedSuccessful = successful(result)
-      tryAndClose {
-        matcher should accept(assertedSuccessful)
-      }
+      matcher should accept(r)
     }
   }
 
 
   Then(EXPECT_ERROR) { (typ: String, phase: String, detail: String) =>
-    ifEnabled {
-      try SpecSuiteErrorHandler(typ, phase, detail).check(result, tx)
-      finally tx.close()
+    scenarioBuilder.expectError { (r: Try[Result], tx: Transaction) =>
+      SpecSuiteErrorHandler(typ, phase, detail).check(r, tx)
     }
   }
 
   Then(EXPECT_SORTED_RESULT) { (expectedTable: DataTable) =>
-    ifEnabled {
+    scenarioBuilder.expect { r: Result =>
       val matcher = constructResultMatcher(expectedTable)
 
-      val assertedSuccessful = successful(result)
-      tryAndClose {
-        matcher should acceptOrdered(assertedSuccessful)
-      }
+      matcher should acceptOrdered(r)
     }
   }
 
   Then(EXPECT_EMPTY_RESULT) {
-    ifEnabled {
+    scenarioBuilder.expect { r: Result =>
       withClue("Expected empty result") {
-        successful(result).hasNext shouldBe false
+        r.hasNext shouldBe false
       }
-      tx.success()
-      tx.close()
     }
   }
 
   And(SIDE_EFFECTS) { (expectations: DataTable) =>
-    ifEnabled {
-      statisticsParser(expectations) should accept(successful(result).getQueryStatistics)
+    scenarioBuilder.sideEffects { stats: QueryStatistics =>
+      statisticsParser(expectations) should accept(stats)
     }
   }
 
   And(NO_SIDE_EFFECTS) {
-    ifEnabled {
-      withClue("Expected no side effects") {
-        successful(result).getQueryStatistics.containsUpdates() shouldBe false
-      }
+    scenarioBuilder.sideEffects { stats: QueryStatistics =>
+      stats.containsUpdates() shouldBe false
     }
   }
 
   When(EXECUTING_CONTROL_QUERY) { (query: String) =>
-    ifEnabled {
-      tx = graph.beginTx()
-      result = Try {
-        graph.execute(query, params)
-      }
+    scenarioBuilder.exec { (g: GraphDatabaseAPI, params: util.Map[String, Object]) =>
+      g.execute(query, params)
     }
   }
-
-  private def ifEnabled(f: => Unit): Unit = {
-    if (!BlacklistPlugin.blacklisted(currentScenarioName) && (requiredScenarioName.isEmpty || currentScenarioName.contains(requiredScenarioName))) {
-      f
-    }
-  }
-
-  private def tryAndClose(f: => Unit) = {
-    try {
-      f
-      tx.success()
-    } finally tx.close()
-  }
-
-  private def successful(value: Try[Result]): Result = value match {
-    case Success(r) => new ResultWrapper(r)
-    case Failure(e) =>
-      tx.failure()
-      tx.close()
-      fail(s"Expected successful result, but got error: $e")
-  }
-
-  private def initEmpty() =
-    if (graph == null || !graph.isAvailable(1L)) {
-      val builder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-      builder.setConfig(currentDatabaseConfig("8M").asJava)
-      graph = builder.newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
-    }
 
   private def lendForReadOnlyUse(recipeName: String) = {
     val recipe = graphArchiveLibrary.recipe(recipeName)
@@ -249,7 +178,7 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
     val path = graphArchiveLibrary.lendForReadOnlyUse(archiveUse)(graphImporter)
     val builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(path.jfile)
     builder.setConfig(archiveUse.dbConfig.asJava)
-    graph = builder.newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
+    builder.newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
   }
 
   private def MB(v: Int) = v * 1024 * 1024
@@ -257,6 +186,7 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   private def currentDatabaseConfig(sizeHint: String) = {
     val builder = Map.newBuilder[String, String]
     builder += GraphDatabaseSettings.pagecache_memory.name() -> sizeHint
+    builder += GraphDatabaseSettings.cypher_hints_error.name() -> "true"
     cypherConfig().foreach { case (s, v) => builder += s.name() -> v }
     builder.result()
   }
@@ -284,8 +214,6 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   }
 
   private def formatColumns(columns: List[String]) = columns.map(column => s"'${column.replace("'", "\\'")}'")
-
-  private def kernelAPI = graph.getDependencyResolver.resolveDependency(classOf[KernelAPI])
 
   private def asKernelSignature(parsedSignature: ProcedureSignature): org.neo4j.kernel.api.proc.ProcedureSignature = {
     val builder = org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature(parsedSignature.namespace.toArray, parsedSignature.name)
@@ -317,5 +245,13 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
       builder.setConfig(archive.dbConfig.asJava)
       builder.newGraphDatabase()
     }
+  }
+}
+
+object DbBuilder {
+  def initEmpty(config: Map[String, String]): GraphDatabaseAPI = {
+      val builder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+      builder.setConfig(config.asJava)
+      builder.newGraphDatabase().asInstanceOf[GraphDatabaseAPI]
   }
 }


### PR DESCRIPTION
The TCK scenarios are now fully read before starting execution, instead of partially executed as they are read. This enables the TCK implementation to report when a blacklisted scenario actually passes, and should be removed from the blacklist (due to a bugfix, TCK update, or feature implementation).

This also isolates the code that executes a scenario to a more comprehensive unit, making it easier to debug scenarios.