### PR TITLE
Attempt to stabilize TransactionConstraintsIT

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -24,10 +24,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.neo4j.cluster.InstanceId;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -45,24 +45,24 @@ import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.qa.tooling.DumpProcessInformationRule;
 import org.neo4j.test.OtherThreadExecutor;
-import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.ha.ClusterRule;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.collection.Iterables.first;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
 
 public class TransactionConstraintsIT
 {
-    private static final int SLAVE_ONLY_ID = 1;
+    private static final int SLAVE_ONLY_ID = ClusterManager.FIRST_SERVER_ID + 1;
 
     @Rule
     public final ClusterRule clusterRule =
@@ -147,7 +147,7 @@ public class TransactionConstraintsIT
 
     private HighlyAvailableGraphDatabase getSlaveOnlySlave()
     {
-        HighlyAvailableGraphDatabase db = first( cluster.getAllMembers() );
+        HighlyAvailableGraphDatabase db = cluster.getMemberByServerId( new InstanceId( SLAVE_ONLY_ID ) );
         assertEquals( SLAVE_ONLY_ID, cluster.getServerId( db ).toIntegerIndex() );
         assertFalse( db.isMaster() );
         return db;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -118,6 +118,7 @@ public class ClusterManager
     private static final int CLUSTER_MAX_PORT = 21_000;
     private static final int HA_MIN_PORT = CLUSTER_MAX_PORT + 1;
     private static final int HA_MAX_PORT = HA_MIN_PORT + 10_000;
+    public static final int FIRST_SERVER_ID = 1;
 
     /**
      * Network Flags for passing into {@link ManagedCluster#fail(HighlyAvailableGraphDatabase, NetworkFlag...)}
@@ -778,7 +779,7 @@ public class ClusterManager
         private Listener<GraphDatabaseService> initialDatasetCreator;
         private List<Predicate<ManagedCluster>> availabilityChecks = Collections.emptyList();
         private boolean consistencyCheck;
-        private int firstInstanceId = 1;
+        private int firstInstanceId = FIRST_SERVER_ID;
 
         public Builder( File root )
         {


### PR DESCRIPTION
It sets up a cluster of 3 where one of the members is a slave-only.
Inconveniently the slave-only member was the first one, which usually creates
the cluster and becomes the master. Because of this there may have been a couple
of more round-trips and unnecessary re-elections causing join timeout.

Changed the slave-only instance to be the second instance in the cluster.