### PR TITLE
remove timeout for connecting to core

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategy.java
@@ -22,7 +22,7 @@ package org.neo4j.causalclustering.helper;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Exponential backoff strategy helper class.
+ * Exponential backoff strategy helper class. Exponent is always 2.
  */
 public class ExponentialBackoffStrategy implements RetryStrategy
 {


### PR DESCRIPTION
changelog: [causal clustering] Read replicas will now try to connect to the core cluster forever during startup.