### PR TITLE
MERGE concurrency for relationships

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/Phase.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/Phase.scala
@@ -56,4 +56,3 @@ trait Phase {
     }
   }
 }
-

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LockNodesPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LockNodesPipe.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.pipes
+
+import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.KeyNames
+import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
+import org.neo4j.graphdb.Node
+
+case class LockNodesPipe(src: Pipe, variablesToLock: Set[String])(val estimatedCardinality: Option[Double] = None)
+                        (implicit pipeMonitor: PipeMonitor)
+  extends PipeWithSource(src, pipeMonitor) with NoEffectsPipe with RonjaPipe {
+  def symbols: SymbolTable = src.symbols
+
+  protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
+    input.map { ctx =>
+      val nodesToLock: Set[Long] = variablesToLock.flatMap { varName =>
+        Option(ctx(varName).asInstanceOf[Node]).map(_.getId)
+      }
+      state.query.lockNodes(nodesToLock.toSeq: _*)
+      ctx
+    }
+
+  override def planDescriptionWithoutCardinality = src.planDescription.andThen(this.id, "Lock", variables, KeyNames(variablesToLock.toSeq))
+
+  override def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+
+  override def dup(sources: List[Pipe]): Pipe = {
+    val (src :: Nil) = sources
+    copy(src = src)(estimatedCardinality)
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -36,7 +36,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{Limit => L
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CantHandleQueryException, PeriodicCommit, logical}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{InstrumentedGraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, Monitors, ast => compilerAst, pipes}
+import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, Monitors, pipes, ast => compilerAst}
 import org.neo4j.cypher.internal.frontend.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.Eagerly
@@ -391,6 +391,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
 
     case RepeatableRead(_) =>
       RepeatableReadPipe(source)()
+
+    case LockNodes(_, nodesToLock) =>
+      LockNodesPipe(source, nodesToLock.map(_.name))()
 
     case x =>
       throw new CantHandleQueryException(x.toString)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.{devNullLogger, InternalNotificationLogger}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Variable
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan, StrictnessMode}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.{InternalNotificationLogger, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Variable
 
 case class LogicalPlanningContext(planContext: PlanContext,
                                   logicalPlanProducer: LogicalPlanProducer,
@@ -36,7 +36,8 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   notificationLogger: InternalNotificationLogger = devNullLogger,
                                   useErrorsOverWarnings: Boolean = false,
                                   errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
-                                  config: QueryPlannerConfiguration = QueryPlannerConfiguration.default) {
+                                  config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
+                                  leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))
 
   def recurse(plan: LogicalPlan) = copy(input = input.recurse(plan))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanSingleQuery.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanSingleQuery.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{countStore
 This coordinates PlannerQuery planning and delegates work to the classes that do the actual planning of
 QueryGraphs and EventHorizons
  */
-case class PlanSingleQuery(planPart: (PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan = planPart,
+case class PlanSingleQuery(planPart: (PlannerQuery, LogicalPlanningContext) => LogicalPlan = planPart,
                            planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = PlanEventHorizon,
                            planWithTail: LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] = PlanWithTail(),
                            planUpdates: LogicalPlanningFunction3[PlannerQuery, LogicalPlan, Boolean, LogicalPlan] = PlanUpdates) extends LogicalPlanningFunction1[PlannerQuery, LogicalPlan] {
@@ -37,7 +37,7 @@ case class PlanSingleQuery(planPart: (PlannerQuery, LogicalPlanningContext, Opti
       case Some(plan) =>
         (plan, context.recurse(plan))
       case None =>
-        val partPlan = planPart(in, context, None)
+        val partPlan = planPart(in, context)
         val planWithUpdates = planUpdates(in, partPlan, true /*first QG*/)(context)
         val projectedPlan = planEventHorizon(in, planWithUpdates)
         val projectedContext = context.recurse(projectedPlan)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanUpdates.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanUpdates.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.mergeUniqueIndexSeekLeafPlanner
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LockNodes, LogicalPlan}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{LogicalPlanProducer, mergeUniqueIndexSeekLeafPlanner}
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{ContainerIndex, PathExpression, Variable}
 
 /*
@@ -35,11 +35,11 @@ case object PlanUpdates
     val plan = if (firstPlannerQuery)
       Eagerness.headReadWriteEagerize(in, query)
     else
-      //// NOTE: tailReadWriteEagerizeRecursive is done after updates, below
+    //// NOTE: tailReadWriteEagerizeRecursive is done after updates, below
       Eagerness.tailReadWriteEagerizeNonRecursive(in, query)
 
     val updatePlan = query.queryGraph.mutatingPatterns.foldLeft(plan) {
-      case (acc, pattern) => planUpdate(query, acc, pattern, firstPlannerQuery)
+      case (acc, pattern) => planUpdate(acc, pattern, firstPlannerQuery)
     }
 
     if (firstPlannerQuery)
@@ -49,8 +49,8 @@ case object PlanUpdates
     }
   }
 
-  private def planUpdate(query: PlannerQuery, source: LogicalPlan, pattern: MutatingPattern, first: Boolean)
-                          (implicit context: LogicalPlanningContext): LogicalPlan = {
+  private def planUpdate(source: LogicalPlan, pattern: MutatingPattern, first: Boolean)
+                        (implicit context: LogicalPlanningContext): LogicalPlan = {
 
     def planAllUpdatesRecursively(query: PlannerQuery, plan: LogicalPlan): LogicalPlan = {
       query.allPlannerQueries.foldLeft((plan, true)) {
@@ -72,7 +72,7 @@ case object PlanUpdates
       case p: CreateRelationshipPattern => context.logicalPlanProducer.planCreateRelationship(source, p)
       //MERGE ()
       case p: MergeNodePattern =>
-        val mergePlan = planMerge(query, source, p.matchGraph, Seq(p.createNodePattern), Seq.empty, p.onCreate,
+        val mergePlan = planMerge(source, p.matchGraph, Seq(p.createNodePattern), Seq.empty, p.onCreate,
           p.onMatch, first)
         //we have to force the plan to solve what we actually solve
         val solved = context.logicalPlanProducer.estimatePlannerQuery(
@@ -81,7 +81,7 @@ case object PlanUpdates
 
       //MERGE (a)-[:T]->(b)
       case p: MergeRelationshipPattern =>
-        val mergePlan = planMerge(query, source, p.matchGraph, p.createNodePatterns, p.createRelPatterns, p.onCreate,
+        val mergePlan = planMerge(source, p.matchGraph, p.createNodePatterns, p.createRelPatterns, p.onCreate,
           p.onMatch, first)
         //we have to force the plan to solve what we actually solve
         val solved = context.logicalPlanProducer.estimatePlannerQuery(
@@ -152,11 +152,11 @@ case object PlanUpdates
    * Note also that merge uses a special leaf planner to enforce the correct behavior
    * when having uniqueness constraints, and unnestApply will remove a lot of the extra Applies
    */
-  private def planMerge(query: PlannerQuery, source: LogicalPlan, matchGraph: QueryGraph, createNodePatterns: Seq[CreateNodePattern],
+  def planMerge(source: LogicalPlan, matchGraph: QueryGraph, createNodePatterns: Seq[CreateNodePattern],
                 createRelationshipPatterns: Seq[CreateRelationshipPattern], onCreatePatterns: Seq[SetMutatingPattern],
                 onMatchPatterns: Seq[SetMutatingPattern], first: Boolean)(implicit context: LogicalPlanningContext): LogicalPlan = {
 
-    val producer = context.logicalPlanProducer
+    val producer: LogicalPlanProducer = context.logicalPlanProducer
 
     //Merge needs to make sure that found nodes have all the expected properties, so we use AssertSame operators here
     val leafPlanners = PriorityLeafPlannerList(LeafPlannerList(mergeUniqueIndexSeekLeafPlanner),
@@ -165,30 +165,20 @@ case object PlanUpdates
     val innerContext: LogicalPlanningContext =
       context.recurse(source).copy(config = context.config.withLeafPlanners(leafPlanners))
 
-    //        apply
-    //        /   \
-    //       /  optional
-    //      /       \
-    // source  mergeReadPart
-    val mergeReadPart = innerContext.strategy.plan(matchGraph)(innerContext)
-    if (mergeReadPart.solved.queryGraph != matchGraph)
-      throw new CantHandleQueryException(s"The planner was unable to successfully plan the MERGE read:\n${mergeReadPart.solved.queryGraph}\n not equal to \n$matchGraph")
+    val ids: Seq[IdName] = createNodePatterns.map(_.nodeName) ++ createRelationshipPatterns.map(_.relName)
 
-    val rhs = producer.planOptional(mergeReadPart, matchGraph.argumentIds)(innerContext)
-    val apply = producer.planApply(source, rhs)(innerContext)
+    val mergeMatch = mergeMatchPart(source, matchGraph, producer, createNodePatterns, createRelationshipPatterns, innerContext, ids)
 
     //            condApply
     //             /   \
     //          apply  onMatch
-    val ids = createNodePatterns.map(_.nodeName) ++ createRelationshipPatterns.map(_.relName)
-
     val condApply = if (onMatchPatterns.nonEmpty) {
       val qgWithAllNeededArguments = matchGraph.addArgumentIds(matchGraph.allCoveredIds.toSeq)
       val onMatch = onMatchPatterns.foldLeft[LogicalPlan](producer.planQueryArgumentRow(qgWithAllNeededArguments)) {
-        case (src, current) => planUpdate(query, src, current, first)
+        case (src, current) => planUpdate(src, current, first)
       }
-      producer.planConditionalApply(apply, onMatch, ids)(innerContext)
-    } else apply
+      producer.planConditionalApply(mergeMatch, onMatch, ids)(innerContext)
+    } else mergeMatch
 
     //       antiCondApply
     //         /     \
@@ -196,7 +186,7 @@ case object PlanUpdates
     //       /         \
     //      /     mergeCreatePart
     // condApply
-    val createNodes = createNodePatterns.foldLeft(producer.planQueryArgumentRow(matchGraph): LogicalPlan){
+    val createNodes = createNodePatterns.foldLeft(producer.planQueryArgumentRow(matchGraph): LogicalPlan) {
       case (acc, current) => producer.planMergeCreateNode(acc, current)
     }
     val mergeCreatePart = createRelationshipPatterns.foldLeft(createNodes) {
@@ -204,11 +194,64 @@ case object PlanUpdates
     }
 
     val onCreate = onCreatePatterns.foldLeft(mergeCreatePart) {
-      case (src, current) => planUpdate(query, src, current, first)
+      case (src, current) => planUpdate(src, current, first)
     }
 
     val antiCondApply = producer.planAntiConditionalApply(condApply, onCreate, ids)(innerContext)
 
     antiCondApply
+  }
+
+  private def mergeMatchPart(source: LogicalPlan,
+                             matchGraph: QueryGraph,
+                             producer: LogicalPlanProducer,
+                             createNodePatterns: Seq[CreateNodePattern],
+                             createRelationshipPatterns: Seq[CreateRelationshipPattern],
+                             context: LogicalPlanningContext,
+                             ids: Seq[IdName]): LogicalPlan = {
+    def mergeRead(ctx: LogicalPlanningContext) = {
+      val mergeReadPart = ctx.strategy.plan(matchGraph)(ctx)
+      if (mergeReadPart.solved.queryGraph != matchGraph)
+        throw new CantHandleQueryException(s"The planner was unable to successfully plan the MERGE read:\n${mergeReadPart.solved.queryGraph}\n not equal to \n$matchGraph")
+      producer.planOptional(mergeReadPart, matchGraph.argumentIds)(ctx)
+    }
+
+    //        apply
+    //        /   \
+    //       /  optional
+    //      /       \
+    // source  mergeReadPart
+    //                \
+    //                arg
+    val matchOrNull = producer.planApply(source, mergeRead(context))(context)
+
+    // If we are MERGEing on relationships, we need to lock nodes before matching again. Otherwise, we are done
+    val nodesToLock = matchGraph.patternNodes intersect matchGraph.argumentIds
+
+    if (nodesToLock.nonEmpty) {
+
+      def addLockToPlan(plan: LogicalPlan): LogicalPlan = {
+        val lockThese = nodesToLock intersect plan.availableSymbols
+        if (lockThese.nonEmpty)
+          LockNodes(plan, lockThese)(plan.solved)
+        else
+          plan
+      }
+
+      val lockingContext = context.copy(leafPlanUpdater = addLockToPlan)
+
+      //        antiCondApply
+      //        /   \
+      //       /  optional
+      //      /       \
+      // source  mergeReadPart
+      //                \
+      //               lock
+      //                  \
+      //                  leaf
+      val ifMissingLockAndMatchAgain = mergeRead(lockingContext)
+      producer.planAntiConditionalApply(matchOrNull, ifMissingLockAndMatchAgain, ids)(context)
+    } else
+      matchOrNull
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanUpdates.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanUpdates.scala
@@ -170,7 +170,7 @@ case object PlanUpdates
     //       /  optional
     //      /       \
     // source  mergeReadPart
-    val mergeReadPart = innerContext.strategy.plan(matchGraph)(innerContext, None)
+    val mergeReadPart = innerContext.strategy.plan(matchGraph)(innerContext)
     if (mergeReadPart.solved.queryGraph != matchGraph)
       throw new CantHandleQueryException(s"The planner was unable to successfully plan the MERGE read:\n${mergeReadPart.solved.queryGraph}\n not equal to \n$matchGraph")
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanWithTail.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanWithTail.scala
@@ -27,7 +27,7 @@ This class ties together disparate query graphs through their event horizons. It
 which in most cases is then rewritten away by LogicalPlan rewriting.
 */
 case class PlanWithTail(planEventHorizon: LogicalPlanningFunction2[PlannerQuery, LogicalPlan, LogicalPlan] = PlanEventHorizon,
-                        planPart: (PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan = planPart,
+                        planPart: (PlannerQuery, LogicalPlanningContext) => LogicalPlan = planPart,
                         planUpdates: LogicalPlanningFunction3[PlannerQuery, LogicalPlan, Boolean, LogicalPlan] = PlanUpdates)
   extends LogicalPlanningFunction2[LogicalPlan, Option[PlannerQuery], LogicalPlan] {
 
@@ -35,8 +35,7 @@ case class PlanWithTail(planEventHorizon: LogicalPlanningFunction2[PlannerQuery,
     remaining match {
       case Some(plannerQuery) =>
         val lhsContext = context.recurse(lhs)
-        val row = context.logicalPlanProducer.planArgumentRowFrom(lhs)
-        val partPlan = planPart(plannerQuery, lhsContext, Some(row))
+        val partPlan = planPart(plannerQuery, lhsContext)
         val firstPlannerQuery = false
         val planWithUpdates = planUpdates(plannerQuery, partPlan, firstPlannerQuery)(context)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/QueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/QueryGraphSolver.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{NodePattern, PatternExpression, RelationshipChain}
 
 trait QueryGraphSolver {
-  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan] = None): LogicalPlan
+  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan
   def planPatternExpression(planArguments: Set[IdName], expr: PatternExpression)(implicit context: LogicalPlanningContext): (LogicalPlan, PatternExpression)
 }
 
@@ -41,17 +41,16 @@ trait PatternExpressionSolving {
     val (namedExpr, namedMap) = PatternExpressionPatternElementNamer(expr)
     val qg = namedExpr.asQueryGraph.withArgumentIds(qgArguments)
 
-    val argLeafPlan = Some(context.logicalPlanProducer.planQueryArgumentRow(qg))
     val namedNodes = namedMap.collect { case (elem: NodePattern, identifier) => identifier}
     val namedRels = namedMap.collect { case (elem: RelationshipChain, identifier) => identifier}
     val patternPlanningContext = context.forExpressionPlanning(namedNodes, namedRels)
-    val plan = self.plan(qg)(patternPlanningContext, argLeafPlan)
+    val plan = self.plan(qg)(patternPlanningContext)
     (plan, namedExpr)
   }
 }
 
 trait TentativeQueryGraphSolver extends QueryGraphSolver with PatternExpressionSolving {
-  def tryPlan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan] = None): Option[LogicalPlan]
-  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan] = None): LogicalPlan =
+  def tryPlan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Option[LogicalPlan]
+  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan =
     tryPlan(queryGraph).getOrElse(throw new InternalException("Failed to create a plan for the given QueryGraph " + queryGraph))
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/QueryPlanner.scala
@@ -60,13 +60,13 @@ case class DefaultQueryPlanner(planRewriter: Rewriter,
   }
 }
 
-case object planPart extends ((PlannerQuery, LogicalPlanningContext, Option[LogicalPlan]) => LogicalPlan) {
+case object planPart extends ((PlannerQuery, LogicalPlanningContext) => LogicalPlan) {
 
-  def apply(query: PlannerQuery, context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
+  def apply(query: PlannerQuery, context: LogicalPlanningContext): LogicalPlan = {
     val ctx = query.preferredStrictness match {
       case Some(mode) if !context.input.strictness.contains(mode) => context.withStrictness(mode)
       case _ => context
     }
-    ctx.strategy.plan(query.queryGraph)(ctx, leafPlan)
+    ctx.strategy.plan(query.queryGraph)(ctx)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.planShortestPaths
+
 import scala.annotation.tailrec
 
 trait IDPQueryGraphSolverMonitor extends IDPSolverMonitor {
@@ -52,7 +53,7 @@ case class IDPQueryGraphSolver(singleComponentSolver: SingleComponentPlannerTrai
 
   private implicit val x = singleComponentSolver
 
-  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = {
+  def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = {
     implicit val kit = kitWithShortestPathSupport(context.config.toKit())
     val components = queryGraph.connectedComponents
     val plans = if (components.isEmpty) planEmptyComponent(queryGraph) else planComponents(components)
@@ -75,12 +76,12 @@ case class IDPQueryGraphSolver(singleComponentSolver: SingleComponentPlannerTrai
       case (plan, _) => plan
     }
 
-  private def planComponents(components: Seq[QueryGraph])(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kit: QueryPlannerKit): Seq[PlannedComponent] =
+  private def planComponents(components: Seq[QueryGraph])(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): Seq[PlannedComponent] =
     components.map { qg =>
       PlannedComponent(qg, singleComponentSolver.planComponent(qg))
     }
 
-  private def planEmptyComponent(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan], kit: QueryPlannerKit): Seq[PlannedComponent] = {
+  private def planEmptyComponent(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): Seq[PlannedComponent] = {
     val plan = if (queryGraph.argumentIds.isEmpty)
       context.logicalPlanProducer.planSingleRow()
     else

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/Argument.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/Argument.scala
@@ -20,8 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.symbols.CypherType
-import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+import org.neo4j.cypher.internal.frontend.v3_0.symbols.{CypherType, _}
 
 // Argument is used inside of an Apply to feed the row from the LHS of the Apply to the leaf of the RHS
 case class Argument(argumentIds: Set[IdName])(val solved: PlannerQuery with CardinalityEstimation)
@@ -29,7 +28,6 @@ case class Argument(argumentIds: Set[IdName])(val solved: PlannerQuery with Card
   extends LogicalLeafPlan {
 
   def availableSymbols = argumentIds
-
 
   override def updateSolved(newSolved: PlannerQuery with CardinalityEstimation) =
     copy(argumentIds)(newSolved)(typeInfo)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LockNodes.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LockNodes.scala
@@ -17,18 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
+package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LeafPlanner, LogicalPlanningContext}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
 
-object argumentLeafPlanner extends LeafPlanner {
-  def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
-    val ids = qg.patternNodes ++ qg.patternRelationships.map(_.name)
-    if ((qg.argumentIds intersect ids).isEmpty)
-      Seq.empty
-    else
-      Seq(context.logicalPlanProducer.planQueryArgumentRow(qg))
-  }
+case class LockNodes(source: LogicalPlan, nodesToLock: Set[IdName])(val solved: PlannerQuery with CardinalityEstimation)
+  extends LogicalPlan with LazyLogicalPlan {
+  override def lhs: Option[LogicalPlan] = Some(source)
+
+  override def rhs: Option[LogicalPlan] = None
+
+  override def availableSymbols: Set[IdName] = source.availableSymbols
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -37,6 +37,8 @@ import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, SemanticDirec
  * much testing
  */
 case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListSupport {
+  def planLock(plan: LogicalPlan, nodesToLock: Set[IdName])(implicit context: LogicalPlanningContext): LogicalPlan =
+    LockNodes(plan, nodesToLock)(plan.solved)
 
   def solvePredicate(plan: LogicalPlan, solved: Expression)(implicit context: LogicalPlanningContext) =
     plan.updateSolved(_.amendQueryGraph(_.addPredicates(solved)))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolver.scala
@@ -184,11 +184,9 @@ case class ListSubQueryExpressionSolver[T <: Expression](namer: T => (T, Map[Pat
     val (namedExpr, namedMap) = namer(expr)
 
     val qg = extractQG(source, namedExpr)
-
-    val argLeafPlan = Some(context.logicalPlanProducer.planQueryArgumentRow(qg))
     val innerContext = createPlannerContext(context, namedMap)
 
-    val innerPlan = innerContext.strategy.plan(qg)(innerContext, argLeafPlan)
+    val innerPlan = innerContext.strategy.plan(qg)(innerContext)
     val collectionName = FreshIdNameGenerator.name(expr.position)
     val projectedPath = projectionCreator(namedExpr)
     val projectedInner = context.logicalPlanProducer.planRegularProjection(innerPlan, Map(collectionName -> projectedPath), Map.empty)(innerContext)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/leafPlanOptions.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/leafPlanOptions.scala
@@ -32,6 +32,6 @@ object leafPlanOptions extends LeafPlanFinder {
     val leafPlanCandidateLists = config.leafPlanners.candidates(queryGraph)
     val leafPlanCandidateListsWithSelections = queryPlannerKit.select(leafPlanCandidateLists, queryGraph)
     val bestLeafPlans: Iterable[LogicalPlan] = leafPlanCandidateListsWithSelections.flatMap(pickBest(_))
-    bestLeafPlans.toSet
+    bestLeafPlans.map(context.leafPlanUpdater).toSet
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{DefaultIDPSolverConfig, IDPQueryGraphSolver, IDPQueryGraphSolverMonitor, SingleComponentPlanner, cartesianProductsOrValueJoins}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter.LogicalPlanRewriter
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
@@ -106,7 +106,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   def newMockedStrategy(plan: LogicalPlan) = {
     val strategy = mock[QueryGraphSolver]
-    doReturn(plan).when(strategy).plan(any())(any(), any())
+    doReturn(plan).when(strategy).plan(any())(any())
     strategy
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
@@ -61,7 +61,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
   var tokenResolver = new SimpleTokenResolver()
   val planRewriter = LogicalPlanRewriter(rewriterSequencer)
   final var planner = new DefaultQueryPlanner(planRewriter) {
-    def internalPlan(query: PlannerQuery)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan] = None): LogicalPlan =
+    def internalPlan(query: PlannerQuery)(implicit context: LogicalPlanningContext): LogicalPlan =
       planSingleQuery(query)
   }
   var queryGraphSolver: QueryGraphSolver = new IDPQueryGraphSolver(SingleComponentPlanner(mock[IDPQueryGraphSolverMonitor]), cartesianProductsOrValueJoins, mock[IDPQueryGraphSolverMonitor])

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/DefaultQueryPlannerTest.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, LogicalPlanningTestSupport2, PlannerQuery, QueryGraph, RegularPlannerQuery, RegularQueryProjection, UnionQuery}
+import org.neo4j.cypher.internal.compiler.v3_0.planner._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{ASTAnnotationMap, Expression, Hint}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
@@ -93,7 +93,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(context.config).thenReturn(QueryPlannerConfiguration.default)
     when(context.input).thenReturn(QueryGraphSolverInput.empty)
     when(context.strategy).thenReturn(new QueryGraphSolver with PatternExpressionSolving {
-      override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, leafPlan: Option[LogicalPlan]): LogicalPlan = lp
+      override def plan(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = lp
     })
     when(context.withStrictness(any())).thenReturn(context)
     val producer = mock[LogicalPlanProducer]

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/MergeRelationshipPlanningIntegrationTest.scala
@@ -97,12 +97,18 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
         Apply(
           AllNodesScan(IdName("n"), Set())(solved),
           AntiConditionalApply(
-            Optional(
-              Expand(
-                Argument(Set(IdName("n")))(solved)(),
-                IdName("n"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
-              Set(IdName("n"))
-            )(solved),
+            AntiConditionalApply(
+              Optional(
+                Expand(
+                  Argument(Set(IdName("n")))(solved)(),
+                  IdName("n"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
+                Set(IdName("n")))(solved),
+              Optional(
+                Expand(
+                  LockNodes(Argument(Set(IdName("n")))(solved)(), Set(IdName("n")))(solved),
+                  IdName("n"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
+                Set(IdName("n")))(solved),
+              Seq(IdName("b"), IdName("r")))(solved),
             MergeCreateRelationship(
               MergeCreateNode(
                 Argument(Set(IdName("n")))(solved)(),
@@ -115,30 +121,39 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
   }
 
   test("should not plan two create nodes when they are already in scope when creating a relationship") {
-    planFor("MATCH (n) MATCH (m) MERGE (n)-[r:T]->(m)").plan should equal(
-      EmptyResult(
-        Apply(
-          CartesianProduct(
-            AllNodesScan(IdName("n"), Set())(solved),
-            AllNodesScan(IdName("m"), Set())(solved)
-          )(solved),
+    val plan = planFor("MATCH (n) MATCH (m) MERGE (n)-[r:T]->(m)").plan
+    plan should equal(EmptyResult(
+      Apply(
+        CartesianProduct(
+          AllNodesScan(IdName("n"), Set())(solved),
+          AllNodesScan(IdName("m"), Set())(solved)
+        )(solved),
+        AntiConditionalApply(
           AntiConditionalApply(
             Optional(
               Expand(
                 Argument(Set(IdName("n"), IdName("m")))(solved)(),
                 IdName("n"), OUTGOING, List(RelTypeName("T")(pos)), IdName("m"), IdName("r"), ExpandInto)(solved),
-              Set(IdName("n"), IdName("m"))
-            )(solved),
-            MergeCreateRelationship(
-              Argument(Set(IdName("n"), IdName("m")))(solved)(),
-              IdName("r"), IdName("n"), LazyType("T"), IdName("m"), None)(solved),
-            Seq(IdName("r")))(solved)
-        )(solved)
+              Set(IdName("n"), IdName("m")))(solved),
+            Optional(
+              Expand(
+                LockNodes(
+                  Argument(Set(IdName("n"), IdName("m")))(solved)(),
+                  Set(IdName("n"), IdName("m")))(solved),
+                IdName("n"), OUTGOING, List(RelTypeName("T")(pos)), IdName("m"), IdName("r"), ExpandInto)(solved),
+              Set(IdName("n"), IdName("m")))(solved),
+            Vector(IdName("r")))(solved),
+          MergeCreateRelationship(
+            Argument(Set(IdName("n"), IdName("m")))(solved)(),
+            IdName("r"), IdName("n"), LazyType("T"), IdName("m"), None)(solved),
+          Vector(IdName("r")))(solved)
       )(solved)
+    )(solved)
     )
   }
 
   test("should not plan two create nodes when they are already in scope and aliased when creating a relationship") {
+
     planFor("MATCH (n) MATCH (m) WITH n AS a, m AS b MERGE (a)-[r:T]->(b)").plan should equal(
       EmptyResult(
         Apply(
@@ -150,12 +165,21 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
             Map("a" -> Variable("n")(pos), "b" -> Variable("m")(pos))
           )(solved),
           AntiConditionalApply(
-            Optional(
-              Expand(
-                Argument(Set(IdName("a"), IdName("b")))(solved)(),
-                IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandInto)(solved),
-              Set(IdName("a"), IdName("b"))
-            )(solved),
+            AntiConditionalApply(
+              Optional(
+                Expand(
+                  Argument(Set(IdName("a"), IdName("b")))(solved)(),
+                  IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandInto)(solved),
+                Set(IdName("a"), IdName("b"))
+              )(solved),
+              Optional(
+                Expand(
+                  LockNodes(
+                    Argument(Set(IdName("a"), IdName("b")))(solved)(), Set(IdName("a"), IdName("b")))(solved),
+                  IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandInto)(solved),
+                Set(IdName("a"), IdName("b"))
+              )(solved),
+              Vector(IdName("r")))(solved),
             MergeCreateRelationship(
               Argument(Set(IdName("a"), IdName("b")))(solved)(),
               IdName("r"), IdName("a"), LazyType("T"), IdName("b"), None)(solved),
@@ -174,12 +198,20 @@ class MergeRelationshipPlanningIntegrationTest extends CypherFunSuite with Logic
             Map("a" -> Variable("n")(pos))
           )(solved),
           AntiConditionalApply(
-            Optional(
-              Expand(
-                Argument(Set(IdName("a")))(solved)(),
-                IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
-              Set(IdName("a"))
-            )(solved),
+            AntiConditionalApply(
+              Optional(
+                Expand(
+                  Argument(Set(IdName("a")))(solved)(),
+                  IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
+                Set(IdName("a"))
+              )(solved),
+              Optional(
+                Expand(
+                  LockNodes(Argument(Set(IdName("a")))(solved)(), Set(IdName("a")))(solved),
+                  IdName("a"), OUTGOING, List(RelTypeName("T")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
+                Set(IdName("a"))
+              )(solved),
+              Seq(IdName("b"), IdName("r")))(solved),
             MergeCreateRelationship(
               MergeCreateNode(
                 Argument(Set(IdName("a")))(solved)(),

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolverTest.scala
@@ -163,7 +163,7 @@ class PatternExpressionSolverTest extends CypherFunSuite with LogicalPlanningTes
 
   private def createStrategy(plan: LogicalPlan*): QueryGraphSolver = {
     val strategy = mock[QueryGraphSolver]
-    when(strategy.plan(any[QueryGraph])(any[LogicalPlanningContext], any())).thenReturn(plan.head, plan.tail:_*)
+    when(strategy.plan(any[QueryGraph])(any[LogicalPlanningContext])).thenReturn(plan.head, plan.tail:_*)
     strategy
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeConcurrencyIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MergeConcurrencyIT.scala
@@ -19,51 +19,53 @@
  */
 package org.neo4j.cypher
 
+import scala.collection.JavaConverters._
+
 class MergeConcurrencyIT extends ExecutionEngineFunSuite {
 
   val nodeCount = 100
   val threadCount = 10
 
   test("should handle ten simultaneous threads") {
-      // Given a constraint on :Label(id), create a linked list
-      execute("CREATE CONSTRAINT ON (n:Label) ASSERT n.id IS UNIQUE")
+    // Given a constraint on :Label(id), create a linked list
+    execute("CREATE CONSTRAINT ON (n:Label) ASSERT n.id IS UNIQUE")
 
-      var exceptionsThrown = List.empty[Throwable]
+    var exceptionsThrown = List.empty[Throwable]
+    val q = "MERGE (a:Label {id:{id}}) " +
+      "MERGE (b:Label {id:{id}+1}) " +
+      "MERGE (a)-[r:TYPE]->(b) " +
+      "RETURN a, b, r"
 
-      val runner = new Runnable {
-        def run() {
-          try {
-            (1 to nodeCount) foreach {
-              x =>
-                val r = execute("MERGE (a:Label {id:{id}}) " +
-                  "MERGE (b:Label {id:{id}+1}) " +
-                  "MERGE (a)-[r:TYPE]->(b) " +
-                  "RETURN a, b, r", "id" -> x)
-            }
-          }
-          catch {
-            case e: Throwable => exceptionsThrown = exceptionsThrown :+ e
+    val runner = new Runnable {
+      def run() {
+        try {
+          (1 to nodeCount) foreach {
+            x =>
+              val r = execute(q, "id" -> x)
           }
         }
+        catch {
+          case e: Throwable => exceptionsThrown = exceptionsThrown :+ e
+        }
       }
+    }
 
-      val threads: Seq[Thread] = (0 to threadCount-1) map (x => new Thread(runner))
+    val threads: Seq[Thread] = 0 until threadCount map (x => new Thread(runner))
 
-      threads.foreach(_.start())
-      threads.foreach(_.join())
-      exceptionsThrown.foreach(throw _)
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    exceptionsThrown.foreach(throw _)
 
-      // Check that we haven't created duplicate nodes or duplicate relationships
-      execute("match (a:Label) with a.id as id, count(*) as c where c > 1 return *") shouldBe empty
-      execute("match (a)-[r1]->(b)<-[r2]-(a) where r1 <> r2 return *") shouldBe empty
+    // Check that we haven't created duplicate nodes or duplicate relationships
+    execute("match (a:Label) with a.id as id, count(*) as c where c > 1 return *") shouldBe empty
+    execute("match (a)-[r1]->(b)<-[r2]-(a) where r1 <> r2 return *") shouldBe empty
 
-      val details = "\n" + execute("match (a)-[r]->(b) return a.id, b.id, id(a), id(r), id(b)").dumpToString()
+    val details = "\n" + execute("match (a)-[r]->(b) return a.id, b.id, id(a), id(r), id(b)").dumpToString()
 
-      assert(execute(s"match p=(:Label {id:1})-[*..1000]->({id:$nodeCount}) return 1").size === 1, details)
+    assert(execute(s"match p=(:Label {id:1})-[*..1000]->({id:$nodeCount}) return 1").size === 1, details)
   }
 
-  test("should handle ten simultaneous threads with only nodes") {
-    // Given a constraint on :Label(id), create a linked list
+  test("should handle ten simultaneous threads with only nodes - with constraint") {
     execute("CREATE CONSTRAINT ON (n:Label) ASSERT n.id IS UNIQUE")
     var exceptionsThrown = List.empty[Throwable]
 
@@ -79,7 +81,7 @@ class MergeConcurrencyIT extends ExecutionEngineFunSuite {
       }
     }
 
-    val threads: Seq[Thread] = (0 to threadCount-1) map (x => new Thread(runner))
+    val threads: Seq[Thread] = 0 until threadCount map (x => new Thread(runner))
 
     threads.foreach(_.start())
     threads.foreach(_.join())
@@ -93,6 +95,107 @@ class MergeConcurrencyIT extends ExecutionEngineFunSuite {
       withClue(s"did not find node with id $i") {
         execute(s"match (:Label {id:$i}) return 1") should have size 1
       }
+    }
+  }
+
+  ignore("should handle ten simultaneous threads with only nodes - without constraint") {
+    var exceptionsThrown = List.empty[Throwable]
+
+    val runner = new Runnable {
+      def run() {
+        try {
+          (0 until nodeCount) foreach {
+            x => execute("MERGE (a:Label {id:{id}})", "id" -> x)
+          }
+        } catch {
+          case e: Throwable => exceptionsThrown = exceptionsThrown :+ e
+        }
+      }
+    }
+
+    val threads: Seq[Thread] = 0 until threadCount map (x => new Thread(runner))
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    exceptionsThrown.foreach(throw _)
+
+    // Check that we haven't created duplicate nodes or duplicate relationships
+    execute("match (a:Label) with a.id as id, count(*) as c where c > 1 return *") shouldBe empty
+    executeScalar[Int]("match (a:Label) return count(a)") shouldBe nodeCount
+
+    0 until nodeCount foreach { i =>
+      withClue(s"did not find node with id $i") {
+        execute(s"match (:Label {id:$i}) return 1") should have size 1
+      }
+    }
+  }
+
+  test("merge relationship - one bound end node") {
+    val n1 = createNode()
+    val n2 = createNode()
+    val query = "MATCH (n) WHERE ID(n) = {id1} MERGE (n)-[r:TEST]-(m)"
+    val compileFirst = execute(s"EXPLAIN $query", "id1" -> n1.getId, "id2" -> n2.getId)
+    var exceptionsThrown = List.empty[Throwable]
+
+    def createRunner(n1: Long, n2: Long) = new Runnable {
+      def run() {
+        try {
+          (0 until nodeCount) foreach {
+            x => execute(query, "id1" -> n1, "id2" -> n2)
+          }
+        } catch {
+          case e: Throwable => exceptionsThrown = exceptionsThrown :+ e
+        }
+      }
+    }
+
+    val threads: Seq[Thread] = 0 until threadCount map { x =>
+      val (from, to) = if(x % 2 == 0) (n1.getId, n2.getId) else (n2.getId, n1.getId)
+      new Thread(createRunner(from, to))
+    }
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    exceptionsThrown.foreach(throw _)
+
+    graph.inTx {
+      n1.getRelationships.asScala.size should equal(1)
+      n2.getRelationships.asScala.size should equal(1)
+    }
+  }
+
+  test("merge relationship - both end nodes matched") {
+    val n1 = createNode()
+    val n2 = createNode()
+    val query = "MATCH (n), (m) WHERE ID(n) = {id1} AND ID(m) = {id2} MERGE (n)-[r:TEST]-(m)"
+    val compileFirst = execute(s"EXPLAIN $query", "id1" -> n1.getId, "id2" -> n2.getId)
+
+    var exceptionsThrown = List.empty[Throwable]
+
+    def createRunner(n1: Long, n2: Long) = new Runnable {
+      def run() {
+        try {
+          (0 until nodeCount) foreach {
+            x => execute(query, "id1" -> n1, "id2" -> n2)
+          }
+        } catch {
+          case e: Throwable => exceptionsThrown = exceptionsThrown :+ e
+        }
+      }
+    }
+
+    val threads: Seq[Thread] = 0 until threadCount map { x =>
+      val (from, to) = if(x % 2 == 0) (n1.getId, n2.getId) else (n2.getId, n1.getId)
+      new Thread(createRunner(from, to))
+    }
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    exceptionsThrown.foreach(throw _)
+
+    graph.inTx {
+      n1.getRelationships.asScala.size should equal(1)
+      n2.getRelationships.asScala.size should equal(1)
     }
   }
 }


### PR DESCRIPTION
When the cost planner started planning MERGE queries, we lost the concurrency guarantees that the rule planner was providing. This change re-introduces double checked locking on nodes before creating relationships.

Changelog: Fixed cost planner ensuring concurrency guarantees on MERGE relationship