### PR TITLE
Added information about environment variables to neo4j-admin help

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -40,6 +40,13 @@ public class Usage
     {
         output.accept( format( "usage: %s <command>", scriptName ) );
         output.accept( "" );
+        output.accept( "Manage your Neo4j instance." );
+        output.accept( "" );
+        output.accept( "environment variables:" );
+        output.accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
+        output.accept( "    NEO4J_HOME    Neo4j home directory." );
+        output.accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
+        output.accept( "" );
         output.accept( "available commands:" );
 
         for ( AdminCommand.Provider command : commands.getAllProviders() )

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -94,6 +94,50 @@ public class HelpCommandTest
         }
     }
 
+    @Test
+    public void testAdminUsage() throws Exception
+    {
+        CommandLocator commandLocator = mock( CommandLocator.class );
+        ArrayList<AdminCommand.Provider> mockCommands = new ArrayList<AdminCommand.Provider>()
+        {{
+            add( mockCommand( "foo" ) );
+            add( mockCommand( "bar" ) );
+            add( mockCommand( "baz" ) );
+        }};
+        when( commandLocator.getAllProviders() ).thenReturn( mockCommands );
+
+        try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
+        {
+            PrintStream ps = new PrintStream( baos );
+
+            Usage usage = new Usage( "neo4j-admin", commandLocator );
+
+            HelpCommand helpCommand = new HelpCommand( usage, ps::println, commandLocator );
+
+            helpCommand.execute();
+
+            assertEquals( String.format( "usage: neo4j-admin <command>%n" +
+                            "%n" +
+                            "Manage your Neo4j instance.%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "%n" +
+                            "available commands:%n" +
+                            "    foo%n" +
+                            "        null%n" +
+                            "    bar%n" +
+                            "        null%n" +
+                            "    baz%n" +
+                            "        null%n" +
+                            "%n" +
+                            "Use neo4j-admin help <command> for more details.%n" ),
+                    baos.toString() );
+        }
+    }
+
     private AdminCommand.Provider mockCommand( String name )
     {
         AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );


### PR DESCRIPTION
* New output:

```
usage: neo4j-admin <command>

Manage your Neo4j instance.

environment variables:
    NEO4J_DEBUG   Set to anything to enable debug output.
    NEO4J_HOME    Neo4j home directory.
    NEO4J_CONF    Path to directory which contains neo4j.conf.

available commands:
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').
    restore
        Restore a backed up database.
    dump
        Dump a database into a single-file archive.
    backup
        Perform an online backup from a running Neo4j enterprise server.
    unbind
        Removes cluster state data from the specified database.
    load
        Load a database from an archive created with the dump command.
    check-consistency
        Check the consistency of a database.
    set-default-admin
        Sets the default admin user when no roles are present.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    help
        This help text, or help for the command specified in <command>.

Use neo4j-admin help <command> for more details.
```

* Compare to old output:

```
usage: neo4j-admin <command>

available commands:
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').
    restore
        Restore a backed up database.
    backup
        Perform a backup, over the network, from a running Neo4j server.
    dump
        Dump a database into a single-file archive.
    unbind
        Removes cluster state data from the specified database.
    load
        Load a database from an archive created with the dump command.
    check-consistency
        Check the consistency of a database.
    set-default-admin
        Sets the default admin user when no roles are present.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    help
        This help text, or help for the command specified in <command>.

Use neo4j-admin help <command> for more details.
```