### PR TITLE
Upgrade Cypher compiler dependency to 2.3.9

### DIFF
--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.3</artifactId>
-      <version>2.3.8</version>
+      <version>2.3.9</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -21,14 +21,13 @@ package org.neo4j.cypher.internal.compatibility
 
 import java.net.URL
 
-import org.neo4j.cypher.internal.compiler.v2_3.spi
+import org.neo4j.cypher.internal.compiler.v2_3.{IndexDescriptor, spi}
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException}
-import org.neo4j.graphdb.{ConstraintViolationException => KernelConstraintViolationException, Node, PropertyContainer, Relationship}
+import org.neo4j.graphdb.{Node, PropertyContainer, Relationship, ConstraintViolationException => KernelConstraintViolationException}
 import org.neo4j.kernel.api.TokenNameLookup
 import org.neo4j.kernel.api.exceptions.KernelException
-import org.neo4j.kernel.api.index.IndexDescriptor
 
 class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends DelegatingQueryContext(inner) {
   override def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.spi.v2_3
+
+import org.neo4j.cypher.internal.compiler.v2_3.{IndexDescriptor => CypherIndexDescriptor}
+import org.neo4j.kernel.api.index.{IndexDescriptor => KernelIndexDescriptor}
+
+trait IndexDescriptorCompatibility {
+  implicit def cypherToKernel(index:CypherIndexDescriptor) =
+    new KernelIndexDescriptor( index.label, index.property )
+
+  implicit def kernelToCypher(index:KernelIndexDescriptor) =
+    CypherIndexDescriptor( index.getLabelId, index.getPropertyKeyId )
+}


### PR DESCRIPTION
This PR is 1 of 3 PRs for Neo4j 3.0, 3.1, and 3.2. I suggest the same person merges all of these in one session, by merging this one, null forward merging into 3.1, merging the 3.1 PR, null forward merging into 3.2, and then merging the 3.2 PR.

Changelog [3.0] Upgrade Neo4j 3.0 to support Cypher compiler for Neo4j 2.3.9