### PR TITLE
move cluster state to data directory

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.commandline.admin;
 
-import org.neo4j.kernel.StoreLockException;
-
 public class CommandFailed extends Exception
 {
     public CommandFailed( String message, Exception cause )
@@ -28,9 +26,9 @@ public class CommandFailed extends Exception
         super( message, cause );
     }
 
-    public CommandFailed( StoreLockException exception )
+    public CommandFailed( Throwable cause )
     {
-        super( exception );
+        super( cause );
     }
 
     public CommandFailed( String message )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
@@ -32,7 +32,7 @@ public class StoreFiles
         // Skip log files and tx files from temporary database
         return !name.startsWith( "metrics" ) && !name.startsWith( "temp-copy" ) &&
                 !name.startsWith( "raft-messages." ) && !name.startsWith( "debug." ) &&
-                !name.startsWith( "cluster-state" ) && !name.startsWith( "store_lock" );
+                !name.startsWith( "store_lock" );
     };
     private FileSystemAbstraction fs;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -59,7 +59,7 @@ import org.neo4j.logging.LogProvider;
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.catchup_batch_size;
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.join_catch_up_timeout;
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.log_shipping_max_lag;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.time.Clocks.systemClock;
 
 public class ConsensusModule
@@ -163,7 +163,7 @@ public class ConsensusModule
 
                 CoreLogPruningStrategy pruningStrategy = new CoreLogPruningStrategyFactory(
                         config.get( CausalClusteringSettings.raft_log_pruning_strategy ), logProvider ).newInstance();
