### PR TITLE
Mutex between check-point and store-copy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -119,6 +119,7 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointThresholds;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerImpl;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CountCommittedTransactionThreshold;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TimeCheckPointThreshold;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
@@ -261,6 +262,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     private final IOLimiter ioLimiter;
     private final AvailabilityGuard availabilityGuard;
     private final SystemNanoClock clock;
+    private final StoreCopyCheckPointMutex storeCopyCheckPointMutex;
 
     private Dependencies dependencies;
     private LifeSupport life;
@@ -314,7 +316,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             IOLimiter ioLimiter,
             AvailabilityGuard availabilityGuard,
             SystemNanoClock clock,
-            AccessCapability accessCapability )
+            AccessCapability accessCapability,
+            StoreCopyCheckPointMutex storeCopyCheckPointMutex )
     {
         this.storeDir = storeDir;
         this.config = config;
@@ -326,6 +329,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         this.scheduler = scheduler;
         this.logService = logService;
         this.autoIndexing = autoIndexing;
+        this.storeCopyCheckPointMutex = storeCopyCheckPointMutex;
         this.logProvider = logService.getInternalLogProvider();
         this.propertyKeyTokenHolder = propertyKeyTokens;
         this.labelTokens = labelTokens;
@@ -640,7 +644,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
 
         final CheckPointerImpl checkPointer = new CheckPointerImpl(
                 transactionIdStore, threshold, storageEngine, logPruning, appender, databaseHealth, logProvider,
-                tracers.checkPointTracer, ioLimiter );
+                tracers.checkPointTracer, ioLimiter, storeCopyCheckPointMutex );
 
         long recurringPeriod = Math.min( timeMillisThreshold, TimeUnit.SECONDS.toMillis( 10 ) );
         CheckPointScheduler checkPointScheduler = new CheckPointScheduler( checkPointer, scheduler, recurringPeriod );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -216,7 +216,8 @@ public class DataSourceModule
                 procedures,
                 editionModule.ioLimiter,
                 platformModule.availabilityGuard,
-                platformModule.clock, editionModule.accessCapability ) );
+                platformModule.clock, editionModule.accessCapability,
+                platformModule.storeCopyCheckPointMutex ) );
 
         dataSourceManager.register( neoStoreDataSource );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.security.URLAccessRules;
 import org.neo4j.kernel.impl.spi.SimpleKernelContext;
 import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerMonitor;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
@@ -113,6 +114,8 @@ public class PlatformModule
     public final TransactionStats transactionMonitor;
 
     public final SystemNanoClock clock;
+
+    public final StoreCopyCheckPointMutex storeCopyCheckPointMutex;
 
     public PlatformModule( File providedStoreDir, Map<String,String> params, DatabaseInfo databaseInfo,
             GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )
@@ -198,6 +201,9 @@ public class PlatformModule
                 externalDependencies.kernelExtensions(), dependencies, UnsatisfiedDependencyStrategies.fail() ) );
 
         urlAccessRule = dependencies.satisfyDependency( URLAccessRules.combined( externalDependencies.urlAccessRules() ) );
