### PR TITLE
Generally faster HA tests

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -183,6 +183,24 @@ public interface JobScheduler extends Lifecycle
         void cancel( boolean mayInterruptIfRunning );
 
         void waitTermination() throws InterruptedException, ExecutionException;
+
+        default void registerCancelListener( CancelListener listener )
+        {
+            throw new UnsupportedOperationException( "Unsupported in this implementation" );
+        }
+    }
+
+    /**
+     * Gets notified about calls to {@link JobHandle#cancel(boolean)}.
+     */
+    interface CancelListener
+    {
+        /**
+         * Notification that {@link JobHandle#cancel(boolean)} was called.
+         *
+         * @param mayInterruptIfRunning argument from {@link JobHandle#cancel(boolean)} call.
+         */
+        void cancelled( boolean mayInterruptIfRunning );
     }
 
     /** Expose a group scheduler as an {@link Executor} */

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/FreePorts.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/FreePorts.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility for discovering free ports within a given range, also for remembering already discovered ports
+ * so that next allocation will be faster. This utility is designed to be shared among many tests,
+ * preferably all tests in an entire component.
+ *
+ * One test should call {@link #newSession()} and allocate its ports there and {@link Session#close() close}
+ * when test is completed. Sessions share discovered ports for faster port allocation.
+ */
+public class FreePorts
+{
+    private static final int NOT_FOUND = -1;
+
+    private final Set<Integer> discoveredPorts = new HashSet<>();
+    private final Set<Integer> deniedPorts = new HashSet<>();
+    private final Set<Integer> currentlyOccupiedPorts = new HashSet<>();
+
+    public Session newSession()
+    {
+        return new Session();
+    }
+
+    private synchronized int findFreePort( int minPort, int maxPort ) throws IOException
+    {
+        int port = findFreeAlreadyDiscoveredPort( minPort, maxPort );
+        if ( port == NOT_FOUND )
+        {
+            port = discoverPort( minPort, maxPort );
+        }
+
+        currentlyOccupiedPorts.add( port );
+        return port;
+    }
+
+    private synchronized void releasePort( int port )
+    {
+        if ( !currentlyOccupiedPorts.remove( port ) )
+        {
+            throw new IllegalStateException( "Port " + port + " not occupied" );
+        }
+    }
+
+    private int discoverPort( int minPort, int maxPort ) throws IOException
+    {
+        int port;
+        for ( port = minPort; port <= maxPort; port++ )
+        {
+            if ( discoveredPorts.contains( port ) || deniedPorts.contains( port ) )
+            {
+                // This port has already been discovered or denied
+                continue;
+            }
+            try
+            {
+                // try binding it at wildcard
+                ServerSocket ss = new ServerSocket();
+                ss.setReuseAddress( false );
+                ss.bind( new InetSocketAddress( port ) );
+                ss.close();
+            }
+            catch ( IOException e )
+            {
+                deniedPorts.add( port );
+                continue;
+            }
+            try
+            {
+                // try binding it at loopback
+                ServerSocket ss = new ServerSocket();
+                ss.setReuseAddress( false );
+                ss.bind( new InetSocketAddress( InetAddress.getLoopbackAddress(), port ) );
+                ss.close();
+            }
+            catch ( IOException e )
+            {
+                deniedPorts.add( port );
+                continue;
+            }
+            try
+            {
+                // try connecting to it at loopback
+                Socket socket = new Socket( InetAddress.getLoopbackAddress(), port );
+                socket.close();
+                deniedPorts.add( port );
+                continue;
+            }
+            catch ( IOException e )
+            {
+                // Port very likely free!
+                discoveredPorts.add( port );
+                return port;
+            }
+        }
+        throw new IOException( "No open port could be found" );
+    }
+
+    private int findFreeAlreadyDiscoveredPort( int minPort, int maxPort )
+    {
+        for ( Integer candidate : discoveredPorts )
+        {
+            if ( candidate >= minPort && candidate <= maxPort && !currentlyOccupiedPorts.contains( candidate ) )
+            {
+                return candidate;
+            }
+        }
+        return NOT_FOUND;
+    }
+
+    public class Session implements AutoCloseable
+    {
+        private final Set<Integer> takenPorts = new HashSet<>();
+
+        public synchronized int findFreePort( int minPort, int maxPort ) throws IOException
+        {
+            int port = FreePorts.this.findFreePort( minPort, maxPort );
+            takenPorts.add( port );
+            return port;
+        }
+
+        public synchronized void releasePort( int port )
+        {
+            if ( !takenPorts.remove( port ) )
+            {
+                throw new IllegalStateException( port + " not taken" );
+            }
+
+            FreePorts.this.releasePort( port );
+        }
+
+        @Override
+        public void close()
+        {
+            takenPorts.forEach( FreePorts.this::releasePort );
+            takenPorts.clear();
+        }
+    }
+}

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/client/Cluster.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/client/Cluster.java
@@ -21,7 +21,6 @@ package org.neo4j.cluster.client;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -88,35 +87,17 @@ public class Cluster
         return result;
     }
 
