### PR TITLE
Fix flaky BoltFailuresIT

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -163,9 +163,8 @@ public class BoltFailuresIT
         db = startTestDb( monitors );
         driver = createDriver();
 
-        try
+        try ( Session session = driver.session() )
         {
-            Session session = driver.session();
             if ( shouldBeAbleToGetSession )
             {
                 session.run( "CREATE ()" ).consume();
@@ -190,10 +189,12 @@ public class BoltFailuresIT
         driver = createDriver();
 
         Session session = driver.session();
+
+        // setup monitor to throw before running the query to make processing of the RUN message fail
+        monitorSetup.accept( sessionMonitor );
         session.run( "CREATE ()" );
         try
         {
-            monitorSetup.accept( sessionMonitor );
             session.close();
             fail( "Exception expected" );
         }


### PR DESCRIPTION
Setup of a monitor that injects failures for `session#run()` was performed after the actual `session#run()` call. This was wrong because driver sends queries eagerly.