+
+        storeCopyCheckPointMutex = new StoreCopyCheckPointMutex();
+        dependencies.satisfyDependency( storeCopyCheckPointMutex );
 
         publishPlatformInfo( dependencies.resolveDependency( UsageData.class ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
 /**
  * This interface represent a check pointer which is responsible to write check points in the transaction log.
  */
@@ -61,4 +63,10 @@ public interface CheckPointer
      * @throws IOException if writing the check point fails
      */
     long forceCheckPoint( TriggerInfo triggerInfo ) throws IOException;
+
+    /**
+     * @return the transaction id which the last checkpoint was made it. If there's no checkpoint then
+     * {@link TransactionIdStore#BASE_TX_ID} is returned.
+     */
+    long lastCheckPointedTransactionId();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.checkpoint;
+
+import java.io.IOException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.graphdb.Resource;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
+/**
+ * Mutex between {@link #storeCopy(ThrowingAction) store-copy} and {@link #checkPoint() check-point}.
+ * This to prevent those two running concurrently.
+ * <p>
+ * Normally a check-point implies first doing a check-point and so this relationships is somewhat intricate.
+ * In addition to having {@link #storeCopy(ThrowingAction)} as the "read lock" and {@link #checkPoint()} as the
+ * "write lock", {@link #storeCopy(ThrowingAction)} also accepts a code snippet to run before first concurrent
+ * store-copy grabs the lock, a snippet which can include a check-point.
+ *
+ * <pre>
+ *                                  <-WAIT--------------------|-CHECKPOINT--------->
+ *                                  |                                              |
+ * |----------|-----|---------------|---|-----------|---------|-------------|------|--------------------------|-> TIME
+ *            |     |                   |           |         |             |                                 |
+ *            |     |                   <-----STORE-|-COPY---->             <-WAIT-|-CHECKPOINT-|-STORE-COPY-->
+ *            |     |                               |
+ *            |     <-WAIT--|-STORE-COPY------------>
+ *            |                                   |
+ *            <-CHECKPOINT--|-STORE-COPY---------->
+ * </pre>
+ *
+ * In the image above there are three "events":
+ * <ol>
+ * <li>Store-copy 1, where there are three concurrent store-copies going on.
+ * Only the first one performs check-point</li>
+ * <li>External check-point, which waits for the ongoing store-copies to complete and then performs it</li>
+ * <li>Store-copy 2, which waits for the external check-point to complete and then starts its own
+ * check-point, which is part of the store-copy algorithm to then perform the store-copy.</li>
+ * </ol>
+ *
+ * Status changes are made in synchronized as opposed to atomic CAS operations, since this results
+ * in simpler code and since this mutex is normally called a couple of times per hour it's not an issue.
+ */
+public class StoreCopyCheckPointMutex
+{
+    /**
+     * Main lock. Read-lock is for {@link #storeCopy(ThrowingAction)} and write-lock is for {@link #checkPoint()}.
+     */
+    private final ReadWriteLock lock;
+
+    /**
+     * Number of currently ongoing store-copy requests.
+     */
+    private int storeCopyCount;
+
+    /**
+     * Whether or not the first (of the concurrently ongoing store-copy requests has had its "before"
+     * action completed. The other store-copy requests will wait for this flag to be {@code true}.
+     */
+    private volatile boolean storeCopyActionCompleted;
+
+    /**
+     * Error which may have happened during first concurrent store-copy request. Made available to
+     * the other concurrent store-copy requests so that they can fail instead of waiting forever.
+     */
+    private volatile Throwable storeCopyActionError;
+
+    public StoreCopyCheckPointMutex()
+    {
+        this( new ReentrantReadWriteLock( true ) );
+    }
+
+    public StoreCopyCheckPointMutex( ReadWriteLock lock )
+    {
+        this.lock = lock;
+    }
+
+    public Resource storeCopy( ThrowingAction<IOException> beforeFirstConcurrentStoreCopy ) throws IOException
+    {
+        Lock readLock = lock.readLock();
+        boolean firstConcurrentRead = incrementCount() == 0;
+        if ( firstConcurrentRead )
+        {
+            try
+            {
+                beforeFirstConcurrentStoreCopy.apply();
+            }
+            catch ( Throwable e )
+            {
+                storeCopyActionError = e;
+                throw launderedException( IOException.class, e );
+            }
+            readLock.lock();
+            storeCopyActionCompleted = true;
+        }
+        else
+        {
+            // Wait for the "before" first store copy to complete
+            while ( !storeCopyActionCompleted )
+            {
+                if ( storeCopyActionError != null )
+                {
+                    throw new IOException( "Co-operative action before store-copy failed", storeCopyActionError );
+                }
+                parkAWhile();
+            }
+            readLock.lock();
+        }
+
+        return () ->
+        {
+            // Decrement concurrent store-copy count
+            decrementCount();
+            readLock.unlock();
+        };
+    }
+
+    private synchronized void decrementCount()
+    {
+        storeCopyCount--;
+        if ( storeCopyCount == 0 )
+        {
+            // If I'm the last one then also clear the other status fields so that a clean new session
+            // can begin on the next store-copy request
+            clear();
+        }
+    }
+
+    private void clear()
+    {
+        storeCopyActionCompleted = false;
+        storeCopyActionError = null;
+    }
+
+    private synchronized int incrementCount()
+    {
+        return storeCopyCount++;
+    }
+
+    private static void parkAWhile()
+    {
+        LockSupport.parkNanos( MILLISECONDS.toNanos( 100 ) );
+    }
+
+    public Resource tryCheckPoint()
+    {
+        Lock writeLock = lock.writeLock();
+        return writeLock.tryLock() ? writeLock::unlock : null;
+    }
+
+    public Resource checkPoint()
+    {
+        Lock writeLock = lock.writeLock();
+        writeLock.lock();
+        return writeLock::unlock;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
@@ -35,7 +35,7 @@ import static org.neo4j.helpers.Exceptions.launderedException;
  * Mutex between {@link #storeCopy(ThrowingAction) store-copy} and {@link #checkPoint() check-point}.
  * This to prevent those two running concurrently.
  * <p>
- * Normally a check-point implies first doing a check-point and so this relationships is somewhat intricate.
+ * Normally a store-copy implies first doing a check-point and so this relationships is somewhat intricate.
  * In addition to having {@link #storeCopy(ThrowingAction)} as the "read lock" and {@link #checkPoint()} as the
  * "write lock", {@link #storeCopy(ThrowingAction)} also accepts a code snippet to run before first concurrent
  * store-copy grabs the lock, a snippet which can include a check-point.
@@ -77,7 +77,7 @@ public class StoreCopyCheckPointMutex
     private int storeCopyCount;
 
     /**
-     * Whether or not the first (of the concurrently ongoing store-copy requests has had its "before"
+     * Whether or not the first (of the concurrently ongoing store-copy requests) has had its "before"
      * action completed. The other store-copy requests will wait for this flag to be {@code true}.
      */
     private volatile boolean storeCopyActionCompleted;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
@@ -154,6 +154,12 @@ public class CheckPointSchedulerTest
             {
                 throw new RuntimeException( "this should have not been called" );
             }
+
+            @Override
+            public long lastCheckPointedTransactionId()
+            {
+                return 42;
+            }
         };
 
         final CheckPointScheduler scheduler = new CheckPointScheduler( checkPointer, jobScheduler, 20L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.checkpoint;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.graphdb.Resource;
+import org.neo4j.test.Race;
+import org.neo4j.test.rule.concurrent.OtherThreadRule;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.test.Race.throwing;
+
+public class StoreCopyCheckPointMutexTest
+{
+    private static final ThrowingAction<IOException> NO_OP = () -> {};
+
+    @Rule
+    public final OtherThreadRule<Void> t2 = new OtherThreadRule<>( "T2" );
+
+    private final StoreCopyCheckPointMutex mutex = new StoreCopyCheckPointMutex();
+
+    @Test
+    public void checkPointShouldBlockStoreCopy() throws Exception
+    {
+        // GIVEN
+        try ( Resource lock = mutex.checkPoint() )
+        {
+            // WHEN
+            t2.execute( state -> mutex.storeCopy( NO_OP ) );
+
+            // THEN
+            t2.get().waitUntilWaiting( details -> details.isAt( StoreCopyCheckPointMutex.class, "storeCopy" ) );
+        }
+    }
+
+    @Test
+    public void checkPointShouldBlockAnotherCheckPoint() throws Exception
+    {
+        // GIVEN
+        try ( Resource lock = mutex.checkPoint() )
+        {
+            // WHEN
+            t2.execute( state -> mutex.checkPoint() );
+
+            // THEN
+            t2.get().waitUntilWaiting( details -> details.isAt( StoreCopyCheckPointMutex.class, "checkPoint" ) );
+        }
+    }
+
+    @Test
+    public void storeCopyShouldBlockCheckPoint() throws Exception
+    {
+        // GIVEN
+        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        {
+            // WHEN
+            t2.execute( state -> mutex.checkPoint() );
+
+            // THEN
+            t2.get().waitUntilWaiting( details -> details.isAt( StoreCopyCheckPointMutex.class, "checkPoint" ) );
+        }
+    }
+
+    @Test
+    public void storeCopyShouldHaveTryCheckPointBackOff() throws Exception
+    {
+        // GIVEN
+        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        {
+            // WHEN
+            assertNull( mutex.tryCheckPoint() );
+        }
+    }
+
+    @Test
+    public void storeCopyShouldAllowAnotherStoreCopy() throws Exception
+    {
+        // GIVEN
+        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        {
+            // WHEN
+            try ( Resource otherLock = mutex.storeCopy( NO_OP ) )
+            {
+                // THEN good
+            }
+        }
+    }
+
+    @Test
+    public void storeCopyShouldAllowAnotherStoreCopyButOnlyFirstShouldPerformBeforeAction() throws Exception
+    {
+        // GIVEN
+        @SuppressWarnings( "unchecked" )
+        ThrowingAction<IOException> action = mock( ThrowingAction.class );
+        try ( Resource lock = mutex.storeCopy( action ) )
+        {
+            verify( action, times( 1 ) ).apply();
+
+            // WHEN
+            try ( Resource otherLock = mutex.storeCopy( action ) )
+            {
+                // THEN good
+                verify( action, times( 1 ) ).apply();
+            }
+        }
+    }
+
+    @Test
+    public void shouldHandleMultipleConcurrentStoreCopyWhenBeforeActionPerformsCheckPoint() throws Throwable
+    {
+        // GIVEN a check-point action which asserts calls to it along the way
+        CheckPointingAction checkPointingAction = new CheckPointingAction( mutex );
+        for ( int i = 0; i < 2; i++ )
+        {
+            // Start first store-copy and assert that the check-point action is triggered
+            Resource firstLock = mutex.storeCopy( checkPointingAction );
+            assertNotNull( checkPointingAction.lock );
+
+            // A second store-copy starts while the first is still going
+            Resource secondLock = mutex.storeCopy( checkPointingAction );
+
+            // The first store-copy completes
+            firstLock.close();
+
+            // A third store-copy starts and completes
+            Resource thirdLock = mutex.storeCopy( checkPointingAction );
+            thirdLock.close();
+
+            // Second store-copy completes
+            secondLock.close();
+            checkPointingAction.unlock();
+
+            // Go another round, now that the check-point action has been reset.
+            // Next round will assert that the mutex got the counting of store-copy jobs right
+        }
+    }
+
+    @Test
+    public void shouldHandleMultipleConcurrentStoreCopyRequests() throws Throwable
+    {
+        // GIVEN
+        Race race = new Race();
+        CountingAction action = new CountingAction();
+        int threads = Runtime.getRuntime().availableProcessors() * 10;
+        race.addContestants( threads, throwing( () ->
+        {
+            parkARandomWhile();
+            try ( Resource lock = mutex.storeCopy( action ) )
+            {
+                parkARandomWhile();
+            }
+        } ) );
+        race.go();
+
+        // THEN
+        // It's hard to make predictions about what should have been seen. Most importantly is that
+        // The lock doesn't hang any requests and that number of calls to the action less than number of threads
+        assertThat( action.count(), lessThan( threads ) );
+    }
+
+    private static void parkARandomWhile()
+    {
+        LockSupport.parkNanos( MILLISECONDS.toNanos( ThreadLocalRandom.current().nextInt( 10 ) ) );
+    }
+
+    private static class CheckPointingAction implements ThrowingAction<IOException>
+    {
+        private final StoreCopyCheckPointMutex mutex;
+        private Resource lock;
+
+        CheckPointingAction( StoreCopyCheckPointMutex mutex )
+        {
+            this.mutex = mutex;
+        }
+
+        @Override
+        public void apply() throws IOException
+        {
+            assertNull( lock );
+            lock = mutex.checkPoint();
+        }
+
+        void unlock()
+        {
+            assertNotNull( lock );
+            lock.close();
+            lock = null;
+        }
+    }
+
+    private static class CountingAction implements ThrowingAction<IOException>
+    {
+        private final AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public void apply() throws IOException
+        {
+            parkARandomWhile();
+            count.incrementAndGet();
+        }
+
+        int count()
+        {
+            return count.get();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -62,6 +62,7 @@ import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -139,7 +140,8 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
                 IOLimiter.unlimited(),
-                mock( AvailabilityGuard.class ), Clocks.nanoClock(), new CanWrite() );
+                mock( AvailabilityGuard.class ), Clocks.nanoClock(),
+                new CanWrite(), new StoreCopyCheckPointMutex() );
 
         return dataSource;
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupExtensionFactory.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -65,6 +66,8 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
         FileSystemAbstraction fileSystemAbstraction();
 
         PageCache pageCache();
+
+        StoreCopyCheckPointMutex storeCopyCheckPointMutex();
     }
 
     public OnlineBackupExtensionFactory()
@@ -89,6 +92,7 @@ public class OnlineBackupExtensionFactory extends KernelExtensionFactory<OnlineB
                 dependencies.logicalTransactionStoreSupplier(),
                 dependencies.logFileInformationSupplier(),
                 dependencies.fileSystemAbstraction(),
-                dependencies.pageCache() );
+                dependencies.pageCache(),
+                dependencies.storeCopyCheckPointMutex() );
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -81,13 +82,14 @@ public class OnlineBackupKernelExtension implements Lifecycle
                                         final Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier,
                                         final Supplier<LogFileInformation> logFileInformationSupplier,
                                         final FileSystemAbstraction fileSystemAbstraction,
-                                        final PageCache pageCache )
+                                        final PageCache pageCache,
+                                        final StoreCopyCheckPointMutex storeCopyCheckPointMutex )
     {
         this( config, graphDatabaseAPI, () -> {
             TransactionIdStore transactionIdStore = transactionIdStoreSupplier.get();
             StoreCopyServer copier = new StoreCopyServer( neoStoreDataSource, checkPointerSupplier.get(),
                     fileSystemAbstraction, new File( graphDatabaseAPI.getStoreDir() ),
-                    monitors.newMonitor( StoreCopyServer.Monitor.class ), pageCache );
+                    monitors.newMonitor( StoreCopyServer.Monitor.class ), pageCache, storeCopyCheckPointMutex );
             LogicalTransactionStore logicalTransactionStore = logicalTransactionStoreSupplier.get();
             LogFileInformation logFileInformation = logFileInformationSupplier.get();
             return new BackupImpl( copier, monitors, logicalTransactionStore, transactionIdStore, logFileInformation,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/GetStoreRequestHandler.java
@@ -29,6 +29,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import org.neo4j.causalclustering.catchup.CatchupServerProtocol;
 import org.neo4j.causalclustering.catchup.ResponseMessageType;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFinishedResponse.Status;
+import org.neo4j.graphdb.Resource;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -36,6 +37,7 @@ import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.storageengine.api.StoreFileMetadata;
@@ -50,18 +52,20 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
     private final Supplier<NeoStoreDataSource> dataSource;
     private final Supplier<CheckPointer> checkPointerSupplier;
     private final FileSystemAbstraction fs;
-    private PageCache pageCache;
+    private final PageCache pageCache;
     private final Log log;
+    private final StoreCopyCheckPointMutex mutex;
 
     public GetStoreRequestHandler( CatchupServerProtocol protocol, Supplier<NeoStoreDataSource> dataSource,
             Supplier<CheckPointer> checkPointerSupplier, FileSystemAbstraction fs, PageCache pageCache,
-            LogProvider logProvider )
+            LogProvider logProvider, StoreCopyCheckPointMutex mutex )
     {
         this.protocol = protocol;
         this.dataSource = dataSource;
         this.checkPointerSupplier = checkPointerSupplier;
         this.fs = fs;
         this.pageCache = pageCache;
+        this.mutex = mutex;
         this.log = logProvider.getLog( getClass() );
     }
 
@@ -74,9 +78,13 @@ public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStore
         }
         else
         {
-            long lastCheckPointedTx = checkPointerSupplier.get().tryCheckPoint( new SimpleTriggerInfo( "Store copy" ) );
-            try ( ResourceIterator<StoreFileMetadata> files = dataSource.get().listStoreFiles( false ) )
+            CheckPointer checkPointer = checkPointerSupplier.get();
+            long lastCheckPointedTx;
+            try ( Resource lock = mutex.storeCopy(
+                    () -> checkPointer.tryCheckPoint( new SimpleTriggerInfo( "Store copy" ) ) );
+                    ResourceIterator<StoreFileMetadata> files = dataSource.get().listStoreFiles( false ) )
             {
+                lastCheckPointedTx = checkPointer.lastCheckPointedTransactionId();
                 while ( files.hasNext() )
                 {
                     StoreFileMetadata fileMetadata = files.next();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -196,7 +196,8 @@ public class CoreServerModule
                 platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                 platformModule.dependencies.provideDependency( LogicalTransactionStore.class ),
                 localDatabase::dataSource, localDatabase::isAvailable, coreState, config, platformModule.monitors,
-                new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache );
+                new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
+                platformModule.storeCopyCheckPointMutex );
 
         servicesToStopOnStoreCopy.add( catchupServer );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.HttpConnector;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.AssertableLogProvider;
@@ -86,7 +87,8 @@ public class ConnectionInfoIT
         CatchupServer catchupServer =
                 new CatchupServer( logProvider, userLogProvider, mockSupplier(), mockSupplier(), mockSupplier(),
                         mockSupplier(), mock( BooleanSupplier.class ), coreState, config, new Monitors(),
-                        mockSupplier(), mock( FileSystemAbstraction.class ), mock( PageCache.class ) );
+                        mockSupplier(), mock( FileSystemAbstraction.class ), mock( PageCache.class ),
+                        new StoreCopyCheckPointMutex() );
 
         //then
         try

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -386,7 +387,8 @@ public class StoreCopyClientTest
                     original.getDependencyResolver().resolveDependency( PageCache.class );
 
             RequestContext requestContext = new StoreCopyServer( neoStoreDataSource, checkPointer, fs,
-                    originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ), pageCache )
+                    originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ), pageCache,
+                    new StoreCopyCheckPointMutex() )
                     .flushStoresAndStreamStoreFiles( "test", writer, false );
 
             final StoreId storeId =

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -419,7 +419,8 @@ public class HighlyAvailableEditionModule
                         platformModule.dependencies.resolveDependency( TransactionIdStore.class ),
                         platformModule.dependencies.resolveDependency( LogicalTransactionStore.class ),
                         platformModule.dependencies.resolveDependency( NeoStoreDataSource.class ),
-                        platformModule.dependencies.resolveDependency( PageCache.class ) );
+                        platformModule.dependencies.resolveDependency( PageCache.class ),
+                        platformModule.storeCopyCheckPointMutex );
 
         final Factory<ConversationSPI> conversationSPIFactory =
                 () -> new DefaultConversationSPI( lockManager, platformModule.jobScheduler );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -62,7 +63,7 @@ public class DefaultMasterImplSPITest
                 mock( PropertyKeyTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ),
                 mock( IdGeneratorFactory.class ), mock( TransactionCommitProcess.class ), checkPointer,
                 mock( TransactionIdStore.class ), mock( LogicalTransactionStore.class ),
-                dataSource, mock( PageCache.class ) );
+                dataSource, mock( PageCache.class ), new StoreCopyCheckPointMutex() );
 
         master.flushStoresAndStreamStoreFiles( mock( StoreWriter.class ) );
 


### PR DESCRIPTION
This to greatly simplify, even at all make possible to copy a GB+Tree with
concurrent changes.

Even currently, without the GB+Tree concurrent check-point during store-copy
may impose problems where a long store-copy might have concurrent check-points
that pruned the logs beyond where it started. The store-copy, after
taking all that time, would in the end fail due to server not being able to
serve the transactions which happened during the copy.

The trade-off to pause check-points while store-copy is running isn't all that big
because generally store-copy implies first making a checkpoint and check-pointing
can be made later instead w/o affecting behaviour of the system all that much.

Javadocs in StoreCopyCheckPointMutex further outlines how the mutex works and how
concurrent store-copy requests can run concurrently even though each store-copy request
performs a check-point first.

cl: [ha,causal clustering] Check-points can no longer run while store-copy is running, and vice versa. This to prevent a class of failures e.g. check-point pruning logs beyond starting point of store-copy and to better support native label indexing.