-                File directory = new File( clusterStateDirectory, PHYSICAL_LOG_DIRECTORY_NAME );
+                File directory = new File( clusterStateDirectory, RAFT_LOG_DIRECTORY_NAME );
                 return life.add( new SegmentedRaftLog( fileSystem, directory, rotateAtSize, marshal,
                         logProvider, readerPoolSize, systemClock(), scheduler, pruningStrategy ) );
             }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/RaftLog.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public interface RaftLog extends ReadableRaftLog
 {
-     String PHYSICAL_LOG_DIRECTORY_NAME = "raft-log";
+     String RAFT_LOG_DIRECTORY_NAME = "raft-log";
 
     /**
      * Appends entry to the end of the log. The first log index is 0.

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateDirectory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateDirectory.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+/**
+ * This represents the base directory for cluster state and contains
+ * functionality capturing the migration paths.
+ */
+public class ClusterStateDirectory
+{
+    static final String CLUSTER_STATE_DIRECTORY_NAME = "cluster-state";
+
+    private final File stateDir;
+    private final File storeDir;
+    private final boolean readOnly;
+
+    private boolean initialized;
+
+    public ClusterStateDirectory( File dataDir )
+    {
+        this( dataDir, null, true );
+    }
+
+    public ClusterStateDirectory( File dataDir, boolean readOnly )
+    {
+        this( dataDir, dataDir, readOnly );
+    }
+
+    public ClusterStateDirectory( File dataDir, File storeDir, boolean readOnly )
+    {
+        this.storeDir = storeDir;
+        this.readOnly = readOnly;
+        this.stateDir = new File( dataDir, CLUSTER_STATE_DIRECTORY_NAME );
+    }
+
+    /**
+     * Returns true if the cluster state base directory exists or
+     * could be created. This method also takes care of any necessary
+     * migration.
+     *
+     * It is a requirement to initialize before using the class, unless
+     * the non-migrating version is used.
+     */
+    public ClusterStateDirectory initialize( FileSystemAbstraction fs ) throws ClusterStateException
+    {
+        assert !initialized;
+        if ( !readOnly )
+        {
+            migrateIfNeeded( fs );
+        }
+        ensureDirectoryExists( fs );
+        initialized = true;
+        return this;
+    }
+
+    /**
+     * For use by special tooling which does not need the functionality
+     * of migration or ensuring the directory for cluster state actually
+     * exists.
+     */
+    public static ClusterStateDirectory withoutInitializing( File dataDir )
+    {
+        ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir );
+        clusterStateDirectory.initialized = true;
+        return clusterStateDirectory;
+    }
+
+    /**
+     * The cluster state directory was previously badly placed under the
+     * store directory, and this method takes care of the migration path from
+     * that. It will now reside under the data directory.
+     */
+    private void migrateIfNeeded( FileSystemAbstraction fs ) throws ClusterStateException
+    {
+        File oldStateDir = new File( storeDir, CLUSTER_STATE_DIRECTORY_NAME );
+        if ( !fs.fileExists( oldStateDir ) || oldStateDir.equals( stateDir ) )
+        {
+            return;
+        }
+
+        if ( fs.fileExists( stateDir ) )
+        {
+            throw new ClusterStateException( "Cluster state exists in both old and new locations" );
+        }
+
+        try
+        {
+            fs.moveToDirectory( oldStateDir, stateDir.getParentFile() );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Failed to migrate cluster state directory", e );
+        }
+    }
+
+    private void ensureDirectoryExists( FileSystemAbstraction fs ) throws ClusterStateException
+    {
+        if ( !fs.fileExists( stateDir ) )
+        {
+            if ( readOnly )
+            {
+                throw new ClusterStateException( "Cluster state directory does not exist" );
+            }
+            else
+            {
+                try
+                {
+                    fs.mkdirs( stateDir );
+                }
+                catch ( IOException e )
+                {
+                    throw new ClusterStateException( e );
+                }
+            }
+        }
+    }
+
+    public File get()
+    {
+        if ( !initialized )
+        {
+            throw new IllegalStateException( "Cluster state has not been initialized" );
+        }
+        return stateDir;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/ClusterStateException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state;
+
+public class ClusterStateException extends Exception
+{
+    ClusterStateException( String message )
+    {
+        super( message );
+    }
+
+    ClusterStateException( Throwable cause )
+    {
+        super( cause );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/DumpClusterState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/DumpClusterState.java
@@ -44,7 +44,6 @@ import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.causalclustering.core.server.CoreServerModule.LAST_FLUSHED_NAME;
 import static org.neo4j.causalclustering.ReplicationModule.SESSION_TRACKER_NAME;
-import static org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.causalclustering.core.IdentityModule.CORE_MEMBER_ID_NAME;
 import static org.neo4j.causalclustering.core.consensus.ConsensusModule.RAFT_MEMBERSHIP_NAME;
 import static org.neo4j.causalclustering.core.consensus.ConsensusModule.RAFT_TERM_NAME;
@@ -59,29 +58,31 @@ public class DumpClusterState
     private final PrintStream out;
 
     /**
-     * @param args [0] = graph database folder
+     * @param args [0] = data directory
      * @throws IOException When IO exception occurs.
      */
-    public static void main( String[] args ) throws IOException
+    public static void main( String[] args ) throws IOException, ClusterStateException
     {
         if ( args.length != 1 )
         {
-            System.out.println( "usage: DumpClusterState <graph.db>" );
+            System.out.println( "usage: DumpClusterState <data directory>" );
             System.exit( 1 );
         }
 
+        File dataDirectory = new File( args[0] );
+
         DumpClusterState dumpTool = new DumpClusterState(
                 new DefaultFileSystemAbstraction(),
-                new File( args[0], CLUSTER_STATE_DIRECTORY_NAME ),
+                dataDirectory,
                 System.out );
 
         dumpTool.dump();
     }
 
-    DumpClusterState( FileSystemAbstraction fs, File clusterStateDirectory, PrintStream out )
+    DumpClusterState( FileSystemAbstraction fs, File dataDirectory, PrintStream out ) throws ClusterStateException
     {
         this.fs = fs;
-        this.clusterStateDirectory = clusterStateDirectory;
+        this.clusterStateDirectory = new ClusterStateDirectory( dataDirectory ).initialize( fs ).get();
         this.out = out;
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/SegmentedRaftLogDurabilityTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/SegmentedRaftLogDurabilityTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.causalclustering.core.consensus.ReplicatedInteger.valueOf;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.causalclustering.core.consensus.log.RaftLogHelper.hasNoContent;
 import static org.neo4j.causalclustering.core.consensus.log.RaftLogHelper.readLogEntry;
 import static org.neo4j.logging.NullLogProvider.getInstance;
@@ -52,7 +52,7 @@ public class SegmentedRaftLogDurabilityTest
 
     private final RaftLogFactory logFactory = ( fileSystem ) ->
     {
-        File directory = new File( PHYSICAL_LOG_DIRECTORY_NAME );
+        File directory = new File( RAFT_LOG_DIRECTORY_NAME );
         fileSystem.mkdir( directory );
 
         long rotateAtSizeBytes = 128;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogContractTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogContractTest.java
@@ -34,7 +34,7 @@ import org.neo4j.test.OnDemandJobScheduler;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 import org.neo4j.time.Clocks;
 
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.logging.NullLogProvider.getInstance;
 
 public class SegmentedRaftLogContractTest extends RaftLogContractTest
@@ -48,7 +48,7 @@ public class SegmentedRaftLogContractTest extends RaftLogContractTest
     @Override
     public RaftLog createRaftLog()
     {
-        File directory = new File( PHYSICAL_LOG_DIRECTORY_NAME );
+        File directory = new File( RAFT_LOG_DIRECTORY_NAME );
         FileSystemAbstraction fileSystem = fsRule.get();
         fileSystem.mkdir( directory );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursorIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogCursorIT.java
@@ -38,7 +38,7 @@ import org.neo4j.time.Clocks;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.raft_log_pruning_strategy;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.logging.NullLogProvider.getInstance;
 
 public class SegmentedRaftLogCursorIT
@@ -60,7 +60,7 @@ public class SegmentedRaftLogCursorIT
             fileSystem = new EphemeralFileSystemAbstraction();
         }
 
-        File directory = new File( PHYSICAL_LOG_DIRECTORY_NAME );
+        File directory = new File( RAFT_LOG_DIRECTORY_NAME );
         fileSystem.mkdir( directory );
 
         LogProvider logProvider = getInstance();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTruncationPruneTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogRotationTruncationPruneTest.java
@@ -34,7 +34,7 @@ import org.neo4j.time.Clocks;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.causalclustering.core.consensus.ReplicatedInteger.valueOf;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.logging.NullLogProvider.getInstance;
 
 public class SegmentedRaftLogRotationTruncationPruneTest
@@ -119,7 +119,7 @@ public class SegmentedRaftLogRotationTruncationPruneTest
     {
         FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
 
-        File directory = new File( PHYSICAL_LOG_DIRECTORY_NAME );
+        File directory = new File( RAFT_LOG_DIRECTORY_NAME );
         fileSystem.mkdir( directory );
 
         LogProvider logProvider = getInstance();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogVerificationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLogVerificationIT.java
@@ -30,7 +30,7 @@ import org.neo4j.test.OnDemandJobScheduler;
 import org.neo4j.time.Clocks;
 
 import static org.neo4j.causalclustering.core.CausalClusteringSettings.raft_log_pruning_strategy;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.logging.NullLogProvider.getInstance;
 
 public class SegmentedRaftLogVerificationIT extends RaftLogVerificationIT
@@ -40,7 +40,7 @@ public class SegmentedRaftLogVerificationIT extends RaftLogVerificationIT
     {
         FileSystemAbstraction fsa = fsRule.get();
 
-        File directory = new File( PHYSICAL_LOG_DIRECTORY_NAME );
+        File directory = new File( RAFT_LOG_DIRECTORY_NAME );
         fsa.mkdir( directory );
 
         long rotateAtSizeBytes = 128;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class ClusterStateDirectoryTest
+{
+    @Rule
+    public DefaultFileSystemRule fsRule = new DefaultFileSystemRule();
+    private DefaultFileSystemAbstraction fs = fsRule.get();
+
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory( fs );
+
+    private File dataDir;
+    private File stateDir;
+
+    @Before
+    public void setup()
+    {
+        dataDir = testDirectory.directory( "data" );
+        stateDir = new File( dataDir, ClusterStateDirectory.CLUSTER_STATE_DIRECTORY_NAME );
+    }
+
+    @Test
+    public void shouldMigrateClusterStateFromStoreDir() throws Exception
+    {
+        // given
+        File storeDir = new File( new File( dataDir, "databases" ), "graph.db" );
+
+        String fileName = "file";
+
+        File oldStateDir = new File( storeDir, ClusterStateDirectory.CLUSTER_STATE_DIRECTORY_NAME );
+        File oldClusterStateFile = new File( oldStateDir, fileName );
+
+        fs.mkdirs( oldStateDir );
+        fs.create( oldClusterStateFile );
+
+        // when
+        ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDir, false );
+        clusterStateDirectory.initialize( fs );
+
+        // then
+        assertEquals( clusterStateDirectory.get(), stateDir );
+        assertTrue( fs.fileExists( new File( clusterStateDirectory.get(), fileName ) ) );
+    }
+
+    @Test
+    public void shouldHandleCaseOfStoreDirBeingDataDir() throws Exception
+    {
+        // given
+        File storeDir = dataDir;
+
+        String fileName = "file";
+
+        File oldStateDir = new File( storeDir, ClusterStateDirectory.CLUSTER_STATE_DIRECTORY_NAME );
+        File oldClusterStateFile = new File( oldStateDir, fileName );
+
+        fs.mkdirs( oldStateDir );
+        fs.create( oldClusterStateFile );
+
+        // when
+        ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDir, false );
+        clusterStateDirectory.initialize( fs );
+
+        // then
+        assertEquals( clusterStateDirectory.get(), stateDir );
+        assertTrue( fs.fileExists( new File( clusterStateDirectory.get(), fileName ) ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/DumpClusterStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/DumpClusterStateTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.core.state;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,7 +58,14 @@ public class DumpClusterStateTest
 {
     @Rule
     public EphemeralFileSystemRule fsa = new EphemeralFileSystemRule();
-    private File clusterStateDirectory = new File( "cluster-state" );
+    private File dataDir = new File( "data" );
+    private ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, false );
+
+    @Before
+    public void setup() throws ClusterStateException
+    {
+        clusterStateDirectory.initialize( fsa );
+    }
 
     @Test
     public void shouldDumpClusterState() throws Exception
@@ -65,7 +73,7 @@ public class DumpClusterStateTest
         // given
         createStates();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        DumpClusterState dumpTool = new DumpClusterState( fsa.get(), clusterStateDirectory, new PrintStream( out ) );
+        DumpClusterState dumpTool = new DumpClusterState( fsa.get(), dataDir, new PrintStream( out ) );
 
         // when
         dumpTool.dump();
@@ -77,7 +85,7 @@ public class DumpClusterStateTest
 
     private void createStates() throws IOException
     {
-        SimpleStorage<MemberId> memberIdStorage = new SimpleFileStorage<>( fsa.get(), clusterStateDirectory, CORE_MEMBER_ID_NAME, new MemberId.Marshal(), NullLogProvider.getInstance() );
+        SimpleStorage<MemberId> memberIdStorage = new SimpleFileStorage<>( fsa.get(), clusterStateDirectory.get(), CORE_MEMBER_ID_NAME, new MemberId.Marshal(), NullLogProvider.getInstance() );
         memberIdStorage.writeState( new MemberId( UUID.randomUUID() ) );
 
         createDurableState( LAST_FLUSHED_NAME, new LongIndexMarshal() );
@@ -94,7 +102,7 @@ public class DumpClusterStateTest
     private <T> void createDurableState( String name, StateMarshal<T> marshal ) throws IOException
     {
         DurableStateStorage<T> storage = new DurableStateStorage<>(
-                fsa.get(), clusterStateDirectory, name, marshal, 1024, NullLogProvider.getInstance() );
+                fsa.get(), clusterStateDirectory.get(), name, marshal, 1024, NullLogProvider.getInstance() );
 
         //noinspection EmptyTryBlock: Will create initial state.
         try ( Lifespan ignored = new Lifespan( storage ) )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -29,6 +29,7 @@ import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.log.segmented.FileNames;
+import org.neo4j.causalclustering.core.state.ClusterStateDirectory;
 import org.neo4j.causalclustering.core.state.CoreState;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -44,8 +45,7 @@ import org.neo4j.server.configuration.ClientConnectorSettings.HttpConnector.Encr
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
-import static org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
-import static org.neo4j.causalclustering.core.consensus.log.RaftLog.PHYSICAL_LOG_DIRECTORY_NAME;
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class CoreClusterMember implements ClusterMember
@@ -53,6 +53,8 @@ public class CoreClusterMember implements ClusterMember
     private final File neo4jHome;
     private final DiscoveryServiceFactory discoveryServiceFactory;
     private final File storeDir;
+    private final File clusterStateDir;
+    private final File raftLogDir;
     private final Map<String, String> config = stringMap();
     private final int serverId;
     private final String boltAdvertisedAddress;
@@ -105,10 +107,14 @@ public class CoreClusterMember implements ClusterMember
         }
 
         this.neo4jHome = new File( parentDir, "server-core-" + serverId );
+        config.put( GraphDatabaseSettings.neo4j_home.name(), neo4jHome.getAbsolutePath() );
         config.put( GraphDatabaseSettings.logs_directory.name(), new File( neo4jHome, "logs" ).getAbsolutePath() );
 
         this.discoveryServiceFactory = discoveryServiceFactory;
-        storeDir = new File( new File( new File( neo4jHome, "data" ), "databases" ), "graph.db" );
+        File dataDir = new File( neo4jHome, "data" );
+        clusterStateDir = ClusterStateDirectory.withoutInitializing( dataDir ).get();
+        raftLogDir = new File( clusterStateDir, RAFT_LOG_DIRECTORY_NAME );
+        storeDir = new File( new File( dataDir, "databases" ), "graph.db" );
         storeDir.mkdirs();
     }
 
@@ -172,8 +178,7 @@ public class CoreClusterMember implements ClusterMember
 
     public SortedMap<Long, File> getLogFileNames()
     {
-        File clusterStateDir = new File( storeDir, CLUSTER_STATE_DIRECTORY_NAME );
-        File logFilesDir = new File( clusterStateDir, PHYSICAL_LOG_DIRECTORY_NAME );
+        File logFilesDir = new File( clusterStateDir, RAFT_LOG_DIRECTORY_NAME );
         return new FileNames( logFilesDir ).getAllFiles( new DefaultFileSystemAbstraction(), null );
     }
 
@@ -197,5 +202,15 @@ public class CoreClusterMember implements ClusterMember
     public ClientConnectorAddresses clientConnectorAddresses()
     {
         return ClientConnectorAddresses.extractFromConfig( new Config( this.config ) );
+    }
+
+    public File clusterStateDirectory()
+    {
+        return clusterStateDir;
+    }
+
+    public File raftLogDirectory()
+    {
+        return raftLogDir;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -45,6 +45,7 @@ public class ReadReplica implements ClusterMember
 {
     private final Map<String, String> config = stringMap();
     private final DiscoveryServiceFactory discoveryServiceFactory;
+    private final File neo4jHome;
     private final File storeDir;
     private final int memberId;
     private final String boltAdvertisedAddress;
@@ -93,7 +94,8 @@ public class ReadReplica implements ClusterMember
         config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).listen_address.name(), "127.0.0.1:" + httpPort );
         config.put( new ClientConnectorSettings.HttpConnector( "http", Encryption.NONE ).advertised_address.name(), "127.0.0.1:" + httpPort );
 
-        File neo4jHome = new File( parentDir, "read-replica-" + memberId );
+        this.neo4jHome = new File( parentDir, "read-replica-" + memberId );
+        config.put( GraphDatabaseSettings.neo4j_home.name(), neo4jHome.getAbsolutePath() );
         config.put( GraphDatabaseSettings.logs_directory.name(), new File( neo4jHome, "logs" ).getAbsolutePath() );
 
         this.discoveryServiceFactory = discoveryServiceFactory;
@@ -163,4 +165,8 @@ public class ReadReplica implements ClusterMember
         return String.format( "bolt://%s", boltAdvertisedAddress );
     }
 
+    public File homeDir()
+    {
+        return neo4jHome;
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdentityIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdentityIT.java
@@ -52,7 +52,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.causalclustering.TestStoreId.assertAllStoresHaveTheSameStoreId;
-import static org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.causalclustering.core.server.CoreServerModule.CLUSTER_ID_NAME;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.RANDOM_NUMBER;
@@ -201,9 +200,9 @@ public class ClusterIdentityIT
             tx.success();
         } );
 
-        File storeDir = cluster.getCoreMemberById( 0 ).storeDir();
+        CoreClusterMember coreMember = cluster.getCoreMemberById( 0 );
         cluster.removeCoreMemberWithMemberId( 0 );
-        changeClusterId( storeDir );
+        changeClusterId( coreMember );
 
         SampleData.createSomeData( 100, cluster );
 
@@ -260,9 +259,9 @@ public class ClusterIdentityIT
         return dbs.stream().map( CoreClusterMember::storeDir ).collect( Collectors.toList() );
     }
 
-    private void changeClusterId( File storeDir ) throws IOException
+    private void changeClusterId( CoreClusterMember coreMember ) throws IOException
     {
-        SimpleStorage<ClusterId> clusterIdStorage = new SimpleFileStorage<>( fs, new File( storeDir, CLUSTER_STATE_DIRECTORY_NAME ),
+        SimpleStorage<ClusterId> clusterIdStorage = new SimpleFileStorage<>( fs, coreMember.clusterStateDirectory(),
                 CLUSTER_ID_NAME, new ClusterId.Marshal(), NullLogProvider.getInstance() );
         clusterIdStorage.writeState( new ClusterId( UUID.randomUUID() ) );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
@@ -72,6 +72,7 @@ public class CoreToCoreCopySnapshotIT
         // shutdown the follower, remove the store, restart
         follower.shutdown();
         FileUtils.deleteRecursively( follower.storeDir() );
+        FileUtils.deleteRecursively( follower.clusterStateDirectory() );
         follower.start();
 
         // then

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
@@ -43,7 +43,6 @@ import org.neo4j.test.causalclustering.ClusterRule;
 import org.neo4j.test.rule.PageCacheRule;
 
 import static java.util.Collections.singletonList;
-import static org.neo4j.causalclustering.core.EnterpriseCoreEditionModule.CLUSTER_STATE_DIRECTORY_NAME;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
 import static org.neo4j.causalclustering.helpers.DataCreator.createNodes;
 
@@ -110,7 +109,7 @@ public class TransactionLogRecoveryIT
 
         // and deleting the cluster state, making sure a snapshot is required during startup
         // effectively a seeding scenario -- representing the use of the unbind command on a crashed store
-        fs.deleteRecursively( new File( core.storeDir(), CLUSTER_STATE_DIRECTORY_NAME ) );
+        fs.deleteRecursively( core.clusterStateDirectory() );
 
         // then: we should still be able to start
         core.start();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.channels.FileChannel;
@@ -30,50 +32,66 @@ import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.UUID;
-import java.util.stream.Stream;
 
+import org.neo4j.causalclustering.core.state.ClusterStateDirectory;
+import org.neo4j.causalclustering.core.state.ClusterStateException;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.admin.Usage;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.startsWith;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.internal.StoreLocker.STORE_LOCK_FILENAME;
 
 public class UnbindFromClusterCommandTest
 {
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
+    private Path homeDir;
+    private Path confDir;
+
+    private FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+    private OutsideWorld outsideWorld = mock( OutsideWorld.class );
+
+    @Before
+    public void setup() throws ClusterStateException
+    {
+        homeDir = testDir.directory( "home" ).toPath();
+        confDir = testDir.directory( "conf" ).toPath();
+        fs.mkdir( homeDir.toFile() );
+
+        when( outsideWorld.fileSystem() ).thenReturn( fs );
+    }
+
+    private File createClusterStateDir( FileSystemAbstraction fs ) throws ClusterStateException
+    {
+        File dataDir = new File( homeDir.toFile(), "data" );
+        ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, false );
+        clusterStateDirectory.initialize( fs );
+        return clusterStateDirectory.get();
+    }
 
     @Test
     public void shouldFailIfSpecifiedDatabaseDoesNotExist() throws Exception
     {
         // given
-        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
-        fsa.mkdir( testDir.directory() );
-
-        UnbindFromClusterCommand command =
-                new UnbindFromClusterCommand( testDir.directory().toPath(), testDir.directory( "conf" ).toPath(),
-                        mock( OutsideWorld.class ) );
+        UnbindFromClusterCommand command = new UnbindFromClusterCommand( homeDir, confDir, outsideWorld );
 
         try
         {
             // when
-            command.execute( nonExistentDatabaseArg() );
+            command.execute( databaseNameParameter( "doesnotexist.db" ) );
             fail();
         }
         catch ( IncorrectUsage e )
@@ -87,19 +105,14 @@ public class UnbindFromClusterCommandTest
     public void shouldFailToUnbindLiveDatabase() throws Exception
     {
         // given
-        FileSystemAbstraction fsa = new DefaultFileSystemAbstraction(); // because locking
-        fsa.mkdir( testDir.directory() );
+        createClusterStateDir( fs );
+        UnbindFromClusterCommand command = new UnbindFromClusterCommand( homeDir, confDir, outsideWorld );
 
-        UnbindFromClusterCommand command =
-                new UnbindFromClusterCommand( testDir.directory().toPath(), testDir.directory( "conf" ).toPath(),
-                        mock( OutsideWorld.class ) );
-
-        FileLock fileLock = createLockedFakeDbDir( testDir.directory().toPath() );
-
+        FileLock fileLock = createLockedFakeDbDir( homeDir );
         try
         {
             // when
-            command.execute( databaseName( "graph.db" ) );
+            command.execute( databaseNameParameter( "graph.db" ) );
             fail();
         }
         catch ( CommandFailed e )
@@ -117,49 +130,39 @@ public class UnbindFromClusterCommandTest
     public void shouldRemoveClusterStateDirectoryForGivenDatabase() throws Exception
     {
         // given
-        final int numberOfFilesAndDirsInANormalNeo4jStoreDir = 35;
-
-        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
-        fsa.mkdir( testDir.directory() );
-
-        Path fakeDbDir = createUnlockedFakeDbDir( testDir.directory().toPath() );
-        UnbindFromClusterCommand command =
-                new UnbindFromClusterCommand( testDir.directory().toPath(), testDir.directory( "conf" ).toPath(),
-                        mock( OutsideWorld.class ) );
+        File clusterStateDir = createClusterStateDir( fs );
+        createUnlockedFakeDbDir( homeDir );
+        UnbindFromClusterCommand command = new UnbindFromClusterCommand( homeDir, confDir, outsideWorld );
 
         // when
-        command.execute( databaseName( "graph.db" ) );
+        command.execute( databaseNameParameter( "graph.db" ) );
 
         // then
-        try ( Stream<Path> files = Files.list( fakeDbDir ) )
-        {
-            assertEquals( numberOfFilesAndDirsInANormalNeo4jStoreDir, files.count() );
-        }
+        assertFalse( fs.fileExists( clusterStateDir ) );
     }
 
     @Test
     public void shouldReportWhenClusterStateDirectoryIsNotPresent() throws Exception
     {
         // given
-        FileSystemAbstraction fsa = new EphemeralFileSystemAbstraction();
-        fsa.mkdir( testDir.directory() );
-
-        Path fakeDbDir = createUnlockedFakeDbDir( testDir.directory().toPath() );
-        Files.delete( Paths.get( fakeDbDir.toString(), "cluster-state" ) );
-
-        OutsideWorld outsideWorld = mock( OutsideWorld.class );
-        UnbindFromClusterCommand command =
-                new UnbindFromClusterCommand( testDir.directory().toPath(), testDir.directory( "conf" ).toPath(),
-                        outsideWorld );
+        createUnlockedFakeDbDir( homeDir );
+        UnbindFromClusterCommand command = new UnbindFromClusterCommand( homeDir, confDir, outsideWorld );
 
         // when
-        command.execute( databaseName( "graph.db" ) );
-
-        verify( outsideWorld ).stdErrLine( startsWith( "No cluster state found in" ) );
+        try
+        {
+            // when
+            command.execute( databaseNameParameter( "graph.db" ) );
+        }
+        catch ( CommandFailed e )
+        {
+            // then
+            assertThat( e.getMessage(), containsString( "Cluster state directory does not exist" ) );
+        }
     }
 
     @Test
-    public void shouldPrintNiceHelp() throws Throwable
+    public void shouldPrintUsage() throws Throwable
     {
         try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
         {
@@ -168,86 +171,28 @@ public class UnbindFromClusterCommandTest
             Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
             usage.printUsageForCommand( new UnbindFromClusterCommand.Provider(), ps::println );
 
-            assertEquals( String.format( "usage: neo4j-admin unbind [--database=<name>]%n" +
-                            "%n" +
-                            "Removes cluster state data from the specified database making it suitable for%n" +
-                            "use in single instance database, or for seeding a new cluster.%n" +
-                            "%n" +
-                            "options:%n" +
-                            "  --database=<name>   Name of database. [default:graph.db]%n" ),
-                    baos.toString() );
+            assertThat( baos.toString(), containsString( "usage" ) );
         }
     }
 
-    private String[] databaseName( String databaseName )
+    private Path createUnlockedFakeDbDir( Path homeDir ) throws IOException
     {
-        return new String[]{"--database=" + databaseName};
-    }
-
-    private Path createUnlockedFakeDbDir( Path parent ) throws IOException
-    {
-        Path fakeDbDir = createFakeDbDir( parent );
+        Path fakeDbDir = createFakeDbDir( homeDir );
         Files.createFile( Paths.get( fakeDbDir.toString(), STORE_LOCK_FILENAME ) );
         return fakeDbDir;
     }
 
-    private FileLock createLockedFakeDbDir( Path parent ) throws IOException
+    private FileLock createLockedFakeDbDir( Path homeDir ) throws IOException
     {
-        return createLockedStoreLockFileIn( createFakeDbDir( parent ) );
+        return createLockedStoreLockFileIn( createFakeDbDir( homeDir ) );
     }
 
-    private Path createFakeDbDir( Path parent ) throws IOException
+    private Path createFakeDbDir( Path homeDir ) throws IOException
     {
-        Path data = createDirectory( parent, "data" );
-        Path database = createDirectory( data, "databases" );
-        Path graph_db = createDirectory( database, "graph.db" );
-        createDirectory( graph_db, "cluster-state" );
-        createDirectory( graph_db, "schema" );
-        createDirectory( graph_db, "index" );
-        createFile( graph_db, "neostore" );
-        createFile( graph_db, "neostore.counts.db.a" );
-        createFile( graph_db, "neostore.id" );
-        createFile( graph_db, "neostore.labeltokenstore.db" );
-        createFile( graph_db, "neostore.labeltokenstore.db.id" );
-        createFile( graph_db, "neostore.labeltokenstore.db.names" );
-        createFile( graph_db, "neostore.labeltokenstore.db.names.id" );
-        createFile( graph_db, "neostore.nodestore.db" );
-        createFile( graph_db, "neostore.nodestore.db.id" );
-        createFile( graph_db, "neostore.nodestore.db.labels" );
-        createFile( graph_db, "neostore.nodestore.db.labels.id" );
-        createFile( graph_db, "neostore.propertystore.db" );
-        createFile( graph_db, "neostore.propertystore.db.arrays" );
-        createFile( graph_db, "neostore.propertystore.db.arrays.id" );
-        createFile( graph_db, "neostore.propertystore.db.id" );
-        createFile( graph_db, "neostore.propertystore.db.index" );
-        createFile( graph_db, "neostore.propertystore.db.index.id" );
-        createFile( graph_db, "neostore.propertystore.db.index.keys" );
-        createFile( graph_db, "neostore.propertystore.db.index.keys.id" );
-        createFile( graph_db, "neostore.propertystore.db.strings" );
-        createFile( graph_db, "neostore.propertystore.db.strings.id" );
-        createFile( graph_db, "neostore.relationshipgroupstore.db" );
-        createFile( graph_db, "neostore.relationshipgroupstore.db.id" );
-        createFile( graph_db, "neostore.relationshipstore.db" );
-        createFile( graph_db, "neostore.relationshipstore.db.id" );
-        createFile( graph_db, "neostore.relationshiptypestore.db" );
-        createFile( graph_db, "neostore.relationshiptypestore.db.id" );
-        createFile( graph_db, "neostore.relationshiptypestore.db.names" );
-        createFile( graph_db, "neostore.relationshiptypestore.db.names.id" );
-        createFile( graph_db, "neostore.schemastore.db" );
-        createFile( graph_db, "neostore.schemastore.db.id" );
-        createFile( graph_db, "neostore.transaction.db.0" );
-
-        return graph_db;
-    }
-
-    private Path createFile( Path parent, String file ) throws IOException
-    {
-        return Files.createFile( Paths.get( parent.toString(), file ) );
-    }
-
-    private Path createDirectory( Path parent, String subDir ) throws IOException
-    {
-        return Files.createDirectory( Paths.get( parent.toString(), subDir ) );
+        Path graphDb = homeDir.resolve( "data/databases/graph.db" );
+        fs.mkdirs( graphDb.toFile() );
+        fs.create( graphDb.resolve( "neostore" ).toFile() );
+        return graphDb;
     }
 
     private FileLock createLockedStoreLockFileIn( Path parent ) throws IOException
@@ -257,8 +202,8 @@ public class UnbindFromClusterCommandTest
         return channel.lock( 0, Long.MAX_VALUE, true );
     }
 
-    private String[] nonExistentDatabaseArg()
+    private String[] databaseNameParameter( String databaseName )
     {
-        return new String[]{"--database=" + UUID.randomUUID().toString()};
+        return new String[]{"--database=" + databaseName};
     }
 }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
@@ -110,7 +110,7 @@ public class CoreEdgeMetricsIT
             assertAllNodesVisible( db.database() );
         }
 
-        File coreMetricsDir = new File( cluster.getCoreMemberById( 0 ).storeDir(), csvPath.getDefaultValue() );
+        File coreMetricsDir = new File( cluster.getCoreMemberById( 0 ).homeDir(), csvPath.getDefaultValue() );
 
         assertEventually( "append index eventually accurate",
                 () -> readLongValue( metricsCsv( coreMetricsDir, CoreMetrics.APPEND_INDEX ) ),
@@ -130,9 +130,9 @@ public class CoreEdgeMetricsIT
 
         assertEventually( "tx pull requests received eventually accurate", () -> {
             long total = 0;
-            for ( final CoreGraphDatabase db : cluster.coreMembers().stream().map( CoreClusterMember::database ).collect( Collectors.toList()) )
+            for ( final File homeDir : cluster.coreMembers().stream().map( CoreClusterMember::homeDir ).collect( Collectors.toList()) )
             {
-                File metricsDir = new File( db.getStoreDir(), "metrics" );
+                File metricsDir = new File( homeDir, "metrics" );
                 total += readLongValue( metricsCsv( metricsDir, CoreMetrics.TX_PULL_REQUESTS_RECEIVED ) );
             }
             return total;
@@ -146,7 +146,7 @@ public class CoreEdgeMetricsIT
                 () -> readLongValue( metricsCsv( coreMetricsDir, CoreMetrics.IS_LEADER ) ),
                 greaterThanOrEqualTo( 0L ), TIMEOUT, TimeUnit.SECONDS );
 
-        File readReplicaMetricsDir = new File( cluster.getReadReplicaById( 0 ).storeDir(), "metrics" );
+        File readReplicaMetricsDir = new File( cluster.getReadReplicaById( 0 ).homeDir(), "metrics" );
 
         assertEventually( "pull update request registered",
                 () -> readLongValue( metricsCsv( readReplicaMetricsDir, PULL_UPDATES ) ),


### PR DESCRIPTION
It was previously placed in the store directory which is not optimal
considering how the store directory usually is handled and because
the cluster state among other things contains unique IDs for the
member as well as for the bound cluster and should not be replicated
around haphazardly.

changelog: Move cluster state to data directory, was previously under graph.db.