### PR TITLE
Fix PageCursor being closed twice causing shared reference between PageCursors

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -127,11 +127,14 @@ abstract class MuninnPageCursor extends PageCursor
         MuninnPageCursor cursor = this;
         do
         {
-            cursor.unpinCurrentPage();
-            cursor.releaseCursor();
-            // We null out the pagedFile field to allow it and its (potentially big) translation table to be garbage
-            // collected when the file is unmapped, since the cursors can stick around in thread local caches, etc.
-            cursor.pagedFile = null;
+            if ( cursor.pagedFile != null )
+            {
+                cursor.unpinCurrentPage();
+                cursor.releaseCursor();
+                // We null out the pagedFile field to allow it and its (potentially big) translation table to be garbage
+                // collected when the file is unmapped, since the cursors can stick around in thread local caches, etc.
+                cursor.pagedFile = null;
+            }
         }
         while ( (cursor = cursor.getAndClearLinkedCursor()) != null );
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -78,6 +78,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -2672,6 +2673,44 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             {
                 assertFalse( cursor.shouldRetry() );
             }
+        }
+    }
+
+    @Test
+    public void pageCursorCloseShouldNotReturnAlreadyClosedLinkedCursorToPool() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize ) )
+        {
+            PageCursor a = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            PageCursor b = a.openLinkedCursor( 0 );
+            b.close();
+            PageCursor c = a.openLinkedCursor( 0 ); // Will close b again, creating a loop in the CursorPool
+            PageCursor d = pf.io( 0, PF_SHARED_WRITE_LOCK ); // Same object as c because of loop in pool
+            assertNotSame( c, d );
+            c.close();
+            d.close();
+        }
+    }
+
+    @Test
+    public void pageCursorCloseShouldNotReturnSameObjectToCursorPoolTwice() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize ) )
+        {
+            PageCursor a = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            a.close();
+            a.close(); // Return same object to CursorPool again, creating a Loop
+            PageCursor b = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            PageCursor c = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            assertNotSame( b, c );
+            b.close();
+            c.close();
         }
     }
 


### PR DESCRIPTION
The PageCursors are pooled in a linked list (in CursorPool). When a PageCursor is
closed they are added to this list. Closing a PageCursor twice would add the same
object to this list twice. Resulting in subsequent calls to io to return the same object.

This was also visible when opening a new linked cursor after already closing the previous
linked cursor.