### PR TITLE
Preserve type of empty primitive arrays

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/ListSupport.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/ListSupport.scala
@@ -55,7 +55,7 @@ trait ListSupport {
 
   class NoValidValuesExceptions extends Exception
 
-  def isList(x: Any) = castToIterable.isDefinedAt(x)
+  def isList(x: Any): Boolean = castToIterable.isDefinedAt(x)
 
   def liftAsList[T](test: PartialFunction[Any, T])(input: Any): Option[Iterable[T]] = try {
     input match {
@@ -78,7 +78,7 @@ trait ListSupport {
   def asListOf[T](test: PartialFunction[Any, T])(input: Iterable[Any]): Option[Iterable[T]] =
     Some(input map { (elem: Any) => if (test.isDefinedAt(elem)) test(elem) else return None })
 
-  def makeTraversable(z: Any): Iterable[Any] = if (castToIterable.isDefinedAt(z)) {
+  def makeTraversable(z: Any): Iterable[Any] = if (isList(z)) {
     castToIterable(z)
   } else {
     if (z == null) Iterable() else Iterable(z)

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/makeValueNeoSafe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/makeValueNeoSafe.scala
@@ -21,6 +21,8 @@ package org.neo4j.cypher.internal.compiler.v3_1.mutation
 
 import org.neo4j.cypher.internal.compiler.v3_1.helpers.{CastSupport, ListSupport}
 
+import scala.collection.mutable
+
 object makeValueNeoSafe extends (Any => Any) with ListSupport {
 
   def apply(a: Any): Any = if (isList(a)) {
@@ -35,9 +37,17 @@ object makeValueNeoSafe extends (Any => Any) with ListSupport {
   can be coerced to according to Cypher coercion rules
    */
   private def transformTraversableToArray(a: Any): Any = {
-    val seq: Seq[Any] = a.asInstanceOf[Traversable[_]].toIndexedSeq
+    val traversable = a.asInstanceOf[Traversable[_]]
+    val seq: Seq[Any] = traversable.toIndexedSeq
 
-    if (seq.isEmpty) {
+    if (seq.isEmpty && traversable.isInstanceOf[mutable.WrappedArray[_]]) {
+      // if the user sent an array by parameter we can use it directly
+      val array = a.asInstanceOf[mutable.WrappedArray[_]].array
+      if (array.getClass.getComponentType.isPrimitive)
+        array
+      else
+        Array[String]()
+    } else if (seq.isEmpty) {
       Array[String]()
     } else {
       val typeValue = seq.reduce(CastSupport.merge)

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/MakeValuesNeoSafeTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/MakeValuesNeoSafeTest.scala
@@ -22,17 +22,37 @@ package org.neo4j.cypher.internal.compiler.v3_1.mutation
 import org.neo4j.cypher.internal.frontend.v3_1.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_1.test_helpers.CypherFunSuite
 
+import scala.Array._
+
 class MakeValuesNeoSafeTest extends CypherFunSuite {
 
-  test("string_collection_turns_into_string_array") {
+  test("string collection turns into string array") {
     makeValueNeoSafe(Seq("a", "b")) should equal(Array("a", "b"))
   }
 
-  test("empty_collection_in_is_empty_array") {
+  test("empty collection in is empty array") {
     makeValueNeoSafe(Seq()) should equal(Array())
   }
 
-  test("mixed_types_are_not_ok") {
+  test("retains type of primitive arrays") {
+    Seq(emptyLongArray, emptyShortArray, emptyByteArray, emptyIntArray,
+      emptyDoubleArray, emptyFloatArray, emptyBooleanArray).foreach { array =>
+
+      makeValueNeoSafe(array) should equal(array)
+      makeValueNeoSafe(array).getClass
+        .getComponentType should equal(array.getClass.getComponentType)
+    }
+  }
+
+  test("string arrays work") {
+    val array = Array[String]()
+
+    makeValueNeoSafe(array) should equal(array)
+    makeValueNeoSafe(array).getClass
+      .getComponentType should equal(array.getClass.getComponentType)
+  }
+
+  test("mixed types are not ok") {
     intercept[CypherTypeException](makeValueNeoSafe(Seq("a", 12, false)))
   }
 }


### PR DESCRIPTION
All empty arrays were stored as String arrays, surprising users as they
would send f.e. an empty long array as parameter, but retrieve the value
and find that it was in fact a String array.

Addresses #8587

Still unclear: should we convert byte/short/int arrays to long arrays only? Same question for float arrays to double arrays. Should we move away from supporting array parameters, and only support proper list objects?

Changelog: Fixes [#8587](https://github.com/neo4j/neo4j/issues/8587) maintaining empty array type when storing and retrieving from properties