-    public boolean contains( URI serverId )
-    {
-        for ( Member member : members )
-        {
-            if ( serverId.toString().contains( member.getHost() ) )
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /**
      * Represents a member tag in the discovery XML file.
      */
     public static class Member
     {
-        private String host;
-        private boolean fullHaMember;
+        private final String host;
+        private final boolean fullHaMember;
 
         public Member( int port, boolean fullHaMember )
         {
             this( localhost() + ":" + port, fullHaMember );
-        }
-
-        public Member( String host )
-        {
-            this( host, true );
         }
 
         public Member( String host, boolean fullHaMember )

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestClusterClientPadding.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestClusterClientPadding.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.ha.ClusterRule;
@@ -35,7 +36,10 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;
 public class TestClusterClientPadding
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withSharedSetting( ClusterSettings.heartbeat_interval, "1s" )
+            .withSharedSetting( ClusterSettings.heartbeat_timeout, "10s" );
+
     private ManagedCluster cluster;
 
     @Before

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
@@ -79,8 +79,6 @@ public class TestPullUpdates
     {
         ClusterManager.ManagedCluster cluster = clusterRule.
                 withSharedSetting( HaSettings.pull_interval, PULL_INTERVAL + "ms" ).
-                withSharedSetting( ClusterSettings.heartbeat_interval, "2s" ).
-                withSharedSetting( ClusterSettings.heartbeat_timeout, "30s" ).
                 startCluster();
 
         cluster.info( "### Creating initial dataset" );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
@@ -47,7 +47,7 @@ public class BiggerThanLogTxIT
 
     protected ClusterManager.ManagedCluster cluster;
 
-    private TransactionTemplate template = new TransactionTemplate().retries( 10 ).backoff( 3, TimeUnit.SECONDS );
+    private final TransactionTemplate template = new TransactionTemplate().retries( 10 ).backoff( 3, TimeUnit.SECONDS );
 
     @Before
     public void setup() throws Exception
@@ -140,14 +140,7 @@ public class BiggerThanLogTxIT
                     if (expectedNodeCount == count)
                         break;
 
-                    try
-                    {
-                        cluster.sync(  );
-                    }
-                    catch ( InterruptedException e )
-                    {
-                        throw new RuntimeException( e );
-                    }
+                    cluster.sync(  );
                 }
             }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
@@ -67,15 +67,15 @@ public class TerminationOfSlavesDuringPullUpdatesTest
             .withSharedSetting( HaSettings.pull_interval, "0" )
             .withSharedSetting( HaSettings.tx_push_factor, "0" );
 
-    @Parameter
+    @Parameter( 0 )
     public ReadContestantActions action;
     @Parameter( 1 )
     public String name;
 
     @Parameters( name = "{1}" )
-    public static Iterable<Object> data()
+    public static Iterable<Object[]> data()
     {
-        return Arrays.<Object>asList( new Object[][]
+        return Arrays.<Object[]>asList( new Object[][]
                 {
                         {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true ),
                                 "NodeStringProperty[txTerminationAwareLocks=yes]"},

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -825,7 +825,8 @@ public class ClusterManager
         {
             // We want this, at least in the ClusterRule case where we fill this Builder instances
             // with all our behavior, but we don't know about the root directory until we evaluate the rule.
-            commonConfig.put( ClusterSettings.heartbeat_interval.name(), constant("1") );
+            commonConfig.put( ClusterSettings.heartbeat_interval.name(), constant( "500ms" ) );
+            commonConfig.put( ClusterSettings.heartbeat_timeout.name(), constant( "2s" ) );
             commonConfig.put( ClusterSettings.leave_timeout.name(), constant( "5" ) );
             commonConfig.put( GraphDatabaseSettings.pagecache_memory.name(), constant( "8m" ) );
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -22,9 +22,6 @@ package org.neo4j.kernel.impl.ha;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -37,22 +34,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.FreePorts;
+import org.neo4j.cluster.FreePorts.Session;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.client.Cluster;
 import org.neo4j.cluster.client.ClusterClient;
@@ -89,7 +81,6 @@ import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.lifecycle.LifeSupport;
-import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
@@ -98,7 +89,10 @@ import org.neo4j.storageengine.api.StorageEngine;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.neo4j.helpers.ArrayUtil.contains;
+import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.fs.FileUtils.copyRecursively;
@@ -137,7 +131,7 @@ public class ClusterManager
         IN;
     }
 
-    public static final long DEFAULT_TIMEOUT_SECONDS = 60L;
+    private static final long DEFAULT_TIMEOUT_SECONDS = 60L;
     public static final Map<String,String> CONFIG_FOR_SINGLE_JVM_CLUSTER = unmodifiableMap( stringMap(
             GraphDatabaseSettings.pagecache_memory.name(), "8m",
             GraphDatabaseSettings.shutdown_transaction_end_timeout.name(), "1s",
@@ -163,7 +157,7 @@ public class ClusterManager
     private final String localAddress;
     private final File root;
     private final Map<String,IntFunction<String>> commonConfig;
-    private final Supplier<Cluster> clustersProvider;
+    private final Function<FreePorts.Session,Cluster> clustersProvider;
     private final HighlyAvailableGraphDatabaseFactory dbFactory;
     private final StoreDirInitializer storeDirInitializer;
     private final Listener<GraphDatabaseService> initialDatasetCreator;
@@ -218,7 +212,7 @@ public class ClusterManager
      *
      * @param memberCount the total number of members in the cluster to start.
      */
-    public static Supplier<Cluster> clusterOfSize( int memberCount )
+    public static Function<FreePorts.Session,Cluster> clusterOfSize( int memberCount )
     {
         return clusterOfSize( getLocalAddress(), memberCount );
     }
@@ -229,18 +223,16 @@ public class ClusterManager
      * @param hostname the hostname/ip-address to bind to
      * @param memberCount the total number of members in the cluster to start.
      */
-    public static Supplier<Cluster> clusterOfSize( String hostname, int memberCount )
+    public static Function<FreePorts.Session,Cluster> clusterOfSize( String hostname, int memberCount )
     {
-        return () -> {
+        return session -> {
             final Cluster cluster = new Cluster();
 
-            HashSet<Integer> takenPorts = new HashSet<>();
             try
             {
                 for ( int i = 0; i < memberCount; i++ )
                 {
-                    int port = findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT, takenPorts );
-                    takenPorts.add( port );
+                    int port = session.findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT );
                     cluster.getMembers().add( new Cluster.Member( hostname + ":" + port, true ) );
                 }
             }
@@ -253,95 +245,29 @@ public class ClusterManager
         };
     }
 
-    /**
-     * Find an available port number which is also not included in the except list.
-     * @param minPort minimum port number to probe
-     * @param maxPort maximum port number to probe
-     * @param except port numbers which should be considered unavailable and already taken
-     * @return a port number
-     * @throws IOException if no open port could be found
-     */
-    private static int findFreePort( final int minPort, final int maxPort, final Set<Integer> except )
-            throws IOException
-    {
-        int port;
-        for ( port = minPort; port <= maxPort; port++ )
-        {
-            if ( except.contains( port ) )
-            {
-                // This port is already taken but not bound yet, ignore it
-                continue;
-            }
-
-            try
-            {
-                // try binding it at wildcard
-                ServerSocket ss = new ServerSocket();
-                ss.setReuseAddress( false );
-                ss.bind( new InetSocketAddress( port ) );
-                ss.close();
-            }
-            catch ( IOException e )
-            {
-                except.add( port );
-                continue;
-            }
-
-            try
-            {
-                // try binding it at loopback
-                ServerSocket ss = new ServerSocket();
-                ss.setReuseAddress( false );
-                ss.bind( new InetSocketAddress( InetAddress.getLoopbackAddress(), port ) );
-                ss.close();
-            }
-            catch ( IOException e )
-            {
-                except.add( port );
-                continue;
-            }
-
-            try
-            {
-                // try connecting to it at loopback
-                Socket socket = new Socket( InetAddress.getLoopbackAddress(), port );
-                socket.close();
-                except.add( port );
-                continue;
-            }
-            catch ( IOException ex )
-            {
-                // Port very likely free!
-                return port;
-            }
-        }
-
-        throw new IOException( "No open port could be found" );
-    }
+    private static final FreePorts PORTS = new FreePorts();
 
     /**
      * Provides a cluster specification with default values
      *
      * @param haMemberCount the total number of members in the cluster to start.
      */
-    public static Supplier<Cluster> clusterWithAdditionalClients( int haMemberCount, int additionalClientCount )
+    public static Function<FreePorts.Session,Cluster> clusterWithAdditionalClients( int haMemberCount,
+            int additionalClientCount )
     {
-        return () -> {
+        return session -> {
             Cluster cluster = new Cluster();
-            HashSet<Integer> takenPorts = new HashSet<>();
 
             try
             {
                 for ( int i = 0; i < haMemberCount; i++ )
                 {
-                    int port = findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT, takenPorts );
-                    takenPorts.add( port );
+                    int port = session.findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT );
                     cluster.getMembers().add( new Cluster.Member( port, true ) );
                 }
                 for ( int i = 0; i < additionalClientCount; i++ )
                 {
-                    int port = findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT, takenPorts );
-                    takenPorts.add( port );
+                    int port = session.findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT );
                     cluster.getMembers().add( new Cluster.Member( port, false ) );
                 }
             }
@@ -360,24 +286,21 @@ public class ClusterManager
      *
      * @param haMemberCount the total number of members in the cluster to start.
      */
-    public static Supplier<Cluster> clusterWithAdditionalArbiters( int haMemberCount, int arbiterCount )
+    public static Function<FreePorts.Session,Cluster> clusterWithAdditionalArbiters( int haMemberCount, int arbiterCount )
     {
-        return () -> {
+        return session -> {
             Cluster cluster = new Cluster();
-            HashSet<Integer> takenPorts = new HashSet<>();
 
             try
             {
                 for ( int i = 0; i < arbiterCount; i++ )
                 {
-                    int port = findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT, takenPorts );
-                    takenPorts.add( port );
+                    int port = session.findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT );
                     cluster.getMembers().add( new Cluster.Member( port, false ) );
                 }
                 for ( int i = 0; i < haMemberCount; i++ )
                 {
-                    int port = findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT, takenPorts );
-                    takenPorts.add( port );
+                    int port = session.findFreePort( CLUSTER_MIN_PORT, CLUSTER_MAX_PORT );
                     cluster.getMembers().add( new Cluster.Member( port, true ) );
                 }
             }
@@ -684,15 +607,24 @@ public class ClusterManager
     @Override
     public void start() throws Throwable
     {
-        Cluster cluster = clustersProvider.get();
+        FreePorts.Session session = PORTS.newSession();
+        Cluster cluster = clustersProvider.apply( session );
 
         life = new LifeSupport();
+        life.add( new LifecycleAdapter()
+        {
+            @Override
+            public void shutdown() throws Throwable
+            {
+                session.close();
+            }
+        } );
 
         // Started so instances added here will be started immediately, and in case of exceptions they can be
         // shutdown() or stop()ped properly
         life.start();
 
-        managedCluster = new ManagedCluster( cluster );
+        managedCluster = new ManagedCluster( cluster, session );
         life.add( managedCluster );
 
         availabilityChecks.forEach( managedCluster::await );
@@ -722,7 +654,8 @@ public class ClusterManager
      *
      * This is intended for unit tests where a failure in cluster shutdown might mask the actual error in the test.
      */
-    public void safeShutdown() {
+    public void safeShutdown()
+    {
         try
         {
             shutdown();
@@ -748,7 +681,7 @@ public class ClusterManager
 
         SELF withDbFactory( HighlyAvailableGraphDatabaseFactory dbFactory );
 
-        SELF withCluster( Supplier<Cluster> provider );
+        SELF withCluster( Function<FreePorts.Session,Cluster> provider );
 
         /**
          * Supplies configuration where config values, as opposed to {@link #withSharedConfig(Map)},
@@ -806,7 +739,7 @@ public class ClusterManager
     public static class Builder implements ClusterBuilder<Builder>
     {
         private File root;
-        private Supplier<Cluster> provider = clusterOfSize( 3 );
+        private Function<FreePorts.Session,Cluster> provider = clusterOfSize( 3 );
         private final Map<String,IntFunction<String>> commonConfig = new HashMap<>();
         private HighlyAvailableGraphDatabaseFactory factory = new HighlyAvailableGraphDatabaseFactory();
         private StoreDirInitializer initializer;
@@ -827,7 +760,7 @@ public class ClusterManager
             // with all our behavior, but we don't know about the root directory until we evaluate the rule.
             commonConfig.put( ClusterSettings.heartbeat_interval.name(), constant( "500ms" ) );
             commonConfig.put( ClusterSettings.heartbeat_timeout.name(), constant( "2s" ) );
-            commonConfig.put( ClusterSettings.leave_timeout.name(), constant( "5" ) );
+            commonConfig.put( ClusterSettings.leave_timeout.name(), constant( "5s" ) );
             commonConfig.put( GraphDatabaseSettings.pagecache_memory.name(), constant( "8m" ) );
         }
 
@@ -859,7 +792,7 @@ public class ClusterManager
         }
 
         @Override
-        public Builder withCluster( Supplier<Cluster> provider )
+        public Builder withCluster( Function<FreePorts.Session,Cluster> provider )
         {
             this.provider = provider;
             return this;
@@ -935,121 +868,6 @@ public class ClusterManager
         }
     }
 
-    private static final class HighlyAvailableGraphDatabaseProxy
-    {
-        private final ExecutorService executor;
-        private GraphDatabaseService result;
-        private final Future<GraphDatabaseService> untilThen;
-
-        public HighlyAvailableGraphDatabaseProxy( final GraphDatabaseBuilder graphDatabaseBuilder )
-        {
-            Callable<GraphDatabaseService> starter = graphDatabaseBuilder::newGraphDatabase;
-            executor = Executors.newFixedThreadPool( 1 );
-            untilThen = executor.submit( starter );
-        }
-
-        public HighlyAvailableGraphDatabase get( long timeoutSeconds )
-        {
-            if ( result == null )
-            {
-                try
-                {
-                    result = untilThen.get( timeoutSeconds, TimeUnit.SECONDS );
-                }
-                catch ( InterruptedException | ExecutionException | TimeoutException e )
-                {
-                    throw new RuntimeException( e );
-                }
-                finally
-                {
-                    executor.shutdownNow();
-                }
-            }
-            return (HighlyAvailableGraphDatabase) result;
-        }
-    }
-
-    private static final class FutureLifecycleAdapter<T extends Lifecycle> extends LifecycleAdapter
-    {
-        private final T wrapped;
-        private final ExecutorService starter;
-        private Future<Void> currentFuture;
-
-        public FutureLifecycleAdapter( T toWrap )
-        {
-            wrapped = toWrap;
-            starter = Executors.newFixedThreadPool( 1 );
-        }
-
-        @Override
-        public void init() throws Throwable
-        {
-            currentFuture = starter.submit( (Callable<Void>) () -> {
-                try
-                {
-                    wrapped.init();
-                }
-                catch ( Throwable throwable )
-                {
-                    throw new RuntimeException( throwable );
-                }
-                return null;
-            } );
-        }
-
-        @Override
-        public void start() throws Throwable
-        {
-            currentFuture.get();
-            currentFuture = starter.submit( (Callable<Void>) () -> {
-                try
-                {
-                    wrapped.start();
-                }
-                catch ( Throwable throwable )
-                {
-                    throw new RuntimeException( throwable );
-                }
-                return null;
-            } );
-        }
-
-        @Override
-        public void stop() throws Throwable
-        {
-            currentFuture.get();
-            currentFuture = starter.submit( (Callable<Void>) () -> {
-                try
-                {
-                    wrapped.stop();
-                }
-                catch ( Throwable throwable )
-                {
-                    throw new RuntimeException( throwable );
-                }
-                return null;
-            } );
-        }
-
-        @Override
-        public void shutdown() throws Throwable
-        {
-            currentFuture = starter.submit( (Callable<Void>) () -> {
-                try
-                {
-                    wrapped.shutdown();
-                }
-                catch ( Throwable throwable )
-                {
-                    throw new RuntimeException( throwable );
-                }
-                return null;
-            } );
-            currentFuture.get();
-            starter.shutdownNow();
-        }
-    }
-
     /**
      * Represent one cluster. It can retrieve the current master, random slave
      * or all members. It can also temporarily fail an instance or shut it down.
@@ -1058,23 +876,24 @@ public class ClusterManager
     {
         private final Cluster spec;
         private final String name;
-        private final Map<InstanceId,HighlyAvailableGraphDatabaseProxy> members = new ConcurrentHashMap<>();
+        private final Map<InstanceId,HighlyAvailableGraphDatabase> members = new ConcurrentHashMap<>();
         private final List<ObservedClusterMembers> arbiters = new ArrayList<>();
         private final Set<RepairKit> pendingRepairs = Collections.synchronizedSet( new HashSet<RepairKit>() );
-        private final HashSet<Integer> takenHaPorts = new HashSet<>();
+        private final ParallelLifecycle parallelLife = new ParallelLifecycle( DEFAULT_TIMEOUT_SECONDS, SECONDS );
+        private final String initialHosts;
+        private final File parent;
+        private final Session ports;
 
-        ManagedCluster( Cluster spec ) throws URISyntaxException, IOException
+        ManagedCluster( Cluster spec, FreePorts.Session ports ) throws URISyntaxException
         {
             this.spec = spec;
+            this.ports = ports;
             this.name = spec.getName();
+            initialHosts = buildInitialHosts();
+            parent = new File( root, name );
             for ( int i = 0; i < spec.getMembers().size(); i++ )
             {
                 startMember( new InstanceId( firstInstanceId + i ) );
-            }
-            for ( HighlyAvailableGraphDatabaseProxy member : members.values() )
-            {
-                HighlyAvailableGraphDatabase graphDatabase = member.get( DEFAULT_TIMEOUT_SECONDS );
-                Config config = graphDatabase.getDependencyResolver().resolveDependency( Config.class );
             }
         }
 
@@ -1092,18 +911,38 @@ public class ClusterManager
         }
 
         @Override
+        public void init() throws Throwable
+        {
+            parallelLife.init();
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+            parallelLife.start();
+        }
+
+        @Override
         public void stop() throws Throwable
         {
-            for ( HighlyAvailableGraphDatabaseProxy member : members.values() )
+            List<HighlyAvailableGraphDatabase> dbs = asList( getAllMembers() );
+
+            // Shut down the dbs in parallel
+            parallelLife.stop();
+
+            for ( HighlyAvailableGraphDatabase db : dbs )
             {
-                HighlyAvailableGraphDatabase memberDb = member.get( DEFAULT_TIMEOUT_SECONDS );
-                File storeDir = memberDb.getStoreDirectory();
-                memberDb.shutdown();
                 if ( consistencyCheck )
                 {
-                    consistencyCheck( storeDir );
+                    consistencyCheck( db.getStoreDirectory() );
                 }
             }
+        }
+
+        @Override
+        public void shutdown() throws Throwable
+        {
+            parallelLife.shutdown();
         }
 
         private void consistencyCheck( File storeDir ) throws Throwable
@@ -1117,9 +956,7 @@ public class ClusterManager
         public Iterable<HighlyAvailableGraphDatabase> getAllMembers( HighlyAvailableGraphDatabase... except )
         {
             Set<HighlyAvailableGraphDatabase> exceptSet = new HashSet<>( asList( except ) );
-
-            return members.values().stream().map( proxy -> proxy.get( DEFAULT_TIMEOUT_SECONDS ) )
-                    .filter( db -> !exceptSet.contains( db ) ).collect( Collectors.toList());
+            return members.values().stream().filter( db -> !exceptSet.contains( db ) ).collect( Collectors.toList());
         }
 
         public Iterable<ObservedClusterMembers> getArbiters()
@@ -1195,7 +1032,7 @@ public class ClusterManager
          */
         public HighlyAvailableGraphDatabase getMemberByServerId( InstanceId serverId )
         {
-            HighlyAvailableGraphDatabase db = members.get( serverId ).get( DEFAULT_TIMEOUT_SECONDS );
+            HighlyAvailableGraphDatabase db = members.get( serverId );
             if ( db == null )
             {
                 throw new IllegalStateException( "Db " + serverId + " not found at the moment in " + name +
@@ -1218,17 +1055,26 @@ public class ClusterManager
             assertMember( db );
             InstanceId serverId =
                     db.getDependencyResolver().resolveDependency( Config.class ).get( ClusterSettings.server_id );
-            members.remove( serverId );
-            db.shutdown();
+            shutdownMember( serverId );
             await( entireClusterSeesMemberAsNotAvailable( db ) );
             return wrap( new StartDatabaseAgainKit( this, serverId ) );
         }
 
+        private void shutdownMember( InstanceId serverId )
+        {
+            HighlyAvailableGraphDatabase db = members.remove( serverId );
+            Config config = db.getDependencyResolver().resolveDependency( Config.class );
+            int haPort = config.get( HaSettings.ha_server ).getPort();
+            db.shutdown();
+            ports.releasePort( haPort );
+            // don't release cluster port here
+        }
+
         private void assertMember( HighlyAvailableGraphDatabase db )
         {
-            for ( HighlyAvailableGraphDatabaseProxy highlyAvailableGraphDatabaseProxy : members.values() )
+            for ( HighlyAvailableGraphDatabase existingMember : members.values() )
             {
-                if ( highlyAvailableGraphDatabaseProxy.get( DEFAULT_TIMEOUT_SECONDS ).equals( db ) )
+                if ( existingMember.equals( db ) )
                 {
                     return;
                 }
@@ -1317,9 +1163,106 @@ public class ClusterManager
             };
         }
 
-        private void startMember( InstanceId serverId ) throws URISyntaxException, IOException
+        private HighlyAvailableGraphDatabase startMemberNow( InstanceId serverId )
+                throws IOException, URISyntaxException
         {
-            Cluster.Member member = spec.getMembers().get( serverId.toIntegerIndex() - firstInstanceId );
+            Cluster.Member member = memberSpec( serverId );
+            URI clusterUri = clusterUri( member );
+            int clusterPort = clusterUri.getPort();
+            int haPort = ports.findFreePort( HA_MIN_PORT, HA_MAX_PORT );
+            File storeDir = new File( parent, "server" + serverId );
+            if ( storeDirInitializer != null )
+            {
+                storeDirInitializer.initializeStoreDir( serverId.toIntegerIndex(), storeDir );
+            }
+            GraphDatabaseBuilder builder = dbFactory.newEmbeddedDatabaseBuilder( storeDir.getAbsoluteFile() );
+            builder.setConfig( ClusterSettings.cluster_name, name );
+            builder.setConfig( ClusterSettings.initial_hosts, initialHosts );
+            builder.setConfig( ClusterSettings.server_id, serverId + "" );
+            builder.setConfig( ClusterSettings.cluster_server, "0.0.0.0:" + clusterPort );
+            builder.setConfig( HaSettings.ha_server, clusterUri.getHost() + ":" + haPort );
+            builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
+            for ( Map.Entry<String,IntFunction<String>> conf : commonConfig.entrySet() )
+            {
+                builder.setConfig( conf.getKey(), conf.getValue().apply( serverId.toIntegerIndex() ) );
+            }
+
+            HighlyAvailableGraphDatabase graphDatabase = (HighlyAvailableGraphDatabase) builder.newGraphDatabase();
+            members.put( serverId, graphDatabase );
+            return graphDatabase;
+        }
+
+        private URI clusterUri( Cluster.Member member ) throws URISyntaxException
+        {
+            return new URI( "cluster://" + member.getHost() );
+        }
+
+        private Cluster.Member memberSpec( InstanceId serverId )
+        {
+            return spec.getMembers().get( serverId.toIntegerIndex() - firstInstanceId );
+        }
+
+        private void startMember( InstanceId serverId ) throws URISyntaxException
+        {
+            Cluster.Member member = memberSpec( serverId );
+            if ( member.isFullHaMember() )
+            {
+                parallelLife.add( new LifecycleAdapter()
+                {
+                    @Override
+                    public void start() throws Throwable
+                    {
+                        startMemberNow( serverId );
+                    }
+
+                    @Override
+                    public void stop() throws Throwable
+                    {
+                        HighlyAvailableGraphDatabase db = members.remove( serverId );
+                        if ( db != null )
+                        {
+                            db.shutdown();
+                        }
+                    }
+                } );
+            }
+            else
+            {
+                URI clusterUri = clusterUri( member );
+                Config config = Config.embeddedDefaults( MapUtil.stringMap(
+                        ClusterSettings.cluster_name.name(), name,
+                        ClusterSettings.initial_hosts.name(), initialHosts,
+                        ClusterSettings.server_id.name(), serverId + "",
+                        ClusterSettings.cluster_server.name(), "0.0.0.0:" + clusterUri.getPort() ) );
+
+                LifeSupport clusterClientLife = new LifeSupport();
+                LogService logService = NullLogService.getInstance();
+                ClusterClientModule clusterClientModule = new ClusterClientModule( clusterClientLife,
+                        new Dependencies(), new Monitors(), config, logService,
+                        new NotElectableElectionCredentialsProvider() );
+
+                arbiters.add( new ObservedClusterMembers( logService.getInternalLogProvider(),
+                        clusterClientModule.clusterClient, clusterClientModule.clusterClient, new ClusterMemberEvents()
+                {
+                    @Override
+                    public void addClusterMemberListener( ClusterMemberListener listener )
+                    {
+                        // noop
+                    }
+
+                    @Override
+                    public void removeClusterMemberListener( ClusterMemberListener listener )
+                    {
+                        // noop
+                    }
+                }, clusterClientModule.clusterClient.getServerId() ) );
+
+                parallelLife.add( clusterClientLife );
+            }
+        }
+
+        private String buildInitialHosts() throws URISyntaxException
+        {
             StringBuilder initialHosts = new StringBuilder();
             for ( int i = 0; i < spec.getMembers().size(); i++ )
             {
@@ -1338,76 +1281,7 @@ public class ClusterManager
                     initialHosts.append( uri.getHost() ).append( ":" ).append( uri.getPort() );
                 }
             }
-            File parent = new File( root, name );
-            URI clusterUri = new URI( "cluster://" + member.getHost() );
-            if ( member.isFullHaMember() )
-            {
-                int clusterPort = clusterUri.getPort();
-                int haPort = findFreePort( HA_MIN_PORT, HA_MAX_PORT, takenHaPorts );
-                takenHaPorts.add( haPort );
-                File storeDir = new File( parent, "server" + serverId );
-                if ( storeDirInitializer != null )
-                {
-                    storeDirInitializer.initializeStoreDir( serverId.toIntegerIndex(), storeDir );
-                }
-                GraphDatabaseBuilder builder = dbFactory.newEmbeddedDatabaseBuilder( storeDir.getAbsoluteFile() );
-                builder.setConfig( ClusterSettings.cluster_name, name );
-                builder.setConfig( ClusterSettings.initial_hosts, initialHosts.toString() );
-                builder.setConfig( ClusterSettings.server_id, serverId + "" );
-                builder.setConfig( ClusterSettings.cluster_server, "0.0.0.0:" + clusterPort );
-                builder.setConfig( HaSettings.ha_server, clusterUri.getHost() + ":" + haPort );
-                builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
-                for ( Map.Entry<String,IntFunction<String>> conf : commonConfig.entrySet() )
-                {
-                    builder.setConfig( conf.getKey(), conf.getValue().apply( serverId.toIntegerIndex() ) );
-                }
-
-                final HighlyAvailableGraphDatabaseProxy graphDatabase =
-                        new HighlyAvailableGraphDatabaseProxy( builder );
-
-                members.put( serverId, graphDatabase );
-
-                life.add( new LifecycleAdapter()
-                {
-                    @Override
-                    public void stop() throws Throwable
-                    {
-                        graphDatabase.get( DEFAULT_TIMEOUT_SECONDS ).shutdown();
-                    }
-                } );
-            }
-            else
-            {
-                Config config = Config.embeddedDefaults( MapUtil.stringMap(
-                        ClusterSettings.cluster_name.name(), name,
-                        ClusterSettings.initial_hosts.name(), initialHosts.toString(),
-                        ClusterSettings.server_id.name(), serverId + "",
-                        ClusterSettings.cluster_server.name(), "0.0.0.0:" + clusterUri.getPort() ) );
-
-                LifeSupport clusterClientLife = new LifeSupport();
-                NullLogService logService = NullLogService.getInstance();
-                ClusterClientModule clusterClientModule = new ClusterClientModule( clusterClientLife,
-                        new Dependencies(), new Monitors(), config, logService,
-                        new NotElectableElectionCredentialsProvider() );
-
-                arbiters.add( new ObservedClusterMembers(  logService.getInternalLogProvider(),
-                        clusterClientModule.clusterClient, clusterClientModule.clusterClient, new ClusterMemberEvents()
-                {
-                    @Override
-                    public void addClusterMemberListener( ClusterMemberListener listener )
-                    {
-                        // noop
-                    }
-
-                    @Override
-                    public void removeClusterMemberListener( ClusterMemberListener listener )
-                    {
-                        // noop
-                    }
-                }, clusterClientModule.clusterClient.getServerId() ) );
-
-                life.add( new FutureLifecycleAdapter<>( clusterClientLife ) );
-            }
+            return initialHosts.toString();
         }
 
         /**
@@ -1474,7 +1348,7 @@ public class ClusterManager
             return member.getStoreDirectory();
         }
 
-        public void sync( HighlyAvailableGraphDatabase... except ) throws InterruptedException
+        public void sync( HighlyAvailableGraphDatabase... except )
         {
             Set<HighlyAvailableGraphDatabase> exceptSet = new HashSet<>( asList( except ) );
             for ( HighlyAvailableGraphDatabase db : getAllMembers() )
@@ -1591,8 +1465,7 @@ public class ClusterManager
         @Override
         public HighlyAvailableGraphDatabase repair() throws Throwable
         {
-            cluster.startMember( serverId );
-            return cluster.getMemberByServerId( serverId );
+            return cluster.startMemberNow( serverId );
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.ha;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+/**
+ * Acts as a holder of multiple {@link Lifecycle} and executes each transition,
+ * all the individual lifecycles in parallel.
+ * <p>
+ * This is only a test utility and so doesn't support
+ */
+class ParallelLifecycle extends LifecycleAdapter
+{
+    private final List<Lifecycle> lifecycles = new ArrayList<>();
+    private final long timeout;
+    private final TimeUnit unit;
+
+    public ParallelLifecycle( long timeout, TimeUnit unit )
+    {
+        this.timeout = timeout;
+        this.unit = unit;
+    }
+
+    public <T extends Lifecycle> T add( T lifecycle )
+    {
+        lifecycles.add( lifecycle );
+        return lifecycle;
+    }
+
+    @Override
+    public void init() throws Throwable
+    {
+        perform( lifecycle -> lifecycle.init() );
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        perform( lifecycle -> lifecycle.start() );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        perform( lifecycle -> lifecycle.stop() );
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        perform( lifecycle -> lifecycle.shutdown() );
+    }
+
+    private void perform( Action action ) throws InterruptedException
+    {
+        ExecutorService service = Executors.newFixedThreadPool( lifecycles.size() );
+        for ( Lifecycle lifecycle : lifecycles )
+        {
+            service.submit( () ->
+            {
+                try
+                {
+                    action.act( lifecycle );
+                }
+                catch ( Throwable e )
+                {
+                    throw new RuntimeException( e );
+                }
+            } );
+        }
+
+        service.shutdown();
+        if ( !service.awaitTermination( timeout, unit ) )
+        {
+            throw new IllegalStateException( "Couldn't perform all actions" );
+        }
+    }
+
+    private interface Action
+    {
+        void act( Lifecycle lifecycle ) throws Throwable;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -28,10 +28,10 @@ import org.junit.runners.model.Statement;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
-
+import org.neo4j.cluster.FreePorts;
 import org.neo4j.cluster.client.Cluster;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
@@ -45,7 +45,6 @@ import org.neo4j.kernel.impl.ha.ClusterManager.StoreDirInitializer;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.test.rule.TestDirectory;
 
-import static org.neo4j.cluster.ClusterSettings.broadcast_timeout;
 import static org.neo4j.cluster.ClusterSettings.default_timeout;
 import static org.neo4j.cluster.ClusterSettings.join_timeout;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
@@ -121,7 +120,7 @@ public class ClusterRule extends ExternalResource implements ClusterBuilder<Clus
     }
 
     @Override
-    public ClusterRule withCluster( Supplier<Cluster> provider )
+    public ClusterRule withCluster( Function<FreePorts.Session,Cluster> provider )
     {
         return set( clusterManagerBuilder.withCluster( provider ) );
     }


### PR DESCRIPTION
A set of changes, _mostly_ in and around ClusterManager/ClusterRule which makes the whole HA component tests run in less than half the time (currently 66 min --> 28 min). High level change view:

- Lowered heartbeat interval/timeout in ClusterManager
- NetworkSender#stop() waits a more reasonable amount of time before closing when unsent messages
- Neo4jJobScheduler cancels uncancelled jobs on shutdown
- ClusterManager starts/stops databases and finds free ports in parallel