### PR TITLE
Test dbs gets null log and skips dump startup diagnostics

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -286,18 +286,17 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
             }
 
             @Override
-            protected LogService createLogService( LogProvider logProvider )
+            protected LogService createLogService( LogProvider userLogProvider )
             {
                 LogProvider internalLogProvider = state.getInternalLogProvider();
                 if ( internalLogProvider == null )
                 {
                     if ( !impermanent )
                     {
-                        return super.createLogService( logProvider );
+                        return super.createLogService( userLogProvider );
                     }
                     internalLogProvider = NullLogProvider.getInstance();
                 }
-                LogProvider userLogProvider = state.databaseDependencies().userLogProvider();
                 return new SimpleLogService( userLogProvider, internalLogProvider );
             }
         }

--- a/community/logging/src/main/java/org/neo4j/logging/NullLogger.java
+++ b/community/logging/src/main/java/org/neo4j/logging/NullLogger.java
@@ -59,6 +59,5 @@ public final class NullLogger implements Logger
     @Override
     public void bulk( @Nonnull Consumer<Logger> consumer )
     {
-        consumer.accept( this );
     }
 }


### PR DESCRIPTION
this to improve test performance. The biggest benefit of having the null logger
is that startup diagnostics aren't dumped at all, due to most diagnostics being
dumped using Logger#bulk, which is now a no-op in null logger.

It turns out that quite a large amount of time starting a db is spent dumping
startup diagnostics.

Overall most tests should benefit from this speedup, e.g. kernel tests run
roughly 10% faster.