### PR TITLE
Check local lock client in SlaveLockClient instead of duplicating state

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -94,6 +94,10 @@ public interface Locks
         /** Try grabbing shared lock, not waiting and returning a boolean indicating if we got the lock. */
         boolean trySharedLock( ResourceType resourceType, long resourceId );
 
+        boolean reEnterShared( ResourceType resourceType, long resourceId );
+
+        boolean reEnterExclusive( ResourceType resourceType, long resourceId );
+
         /** Release a set of shared locks */
         void releaseShared( ResourceType resourceType, long resourceId );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -49,6 +49,18 @@ public class NoOpClient implements Locks.Client
     }
 
     @Override
+    public boolean reEnterShared( ResourceType resourceType, long resourceId )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean reEnterExclusive( ResourceType resourceType, long resourceId )
+    {
+        return false;
+    }
+
+    @Override
     public void releaseShared( ResourceType resourceType, long resourceId )
     {
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -228,6 +228,48 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
+    public boolean reEnterShared( ResourceType resourceType, long resourceId )
+    {
+        stateHolder.incrementActiveClients( this );
+        try
+        {
+            return reEnter( localShared( resourceType ), resourceId );
+        }
+        finally
+        {
+            stateHolder.decrementActiveClients();
+        }
+    }
+
+    @Override
+    public boolean reEnterExclusive( ResourceType resourceType, long resourceId )
+    {
+        stateHolder.incrementActiveClients( this );
+        try
+        {
+            return reEnter( localExclusive( resourceType ), resourceId );
+        }
+        finally
+        {
+            stateHolder.decrementActiveClients();
+        }
+    }
+
+    private boolean reEnter( PrimitiveLongObjectMap<LockResource> localLocks, long resourceId )
+    {
+        LockResource resource = localLocks.get( resourceId );
+        if ( resource != null )
+        {
+            resource.acquireReference();
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    @Override
     public void releaseShared( ResourceType resourceType, long resourceId )
     {
         stateHolder.incrementActiveClients( this );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -231,6 +231,19 @@ public class LeaderOnlyLockManager implements Locks
         }
 
         @Override
+        public boolean reEnterShared( ResourceType resourceType, long resourceId )
+        {
+            return localClient.reEnterShared( resourceType, resourceId );
+        }
+
+        @Override
+        public boolean reEnterExclusive( ResourceType resourceType, long resourceId )
+        {
+            ensureHoldingToken();
+            return localClient.reEnterExclusive( resourceType, resourceId );
+        }
+
+        @Override
         public void releaseShared( ResourceType resourceType, long resourceId )
         {
             localClient.releaseShared( resourceType, resourceId );

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -76,6 +76,18 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
+    public boolean reEnterShared( ResourceType resourceType, long resourceId )
+    {
+        throw new UnsupportedOperationException( "Should not be needed" );
+    }
+
+    @Override
+    public boolean reEnterExclusive( ResourceType resourceType, long resourceId )
+    {
+        throw new UnsupportedOperationException( "Should not be needed" );
+    }
+
+    @Override
     public void releaseShared( ResourceType resourceType, long resourceId )
     {
         assertNotStopped();

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -445,6 +445,18 @@ public class DeferringLockClientTest
         }
 
         @Override
+        public boolean reEnterShared( ResourceType resourceType, long resourceId )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean reEnterExclusive( ResourceType resourceType, long resourceId )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void releaseShared( ResourceType resourceType, long resourceId )
         {
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -181,7 +181,7 @@ public class SlaveLocksClientTest
     }
 
     @Test
-    public void shouldNotTalkToLocalLocksOnReentrancyExclusive() throws Exception
+    public void shouldUseReEntryMethodsOnLocalLocksForReEntryExclusive() throws Exception
     {
         // Given we have grabbed and released a lock
         client.acquireExclusive( LockTracer.NONE, NODE, 1L );
@@ -191,12 +191,16 @@ public class SlaveLocksClientTest
         client.releaseExclusive( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
-        verify( local, times( 1 ) ).tryExclusiveLock( NODE, 1L );
-        verify( local, times( 0 ) ).releaseExclusive( NODE, 1L );
+        InOrder order = inOrder( local );
+        order.verify( local, times( 1 ) ).reEnterExclusive( NODE, 1L );
+        order.verify( local, times( 1 ) ).tryExclusiveLock( NODE, 1L );
+        order.verify( local, times( 1 ) ).reEnterExclusive( NODE, 1L );
+        order.verify( local, times( 1 ) ).releaseExclusive( NODE, 1L );
+        order.verifyNoMoreInteractions();
     }
 
     @Test
-    public void shouldNotTalkToLocalLocksOnReentrancyShared() throws Exception
+    public void shouldUseReEntryMethodsOnLocalLocksForReEntryShared() throws Exception
     {
         // Given we have grabbed and released a lock
         client.acquireShared( LockTracer.NONE, NODE, 1L );
@@ -206,8 +210,12 @@ public class SlaveLocksClientTest
         client.releaseShared( NODE, 1L );
 
         // Then this should cause the local lock manager to hold the lock
-        verify( local, times( 1 ) ).trySharedLock( NODE, 1L );
-        verify( local, times( 0 ) ).releaseShared( NODE, 1L );
+        InOrder order = inOrder( local );
+        order.verify( local, times( 1 ) ).reEnterShared( NODE, 1L );
+        order.verify( local, times( 1 ) ).trySharedLock( NODE, 1L );
+        order.verify( local, times( 1 ) ).reEnterShared( NODE, 1L );
+        order.verify( local, times( 1 ) ).releaseShared( NODE, 1L );
+        order.verifyNoMoreInteractions();
     }
 
     @Test


### PR DESCRIPTION
By adding explicit methods for re-entry on the Locks.Client interface we can use the local lock client for checking if the lock is held locally, and achieve the same behaviour of locking on the master first, and not talking to the master on re-entry, while lowering the overhead of lock maintenance on the slave.

The lock maps in the SlaveLockClient completely disappear, and instead the state of the local lock client is used, since that already contains the same state.

Not only does this lower the memory footprint (for slaves that execute a write load), it also simplifies the code of the SlaveLockClient.