### PR TITLE
Includes stack trace of unexpected checker dispatch error

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNode2LabelIndexProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNode2LabelIndexProcessor.java
@@ -64,10 +64,19 @@ public class PropertyAndNode2LabelIndexProcessor extends RecordProcessor.Adapter
         try ( MandatoryProperties.Check<NodeRecord,ConsistencyReport.NodeConsistencyReport> mandatoryCheck =
                 mandatoryProperties.apply( nodeRecord ) )
         {
-            for ( PropertyRecord property : client.getPropertiesFromCache() )
+            Iterable<PropertyRecord> properties = client.getPropertiesFromCache();
+
+            // We do this null-check here because even if nodeIndexCheck should provide the properties for us,
+            // or an empty list at least, it may fail in one way or another and exception be caught by
+            // broad exception handler in reporter. The caught exception will produce an ERROR so it will not
+            // go by unnoticed.
+            if ( properties != null )
             {
-                reporter.forProperty( property, propertyCheck );
-                mandatoryCheck.receive( ChainCheck.keys( property ) );
+                for ( PropertyRecord property : properties )
+                {
+                    reporter.forProperty( property, propertyCheck );
+                    mandatoryCheck.receive( ChainCheck.keys( property ) );
+                }
             }
         }
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import static java.util.Arrays.asList;
 
 import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.Exceptions.stringify;
 import static org.neo4j.helpers.Exceptions.withCause;
 
 public class ConsistencyReporter implements ConsistencyReport.Reporter
@@ -126,7 +127,10 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
         }
         catch ( Exception e )
         {
-            handler.report.error( type, record, "Failed to check record: " + e.getMessage(), new Object[0] );
+            // This is a rare event and exposing the stack trace is a good idea, otherwise we
+            // can only see that something went wrong, not at all what.
+            handler.report.error( type, record, "Failed to check record: " + stringify( e ),
+                    new Object[0] );
         }
         handler.updateSummary();
     }


### PR DESCRIPTION
Previously only the exception message was logged into the consistency report.
This in addition to the exception being swallowed created second failures that
were hard to find root cause of.