### PR TITLE
Reintroduce Cypher test comparisons with rule planner

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
@@ -27,16 +27,20 @@ class ComparisonOperatorAcceptanceTest extends ExecutionEngineFunSuite with NewP
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1 < 2 < 3 < 4 as val") shouldBe true
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1 < 3 < 2 < 4 as val") shouldBe false
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1 < 2 < 2 < 4 as val") shouldBe false
-    executeScalarWithAllPlanners[Boolean]("RETURN 1 < 2 <= 2 < 4 as val") shouldBe true
+    //TODO change to all planners when 3.1 is updated
+    executeWithCostPlannerAndInterpretedRuntimeOnly("RETURN 1 < 2 <= 2 < 4 as val").next()("val") shouldBe true
 
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1.0 < 2.1 < 3.2 < 4.2 as val") shouldBe true
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1.0 < 3.2 < 2.1 < 4.2 as val") shouldBe false
     executeScalarWithAllPlannersAndRuntimes[Boolean]("RETURN 1.0 < 2.1 < 2.1 < 4.2 as val") shouldBe false
-    executeScalarWithAllPlanners[Boolean]("RETURN 1.0 < 2.1 <= 2.1 < 4.2 as val") shouldBe true
+    //TODO change to all planners when 3.1 is updated
+    executeWithCostPlannerAndInterpretedRuntimeOnly("RETURN 1.0 < 2.1 <= 2.1 < 4.2 as val").next()("val") shouldBe true
 
-    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' < 'c' < 'd' as val") shouldBe true
+    //TODO change to all planners when 3.1 is updated
+    executeWithCostPlannerAndInterpretedRuntimeOnly("RETURN 'a' < 'b' < 'c' < 'd' as val").next()("val") shouldBe true
     executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'c' < 'b' < 'd' as val") shouldBe false
     executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' < 'b' < 'd' as val") shouldBe false
-    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' <= 'b' < 'd' as val") shouldBe true
+    //TODO change to all planners when 3.1 is updated
+    executeWithCostPlannerAndInterpretedRuntimeOnly("RETURN 'a' < 'b' <= 'b' < 'd' as val").next()("val") shouldBe true
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -117,7 +117,7 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -135,7 +135,7 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -2639,7 +2639,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -2656,7 +2656,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
     assertNumberOfEagerness(query, 1)
@@ -2672,7 +2672,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
                                     Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
     assertStats(result, labelsAdded = 2)
@@ -2707,7 +2707,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
+    val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
                                     Map("labels(n)" -> List(), "labels(m)" -> List())))
     assertStats(result, labelsRemoved = 2)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -117,7 +117,7 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -135,7 +135,7 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -2639,7 +2639,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -2656,7 +2656,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
     assertNumberOfEagerness(query, 1)
@@ -2672,7 +2672,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
                                     Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
     assertStats(result, labelsAdded = 2)
@@ -2707,7 +2707,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithCostPlannerOnly(query) // Until 3.1 is released including fixes for rule planner we cannot run this with rule planner compatibility
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
                                     Map("labels(n)" -> List(), "labels(m)" -> List())))
     assertStats(result, labelsRemoved = 2)

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -23,10 +23,12 @@ import org.neo4j.cypher.NewPlannerMonitor.{NewPlannerMonitorCall, NewQuerySeen, 
 import org.neo4j.cypher.NewRuntimeMonitor.{NewPlanSeen, NewRuntimeMonitorCall, UnableToCompileQuery}
 import org.neo4j.cypher.internal.compatibility.v3_2.ExecutionResultWrapper
 import org.neo4j.cypher.internal.compatibility.{ClosingExecutionResult, v2_3, v3_1}
+import org.neo4j.cypher.internal.compiler.v3_1.{CartesianPoint => CartesianPointv3_1, GeographicPoint => GeographicPointv3_1}
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{InternalExecutionResult, NewLogicalPlanSuccessRateMonitor, NewRuntimeSuccessRateMonitor}
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription
-import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v3_2.{CRS, CartesianPoint, GeographicPoint}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.Eagerly
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherTestSupport
@@ -421,6 +423,8 @@ trait NewPlannerTestSupport extends CypherTestSupport {
 
     def toCompararableSeq(replaceNaNs: Boolean): Seq[Map[String, Any]] = {
       def convert(v: Any): Any = v match {
+        case p: GeographicPointv3_1 => GeographicPoint(p.longitude, p.latitude, CRS(p.crs.name, p.crs.code, p.crs.url))
+        case p: CartesianPointv3_1  => CartesianPoint(p.x, p.y, CRS(p.crs.name, p.crs.code, p.crs.url))
         case a: Array[_] => a.toList.map(convert)
         case m: Map[_, _] =>
           Eagerly.immutableMapValues(m, convert)


### PR DESCRIPTION
The rule planner still exists in Cypher 3.1, so we can run the Cypher tests
with assertions that the results are the same between the latest and the
old rule planner.
