### PR TITLE
LabelScanStore compliance testing

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -31,7 +31,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.cursor.RawCursor;
@@ -143,6 +142,10 @@ public class GBPTree<KEY,VALUE> implements Closeable
          * {@link GBPTree#writer() writers} are re-enabled.
          */
         default void checkpointCompleted()
+        {   // no-op by default
+        }
+
+        default void noStoreFile()
         {   // no-op by default
         }
     }
@@ -366,6 +369,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         catch ( NoSuchFileException e )
         {
             // First time
+            monitor.noStoreFile();
             pageSize = pageSizeForCreation == 0 ? pageCache.pageSize() : pageSizeForCreation;
             if ( pageSize > pageCache.pageSize() )
             {

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdSpace.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdSpace.java
@@ -22,13 +22,13 @@ package org.neo4j.index.internal.gbptree;
 /**
  * Defines special page ids for {@link GBPTree}.
  */
-class IdSpace
+public class IdSpace
 {
     /**
      * Page id of the meta page holding information about root id and custom user meta information.
      * This page id is statically allocated throughout the life of a tree.
      */
-    static final long META_PAGE_ID = 0L;
+    public static final long META_PAGE_ID = 0L;
 
     /**
      * State page with IDs such as free-list, highId, rootId and more. There are two such pages alternating

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -480,6 +480,14 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Integer> batch_inserter_batch_size = setting( "unsupported.tools.batch_inserter.batch_size", INTEGER,
             "10000" );
 
+    @Description( "Overrides otherwise automatically selected label scan store to use. " +
+            "If this setting is specified then this configured name will be matched with one of the loaded " +
+            "label scan stores, or fail if not found. If this setting isn't specified then the loaded " +
+            "label scan store with highest priority will be selected. Both name and priority of each " +
+            "label scan store is set by the kernel extension loading it." )
+    @Internal
+    public static final Setting<String> label_scan_store = setting( "unsupported.dbms.label_scan_store", STRING, NO_DEFAULT );
+
     // Security settings
 
     @Description("Enable auth requirement to access Neo4j.")

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -37,49 +37,32 @@ public interface LabelScanStore extends Lifecycle
     interface Monitor
     {
         Monitor EMPTY = new Monitor()
-        {
-            @Override
-            public void init()
-            {
-            }
-
-            @Override
-            public void noIndex()
-            {
-            }
-
-            @Override
-            public void lockedIndex( Exception e )
-            {
-            }
-
-            @Override
-            public void notValidIndex()
-            {
-            }
-
-            @Override
-            public void rebuilding()
-            {
-            }
-
-            @Override
-            public void rebuilt( long roughNodeCount )
-            {
-            }
+        {   // empty
         };
 
-        void init();
+        default void init()
+        {   // empty
+        }
 
-        void noIndex();
+        default void noIndex()
+        {   // empty
+        }
 
-        void lockedIndex( Exception e );
+        default void lockedIndex( Exception e )
+        {   // empty
+        }
 
-        void notValidIndex();
+        default void notValidIndex()
+        {   // empty
+        }
 
-        void rebuilding();
+        default void rebuilding()
+        {   // empty
+        }
 
-        void rebuilt( long roughNodeCount );
+        default void rebuilt( long roughNodeCount )
+        {   // empty
+        }
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.labelscan;
+
+import org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor;
+import org.neo4j.logging.Log;
+
+/**
+ * Logs about important events about {@link LabelScanStore} {@link Monitor}.
+ */
+public class LoggingMonitor implements Monitor
+{
+    private final Log log;
+    private final Monitor delegate;
+
+    public LoggingMonitor( Log log )
+    {
+        this( log, Monitor.EMPTY );
+    }
+
+    public LoggingMonitor( Log log, Monitor delegate )
+    {
+        this.log = log;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void init()
+    {
+        delegate.init();
+    }
+
+    @Override
+    public void noIndex()
+    {
+        log.info( "No scan store found, this might just be first use. Preparing to rebuild." );
+        delegate.noIndex();
+    }
+
+    @Override
+    public void lockedIndex( Exception e )
+    {
+        log.error( "Scan store is locked by another process or database", e );
+        delegate.lockedIndex( e );
+    }
+
+    @Override
+    public void notValidIndex()
+    {
+        log.warn( "Scan store could not be read. Preparing to rebuild." );
+        delegate.notValidIndex();
+    }
+
+    @Override
+    public void rebuilding()
+    {
+        log.info( "Rebuilding scan store, this may take a while" );
+        delegate.rebuilding();
+    }
+
+    @Override
+    public void rebuilt( long roughNodeCount )
+    {
+        log.info( "Scan store rebuilt (roughly " + roughNodeCount + " nodes)" );
+        delegate.rebuilt( roughNodeCount );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/HighestPrioritizedLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/HighestPrioritizedLabelScanStore.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.extension.dependency;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.extension.KernelExtensions;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+
+/**
+ * Select the "correct" {@link LabelScanStoreProvider} among potentially several implementations
+ * loaded as {@link KernelExtensions}.
+ * <p>
+ * Two parameters affects which {@link LabelScanStoreProvider} is selected:
+ * <ol>
+ * <li>Specifically configured label scan store name, see {@link GraphDatabaseSettings#label_scan_store},
+ * each {@link LabelScanStoreProvider} is instantiated with a name, which is matched with the configured name.
+ * The setting can also be left unspecified, at which point the next parameter kicks in:</li>
+ * <li>Highest prioritized instance, actually using {@link HighestSelectionStrategy}</li>
+ */
+public class HighestPrioritizedLabelScanStore implements DependencyResolver.SelectionStrategy
+{
+    private final String specificallyConfigured;
+
+    public HighestPrioritizedLabelScanStore( String specificallyConfigured )
+    {
+        this.specificallyConfigured = specificallyConfigured;
+    }
+
+    @Override
+    public <T> T select( Class<T> type, Iterable<T> candidates ) throws IllegalArgumentException
+    {
+        if ( !type.equals( LabelScanStoreProvider.class ) )
+        {
+            throw new IllegalArgumentException( "Was expecting " + LabelScanStoreProvider.class );
+        }
+
+        if ( specificallyConfigured != null )
+        {
+            Iterable<T> filtered = Iterables.filter(
+                    item -> nameOf( item ).equals( specificallyConfigured ), candidates );
+            T specificItem = Iterables.single( filtered, null );
+            if ( specificItem == null )
+            {
+                throw new IllegalArgumentException( "Configured label scan store '" + specificallyConfigured +
+                        "', but couldn't find it among candidates " + candidateNames( candidates ) );
+            }
+            return specificItem;
+        }
+
+        return HighestSelectionStrategy.getInstance().select( type, candidates );
+    }
+
+    private static String candidateNames( Iterable<?> candidates )
+    {
+        StringBuilder builder = new StringBuilder( "[" );
+        int i = 0;
+        for ( Object candidate : candidates )
+        {
+            if ( i > 0 )
+            {
+                builder.append( "," );
+            }
+            builder.append( nameOf( candidate ) );
+            i++;
+        }
+        return builder.append( "]" ).toString();
+    }
+
+    private static String nameOf( Object candidate )
+    {
+        return ((LabelScanStoreProvider)candidate).getName();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -45,13 +45,20 @@ public class LabelScanStoreProvider extends LifecycleAdapter implements Comparab
 {
     private static final String KEY = "lucene";
 
+    private final String name;
     private final LabelScanStore labelScanStore;
     private final int priority;
 
-    public LabelScanStoreProvider( LabelScanStore labelScanStore, int priority )
+    public LabelScanStoreProvider( String name, LabelScanStore labelScanStore, int priority )
     {
+        this.name = name;
         this.labelScanStore = labelScanStore;
         this.priority = priority;
+    }
+
+    public String getName()
+    {
+        return name;
     }
 
     public static File getStoreDirectory( File storeRootDir )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -23,13 +23,17 @@ import java.util.function.Supplier;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.LoggingMonitor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.logging.Log;
 
 public class NativeLabelScanStoreExtension extends
         KernelExtensionFactory<NativeLabelScanStoreExtension.Dependencies>
@@ -45,6 +49,8 @@ public class NativeLabelScanStoreExtension extends
         PageCache pageCache();
 
         Supplier<IndexStoreView> indexStoreView();
+
+        LogService getLogService();
     }
 
     public NativeLabelScanStoreExtension()
@@ -62,6 +68,8 @@ public class NativeLabelScanStoreExtension extends
     @Override
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
+        Log log = dependencies.getLogService().getInternalLog( NativeLabelScanStore.class );
+        Monitor monitor = new LoggingMonitor( log, this.monitor );
         NativeLabelScanStore labelScanStore = new NativeLabelScanStore(
                 dependencies.pageCache(),
                 context.storeDir(),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -34,6 +34,8 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 public class NativeLabelScanStoreExtension extends
         KernelExtensionFactory<NativeLabelScanStoreExtension.Dependencies>
 {
+    public static final String LABEL_SCAN_STORE_NAME = "native";
+
     public interface Dependencies
     {
         Config getConfig();
@@ -45,7 +47,7 @@ public class NativeLabelScanStoreExtension extends
 
     public NativeLabelScanStoreExtension()
     {
-        super( "native" );
+        super( LABEL_SCAN_STORE_NAME );
     }
 
     @Override
@@ -57,6 +59,6 @@ public class NativeLabelScanStoreExtension extends
                 new FullLabelStream( dependencies.indexStoreView() ),
                 dependencies.getConfig().get( GraphDatabaseSettings.read_only ),
                 LabelScanStore.Monitor.EMPTY );
-        return new LabelScanStoreProvider( labelScanStore, 0 );
+        return new LabelScanStoreProvider( LABEL_SCAN_STORE_NAME, labelScanStore, 0 /*disabled by default*/ );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -35,6 +35,8 @@ public class NativeLabelScanStoreExtension extends
         KernelExtensionFactory<NativeLabelScanStoreExtension.Dependencies>
 {
     public static final String LABEL_SCAN_STORE_NAME = "native";
+    private final int priority;
+    private final LabelScanStore.Monitor monitor;
 
     public interface Dependencies
     {
@@ -47,7 +49,14 @@ public class NativeLabelScanStoreExtension extends
 
     public NativeLabelScanStoreExtension()
     {
+        this( 0 /*disabled by default*/, LabelScanStore.Monitor.EMPTY );
+    }
+
+    public NativeLabelScanStoreExtension( int priority, LabelScanStore.Monitor monitor )
+    {
         super( LABEL_SCAN_STORE_NAME );
+        this.priority = priority;
+        this.monitor = monitor;
     }
 
     @Override
@@ -58,7 +67,7 @@ public class NativeLabelScanStoreExtension extends
                 context.storeDir(),
                 new FullLabelStream( dependencies.indexStoreView() ),
                 dependencies.getConfig().get( GraphDatabaseSettings.read_only ),
-                LabelScanStore.Monitor.EMPTY );
-        return new LabelScanStoreProvider( LABEL_SCAN_STORE_NAME, labelScanStore, 0 /*disabled by default*/ );
+                monitor );
+        return new LabelScanStoreProvider( LABEL_SCAN_STORE_NAME, labelScanStore, priority );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -21,7 +21,10 @@ package org.neo4j.kernel.impl.api.scan;
 
 import java.util.function.Supplier;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
@@ -33,6 +36,8 @@ public class NativeLabelScanStoreExtension extends
 {
     public interface Dependencies
     {
+        Config getConfig();
+
         PageCache pageCache();
 
         Supplier<IndexStoreView> indexStoreView();
@@ -46,7 +51,12 @@ public class NativeLabelScanStoreExtension extends
     @Override
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
-        return new LabelScanStoreProvider( new NativeLabelScanStore( dependencies.pageCache(),
-                context.storeDir(), new FullLabelStream( dependencies.indexStoreView() ) ), 0 );
+        NativeLabelScanStore labelScanStore = new NativeLabelScanStore(
+                dependencies.pageCache(),
+                context.storeDir(),
+                new FullLabelStream( dependencies.indexStoreView() ),
+                dependencies.getConfig().get( GraphDatabaseSettings.read_only ),
+                LabelScanStore.Monitor.EMPTY );
+        return new LabelScanStoreProvider( labelScanStore, 0 );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreChaosIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreChaosIT.java
@@ -23,8 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Set;
 
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.api.impl.labelscan.LabelScanStoreTest;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import org.neo4j.test.rule.RandomRule;
@@ -38,10 +42,19 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
  */
 public abstract class LabelScanStoreChaosIT
 {
-    private final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    private final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() )
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            addSpecificConfig( builder );
+        }
+    };
     protected final RandomRule randomRule = new RandomRule();
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( randomRule ).around( dbRule );
+
+    protected abstract void addSpecificConfig( GraphDatabaseBuilder builder );
 
     @Test
     public void shouldRebuildDeletedLabelScanStoreOnStartup() throws Exception
@@ -89,6 +102,11 @@ public abstract class LabelScanStoreChaosIT
         {
             return asSet( dbRule.getGraphDatabaseAPI().findNodes( label ) );
         }
+    }
+
+    protected void scrambleFile( File file ) throws IOException
+    {
+        LabelScanStoreTest.scrambleFile( randomRule.random(), file );
     }
 
     private void deleteNode( Node node )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreUpdateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreUpdateIT.java
@@ -20,7 +20,6 @@
 package org.neo4j.graphdb;
 
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,10 +30,6 @@ import java.util.Set;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.test.rule.DatabaseRule;
-import org.neo4j.test.rule.ImpermanentDatabaseRule;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -43,11 +38,8 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.emptySetOf;
 import static org.neo4j.helpers.collection.Iterators.single;
 
-public class LabelScanStoreUpdateIT
+public abstract class LabelScanStoreUpdateIT
 {
-    @ClassRule
-    public static final DatabaseRule dbRule = new ImpermanentDatabaseRule();
-
     @Rule
     public final TestName testName = new TestName();
 
@@ -178,7 +170,7 @@ public class LabelScanStoreUpdateIT
     public void shouldHandleLargeAmountsOfNodesAddedAndRemovedInSameTx() throws Exception
     {
         // Given
-        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        GraphDatabaseService db = db();
         int labelsToAdd = 80;
         int labelsToRemove = 40;
 
@@ -216,11 +208,13 @@ public class LabelScanStoreUpdateIT
         }
     }
 
+    protected abstract GraphDatabaseService db();
+
     private void verifyFoundNodes( Label label, String sizeMismatchMessage, long... expectedNodeIds )
     {
-        try ( Transaction ignored = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction ignored = db().beginTx() )
         {
-            ResourceIterator<Node> nodes = dbRule.getGraphDatabaseAPI().findNodes( label );
+            ResourceIterator<Node> nodes = db().findNodes( label );
             List<Node> nodeList = Iterators.asList( nodes );
             assertThat( sizeMismatchMessage, nodeList, Matchers.hasSize( expectedNodeIds.length ) );
             int index = 0;
@@ -233,7 +227,7 @@ public class LabelScanStoreUpdateIT
 
     private void removeLabels( Node node, Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction tx = db().beginTx() )
         {
             for ( Label label : labels )
             {
@@ -245,7 +239,7 @@ public class LabelScanStoreUpdateIT
 
     private void deleteNode( Node node )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction tx = db().beginTx() )
         {
             node.delete();
             tx.success();
@@ -254,17 +248,17 @@ public class LabelScanStoreUpdateIT
 
     private Set<Node> getAllNodesWithLabel( Label label )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction tx = db().beginTx() )
         {
-            return asSet( dbRule.getGraphDatabaseAPI().findNodes( label ) );
+            return asSet( db().findNodes( label ) );
         }
     }
 
     private Node createLabeledNode( Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction tx = db().beginTx() )
         {
-            Node node = dbRule.getGraphDatabaseAPI().createNode( labels );
+            Node node = db().createNode( labels );
             tx.success();
             return node;
         }
@@ -272,7 +266,7 @@ public class LabelScanStoreUpdateIT
 
     private void addLabels( Node node, Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseAPI().beginTx() )
+        try ( Transaction tx = db().beginTx() )
         {
             for ( Label label : labels )
             {
@@ -284,9 +278,9 @@ public class LabelScanStoreUpdateIT
 
     private Node getNodeById(long id)
     {
-        try (Transaction ignored = dbRule.beginTx())
+        try (Transaction ignored = db().beginTx())
         {
-            return dbRule.getNodeById( id );
+            return db().getNodeById( id );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -560,19 +560,24 @@ public abstract class LabelScanStoreTest
 
     protected void scrambleFile( File file ) throws IOException
     {
+        scrambleFile( this.random.random(), file );
+    }
+
+    public static void scrambleFile( Random random, File file ) throws IOException
+    {
         try ( RandomAccessFile fileAccess = new RandomAccessFile( file, "rw" );
               FileChannel channel = fileAccess.getChannel() )
         {
             // The files will be small, so OK to allocate a buffer for the full size
             byte[] bytes = new byte[(int) channel.size()];
-            putRandomBytes( random.random(), bytes );
+            putRandomBytes( random, bytes );
             ByteBuffer buffer = ByteBuffer.wrap( bytes );
             channel.position( 0 );
             channel.write( buffer );
         }
     }
 
-    private void putRandomBytes( Random random, byte[] bytes )
+    private static void putRandomBytes( Random random, byte[] bytes )
     {
         for ( int i = 0; i < bytes.length; i++ )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStoreExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/scan/InMemoryLabelScanStoreExtension.java
@@ -27,6 +27,8 @@ import org.neo4j.kernel.impl.spi.KernelContext;
 public class InMemoryLabelScanStoreExtension extends
         KernelExtensionFactory<InMemoryLabelScanStoreExtension.NoDependencies>
 {
+    public static final String LABEL_SCAN_STORE_NAME = "in-memory";
+
     public interface NoDependencies
     {   // No dependencies
     }
@@ -39,6 +41,6 @@ public class InMemoryLabelScanStoreExtension extends
     @Override
     public LabelScanStoreProvider newInstance( KernelContext context, NoDependencies dependencies ) throws Throwable
     {
-        return new LabelScanStoreProvider( new InMemoryLabelScanStore(), 2 );
+        return new LabelScanStoreProvider( LABEL_SCAN_STORE_NAME, new InMemoryLabelScanStore(), 2 );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreChaosIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreChaosIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import java.io.File;
+
+import org.neo4j.graphdb.LabelScanStoreChaosIT;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.impl.api.scan.NativeLabelScanStoreExtension;
+import org.neo4j.test.rule.DatabaseRule.RestartAction;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.label_scan_store;
+
+public class NativeLabelScanStoreChaosIT extends LabelScanStoreChaosIT
+{
+    @Override
+    protected RestartAction corruptTheLabelScanStoreIndex()
+    {
+        return (fs, directory) -> scrambleFile( storeFile( directory ) );
+    }
+
+    @Override
+    protected RestartAction deleteTheLabelScanStoreIndex()
+    {
+        return (fs, directory) -> fs.deleteFile( storeFile( directory ) );
+    }
+
+    private static File storeFile( File directory )
+    {
+        return new File( directory, NativeLabelScanStore.FILE_NAME );
+    }
+
+    @Override
+    protected void addSpecificConfig( GraphDatabaseBuilder builder )
+    {
+        builder.setConfig( label_scan_store, NativeLabelScanStoreExtension.LABEL_SCAN_STORE_NAME );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
@@ -30,6 +30,7 @@ import java.util.Random;
 
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
@@ -64,6 +65,7 @@ public class NativeLabelScanStoreIT
         PageCache pageCache = pageCacheRule.getPageCache( new DefaultFileSystemAbstraction() );
         store = life.add( new NativeLabelScanStore( pageCache, directory.absolutePath(),
                 FullStoreChangeStream.EMPTY,
+                false, LabelScanStore.Monitor.EMPTY,
                 // a bit of random pageSize
                 Math.min( pageCache.pageSize(), 256 << random.nextInt( 5 ) ) ) );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreIT.java
@@ -45,7 +45,7 @@ import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.asArray;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
 
-public class NativeLabelScanStoreTest
+public class NativeLabelScanStoreIT
 {
     private final TestDirectory directory = TestDirectory.testDirectory( getClass() );
     private final PageCacheRule pageCacheRule = new PageCacheRule();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreStartupIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.LabelScanStoreStartupIT;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.impl.api.scan.NativeLabelScanStoreExtension;
+
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.label_scan_store;
+
+public class NativeLabelScanStoreStartupIT extends LabelScanStoreStartupIT
+{
+    @Override
+    protected void addSpecificConfig( GraphDatabaseBuilder builder )
+    {
+        builder.setConfig( label_scan_store, NativeLabelScanStoreExtension.LABEL_SCAN_STORE_NAME );
+    }
+
+    @Override
+    protected void corruptLabelScanStoreFiles( File storeDirectory ) throws IOException
+    {
+        scrambleFile( storeFile( storeDirectory ) );
+    }
+
+    @Override
+    protected void deleteLabelScanStoreFiles( File storeDirectory ) throws IOException
+    {
+        assertTrue( storeFile( storeDirectory ).delete() );
+    }
+
+    private static File storeFile( File directory )
+    {
+        return new File( directory, NativeLabelScanStore.FILE_NAME );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.impl.labelscan.LabelScanStoreTest;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.test.rule.PageCacheRule;
+
+public class NativeLabelScanStoreTest extends LabelScanStoreTest
+{
+    @Rule
+    public PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @Override
+    protected LabelScanStore createLabelScanStore( FileSystemAbstraction fileSystemAbstraction, File rootFolder,
+            List<NodeLabelUpdate> existingData, boolean usePersistentStore, boolean readOnly,
+            LabelScanStore.Monitor monitor )
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemAbstraction );
+        NativeLabelScanStore nativeLabelScanStore = new NativeLabelScanStore( pageCache, rootFolder,
+                asStream( existingData ), readOnly, monitor );
+        return nativeLabelScanStore;
+    }
+
+    @Override
+    protected Matcher<Iterable<? super String>> hasBareMinimumFileList()
+    {
+        return Matchers.hasItem( Matchers.equalTo( NativeLabelScanStore.FILE_NAME ) );
+    }
+
+    @Override
+    protected void corruptIndex( FileSystemAbstraction fileSystem, File rootFolder ) throws IOException
+    {
+        File lssFile = new File( rootFolder, NativeLabelScanStore.FILE_NAME );
+        scrambleFile( lssFile );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreUpdateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreUpdateIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import org.junit.ClassRule;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.LabelScanStoreUpdateIT;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.impl.api.scan.NativeLabelScanStoreExtension;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.label_scan_store;
+
+public class NativeLabelScanStoreUpdateIT extends LabelScanStoreUpdateIT
+{
+    @ClassRule
+    public static final DatabaseRule dbRule = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( label_scan_store, NativeLabelScanStoreExtension.LABEL_SCAN_STORE_NAME );
+        }
+    };
+
+    @Override
+    protected GraphDatabaseService db()
+    {
+        return dbRule;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
@@ -45,9 +45,9 @@ import static java.lang.Integer.max;
 
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.asArray;
-import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreTest.flipRandom;
-import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreTest.getLabels;
-import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreTest.nodesWithLabel;
+import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreIT.flipRandom;
+import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreIT.getLabels;
+import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreIT.nodesWithLabel;
 
 public class NativeLabelScanWriterTest
 {

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -20,7 +20,6 @@
 package org.neo4j.test.rule;
 
 import java.io.File;
-import java.time.Clock;
 import java.util.Map;
 
 import org.neo4j.graphdb.DependencyResolver;
@@ -36,6 +35,7 @@ import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.legacyindex.InternalAutoIndexing;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStore;
+import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.kernel.impl.core.DatabasePanicEventGenerator;
@@ -71,7 +71,6 @@ import org.neo4j.time.Clocks;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class NeoStoreDataSourceRule extends ExternalResource
 {
@@ -149,7 +148,8 @@ public class NeoStoreDataSourceRule extends ExternalResource
         return new DependencyResolver.Adapter()
         {
             private final LabelScanStoreProvider labelScanStoreProvider =
-                    new LabelScanStoreProvider( new InMemoryLabelScanStore(), 10 );
+                    new LabelScanStoreProvider( InMemoryLabelScanStoreExtension.LABEL_SCAN_STORE_NAME,
+                            new InMemoryLabelScanStore(), 10 );
 
             @Override
             public <T> T resolveDependency( Class<T> type, SelectionStrategy selector ) throws IllegalArgumentException

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
@@ -101,7 +101,7 @@ public class RecordStorageEngineRule extends ExternalResource
             throw new IllegalStateException();
         }
         IdGeneratorFactory idGeneratorFactory = new EphemeralIdGenerator.Factory();
-        LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider( labelScanStore, 42 );
+        LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider( "test", labelScanStore, 42 );
         LegacyIndexProviderLookup legacyIndexProviderLookup = mock( LegacyIndexProviderLookup.class );
         when( legacyIndexProviderLookup.all() ).thenReturn( Iterables.empty() );
         IndexConfigStore indexConfigStore = new IndexConfigStore( storeDirectory, fs );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1541,7 +1541,7 @@ public class BatchInsertTest
         @Override
         public Lifecycle newInstance( KernelContext context, NoDependencies dependencies ) throws Throwable
         {
-            return new LabelScanStoreProvider( labelScanStore, 100 );
+            return new LabelScanStoreProvider( "test", labelScanStore, 100 );
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneLabelScanStoreBuilder.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.impl.labelscan.LabelScanIndex;
 import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanIndexBuilder;
 import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.LoggingMonitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
@@ -76,14 +77,14 @@ public class LuceneLabelScanStoreBuilder
         if ( null == labelScanStore )
         {
             // TODO: Replace with kernel extension based lookup
+            LabelScanStore.Monitor monitor = new LoggingMonitor( logProvider.getLog( LuceneLabelScanStore.class ) );
             LabelScanIndex index = LuceneLabelScanIndexBuilder.create()
                     .withFileSystem( fileSystem )
                     .withIndexRootFolder( getStoreDirectory( storeDir ) )
                     .withConfig( config )
                     .withOperationalMode( operationalMode )
                     .build();
-            labelScanStore = new LuceneLabelScanStore( index, new FullLabelStream( storeViewSupplier ),
-                    logProvider, LabelScanStore.Monitor.EMPTY );
+            labelScanStore = new LuceneLabelScanStore( index, new FullLabelStream( storeViewSupplier ), monitor );
 
             try
             {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
@@ -40,6 +40,8 @@ import static org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor;
 @Service.Implementation(KernelExtensionFactory.class)
 public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<LuceneLabelScanStoreExtension.Dependencies>
 {
+    public static final String LABEL_SCAN_STORE_NAME = "lucene";
+
     private final int priority;
     private final Monitor monitor;
 
@@ -65,7 +67,7 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
 
     LuceneLabelScanStoreExtension( int priority, Monitor monitor )
     {
-        super( "lucene-scan-store");
+        super( "lucene-scan-store" );
         this.priority = priority;
         this.monitor = (monitor == null) ? Monitor.EMPTY : monitor;
     }
@@ -81,7 +83,7 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 new FullLabelStream( dependencies.indexStoreView() ),
                 dependencies.getLogService().getInternalLogProvider(), monitor );
 
-        return new LabelScanStoreProvider( scanStore, priority );
+        return new LabelScanStoreProvider( LABEL_SCAN_STORE_NAME, scanStore, priority );
     }
 
     private LabelScanIndex getLuceneIndex( KernelContext context, DirectoryFactory directoryFactory )
@@ -92,5 +94,4 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
                 .withIndexRootFolder( LabelScanStoreProvider.getStoreDirectory( context.storeDir() ) )
                 .build();
     }
-
 }

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
@@ -20,19 +20,19 @@
 package org.neo4j.graphdb;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanIndexBuilder;
+import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStoreExtension;
 import org.neo4j.test.rule.DatabaseRule;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.label_scan_store;
 import static org.neo4j.io.fs.FileUtils.deleteRecursively;
 
 public class LuceneLabelScanStoreChaosIT extends LabelScanStoreChaosIT
@@ -41,44 +41,31 @@ public class LuceneLabelScanStoreChaosIT extends LabelScanStoreChaosIT
     protected DatabaseRule.RestartAction corruptTheLabelScanStoreIndex()
     {
         return ( fs, storeDirectory ) -> {
-            try
+            int filesCorrupted = 0;
+            List<File> partitionDirs = labelScanStoreIndexDirectories( storeDirectory );
+            for ( File partitionDir : partitionDirs )
             {
-                int filesCorrupted = 0;
-                List<File> partitionDirs = labelScanStoreIndexDirectories( storeDirectory );
-                for ( File partitionDir : partitionDirs )
+                for ( File file : partitionDir.listFiles() )
                 {
-                    for ( File file : partitionDir.listFiles() )
-                    {
-                        scrambleFile( file );
-                        filesCorrupted++;
-                    }
+                    scrambleFile( file );
+                    filesCorrupted++;
                 }
-                assertTrue( "No files found to corrupt", filesCorrupted > 0 );
             }
-            catch ( IOException e )
-            {
-                throw new RuntimeException( e );
-            }
+            assertTrue( "No files found to corrupt", filesCorrupted > 0 );
         };
     }
 
     @Override
     protected DatabaseRule.RestartAction deleteTheLabelScanStoreIndex()
     {
-        return ( fs, storeDirectory ) -> {
-            try
+        return ( fs, storeDirectory ) ->
+        {
+            List<File> partitionDirs = labelScanStoreIndexDirectories( storeDirectory );
+            for ( File dir : partitionDirs )
             {
-                List<File> partitionDirs = labelScanStoreIndexDirectories( storeDirectory );
-                for ( File dir : partitionDirs )
-                {
-                    assertTrue( "We seem to want to delete the wrong directory here", dir.exists() );
-                    assertTrue( "No index files to delete", dir.listFiles().length > 0 );
-                    deleteRecursively( dir );
-                }
-            }
-            catch ( IOException e )
-            {
-                throw new RuntimeException( e );
+                assertTrue( "We seem to want to delete the wrong directory here", dir.exists() );
+                assertTrue( "No index files to delete", dir.listFiles().length > 0 );
+                deleteRecursively( dir );
             }
         };
     }
@@ -92,25 +79,9 @@ public class LuceneLabelScanStoreChaosIT extends LabelScanStoreChaosIT
         return (partitionDirs == null) ? Collections.emptyList() : Stream.of( partitionDirs ).collect( toList() );
     }
 
-    private void scrambleFile( File file ) throws IOException
+    @Override
+    protected void addSpecificConfig( GraphDatabaseBuilder builder )
     {
-        try ( RandomAccessFile fileAccess = new RandomAccessFile( file, "rw" );
-              FileChannel channel = fileAccess.getChannel() )
-        {
-            // The files will be small, so OK to allocate a buffer for the full size
-            byte[] bytes = new byte[(int) channel.size()];
-            putRandomBytes( bytes );
-            ByteBuffer buffer = ByteBuffer.wrap( bytes );
-            channel.position( 0 );
-            channel.write( buffer );
-        }
-    }
-
-    private void putRandomBytes( byte[] bytes )
-    {
-        for ( int i = 0; i < bytes.length; i++ )
-        {
-            bytes[i] = (byte) randomRule.nextInt();
-        }
+        builder.setConfig( label_scan_store, LuceneLabelScanStoreExtension.LABEL_SCAN_STORE_NAME );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreUpdateIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreUpdateIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.ClassRule;
+
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStoreExtension;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.label_scan_store;
+
+public class LuceneLabelScanStoreUpdateIT extends LabelScanStoreUpdateIT
+{
+    @ClassRule
+    public static final DatabaseRule dbRule = new ImpermanentDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( label_scan_store, LuceneLabelScanStoreExtension.LABEL_SCAN_STORE_NAME );
+        }
+    };
+
+    @Override
+    protected GraphDatabaseService db()
+    {
+        return dbRule;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
@@ -19,16 +19,14 @@
  */
 package org.neo4j.kernel.api.impl.labelscan;
 
+import org.apache.lucene.index.IndexFileNames;
+import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.List;
-import java.util.Random;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -43,6 +41,8 @@ import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 @RunWith( Parameterized.class )
 public class LuceneLabelScanStoreTest extends LabelScanStoreTest
@@ -82,7 +82,13 @@ public class LuceneLabelScanStoreTest extends LabelScanStoreTest
     }
 
     @Override
-    protected void corruptIndex() throws IOException
+    protected Matcher<Iterable<? super String>> hasBareMinimumFileList()
+    {
+        return hasItem( startsWith( IndexFileNames.SEGMENTS ) );
+    }
+
+    @Override
+    protected void corruptIndex( FileSystemAbstraction fileSystem, File rootFolder ) throws IOException
     {
         List<File> indexPartitions = indexStorage.listFolders();
         for ( File partition : indexPartitions )
@@ -95,27 +101,6 @@ public class LuceneLabelScanStoreTest extends LabelScanStoreTest
                     scrambleFile( indexFile );
                 }
             }
-        }
-    }
-    private void scrambleFile( File file ) throws IOException
-    {
-        try ( RandomAccessFile fileAccess = new RandomAccessFile( file, "rw" );
-              FileChannel channel = fileAccess.getChannel() )
-        {
-            // The files will be small, so OK to allocate a buffer for the full size
-            byte[] bytes = new byte[(int) channel.size()];
-            putRandomBytes( random.random(), bytes );
-            ByteBuffer buffer = ByteBuffer.wrap( bytes );
-            channel.position( 0 );
-            channel.write( buffer );
-        }
-    }
-
-    private void putRandomBytes( Random random, byte[] bytes )
-    {
-        for ( int i = 0; i < bytes.length; i++ )
-        {
-            bytes[i] = (byte) random.nextInt();
         }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
@@ -38,8 +38,6 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.logging.NullLogProvider;
-
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
@@ -78,7 +76,7 @@ public class LuceneLabelScanStoreTest extends LabelScanStoreTest
                 .withDocumentFormat( documentFormat )
                 .build();
 
-        return new LuceneLabelScanStore( index, asStream( existingData ), NullLogProvider.getInstance(), monitor );
+        return new LuceneLabelScanStore( index, asStream( existingData ), monitor );
     }
 
     @Override

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -88,8 +88,8 @@ public class StoreUpgraderInterruptionTestIT
     @Parameterized.Parameter
     public String version;
     private final SchemaIndexProvider schemaIndexProvider = new InMemoryIndexProvider();
-    private final LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider( new
-            InMemoryLabelScanStore(), 2 );
+    private final LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider(
+            "test", new InMemoryLabelScanStore(), 2 );
     protected static final Config CONFIG = Config.defaults().augment(
             stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
 

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -131,8 +131,8 @@ public class StoreUpgraderTest
     private StoreVersionCheck check;
     private final String version;
     private final SchemaIndexProvider schemaIndexProvider = new InMemoryIndexProvider();
-    private final LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider( new
-            InMemoryLabelScanStore(), 2 );
+    private final LabelScanStoreProvider labelScanStoreProvider = new LabelScanStoreProvider(
+            "test", new InMemoryLabelScanStore(), 2 );
 
     private final Config allowMigrateConfig = Config.embeddedDefaults( MapUtil.stringMap( GraphDatabaseSettings
             .allow_store_upgrade.name(), "true" ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
@@ -52,7 +52,9 @@ public abstract class LabelScanStoreHaIT
         // This check is here o check so that the extension provided by this test is selected.
         // It can be higher than 3 (number of cluster members) since some members may restart
         // some services to switch role.
-        assertTrue( monitor.callsTo_init >= 3 );
+        assertTrue( "Expected initial calls to init to be at least one per cluster member (>= 3), " +
+                "but was " + monitor.callsTo_init,
+                monitor.callsTo_init >= 3 );
 
         // GIVEN
         // An HA cluster where the master started with initial data consisting
@@ -116,6 +118,7 @@ public abstract class LabelScanStoreHaIT
                     if ( serverId == 1 )
                     {
                         GraphDatabaseService db = new TestGraphDatabaseFactory()
+                                .addKernelExtension( testExtension )
                                 .newEmbeddedDatabaseBuilder( storeDir.getAbsoluteFile() )
                                 .newGraphDatabase();
                         try

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/NativeLabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/NativeLabelScanStoreHaIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.labelscan;
+
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.api.scan.NativeLabelScanStoreExtension;
+
+public class NativeLabelScanStoreHaIT extends LabelScanStoreHaIT
+{
+    @Override
+    protected KernelExtensionFactory<?> labelScanStoreExtension( LabelScanStore.Monitor monitor )
+    {
+        return new NativeLabelScanStoreExtension( 100, monitor );
+    }
+}

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StoreMigratorFrom20IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StoreMigratorFrom20IT.java
@@ -123,7 +123,7 @@ public class StoreMigratorFrom20IT
 
         schemaIndexProvider = new LuceneSchemaIndexProvider( fs, DirectoryFactory.PERSISTENT, storeDir.directory(),
                 NullLogProvider.getInstance(), Config.empty(), OperationalMode.single );
-        labelScanStoreProvider = new LabelScanStoreProvider( new InMemoryLabelScanStore(), 1 );
+        labelScanStoreProvider = new LabelScanStoreProvider( "test", new InMemoryLabelScanStore(), 1 );
 
         upgradableDatabase = new UpgradableDatabase( fs, new StoreVersionCheck( pageCache ),
                 new LegacyStoreVersionCheck( fs ), recordFormat );


### PR DESCRIPTION
There were a couple of test classes testing LabelScanStore functionality as well as its integration with the rest of Neo4j. They have been refactored to be more abstract, only working with LabelScanStore instead of LuceneLabelScanStore and all those tests now also have a "Native" counterpart to them.

This PR also introduces a configuration option `unsupported.dbms.label_scan_store` (perhaps renamed before a GA release) to allow user to control which LabelScanStore implementation to use. LuceneLabelScanStore is still the default a little while longer.