### PR TITLE
Package the sources necessary to produce Javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,27 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
         <plugin>
           <groupId>org.neo4j.build.plugins</groupId>
           <artifactId>clirr-maven-plugin</artifactId>


### PR DESCRIPTION
When the fullBuild profile was removed some modules no longer produced
the sources-jar necessary in the downstream Javadocs build.
This adds `maven-source-plugin` to these modules directly so that
a sources-jar is produced by default as part of the `package` phase.