### PR TITLE
Support ORDER BY in compiled runtime

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
@@ -163,54 +163,6 @@ public class CodeBlock implements AutoCloseable
         return block;
     }
 
-    public CodeBlock forEachLong( Parameter local, Expression iterable )
-    {
-        String iteratorName = local.name() + "Iter";
-
-        assign( PrimitiveIterator.OfLong.class, iteratorName, Expression.invoke( iterable,
-                MethodReference.methodReference( LongStream.class, PrimitiveIterator.OfLong.class, "iterator" ) ) );
-        CodeBlock block = whileLoop( Expression
-                .invoke( load( iteratorName ), methodReference( PrimitiveIterator.OfLong.class, boolean.class, "hasNext" ) ) );
-        block.assign( local.type(), local.name(),
-                Expression.invoke( block.load( iteratorName ),
-                        methodReference( PrimitiveIterator.OfLong.class, long.class, "nextLong" ) ) );
-
-        return block;
-    }
-
-    public CodeBlock forEachDouble( Parameter local, Expression iterable )
-    {
-        String iteratorName = local.name() + "Iter";
-
-        assign( PrimitiveIterator.OfDouble.class, iteratorName, Expression.invoke( iterable,
-                MethodReference.methodReference( DoubleStream.class, PrimitiveIterator.OfDouble.class, "iterator" ) ) );
-        CodeBlock block = whileLoop( Expression
-                .invoke( load( iteratorName ), methodReference( PrimitiveIterator.OfDouble.class, boolean.class, "hasNext" ) ) );
-        block.assign( local.type(), local.name(),
-                Expression.invoke( block.load( iteratorName ),
-                        methodReference( PrimitiveIterator.OfDouble.class, double.class, "nextDouble" ) ) );
-
-        return block;
-    }
-
-    public CodeBlock forEachBoolean( Parameter local, Expression iterable )
-    {
-        String iteratorName = local.name() + "Iter";
-
-        // IntStream is used for iterable expressions of primitive booleans
-        assign( PrimitiveIterator.OfInt.class, iteratorName, Expression.invoke( iterable,
-                MethodReference.methodReference( IntStream.class, PrimitiveIterator.OfInt.class, "iterator" ) ) );
-        CodeBlock block = whileLoop( Expression
-                .invoke( load( iteratorName ), methodReference( PrimitiveIterator.OfInt.class, boolean.class, "hasNext" ) ) );
-        block.assign( local.type(), local.name(),
-                Expression.not( Expression.equal(
-                        Expression.constant( 0 ),
-                        Expression.invoke( block.load( iteratorName ),
-                                methodReference( PrimitiveIterator.OfInt.class, int.class, "nextInt" ) ) ) ) );
-
-        return block;
-    }
-
     public CodeBlock whileLoop( Expression...tests )
     {
         emitter.beginWhile( tests );

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
@@ -189,6 +189,12 @@ public class CodeBlock implements AutoCloseable
         return new CodeBlock( this );
     }
 
+    public CodeBlock block()
+    {
+        emitter.beginBlock();
+        return new CodeBlock( this );
+    }
+
     public void tryCatch( Consumer<CodeBlock> body, Consumer<CodeBlock> onError, Parameter exception )
     {
         emitter.tryCatchBlock( body, onError, localVariables.createNew( exception.type(), exception.name() ),

--- a/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/CodeBlock.java
@@ -20,7 +20,9 @@
 package org.neo4j.codegen;
 
 import java.util.Iterator;
+import java.util.PrimitiveIterator;
 import java.util.function.Consumer;
+import java.util.stream.LongStream;
 
 import static org.neo4j.codegen.LocalVariables.copy;
 import static org.neo4j.codegen.MethodReference.methodReference;
@@ -155,6 +157,21 @@ public class CodeBlock implements AutoCloseable
         block.assign( local.type(), local.name(),
                 Expression.cast( local.type(), Expression.invoke( block.load( iteratorName ),
                         methodReference( Iterator.class, Object.class, "next" ) ) ) );
+
+        return block;
+    }
+
+    public CodeBlock forEachLong( Parameter local, Expression iterable )
+    {
+        String iteratorName = local.name() + "Iter";
+
+        assign( PrimitiveIterator.OfLong.class, iteratorName, Expression.invoke( iterable,
+                MethodReference.methodReference( LongStream.class, PrimitiveIterator.OfLong.class, "iterator" ) ) );
+        CodeBlock block = whileLoop( Expression
+                .invoke( load( iteratorName ), methodReference( PrimitiveIterator.OfLong.class, boolean.class, "hasNext" ) ) );
+        block.assign( local.type(), local.name(),
+                Expression.invoke( block.load( iteratorName ),
+                        methodReference( PrimitiveIterator.OfLong.class, long.class, "nextLong" ) ) );
 
         return block;
     }

--- a/community/codegen/src/main/java/org/neo4j/codegen/InvalidState.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/InvalidState.java
@@ -119,6 +119,12 @@ class InvalidState implements MethodEmitter
     }
 
     @Override
+    public void beginBlock()
+    {
+        throw new IllegalStateException( reason );
+    }
+
+    @Override
     public void endBlock()
     {
         throw new IllegalStateException( reason );

--- a/community/codegen/src/main/java/org/neo4j/codegen/MethodEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/MethodEmitter.java
@@ -59,6 +59,8 @@ public interface MethodEmitter
 
     void beginIfNonNull( Expression...tests );
 
+    void beginBlock();
+
     void endBlock();
 
     <T> void tryCatchBlock( Consumer<T> body, Consumer<T> handler, LocalVariable exception, T block);

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
@@ -210,6 +210,12 @@ class MethodByteCodeEmitter implements MethodEmitter
     }
 
     @Override
+    public void beginBlock()
+    {
+        stateStack.push( () -> {} );
+    }
+
+    @Override
     public void endBlock()
     {
         if ( stateStack.isEmpty() )

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodSourceWriter.java
@@ -198,6 +198,13 @@ class MethodSourceWriter implements MethodEmitter, ExpressionVisitor
     }
 
     @Override
+    public void beginBlock()
+    {
+        indent().append( "{\n" );
+        level.push( LEVEL );
+    }
+
+    @Override
     public <T> void tryCatchBlock( Consumer<T> body, Consumer<T> handler, LocalVariable exception, T block)
     {
 

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -51,3 +51,7 @@ Explanation of   in-query procedure call
 Pattern expression inside list comprehension
 Get node degree via length of pattern expression
 Get node degree via length of pattern expression that specifies a relationship type
+
+//OrderByAcceptance.feature - Unsupported orderability
+ORDER BY nodes should return null results last in ascending order
+ORDER BY relationships should return null results last in ascending order

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -1,2 +1,5 @@
+//OrderByAcceptance.feature - Unsupported orderability
+ORDER BY nodes should return null results last in ascending order
+ORDER BY relationships should return null results last in ascending order
 
 

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -131,3 +131,5 @@ Find a shortest path of length 1 if requested to
 Find a shortest path among paths matched using a non-variable length pattern
 Find a combination of a shortest path and a pattern expression
 Filter with AND/OR
+// unsupported orderability
+ORDER BY nodes should return null results last in ascending order

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -131,5 +131,6 @@ Find a shortest path of length 1 if requested to
 Find a shortest path among paths matched using a non-variable length pattern
 Find a combination of a shortest path and a pattern expression
 Filter with AND/OR
-// unsupported orderability
+//OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order
+ORDER BY relationships should return null results last in ascending order

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost.txt
@@ -1,2 +1,3 @@
-// unsupported orderability
+//OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order
+ORDER BY relationships should return null results last in ascending order

--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost.txt
@@ -1,2 +1,2 @@
-
-
+// unsupported orderability
+ORDER BY nodes should return null results last in ascending order

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -1,0 +1,40 @@
+#
+# Copyright 2016 "Neo Technology",
+# Network Engine for Objects in Lund AB (http://neotechnology.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Feature: OrderByAcceptance
+
+  Background:
+    Given any graph
+
+  Scenario: ORDER BY nodes should return null results last in ascending order
+    And having executed:
+      """
+      CREATE (:A)-[:REL]->(:B),
+             (:A)
+      """
+    When executing query:
+      """
+      MATCH (a:A)
+      OPTIONAL MATCH (a)-[:REL]->(b:B)
+      RETURN b
+      ORDER BY b
+      """
+    Then the result should be, in order:
+      | b    |
+      | (:B) |
+      | null |
+    And no side effects

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -20,10 +20,8 @@
 
 Feature: OrderByAcceptance
 
-  Background:
-    Given any graph
-
   Scenario: ORDER BY nodes should return null results last in ascending order
+    Given an empty graph
     And having executed:
       """
       CREATE (:A)-[:REL]->(:B),
@@ -43,6 +41,7 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY relationships should return null results last in ascending order
+    Given an empty graph
     And having executed:
       """
       CREATE (:A)-[:REL]->(:B),
@@ -63,9 +62,10 @@ Feature: OrderByAcceptance
 
   # The ORDER BY should work even if the "WITH x" will not become a `Projection` in the logical plan
   Scenario: ORDER BY with unwind primitive integer
+    Given any graph
     When executing query:
       """
-      WITH [4, 3, 1, 2] as lst
+      WITH [4, 3, 1, 2] AS lst
       UNWIND lst AS x
       WITH x
       ORDER BY x
@@ -81,6 +81,7 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY two node properties
+    Given an empty graph
     And having executed:
       """
       CREATE (:L {a: 3, b: "a"}),
@@ -92,7 +93,7 @@ Feature: OrderByAcceptance
     When executing query:
       """
       MATCH (n:L)
-      WITH n.a as a, n.b as b
+      WITH n.a AS a, n.b AS b
       ORDER BY a, b DESC
       RETURN a, b
       """

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -1,18 +1,21 @@
 #
-# Copyright 2016 "Neo Technology",
-# Network Engine for Objects in Lund AB (http://neotechnology.com)
+# Copyright (c) 2002-2017 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# This file is part of Neo4j.
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 Feature: OrderByAcceptance

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -41,3 +41,22 @@ Feature: OrderByAcceptance
       | (:B) |
       | null |
     And no side effects
+
+  Scenario: ORDER BY relationships should return null results last in ascending order
+    And having executed:
+      """
+      CREATE (:A)-[:REL]->(:B),
+             (:A)
+      """
+    When executing query:
+      """
+      MATCH (a:A)
+      OPTIONAL MATCH (a)-[r:REL]->()
+      RETURN r
+      ORDER BY r
+      """
+    Then the result should be, in order:
+      | r      |
+      | [:REL] |
+      | null   |
+    And no side effects

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -53,12 +53,14 @@ Feature: UnwindAcceptance
       """
       MATCH (n:A {prop: 'a'})-[r:R {prop: 'r'}]->()
       WITH *
-      UNWIND [[42],[n],[r],[n,42],[r,42]] as i
+      UNWIND [[42],[0.7],[true],[n],[r],[n,42],[r,42]] as i
       RETURN i
       """
     Then the result should be:
       | i                      |
       | [42]                   |
+      | [0.7]                  |
+      | [true]                 |
       | [(:A {prop: 'a'})]     |
       | [[:R {prop: 'r'}]]     |
       | [(:A {prop: 'a'}), 42] |
@@ -144,3 +146,46 @@ Feature: UnwindAcceptance
       | {k: [[:R]], l: 's'}     |
       | [{k: [(:A), [:R]]}]      |
     And no side effects
+
+  Scenario: Primitive node type support in list literal
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A)
+      CREATE (:B)
+      CREATE (:C)
+      """
+    When executing query:
+      """
+      MATCH (a:A), (b:B), (c:C)
+      WITH *
+      UNWIND [a, b, c] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i    |
+      | (:A) |
+      | (:B) |
+      | (:C) |
+    And no side effects
+
+  Scenario: Primitive relationship type support in list literal
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R]->()
+      CREATE ()-[:S]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->(), ()-[s:S]->()
+      WITH *
+      UNWIND [r, s] as i
+      RETURN i
+      """
+    Then the result should be:
+      | i    |
+      | [:R] |
+      | [:S] |
+    And no side effects
+

--- a/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -32,6 +32,7 @@ Feature: UnwindAcceptance
       WITH *
       UNWIND [42, 0.7, true, 's', n, r] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i                 |
@@ -55,6 +56,7 @@ Feature: UnwindAcceptance
       WITH *
       UNWIND [[42],[0.7],[true],[n],[r],[n,42],[r,42]] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i                      |
@@ -83,6 +85,7 @@ Feature: UnwindAcceptance
                {k: r, l: 's'}
              ] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i                 |
@@ -109,6 +112,7 @@ Feature: UnwindAcceptance
                [ {k: [n, r]} ]
              ] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i                        |
@@ -137,6 +141,7 @@ Feature: UnwindAcceptance
              ] as i
       WITH i as j
       RETURN j
+      ORDER BY "no order"
       """
     Then the result should be:
       | j                        |
@@ -161,6 +166,7 @@ Feature: UnwindAcceptance
       WITH *
       UNWIND [a, b, c] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i    |
@@ -182,6 +188,7 @@ Feature: UnwindAcceptance
       WITH *
       UNWIND [r, s] as i
       RETURN i
+      ORDER BY "no order"
       """
     Then the result should be:
       | i    |

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -163,7 +163,6 @@ Matching relationships into a list and matching variable length using the list, 
 Matching and optionally matching with bound nodes in reverse direction
 Matching and optionally matching with unbound nodes and equality predicate in reverse direction
 Fail when using property access on primitive type
-Matching and returning ordered results, with LIMIT
 Counting an empty graph
 Matching variable length pattern with property predicate
 Variable length pattern checking labels on endnodes
@@ -212,15 +211,6 @@ Handling optional matches between optionally matched entities
 Handling optional matches between nulls
 OPTIONAL MATCH and `collect()`
 ORDER BY of a column introduced in RETURN should return salient results in ascending order
-ORDER BY should order booleans in the expected order
-ORDER BY DESC should order booleans in the expected order
-ORDER BY should order strings in the expected order
-ORDER BY DESC should order strings in the expected order
-ORDER BY should order ints in the expected order
-ORDER BY DESC should order ints in the expected order
-ORDER BY should order floats in the expected order
-ORDER BY DESC should order floats in the expected order
-ORDER BY with a negative LIMIT should fail with a syntax exception
 Pattern comprehension and ORDER BY
 Returning a pattern comprehension
 Returning a pattern comprehension with label predicate
@@ -245,13 +235,7 @@ Remove a single relationship property
 Remove a single relationship property
 Remove multiple relationship properties
 Remove a missing property should be a valid operation
-Start the result from the second row
-Start the result from the second row by param
-Get rows in the middle
-Get rows in the middle by param
 Sort on aggregated function
-Support sort and distinct
-Support ordering by a property after being distinct-ified
 Count star should count everything in scope
 Absolute function
 Return collection size
@@ -271,11 +255,7 @@ Matching and disregarding output, then matching again
 Returning an expression
 Concatenating and returning the size of literal lists
 Concatenating and returning the size of literal lists
-Limiting amount of rows when there are fewer left than the LIMIT argument
 `substring()` with default second argument
-Returning all variables with ordering
-Using aliased DISTINCT expression in ORDER BY
-Returned columns do not change from using ORDER BY
 Arithmetic expressions should propagate null values
 Indexing into nested literal lists
 Multiple aliasing and backreferencing
@@ -406,14 +386,12 @@ Handling mixed relationship patterns 2
 Handling relationships that are already bound in variable length paths
 NOT and false
 Fail when trying to compare strings and numbers
-ORDER BY and LIMIT can be used
 Aliasing
 Handle dependencies across WITH
 Handle dependencies across WITH with SKIP
 WHERE after WITH should filter results
 WHERE after WITH can filter on top of an aggregation
 ORDER BY on an aggregating key
-ORDER BY a DISTINCT column
 WHERE on a DISTINCT column
 A simple pattern with one bound endpoint
 Null handling
@@ -432,8 +410,6 @@ Fail when adding new label predicate on a node that is already bound 4
 Fail when adding new label predicate on a node that is already bound 5
 Failing on incorrect unicode literal
 Failing on aggregation in WHERE
-Failing on aggregation in ORDER BY after RETURN
-Failing on aggregation in ORDER BY after WITH
 Failing when not aliasing expressions in WITH
 Failing when using undefined variable in pattern
 Failing when using undefined variable in SET

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -211,11 +211,7 @@ Longer pattern with bound nodes without matches
 Handling optional matches between optionally matched entities
 Handling optional matches between nulls
 OPTIONAL MATCH and `collect()`
-ORDER BY should return results in ascending order
-ORDER BY DESC should return results in descending order
 ORDER BY of a column introduced in RETURN should return salient results in ascending order
-Renaming columns before ORDER BY should return results in ascending order
-Handle projections with ORDER BY - GH#4937
 ORDER BY should order booleans in the expected order
 ORDER BY DESC should order booleans in the expected order
 ORDER BY should order strings in the expected order
@@ -224,9 +220,6 @@ ORDER BY should order ints in the expected order
 ORDER BY DESC should order ints in the expected order
 ORDER BY should order floats in the expected order
 ORDER BY DESC should order floats in the expected order
-Handle ORDER BY with LIMIT 1
-ORDER BY with LIMIT 0 should not generate errors
-ORDER BY with negative parameter for LIMIT should not generate errors
 ORDER BY with a negative LIMIT should fail with a syntax exception
 Pattern comprehension and ORDER BY
 Returning a pattern comprehension

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
@@ -80,3 +80,7 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
     operatorIds.getOrElseUpdate(idMap(plan), namer.newOpName(plan.getClass.getSimpleName))
   }
 }
+
+object CodeGenContext {
+  def sanitizedName(name: String) = name.replace(" ", "_")
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
@@ -51,10 +51,14 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
 
   def variableQueryVariables(): Set[String] = variables.keySet.toSet
 
+  // We need to keep track of variables that are exposed by a QueryHorizon,
+  // e.g. Projection, Unwind, ProcedureCall, LoadCsv
+  // These variables are the only ones that needs to be considered for materialization by an eager operation, e.g. Sort
   def addProjectedVariable(queryVariable: String, variable: Variable) {
     projectedVariables.put(queryVariable, variable)
   }
 
+  // We need to clear projected variables that are no longer exposed by a QueryHorizon, e.g a regular Projection
   def clearProjectedVariables(): Unit = {
     projectedVariables.clear()
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
@@ -38,7 +38,7 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
   val operatorIds: mutable.Map[Id, String] = mutable.Map()
 
   def addVariable(queryVariable: String, variable: Variable) {
-    assert(!variables.isDefinedAt(queryVariable))
+    //assert(!variables.isDefinedAt(queryVariable)) // TODO: Make the cases where overwriting the value is ok explicit (by using updateVariable)
     variables.put(queryVariable, variable)
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGenContext.scala
@@ -32,17 +32,34 @@ case class Variable(name: String, codeGenType: CodeGenType, nullable: Boolean = 
 class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, Id], val namer: Namer = Namer()) {
 
   private val variables: mutable.Map[String, Variable] = mutable.Map()
+  private val projectedVariables: mutable.Map[String, Variable] = mutable.Map.empty
   private val probeTables: mutable.Map[CodeGenPlan, JoinData] = mutable.Map()
   private val parents: mutable.Stack[CodeGenPlan] = mutable.Stack()
   val operatorIds: mutable.Map[Id, String] = mutable.Map()
 
   def addVariable(queryVariable: String, variable: Variable) {
+    assert(!variables.isDefinedAt(queryVariable))
+    variables.put(queryVariable, variable)
+  }
+
+  def updateVariable(queryVariable: String, variable: Variable) {
+    assert(variables.isDefinedAt(queryVariable))
     variables.put(queryVariable, variable)
   }
 
   def getVariable(queryVariable: String): Variable = variables(queryVariable)
 
   def variableQueryVariables(): Set[String] = variables.keySet.toSet
+
+  def addProjectedVariable(queryVariable: String, variable: Variable) {
+    projectedVariables.put(queryVariable, variable)
+  }
+
+  def clearProjectedVariables(): Unit = {
+    projectedVariables.clear()
+  }
+
+  def getProjectedVariables: Map[String, Variable] = projectedVariables.toMap
 
   def addProbeTable(plan: CodeGenPlan, codeThunk: JoinData) {
     probeTables.put(plan, codeThunk)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -308,12 +308,12 @@ object LogicalPlanConverter {
     private def expandAllConsume(context: CodeGenContext,
                                  child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val relVar = Variable(context.namer.newVarName(), CodeGenType.primitiveRel)
+      val fromNodeVar = context.getVariable(expand.from.name)
       val toNodeVar = Variable(context.namer.newVarName(), CodeGenType.primitiveNode)
       context.addVariable(expand.relName.name, relVar)
       context.addVariable(expand.to.name, toNodeVar)
 
       val (methodHandle, action :: tl) = context.popParent().consume(context, this)
-      val fromNodeVar = context.getVariable(expand.from.name)
       val typeVar2TypeName = expand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(expand)
       val expandGenerator = ExpandAllLoopDataGenerator(opName, fromNodeVar, expand.dir, typeVar2TypeName, toNodeVar,
@@ -326,10 +326,10 @@ object LogicalPlanConverter {
                                   child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val relVar = Variable(context.namer.newVarName(), CodeGenType.primitiveRel)
       context.addVariable(expand.relName.name, relVar)
-
-      val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val fromNodeVar = context.getVariable(expand.from.name)
       val toNodeVar = context.getVariable(expand.to.name)
+
+      val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val typeVar2TypeName = expand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(expand)
       val expandGenerator = ExpandIntoLoopDataGenerator(opName, fromNodeVar, expand.dir, typeVar2TypeName, toNodeVar,
@@ -358,12 +358,12 @@ object LogicalPlanConverter {
                                  child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       //mark relationship and node to visit as nullable
       val relVar = Variable(context.namer.newVarName(), CodeGenType.primitiveRel, nullable = true)
+      val fromNodeVar = context.getVariable(optionalExpand.from.name)
       val toNodeVar = Variable(context.namer.newVarName(), CodeGenType.primitiveNode, nullable = true)
       context.addVariable(optionalExpand.relName.name, relVar)
       context.addVariable(optionalExpand.to.name, toNodeVar)
 
       val (methodHandle, action :: tl) = context.popParent().consume(context, this)
-      val fromNodeVar = context.getVariable(optionalExpand.from.name)
       val typeVar2TypeName = optionalExpand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(optionalExpand)
 
@@ -396,10 +396,10 @@ object LogicalPlanConverter {
       //mark relationship  to visit as nullable
       val relVar = Variable(context.namer.newVarName(), CodeGenType.primitiveRel, nullable = true)
       context.addVariable(optionalExpand.relName.name, relVar)
-
-      val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val fromNodeVar = context.getVariable(optionalExpand.from.name)
       val toNodeVar = context.getVariable(optionalExpand.to.name)
+
+      val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val typeVar2TypeName = optionalExpand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(optionalExpand)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -583,7 +583,8 @@ object LogicalPlanConverter {
           throw new CantCompileQueryException(s"Unwind collection type $t not supported")
       }
 
-      val variable = Variable(unwind.variable.name, elementCodeGenType, nullable = elementCodeGenType.canBeNullable)
+      val variableName = context.namer.newVarName()
+      val variable = Variable(variableName, elementCodeGenType, nullable = elementCodeGenType.canBeNullable)
       context.addVariable(unwind.variable.name, variable)
 
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/LogicalPlanConverter.scala
@@ -589,6 +589,8 @@ object LogicalPlanConverter {
       val variableName = context.namer.newVarName()
       val variable = Variable(variableName, elementCodeGenType, nullable = elementCodeGenType.canBeNullable)
       context.addVariable(unwind.variable.name, variable)
+      // Unwind is a kind of projection that only adds one exposed variable, and keeps everything exposed that was already projected
+      context.addProjectedVariable(unwind.variable.name, variable)
 
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildProbeTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildProbeTable.scala
@@ -51,7 +51,7 @@ case class BuildRecordingProbeTable(id: String, name: String, nodes: Set[Variabl
     generator.trace(id, Some(this.getClass.getSimpleName)) { body =>
       val tuple = body.newTableValue(context.namer.newVarName(), tupleDescriptor)
       fieldToVarName.foreach {
-        case (fieldName, localName) => body.putField(tupleDescriptor, tuple, localName.incoming.codeGenType, fieldName, localName.incoming.name)
+        case (fieldName, localName) => body.putField(tupleDescriptor, tuple, fieldName, localName.incoming.name)
       }
       body.updateProbeTable(tupleDescriptor, name, tableType, keyVars = nodes.toIndexedSeq.map(_.name), tuple)
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen._
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.CodeGenType
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi._
+
+case class BuildSortTable(opName: String, tableName: String, tupleQueryVariables: Map[String, Variable])
+                         (implicit context: CodeGenContext)
+  extends Instruction
+{
+
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+    val initialCapacity = 128 // TODO: Use value from cardinality estimation if possible
+    generator.allocateSortTable(tableName, initialCapacity, valueStructure)
+  }
+
+  override def body[E](generator: MethodStructure[E])(implicit ignored: CodeGenContext): Unit = {
+    generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
+      val tuple = body.newTableValue(context.namer.newVarName(), valueStructure)
+      fieldToVariableInfo.foreach {
+        case (fieldName: String, info: FieldAndVariableInfo) =>
+          body.putField(valueStructure, tuple, info.incomingVariable.codeGenType, fieldName, info.incomingVariable.name)
+      }
+      body.sortTableAdd(tableName, valueStructure, tuple)
+    }
+  }
+
+  override protected def children = Seq.empty
+
+  override protected def operatorId = Set(opName)
+
+  private val fieldToVariableInfo: Map[String, FieldAndVariableInfo] = tupleQueryVariables.map {
+    case (queryVariableName: String, incoming: Variable) =>
+      (queryVariableName, // < Name the field after the query variable
+        FieldAndVariableInfo(
+          fieldName = queryVariableName,
+          queryVariableName = queryVariableName,
+          incomingVariable = incoming,
+          outgoingVariable = incoming.copy(name = context.namer.newVarName())))
+  }
+
+  private val outgoingVariableNameToVariableInfo: Map[String, FieldAndVariableInfo] =
+    fieldToVariableInfo.map {
+      case (fieldName, info) => info.outgoingVariable.name -> info
+    }
+
+  private val valueStructure: Map[String, CodeGenType] =
+    fieldToVariableInfo.mapValues(c => c.outgoingVariable.codeGenType)
+
+  val sortTableInfo: SortTableInfo = SortTableInfo(
+    tableName,
+    fieldToVariableInfo,
+    valueStructure,
+    outgoingVariableNameToVariableInfo)
+}
+
+case class SortTableInfo(tableName: String,
+                         fieldToVariableInfo: Map[String, FieldAndVariableInfo],
+                         valueStructure: Map[String, CodeGenType],
+                         outgoingVariableNameToVariableInfo: Map[String, FieldAndVariableInfo])
+
+case class FieldAndVariableInfo(fieldName: String,
+                                queryVariableName: String,
+                                incomingVariable: Variable,
+                                outgoingVariable: Variable)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
@@ -50,9 +50,10 @@ case class BuildSortTable(opName: String, tableName: String, columnVariables: Ma
 
   private val fieldToVariableInfo: Map[String, FieldAndVariableInfo] = columnVariables.map {
     case (queryVariableName: String, incoming: Variable) =>
-      (queryVariableName, // < Name the field after the query variable
+      val fieldName = CodeGenContext.sanitizedName(queryVariableName) // < Name the field after the query variable
+      (fieldName,
         FieldAndVariableInfo(
-          fieldName = queryVariableName,
+          fieldName = fieldName,
           queryVariableName = queryVariableName,
           incomingVariable = incoming,
           outgoingVariable = incoming.copy(name = context.namer.newVarName())))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/BuildSortTable.scala
@@ -35,11 +35,10 @@ case class BuildSortTable(opName: String, tableName: String, columnVariables: Ma
 
   override def body[E](generator: MethodStructure[E])(implicit ignored: CodeGenContext): Unit = {
     generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
-      val tuple = body.newSortTableValue(context.namer.newVarName(), tupleDescriptor)
+      val tuple = body.newTableValue(context.namer.newVarName(), tupleDescriptor)
       fieldToVariableInfo.foreach {
         case (fieldName: String, info: FieldAndVariableInfo) =>
-          body.sortTableValuePutField(tupleDescriptor,
-            tuple, info.incomingVariable.codeGenType, fieldName, info.incomingVariable.name)
+          body.putField(tupleDescriptor, tuple, fieldName, info.incomingVariable.name)
       }
       body.sortTableAdd(tableName, tupleDescriptor, tuple)
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -43,8 +43,10 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
   }
 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) =
+                             (implicit context: CodeGenContext) = {
+    generator.incrementDbHits()
     generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
+  }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextRelationship(iterVar)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -43,8 +43,10 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
   }
 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) =
+                             (implicit context: CodeGenContext) = {
+    generator.incrementDbHits()
     generator.nextRelationship(iterVar, dir, relVar.name)
+  }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextRelationship(iterVar)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetMatchesFromProbeTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetMatchesFromProbeTable.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable
 case class GetMatchesFromProbeTable(keys: Set[Variable], code: JoinData, action: Instruction) extends Instruction {
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
-    generator.trace(code.id) { traced =>
+    generator.trace(code.id, Some(this.getClass.getSimpleName)) { traced =>
       traced.probe(code.tableVar, code.tableType, keys.toIndexedSeq.map(_.name)) { body =>
         body.incrementRows()
         action.body(body)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
@@ -36,8 +36,7 @@ case class GetSortedResult(opName: String,
         case (_, FieldAndVariableInfo(fieldName, queryVariableName, incoming, outgoing))
           if variablesToKeep.isDefinedAt(queryVariableName) => (outgoing.name, fieldName)
       }
-      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.valueStructure, sortTableInfo.sortItems,
-        variablesToGetFromFields) { l2 =>
+      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.tupleDescriptor, variablesToGetFromFields) { l2 =>
         l2.incrementRows()
         action.body(l2)
       }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
@@ -36,7 +36,8 @@ case class GetSortedResult(opName: String,
         case (_, FieldAndVariableInfo(fieldName, queryVariableName, incoming, outgoing))
           if variablesToKeep.isDefinedAt(queryVariableName) => (outgoing.name, fieldName)
       }
-      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.valueStructure, variablesToGetFromFields) { l2 =>
+      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.valueStructure, sortTableInfo.sortItems,
+        variablesToGetFromFields) { l2 =>
         l2.incrementRows()
         action.body(l2)
       }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/GetSortedResult.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
+
+case class GetSortedResult(opName: String,
+                           variablesToKeep: Map[String, Variable],
+                           sortTableInfo: SortTableInfo,
+                           action: Instruction) extends Instruction {
+
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
+    action.init(generator)
+
+  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
+    generator.trace(opName, Some(this.getClass.getSimpleName)) { l1 =>
+      val variablesToGetFromFields = sortTableInfo.outgoingVariableNameToVariableInfo.collect {
+        case (_, FieldAndVariableInfo(fieldName, queryVariableName, incoming, outgoing))
+          if variablesToKeep.isDefinedAt(queryVariableName) => (outgoing.name, fieldName)
+      }
+      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.valueStructure, variablesToGetFromFields) { l2 =>
+        l2.incrementRows()
+        action.body(l2)
+      }
+    }
+
+  override def children = Seq(action)
+
+  override protected def operatorId = Set(opName)
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/IndexSeek.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/IndexSeek.scala
@@ -41,8 +41,10 @@ case class IndexSeek(opName: String, labelName: String, propName: String, descri
   }
 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) =
+                             (implicit context: CodeGenContext) = {
+    generator.incrementDbHits()
     generator.nextNode(nextVar.name, iterVar)
+  }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextNode(iterVar)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/Projection.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
 
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenType, CodeGenExpression}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.CodeGenExpression
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 
@@ -43,9 +43,8 @@ case class Projection(projectionOpName: String, variables: Map[Variable, CodeGen
             body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
           }
           else {
-            // Declare the variable with a non-specific Object type for non-primitive types to avoid casting
-            body.declare(variable.name, CodeGenType.Any)
-            body.assign(variable.name, CodeGenType.Any, expr.generateExpression(body))
+            body.declare(variable.name, variable.codeGenType)
+            body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
           }
       }
       action.body(body)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ScanAllNodes.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ScanAllNodes.scala
@@ -32,8 +32,10 @@ case class ScanAllNodes(opName: String) extends LoopDataGenerator {
   }
 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) =
+                             (implicit context: CodeGenContext) = {
+    generator.incrementDbHits()
     generator.nextNode(nextVar.name, iterVar)
+  }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextNode(iterVar)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ScanForLabel.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/ScanForLabel.scala
@@ -33,8 +33,10 @@ case class ScanForLabel(opName: String, labelName: String, labelVar: String) ext
   }
 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) =
+                             (implicit context: CodeGenContext) = {
+    generator.incrementDbHits()
     generator.nextNode(nextVar.name, iterVar)
+  }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextNode(iterVar)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
@@ -31,7 +31,7 @@ case class SortInstruction(opName: String,
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
-      body.sortTableSort(sortTableInfo.tableName, sortTableInfo.valueStructure, sortTableInfo.sortItems)
+      body.sortTableSort(sortTableInfo.tableName, sortTableInfo.tupleDescriptor)
     }
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.{Variable, CodeGenContext}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+
+case class SortInstruction(opName: String,
+                           sortVariables: Seq[SortVariableInfo],
+                           sortTableInfo: SortTableInfo)
+  extends Instruction {
+
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  }
+
+  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+    generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
+      // TODO: Invoke sorting algorithm
+      body
+    }
+  }
+
+  override protected def children: Seq[Instruction] = Seq.empty
+
+  override protected def operatorId = Set(opName)
+}
+
+sealed trait SortOrder
+case object Ascending extends SortOrder
+case object Descending extends SortOrder
+
+case class SortVariableInfo(queryVariableName: String, variable: Variable, sortOrder: SortOrder)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/SortInstruction.scala
@@ -19,11 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
 
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.{Variable, CodeGenContext}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 
 case class SortInstruction(opName: String,
-                           sortVariables: Seq[SortVariableInfo],
                            sortTableInfo: SortTableInfo)
   extends Instruction {
 
@@ -32,8 +31,7 @@ case class SortInstruction(opName: String,
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
-      // TODO: Invoke sorting algorithm
-      body
+      body.sortTableSort(sortTableInfo.tableName, sortTableInfo.valueStructure, sortTableInfo.sortItems)
     }
   }
 
@@ -41,9 +39,3 @@ case class SortInstruction(opName: String,
 
   override protected def operatorId = Set(opName)
 }
-
-sealed trait SortOrder
-case object Ascending extends SortOrder
-case object Descending extends SortOrder
-
-case class SortVariableInfo(queryVariableName: String, variable: Variable, sortOrder: SortOrder)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/UnwindCollection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/UnwindCollection.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{CodeGenExpression, CodeGenType}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+
+case class UnwindCollection(opName: String, collection: CodeGenExpression) extends LoopDataGenerator {
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit =
+    collection.init(generator)
+
+  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])
+                                 (implicit context: CodeGenContext): Unit = {
+    generator.declareIterator(iterVar)
+    val iterator = generator.iteratorFrom(collection.generateExpression(generator))
+    generator.assign(iterVar, CodeGenType.Any, iterator)
+  }
+
+  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                             (implicit context: CodeGenContext): Unit = {
+    val next = generator.iteratorNext(generator.loadVariable(iterVar))
+    generator.assign(nextVar.name, CodeGenType.Any, next)
+  }
+
+  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E =
+    generator.iteratorHasNext(generator.loadVariable(iterVar))
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/UnwindPrimitiveCollection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/UnwindPrimitiveCollection.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions._
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
+import org.neo4j.cypher.internal.frontend.v3_2.symbols
+
+case class UnwindPrimitiveCollection(opName: String, collection: CodeGenExpression) extends LoopDataGenerator {
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit =
+    collection.init(generator)
+
+  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])
+                                 (implicit context: CodeGenContext): Unit = {
+    generator.declarePrimitiveIterator(iterVar, collection.codeGenType)
+    val iterator = generator.primitiveIteratorFrom(collection.generateExpression(generator), collection.codeGenType)
+    generator.assign(iterVar, CodeGenType.Any, iterator)
+  }
+
+  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                             (implicit context: CodeGenContext): Unit = {
+    val elementType = collection.codeGenType match {
+      case CodeGenType(symbols.ListType(innerCt), ListReferenceType(innerRepr)) => CodeGenType(innerCt, innerRepr)
+      case _ => throw new IllegalArgumentException(s"CodeGenType $collection.codeGenType not supported as primitive iterator")
+    }
+    val next = generator.primitiveIteratorNext(generator.loadVariable(iterVar), collection.codeGenType)
+    generator.assign(nextVar.name, elementType, next)
+  }
+
+  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E =
+    generator.iteratorHasNext(generator.loadVariable(iterVar))
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/WhileLoop.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/WhileLoop.scala
@@ -29,7 +29,6 @@ case class WhileLoop(variable: Variable, producer: LoopDataGenerator, action: In
     generator.trace(producer.opName) { body =>
       producer.produceIterator(iterator, body)
       body.whileLoop(producer.hasNext(body, iterator)) { loopBody =>
-        loopBody.incrementDbHits()
         loopBody.incrementRows()
         producer.produceNext(variable, iterator, loopBody)
         action.body(loopBody)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/Distinct.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/Distinct.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.aggregation
 
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.Instruction
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.{HashableTupleDescriptor, MethodStructure}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 
 case class Distinct(opName: String, setName: String, vars: Iterable[Variable]) extends AggregateExpression {
@@ -44,7 +44,7 @@ case class Distinct(opName: String, setName: String, vars: Iterable[Variable]) e
     override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
       generator.trace(opName) { body =>
         val keyArg = vars.map(k => k.name -> k.codeGenType).toMap
-        body.distinctSetIterate(setName, keyArg) { inner =>
+        body.distinctSetIterate(setName, HashableTupleDescriptor(keyArg)) { inner =>
           inner.incrementRows()
           instruction.body(inner)
         }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/DynamicCount.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/aggregation/DynamicCount.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.aggregation
 
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.Instruction
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.{HashableTupleDescriptor, MethodStructure}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.{CodeGenContext, Variable}
 
 /*
@@ -76,7 +76,7 @@ class DynamicCount(opName: String, variable: Variable, expression: CodeGenExpres
     override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
       generator.trace(opName) { body =>
         val keyArg = groupingKey.map(k => k.name -> k.codeGenType).toMap
-        body.aggregationMapIterate(mapName, keyArg, variable.name) { inner =>
+        body.aggregationMapIterate(mapName, HashableTupleDescriptor(keyArg), variable.name) { inner =>
           inner.incrementRows()
           instruction.body(inner)
         }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/CodeGenType.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/CodeGenType.scala
@@ -23,7 +23,9 @@ import org.neo4j.cypher.internal.frontend.v3_2.symbols
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.CypherType
 
 case class CodeGenType(ct: CypherType, repr: RepresentationType) {
-  def isPrimitive = repr != ReferenceType
+  def isPrimitive = RepresentationType.isPrimitive(repr)
+
+  def canBeNullable = !isPrimitive || (ct == symbols.CTNode) || (ct == symbols.CTRelationship)
 }
 
 object CodeGenType {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.functions.functionConv
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_2.ast
+import org.neo4j.cypher.internal.frontend.v3_2.ast.PropertyKeyName
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 object ExpressionConverter {
@@ -109,6 +110,9 @@ object ExpressionConverter {
       case ast.Property(rel@ast.Variable(name), propKey) if context.semanticTable.isRelationship(rel) =>
         val token = propKey.id(context.semanticTable).map(_.id)
         RelProperty(token, propKey.name, context.getVariable(name), context.namer.newVarName())
+
+      case ast.Property(variable@ast.Variable(name), PropertyKeyName(propKeyName)) =>
+        MapProperty(context.getVariable(name), propKeyName)
 
       case ast.Parameter(name, _) => expressions.Parameter(name, context.namer.newVarName())
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -85,6 +85,9 @@ object ExpressionConverter {
       case CTNode => NodeProjection(variable)
       case CTRelationship => RelationshipProjection(variable)
       case CTString | CTBoolean | CTInteger | CTFloat => LoadVariable(variable)
+      case ListType(CTInteger) if variable.codeGenType.repr == ListReferenceType(IntType) =>
+        // TODO: PrimitiveProjection(variable)
+        AnyProjection(variable) // Temporarily resort to runtime projection
       case ListType(CTString) | ListType(CTBoolean) | ListType(CTInteger) | ListType(CTFloat) => LoadVariable(variable)
       case CTAny => AnyProjection(variable)
       case CTMap => AnyProjection(variable)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/ListLiteral.scala
@@ -33,9 +33,8 @@ case class ListLiteral(expressions: Seq[CodeGenExpression]) extends CodeGenExpre
     }
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
-    val cType = codeGenType
-    cType match {
-      case CodeGenType(ListType(_), ListReferenceType(innerRepr)) if RepresentationType.isPrimitive(innerRepr) =>
+    codeGenType match {
+      case cType@CodeGenType(ListType(_), ListReferenceType(innerRepr)) if RepresentationType.isPrimitive(innerRepr) =>
         structure.asPrimitiveStream(expressions.map(e => {
           e.generateExpression(structure)
         }), cType)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MapProperty.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/MapProperty.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions
+
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.{Variable, CodeGenContext}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.MethodStructure
+
+case class MapProperty(mapVariable: Variable, propertyKeyName: String) extends CodeGenExpression {
+  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
+
+  override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext): E =
+    structure.mapGetExpression(mapVariable.name, propertyKeyName)
+
+  override def nullable(implicit context: CodeGenContext) = true
+
+  override def codeGenType(implicit context: CodeGenContext) = CodeGenType.Any
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RepresentationType.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/ir/expressions/RepresentationType.scala
@@ -32,3 +32,11 @@ case object FloatType extends RepresentationType
 
 case object ReferenceType extends RepresentationType
 
+case class ListReferenceType(inner: RepresentationType) extends RepresentationType
+
+object RepresentationType {
+  def isPrimitive(repr: RepresentationType) = repr match {
+    case IntType | FloatType | BoolType => true
+    case _ => false
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -61,6 +61,7 @@ trait MethodStructure[E] {
   def constantExpression(value: Object): E
   def asMap(map: Map[String, E]): E
   def asList(values: Seq[E]): E
+  def asPrimitiveStream(values: Seq[E], codeGenType: CodeGenType): E
 
   def toSet(value: E): E
   def newDistinctSet(name: String, codeGenTypes: Iterable[CodeGenType])

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -68,12 +68,17 @@ trait MethodStructure[E] {
   def distinctSetIterate(name: String, key: Map[String, CodeGenType])
                                  (block: (MethodStructure[E]) => Unit)
   def newUniqueAggregationKey(varName: String, structure: Map[String, (CodeGenType,E)]): Unit
-  def newAggregationMap(name: String, keyTypes: IndexedSeq[CodeGenType])
+  def newAggregationMap(name: String, keyTypes: IndexedSeq[CodeGenType]): Unit
   def aggregationMapGet(name: String, varName: String, key: Map[String,(CodeGenType,E)], keyVar: String)
   def aggregationMapPut(name: String, key: Map[String,(CodeGenType,E)], keyVar: String, value: E): Unit
   def aggregationMapIterate(name: String, key: Map[String,CodeGenType], valueVar: String)(block: MethodStructure[E] => Unit): Unit
   def newMapOfSets(name: String, keyTypes: IndexedSeq[CodeGenType], elementType: CodeGenType)
   def checkDistinct(name: String, key: Map[String,(CodeGenType, E)], keyVar: String, value: E, valueType: CodeGenType)(block: MethodStructure[E] => Unit)
+
+  def allocateSortTable(name: String, initialCapacity: Int, valueStructure: Map[String, CodeGenType]): Unit
+  def sortTableAdd(name: String, valueStructure: Map[String, CodeGenType], value: E): Unit
+  def sortTableIterate(name: String, valueStructure: Map[String, CodeGenType], varNameToField: Map[String, String])
+                      (block: (MethodStructure[E]) => Unit): Unit
 
   def castToCollection(value: E): E
 
@@ -109,7 +114,7 @@ trait MethodStructure[E] {
   def expectParameter(key: String, variableName: String): Unit
 
   // tracing
-  def trace[V](planStepId: String)(block: MethodStructure[E] => V): V
+  def trace[V](planStepId: String, maybeSuffix: Option[String] = None)(block: MethodStructure[E] => V): V
   def incrementDbHits(): Unit
   def incrementRows(): Unit
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -211,7 +211,7 @@ case class SortItem(fieldName: String, sortOrder: SortOrder)
   * e.g. a result row (or intermediate row).
   * The TupleDescriptor carries type information used to generate a materialization of this,
   * e.g. a class with fields.
-  * The order of individual fields are not specified, but is left as an implementation detail.
+  * The order of individual fields is not specified, but is left as an implementation detail.
   */
 sealed trait TupleDescriptor {
   val structure: Map[String, CodeGenType]

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -75,10 +75,16 @@ trait MethodStructure[E] {
   def newMapOfSets(name: String, keyTypes: IndexedSeq[CodeGenType], elementType: CodeGenType)
   def checkDistinct(name: String, key: Map[String,(CodeGenType, E)], keyVar: String, value: E, valueType: CodeGenType)(block: MethodStructure[E] => Unit)
 
-  def allocateSortTable(name: String, initialCapacity: Int, valueStructure: Map[String, CodeGenType]): Unit
-  def sortTableAdd(name: String, valueStructure: Map[String, CodeGenType], value: E): Unit
-  def sortTableIterate(name: String, valueStructure: Map[String, CodeGenType], varNameToField: Map[String, String])
+  def allocateSortTable(name: String, initialCapacity: Int, valueStructure: Map[String, CodeGenType],
+                        sortItems: Iterable[SortItem]): Unit
+  def sortTableAdd(name: String, valueStructure: Map[String, CodeGenType], sortItems: Iterable[SortItem], value: E): Unit
+  def sortTableSort(name: String, valueStructure: Map[String, CodeGenType], sortItems: Iterable[SortItem]): Unit
+  def sortTableIterate(name: String, valueStructure: Map[String, CodeGenType], sortItems: Iterable[SortItem],
+                       varNameToField: Map[String, String])
                       (block: (MethodStructure[E]) => Unit): Unit
+  def newSortTableValue(targetVar: String, structure: Map[String, CodeGenType], sortItems: Iterable[SortItem]): E
+  def sortTableValuePutField(structure: Map[String, CodeGenType], sortItems: Iterable[SortItem],
+                             value: E, fieldType: CodeGenType, fieldName: String, localVar: String): Unit
 
   def castToCollection(value: E): E
 
@@ -184,3 +190,9 @@ case object LongToCountTable extends CountingJoinTableType
 case object LongsToCountTable extends CountingJoinTableType
 case class LongToListTable(structure: Map[String, CodeGenType], localMap: Map[String, String]) extends RecordingJoinTableType
 case class LongsToListTable(structure: Map[String, CodeGenType], localMap: Map[String, String]) extends RecordingJoinTableType
+
+sealed trait SortOrder
+case object Ascending extends SortOrder
+case object Descending extends SortOrder
+
+case class SortItem(fieldName: String, sortOrder: SortOrder)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -63,6 +63,16 @@ trait MethodStructure[E] {
   def asList(values: Seq[E]): E
   def asPrimitiveStream(values: Seq[E], codeGenType: CodeGenType): E
 
+  def declarePrimitiveIterator(name: String, iterableCodeGenType: CodeGenType): Unit
+  def primitiveIteratorFrom(iterable: E, iterableCodeGenType: CodeGenType): E
+  def primitiveIteratorNext(iterator: E, iterableCodeGenType: CodeGenType): E
+  def primitiveIteratorHasNext(iterator: E, iterableCodeGenType: CodeGenType): E
+
+  def declareIterator(name: String): Unit
+  def iteratorFrom(iterable: E): E
+  def iteratorNext(iterator: E): E
+  def iteratorHasNext(iterator: E): E
+
   def toSet(value: E): E
   def newDistinctSet(name: String, codeGenTypes: Iterable[CodeGenType])
   def distinctSetIfNotContains(name: String, structure: Map[String,(CodeGenType,E)])(block: MethodStructure[E] => Unit)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -46,8 +46,8 @@ trait MethodStructure[E] {
   def declare(varName: String, codeGenType: CodeGenType): Unit
   def declareProperty(name: String): Unit
   def declareCounter(name: String, initialValue: E): Unit
-  def putField(structure: Map[String, CodeGenType], value: E, fieldType: CodeGenType, fieldName: String, localVar: String): Unit
-  def updateProbeTable(structure: Map[String, CodeGenType], tableVar: String, tableType: RecordingJoinTableType, keyVars: Seq[String], element: E): Unit
+  def putField(tupleDescriptor: TupleDescriptor, value: E, fieldType: CodeGenType, fieldName: String, localVar: String): Unit
+  def updateProbeTable(tupleDescriptor: TupleDescriptor, tableVar: String, tableType: RecordingJoinTableType, keyVars: Seq[String], element: E): Unit
   def probe(tableVar: String, tableType: JoinTableType, keyVars: Seq[String])(block: MethodStructure[E]=>Unit): Unit
   def updateProbeTableCount(tableVar: String, tableType: CountingJoinTableType, keyVar: Seq[String]): Unit
   def allocateProbeTable(tableVar: String, tableType: JoinTableType): Unit
@@ -57,7 +57,7 @@ trait MethodStructure[E] {
   def incrementInteger(name: String): Unit
   def decrementInteger(name: String): Unit
   def checkInteger(variableName: String, comparator: Comparator, value: Long): E
-  def newTableValue(targetVar: String, structure: Map[String, CodeGenType]): E
+  def newTableValue(targetVar: String, tupleDescriptor: TupleDescriptor): E
   def constantExpression(value: Object): E
   def asMap(map: Map[String, E]): E
   def asList(values: Seq[E]): E
@@ -65,13 +65,12 @@ trait MethodStructure[E] {
   def toSet(value: E): E
   def newDistinctSet(name: String, codeGenTypes: Iterable[CodeGenType])
   def distinctSetIfNotContains(name: String, structure: Map[String,(CodeGenType,E)])(block: MethodStructure[E] => Unit)
-  def distinctSetIterate(name: String, key: Map[String, CodeGenType])
-                                 (block: (MethodStructure[E]) => Unit)
+  def distinctSetIterate(name: String, key: HashableTupleDescriptor)(block: (MethodStructure[E]) => Unit)
   def newUniqueAggregationKey(varName: String, structure: Map[String, (CodeGenType,E)]): Unit
   def newAggregationMap(name: String, keyTypes: IndexedSeq[CodeGenType]): Unit
   def aggregationMapGet(name: String, varName: String, key: Map[String,(CodeGenType,E)], keyVar: String)
   def aggregationMapPut(name: String, key: Map[String,(CodeGenType,E)], keyVar: String, value: E): Unit
-  def aggregationMapIterate(name: String, key: Map[String,CodeGenType], valueVar: String)(block: MethodStructure[E] => Unit): Unit
+  def aggregationMapIterate(name: String, key: HashableTupleDescriptor, valueVar: String)(block: MethodStructure[E] => Unit): Unit
   def newMapOfSets(name: String, keyTypes: IndexedSeq[CodeGenType], elementType: CodeGenType)
   def checkDistinct(name: String, key: Map[String,(CodeGenType, E)], keyVar: String, value: E, valueType: CodeGenType)(block: MethodStructure[E] => Unit)
 
@@ -187,8 +186,8 @@ sealed trait RecordingJoinTableType extends JoinTableType
 
 case object LongToCountTable extends CountingJoinTableType
 case object LongsToCountTable extends CountingJoinTableType
-case class LongToListTable(structure: Map[String, CodeGenType], localMap: Map[String, String]) extends RecordingJoinTableType
-case class LongsToListTable(structure: Map[String, CodeGenType], localMap: Map[String, String]) extends RecordingJoinTableType
+case class LongToListTable(tupleDescriptor: TupleDescriptor, localMap: Map[String, String]) extends RecordingJoinTableType
+case class LongsToListTable(tupleDescriptor: TupleDescriptor, localMap: Map[String, String]) extends RecordingJoinTableType
 
 sealed trait SortOrder
 case object Ascending extends SortOrder

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -46,7 +46,7 @@ trait MethodStructure[E] {
   def declare(varName: String, codeGenType: CodeGenType): Unit
   def declareProperty(name: String): Unit
   def declareCounter(name: String, initialValue: E): Unit
-  def putField(tupleDescriptor: TupleDescriptor, value: E, fieldType: CodeGenType, fieldName: String, localVar: String): Unit
+  def putField(tupleDescriptor: TupleDescriptor, value: E, fieldName: String, localVar: String): Unit
   def updateProbeTable(tupleDescriptor: TupleDescriptor, tableVar: String, tableType: RecordingJoinTableType, keyVars: Seq[String], element: E): Unit
   def probe(tableVar: String, tableType: JoinTableType, keyVars: Seq[String])(block: MethodStructure[E]=>Unit): Unit
   def updateProbeTableCount(tableVar: String, tableType: CountingJoinTableType, keyVar: Seq[String]): Unit
@@ -80,9 +80,6 @@ trait MethodStructure[E] {
   def sortTableIterate(name: String, tupleDescriptor: OrderableTupleDescriptor,
                        varNameToField: Map[String, String])
                       (block: (MethodStructure[E]) => Unit): Unit
-  def newSortTableValue(targetVar: String, tupleDescriptor: OrderableTupleDescriptor): E
-  def sortTableValuePutField(tupleDescriptor: OrderableTupleDescriptor,
-                             value: E, fieldType: CodeGenType, fieldName: String, localVar: String): Unit
 
   def castToCollection(value: E): E
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -103,7 +103,7 @@ trait MethodStructure[E] {
 
   // object handling
   def markAsNull(varName: String, codeGenType: CodeGenType): Unit
-  def nullablePrimitive(varName: String, codegenType: CodeGenType, onSuccess: E): E
+  def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: E): E
   def nullableReference(varName: String, codeGenType: CodeGenType, onSuccess: E): E
   def isNull(name: String, codeGenType: CodeGenType): E
   def notNull(name: String, codeGenType: CodeGenType): E
@@ -159,7 +159,7 @@ trait MethodStructure[E] {
   def ifStatement(test: E)(block: MethodStructure[E] => Unit): Unit
   def ifNotStatement(test: E)(block: MethodStructure[E] => Unit): Unit
   def ifNonNullStatement(test: E)(block: MethodStructure[E] => Unit): Unit
-  def ternaryOperator(test:E, onSuccess:E, onError: E): E
+  def ternaryOperator(test: E, onTrue: E, onFalse: E): E
   def returnSuccessfully(): Unit
 
   // results

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/spi/MethodStructure.scala
@@ -114,6 +114,9 @@ trait MethodStructure[E] {
   // parameters
   def expectParameter(key: String, variableName: String): Unit
 
+  // map
+  def mapGetExpression(mapName: String, key: String): E
+
   // tracing
   def trace[V](planStepId: String, maybeSuffix: Option[String] = None)(block: MethodStructure[E] => V): V
   def incrementDbHits(): Unit

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/helpers/LiteralTypeSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/helpers/LiteralTypeSupport.scala
@@ -27,7 +27,7 @@ object LiteralTypeSupport {
   def deriveCypherType(obj: Any): CypherType = obj match {
     case _: String                          => CTString
     case _: Char                            => CTString
-    case _: Integer|_:Long|_:Short|_:Byte   => CTInteger
+    case _: Integer|_:java.lang.Long|_:Int|_:Long|_:Short|_:Byte => CTInteger
     case _: Number                          => CTFloat
     case _: Boolean                         => CTBoolean
     case IsMap(_)                           => CTMap

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import org.neo4j.cypher.internal.frontend.v3_2.CypherTypeException;
@@ -200,6 +202,14 @@ public abstract class CompiledConversionUtils
         else if ( anyValue instanceof LongStream )
         {
             return ((LongStream) anyValue).boxed().collect( Collectors.toList() );
+        }
+        else if ( anyValue instanceof DoubleStream )
+        {
+            return ((DoubleStream) anyValue).boxed().collect( Collectors.toList() );
+        }
+        else if ( anyValue instanceof IntStream )
+        {
+            return ((IntStream) anyValue).mapToObj( i -> i != 0 ).collect( Collectors.toList() );
         }
         else
         {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -26,8 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
-import org.neo4j.cypher.internal.compiler.v3_2.helpers.JavaListWrapper;
 import org.neo4j.cypher.internal.frontend.v3_2.CypherTypeException;
 import org.neo4j.cypher.internal.frontend.v3_2.IncomparableValuesException;
 import org.neo4j.graphdb.Node;
@@ -196,6 +196,10 @@ public abstract class CompiledConversionUtils
         {
             ((Map) anyValue).replaceAll( (k, v) -> materializeAnyResult( nodeManager, v ) );
             return anyValue;
+        }
+        else if ( anyValue instanceof LongStream )
+        {
+            return ((LongStream) anyValue).boxed().collect( Collectors.toList() );
         }
         else
         {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -228,6 +229,38 @@ public abstract class CompiledConversionUtils
         else
         {
             return anyValue;
+        }
+    }
+
+    public static final Iterator iteratorFrom( Object iterable )
+    {
+        if ( iterable instanceof Iterable )
+        {
+            return ((Iterable) iterable).iterator();
+        }
+        else if ( iterable instanceof PrimitiveEntityStream )
+        {
+            return ((PrimitiveEntityStream) iterable).iterator();
+        }
+        else if ( iterable instanceof LongStream )
+        {
+            return ((LongStream) iterable).iterator();
+        }
+        else if ( iterable instanceof DoubleStream )
+        {
+            return ((DoubleStream) iterable).iterator();
+        }
+        else if ( iterable instanceof IntStream )
+        {
+            return ((IntStream) iterable).iterator();
+        }
+        else if ( iterable == null )
+        {
+            return Collections.emptyIterator();
+        }
+        else
+        {
+            throw new CypherTypeException( "Don't know how to create an iterator out of " + iterable.getClass().getSimpleName(), null );
         }
     }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -66,6 +66,7 @@ public abstract class CompiledConversionUtils
         {
             return ((Collection<?>) value);
         }
+        // TODO: Handle primitive streams
 
         throw new CypherTypeException( "Don't know how to create an iterable out of " + value.getClass().getSimpleName(), null );
     }
@@ -199,6 +200,18 @@ public abstract class CompiledConversionUtils
             ((Map) anyValue).replaceAll( (k, v) -> materializeAnyResult( nodeManager, v ) );
             return anyValue;
         }
+        else if ( anyValue instanceof PrimitiveNodeStream )
+        {
+            return ((PrimitiveNodeStream) anyValue).longStream()
+                    .mapToObj( nodeManager::newNodeProxyById )
+                    .collect( Collectors.toList() );
+        }
+        else if ( anyValue instanceof PrimitiveRelationshipStream )
+        {
+            return ((PrimitiveRelationshipStream) anyValue).longStream()
+                    .mapToObj( nodeManager::newRelationshipProxyById )
+                    .collect( Collectors.toList() );
+        }
         else if ( anyValue instanceof LongStream )
         {
             return ((LongStream) anyValue).boxed().collect( Collectors.toList() );
@@ -209,6 +222,7 @@ public abstract class CompiledConversionUtils
         }
         else if ( anyValue instanceof IntStream )
         {
+            // IntStream is only used for list of primitive booleans
             return ((IntStream) anyValue).mapToObj( i -> i != 0 ).collect( Collectors.toList() );
         }
         else

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper class for dealing with orderability in compiled code.
+ *
+ * <h1>
+ * Orderability
+ *
+ * <a href="https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc">
+ *   The Cypher CIP defining orderability
+ * </a>
+ *
+ * <p>
+ * Ascending global sort order of disjoint types:
+ *
+ * <ul>
+ *   <li> MAP types
+ *    <ul>
+ *      <li> Regular map
+ *
+ *      <li> NODE
+ *
+ *      <li> RELATIONSHIP
+ *    <ul>
+ *
+ *  <li> LIST OF ANY?
+ *
+ *  <li> PATH
+ *
+ *  <li> STRING
+ *
+ *  <li> BOOLEAN
+ *
+ *  <li> NUMBER
+ *    <ul>
+ *      <li> NaN values are treated as the largest numbers in orderability only (i.e. they are put after positive infinity)
+ *    </ul>
+ *  <li> VOID (i.e. the type of null)
+ * </ul>
+ */
+public class CompiledOrderabilityUtils {
+    /**
+     * Do not instantiate this class
+     */
+    private CompiledOrderabilityUtils()
+    {
+        throw new UnsupportedOperationException(  );
+    }
+
+    /*
+        if (x == null) {
+          if (y == null) 0 else -1
+        } else if (y == null) {
+          +1
+        } else {
+     */
+
+    /**
+     * Compare with Cypher orderability semantics for disjoint types
+     *
+     * @param lhs
+     * @param rhs
+     * @return
+     */
+    public static int compare( Object lhs, Object rhs )
+    {
+        if ( lhs == rhs )
+        {
+            return 0;
+        }
+        // null is greater than any other type
+        else if ( lhs == null )
+        {
+            return 1;
+        }
+        else if ( rhs == null )
+        {
+            return -1;
+        }
+        // MAP types
+//        else if ( lhs instanceof Map<?, ?>)
+//        {
+//            if ( rhs instanceof Map<?, ?> ) {
+//                // Compare maps
+//                Map<String, Object> lMap = (Map<String, Object>) lhs;
+//                Map<String, Object> rMap = (Map<String, Object>) rhs;
+//
+//
+//            }
+//            else
+//            {
+//                return -1;
+//            }
+//        }
+        else if ( lhs instanceof Comparable && rhs instanceof Comparable )
+        {
+            return ((Comparable) lhs).compareTo( rhs );
+        }
+        throw new RuntimeException( "Comparing unsupported types" );
+    }
+
+    public enum SuperType
+    {
+        MAP( 0 ),
+        NODE( 1 ),
+        RELATIONSHIP( 2 ),
+        LIST( 3 ),
+        PATH( 4 ),
+        STRING( 5 ),
+        BOOLEAN( 6 ),
+        NUMBER( 7 ),
+        VOID( 8 );
+
+        public final int typeId;
+
+        SuperType( int typeId )
+        {
+            this.typeId = typeId;
+        }
+
+        public boolean isSuperTypeOf( Object value )
+        {
+            return this == ofValue( value );
+        }
+
+        public static SuperType ofValue( Object value )
+        {
+            if ( null == value )
+            {
+                throw new NullPointerException( "null is not a valid property value and hence has no " +
+                        "PropertyValueComparison.SuperType" );
+            }
+            if ( value instanceof String )
+            {
+                return STRING;
+            }
+            else if ( value instanceof Number )
+            {
+                return NUMBER;
+            }
+            else if ( value instanceof Boolean )
+            {
+                return BOOLEAN;
+            }
+            else if ( value instanceof Character )
+            {
+                return STRING;
+            }
+            else if ( value instanceof Map<?,?> )
+            {
+                return MAP;
+            }
+            else if ( value instanceof List<?> )
+            {
+                return LIST;
+            }
+            else if ( value instanceof NodeIdWrapper )
+            {
+                return NODE;
+            }
+            else if ( value instanceof RelationshipIdWrapper )
+            {
+                return RELATIONSHIP;
+            }
+            // TODO: PATH
+            return VOID;
+        }
+
+        public static Comparator<SuperType> TYPE_ID_COMPARATOR = new Comparator<SuperType>()
+        {
+            @Override
+            public int compare( SuperType left, SuperType right )
+            {
+                return left.typeId - right.typeId;
+            }
+        };
+    }
+}

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.neo4j.cypher.internal.frontend.v3_2.IncomparableValuesException;
 import org.neo4j.graphdb.Path;
@@ -279,30 +280,17 @@ public class CompiledOrderabilityUtils
         {
             Iterator lhsIter = (lhs.getClass().isArray()) ? arrayToIterator( lhs ) : ((List) lhs).iterator();
             Iterator rhsIter = (rhs.getClass().isArray()) ? arrayToIterator( rhs ) : ((List) rhs).iterator();
-            while ( lhsIter.hasNext() )
+            while ( lhsIter.hasNext() && rhsIter.hasNext() )
             {
-                if ( !rhsIter.hasNext() )
-                {
-                    return 1;
-                }
                 int result = CompiledOrderabilityUtils.compare( lhsIter.next(), rhsIter.next() );
                 if ( 0 != result )
                 {
-                    if ( rhsIter.hasNext() == lhsIter.hasNext() )
-                    {
-                        return result;
-                    }
-                    else
-                    {
-                        return (lhsIter.hasNext()) ? 1 : -1;
-                    }
+                    return result;
                 }
             }
-            if ( rhsIter.hasNext() )
-            {
-                return -1;
-            }
-            return 0;
+            return (lhsIter.hasNext()) ? 1
+                                       : (rhsIter.hasNext()) ? -1
+                                                             : 0;
         }
 
         private Iterator arrayToIterator( Object o )
@@ -310,35 +298,36 @@ public class CompiledOrderabilityUtils
             Class clazz = o.getClass();
             if ( clazz.equals( Object[].class ) )
             {
-                return Arrays.asList( (Object[]) o ).iterator();
+                return Arrays.stream( (Object[]) o ).iterator();
             }
             else if ( clazz.equals( int[].class ) )
             {
-                return Arrays.asList( (int[]) o ).iterator();
+                return Arrays.stream( (int[]) o ).iterator();
             }
             else if ( clazz.equals( Integer[].class ) )
             {
-                return Arrays.asList( (Integer[]) o ).iterator();
+                return Arrays.stream( (Integer[]) o ).iterator();
             }
             else if ( clazz.equals( long[].class ) )
             {
-                return Arrays.asList( (long[]) o ).iterator();
+                return Arrays.stream( (long[]) o ).iterator();
             }
             else if ( clazz.equals( Long[].class ) )
             {
-                return Arrays.asList( (Long[]) o ).iterator();
+                return Arrays.stream( (Long[]) o ).iterator();
             }
             else if ( clazz.equals( String[].class ) )
             {
-                return Arrays.asList( (String[]) o ).iterator();
+                return Arrays.stream( (String[]) o ).iterator();
             }
             else if ( clazz.equals( boolean[].class ) )
             {
-                return Arrays.asList( (boolean[]) o ).iterator();
+                // TODO Is there a better way to covert boolean[] to Iterator?
+                return IntStream.range( 0, ((boolean[]) o).length ).mapToObj( i -> ((boolean[]) o)[i] ).iterator();
             }
             else if ( clazz.equals( Boolean[].class ) )
             {
-                return Arrays.asList( (Boolean[]) o ).iterator();
+                return Arrays.stream( (Boolean[]) o ).iterator();
             }
             else
             {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
@@ -137,8 +137,8 @@ public class CompiledOrderabilityUtils
 
         SuperType( int typeId, Comparator comparator )
         {
-            this.comparator = comparator;
             this.typeId = typeId;
+            this.comparator = comparator;
         }
 
         public boolean isSuperTypeOf( Object value )
@@ -192,6 +192,9 @@ public class CompiledOrderabilityUtils
             }
         };
     }
+
+    // NOTE: nulls are handled at the top of the public compare() method
+    // so the type-specific comparators should not check arguments for null
 
     private static Comparator FALLBACK_COMPARATOR = new Comparator<Object>()
     {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.LongStream;
+
+public abstract class PrimitiveEntityStream implements Iterable<Long>
+{
+    private final LongStream inner;
+
+    public PrimitiveEntityStream( LongStream inner )
+    {
+        this.inner = inner;
+    }
+
+    public LongStream longStream()
+    {
+        return inner;
+    }
+
+    @Override
+    public Iterator<Long> iterator()
+    {
+        return inner.iterator();
+    }
+
+    @Override
+    public void forEach( Consumer<? super Long> action )
+    {
+        throw new UnsupportedOperationException( "PrimitiveEntityStream does not support forEach" );
+    }
+
+    @Override
+    public Spliterator<Long> spliterator()
+    {
+        throw new UnsupportedOperationException( "PrimitiveEntityStream does not support spliterator" );
+    }
+}

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveEntityStream.java
@@ -20,17 +20,21 @@
 package org.neo4j.cypher.internal.codegen;
 
 import java.util.Iterator;
-import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.PrimitiveIterator;
 import java.util.stream.LongStream;
 
-public abstract class PrimitiveEntityStream implements Iterable<Long>
+public abstract class PrimitiveEntityStream<T>
 {
-    private final LongStream inner;
+    protected final LongStream inner;
 
     public PrimitiveEntityStream( LongStream inner )
     {
         this.inner = inner;
+    }
+
+    public PrimitiveIterator.OfLong primitiveIterator()
+    {
+        return inner.iterator();
     }
 
     public LongStream longStream()
@@ -38,21 +42,5 @@ public abstract class PrimitiveEntityStream implements Iterable<Long>
         return inner;
     }
 
-    @Override
-    public Iterator<Long> iterator()
-    {
-        return inner.iterator();
-    }
-
-    @Override
-    public void forEach( Consumer<? super Long> action )
-    {
-        throw new UnsupportedOperationException( "PrimitiveEntityStream does not support forEach" );
-    }
-
-    @Override
-    public Spliterator<Long> spliterator()
-    {
-        throw new UnsupportedOperationException( "PrimitiveEntityStream does not support spliterator" );
-    }
+    public abstract Iterator<T> iterator();
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.cypher.internal.codegen;
 
+import java.util.Iterator;
 import java.util.stream.LongStream;
 
-public class PrimitiveNodeStream extends PrimitiveEntityStream
+public class PrimitiveNodeStream extends PrimitiveEntityStream<NodeIdWrapper>
 {
     public PrimitiveNodeStream( LongStream inner )
     {
@@ -31,5 +32,12 @@ public class PrimitiveNodeStream extends PrimitiveEntityStream
     public static PrimitiveNodeStream of( long[] array )
     {
         return new PrimitiveNodeStream( LongStream.of( array ) );
+    }
+
+    @Override
+    // This method is only used when we do not know the element type at compile time, so it has to box the elements
+    public Iterator<NodeIdWrapper> iterator()
+    {
+        return inner.mapToObj( NodeIdWrapper::new ).iterator();
     }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.stream.LongStream;
+
+public class PrimitiveNodeStream extends PrimitiveEntityStream
+{
+    public PrimitiveNodeStream( LongStream inner )
+    {
+        super( inner );
+    }
+
+    public static PrimitiveNodeStream of( long[] array )
+    {
+        return new PrimitiveNodeStream( LongStream.of( array ) );
+    }
+}

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.stream.LongStream;
+
+public class PrimitiveRelationshipStream extends PrimitiveEntityStream
+{
+    public PrimitiveRelationshipStream( LongStream inner )
+    {
+        super( inner );
+    }
+
+    public static PrimitiveRelationshipStream of( long[] array )
+    {
+        return new PrimitiveRelationshipStream( LongStream.of( array ) );
+    }
+}

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.cypher.internal.codegen;
 
+import java.util.Iterator;
 import java.util.stream.LongStream;
 
-public class PrimitiveRelationshipStream extends PrimitiveEntityStream
+public class PrimitiveRelationshipStream extends PrimitiveEntityStream<RelationshipIdWrapper>
 {
     public PrimitiveRelationshipStream( LongStream inner )
     {
@@ -31,5 +32,12 @@ public class PrimitiveRelationshipStream extends PrimitiveEntityStream
     public static PrimitiveRelationshipStream of( long[] array )
     {
         return new PrimitiveRelationshipStream( LongStream.of( array ) );
+    }
+
+    @Override
+    // This method is only used when we do not know the element type at compile time, so it has to box the elements
+    public Iterator<RelationshipIdWrapper> iterator()
+    {
+        return inner.mapToObj( RelationshipIdWrapper::new ).iterator();
     }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -170,6 +170,14 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
         using(generator.forEachLong(Parameter.param(lowerType(codeGenType), varName), iterable)) { body =>
           block(copy(generator = body))
         }
+      case CodeGenType.primitiveFloat =>
+        using(generator.forEachDouble(Parameter.param(lowerType(codeGenType), varName), iterable)) { body =>
+          block(copy(generator = body))
+        }
+      case CodeGenType.primitiveBool =>
+        using(generator.forEachBoolean(Parameter.param(lowerType(codeGenType), varName), iterable)) { body =>
+          block(copy(generator = body))
+        }
       case _ => {
         using(generator.forEach(Parameter.param(lowerType(codeGenType), varName), iterable)) { body =>
           block(copy(generator = body))
@@ -480,6 +488,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     codeGenType match {
       case CodeGenType(_, ListReferenceType(IntType)) =>
         Templates.asLongStream(values)
+      case CodeGenType(_, ListReferenceType(FloatType)) =>
+        Templates.asDoubleStream(values)
+      case CodeGenType(_, ListReferenceType(BoolType)) =>
+        // There are no primitive streams for booleans, so we use an IntStream with value conversions
+        // 0 = false, 1 = true
+        Templates.asIntStream(values.map(Expression.ternary(_, Expression.constant(1), Expression.constant(0))))
       case _ =>
         throw new IllegalArgumentException(s"CodeGenType $codeGenType not supported as primitive stream")
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -34,7 +34,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{BoolType,
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
-import org.neo4j.cypher.internal.frontend.v3_2.symbols.{CTNode, CTRelationship}
+import org.neo4j.cypher.internal.frontend.v3_2.symbols.{ListType, CTNode, CTRelationship}
 import org.neo4j.cypher.internal.frontend.v3_2.{ParameterNotFoundException, SemanticDirection, symbols}
 import org.neo4j.cypher.internal.spi.v3_2.codegen.Methods._
 import org.neo4j.cypher.internal.spi.v3_2.codegen.Templates.{createNewInstance, handleKernelExceptions, newRelationshipDataExtractor, tryCatch}
@@ -486,6 +486,10 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def asPrimitiveStream(values: Seq[Expression], codeGenType: CodeGenType) = {
     codeGenType match {
+      case CodeGenType(ListType(CTNode), ListReferenceType(IntType)) =>
+        Templates.asPrimitiveNodeStream(values)
+      case CodeGenType(ListType(CTRelationship), ListReferenceType(IntType)) =>
+        Templates.asPrimitiveRelationshipStream(values)
       case CodeGenType(_, ListReferenceType(IntType)) =>
         Templates.asLongStream(values)
       case CodeGenType(_, ListReferenceType(FloatType)) =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -329,6 +329,10 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
                                                            invoke(params, mapGet, constantExpression(key))))
   }
 
+  override def mapGetExpression(mapName: String, key: String): Expression = {
+    invoke(cast(typeRef[java.util.Map[String, Object]], generator.load(mapName)), mapGet, constantExpression(key))
+  }
+
   override def constantExpression(value: Object) = value match {
     case n: java.lang.Byte => constant(n.toLong)
     case n: java.lang.Short => constant(n.toLong)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.spi.v3_2.codegen
 
 import java.util
+import java.util.stream.LongStream
 
 import org.neo4j.codegen.Expression.{not, or, _}
 import org.neo4j.codegen.MethodReference.methodReference
@@ -166,6 +167,16 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   override def forEach(varName: String, codeGenType: CodeGenType, iterable: Expression)
                       (block: MethodStructure[Expression] => Unit) =
     codeGenType match {
+      case CodeGenType.primitiveNode =>
+        using(generator.forEachLong(Parameter.param(lowerType(codeGenType), varName),
+          invoke(iterable, methodReference(typeRef[PrimitiveEntityStream], typeRef[LongStream], "longStream")))) { body =>
+          block(copy(generator = body))
+        }
+      case CodeGenType.primitiveRel =>
+        using(generator.forEachLong(Parameter.param(lowerType(codeGenType), varName),
+          invoke(iterable, methodReference(typeRef[PrimitiveRelationshipStream], typeRef[LongStream], "longStream")))) { body =>
+          block(copy(generator = body))
+        }
       case CodeGenType.primitiveInt =>
         using(generator.forEachLong(Parameter.param(lowerType(codeGenType), varName), iterable)) { body =>
           block(copy(generator = body))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -27,7 +27,7 @@ import org.neo4j.codegen.TypeReference._
 import org.neo4j.codegen.source.{SourceCode, SourceVisitor}
 import org.neo4j.codegen.{CodeGenerator, Parameter, _}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
-import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions.{BoolType, CodeGenType, FloatType, IntType, ReferenceType}
+import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.{CodeStructure, CodeStructureResult, MethodStructure}
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers._
@@ -191,6 +191,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     case CodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
     case CodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
     case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String]
+    case CodeGenType(symbols.ListType(_), ListReferenceType(IntType)) => typeRef[Array[Long]]
     case _ => typeRef[Object]
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -21,11 +21,13 @@ package org.neo4j.cypher.internal.spi.v3_2.codegen
 
 import java.lang.reflect.Modifier
 import java.util
+import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import org.neo4j.codegen.CodeGeneratorOption._
 import org.neo4j.codegen.TypeReference._
 import org.neo4j.codegen.source.{SourceCode, SourceVisitor}
 import org.neo4j.codegen.{CodeGenerator, Parameter, _}
+import org.neo4j.cypher.internal.codegen.{PrimitiveNodeStream, PrimitiveRelationshipStream}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.{CodeStructure, CodeStructureResult, MethodStructure}
@@ -190,8 +192,13 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     case CodeGenType(symbols.CTInteger, IntType) => typeRef[Long]
     case CodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
     case CodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
-    case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String]
-    case CodeGenType(symbols.ListType(_), ListReferenceType(IntType)) => typeRef[Array[Long]]
+    //case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String] // We do not care about non-primitive types
+    case CodeGenType(symbols.ListType(symbols.CTNode), ListReferenceType(IntType)) => typeRef[PrimitiveNodeStream]
+    case CodeGenType(symbols.ListType(symbols.CTRelationship), ListReferenceType(IntType)) => typeRef[PrimitiveRelationshipStream]
+    case CodeGenType(symbols.ListType(_), ListReferenceType(IntType)) => typeRef[LongStream]
+    case CodeGenType(symbols.ListType(_), ListReferenceType(FloatType)) => typeRef[DoubleStream]
+    case CodeGenType(symbols.ListType(_), ListReferenceType(BoolType)) => typeRef[IntStream]
+    case CodeGenType(symbols.ListType(_), _) => typeRef[java.lang.Iterable[Object]]
     case _ => typeRef[Object]
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -192,13 +192,13 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     case CodeGenType(symbols.CTInteger, IntType) => typeRef[Long]
     case CodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
     case CodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
-    //case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String] // We do not care about non-primitive types
+    //case CodeGenType(symbols.CTString, ReferenceType) => typeRef[String] // We do not (yet) care about non-primitive types
     case CodeGenType(symbols.ListType(symbols.CTNode), ListReferenceType(IntType)) => typeRef[PrimitiveNodeStream]
     case CodeGenType(symbols.ListType(symbols.CTRelationship), ListReferenceType(IntType)) => typeRef[PrimitiveRelationshipStream]
     case CodeGenType(symbols.ListType(_), ListReferenceType(IntType)) => typeRef[LongStream]
     case CodeGenType(symbols.ListType(_), ListReferenceType(FloatType)) => typeRef[DoubleStream]
     case CodeGenType(symbols.ListType(_), ListReferenceType(BoolType)) => typeRef[IntStream]
-    case CodeGenType(symbols.ListType(_), _) => typeRef[java.lang.Iterable[Object]]
+    //case CodeGenType(symbols.ListType(_), _) => typeRef[java.lang.Iterable[Object]] // We do not (yet) have a shared base class for List types
     case _ => typeRef[Object]
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.spi.v3_2.codegen
 import java.util
 import java.util.function.Consumer
-import java.util.stream.LongStream
+import java.util.stream.{IntStream, DoubleStream, LongStream}
 
 import org.neo4j.codegen.ExpressionTemplate._
 import org.neo4j.codegen.MethodReference._
@@ -62,6 +62,14 @@ object Templates {
   def asLongStream(values: Seq[Expression]): Expression = Expression.invoke(
     methodReference(typeRef[LongStream], typeRef[LongStream], "of", typeRef[Array[Long]]),
     Expression.newArray(typeRef[Long], values: _*))
+
+  def asDoubleStream(values: Seq[Expression]): Expression = Expression.invoke(
+    methodReference(typeRef[DoubleStream], typeRef[DoubleStream], "of", typeRef[Array[Double]]),
+    Expression.newArray(typeRef[Double], values: _*))
+
+  def asIntStream(values: Seq[Expression]): Expression = Expression.invoke(
+    methodReference(typeRef[IntStream], typeRef[IntStream], "of", typeRef[Array[Int]]),
+    Expression.newArray(typeRef[Int], values: _*))
 
   def handleKernelExceptions[V](generate: CodeBlock, ro: FieldReference, finalizers: Seq[CodeBlock => Unit])
                          (block: CodeBlock => V): V = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.spi.v3_2.codegen
 import java.util
 import java.util.function.Consumer
+import java.util.stream.LongStream
 
 import org.neo4j.codegen.ExpressionTemplate._
 import org.neo4j.codegen.MethodReference._
@@ -57,6 +58,10 @@ object Templates {
   def asList[T](values: Seq[Expression])(implicit manifest: Manifest[T]): Expression = Expression.invoke(
     methodReference(typeRef[util.Arrays], typeRef[util.List[T]], "asList", typeRef[Array[Object]]),
     Expression.newArray(typeRef[T], values: _*))
+
+  def asLongStream(values: Seq[Expression]): Expression = Expression.invoke(
+    methodReference(typeRef[LongStream], typeRef[LongStream], "of", typeRef[Array[Long]]),
+    Expression.newArray(typeRef[Long], values: _*))
 
   def handleKernelExceptions[V](generate: CodeBlock, ro: FieldReference, finalizers: Seq[CodeBlock => Unit])
                          (block: CodeBlock => V): V = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Templates.scala
@@ -20,12 +20,13 @@
 package org.neo4j.cypher.internal.spi.v3_2.codegen
 import java.util
 import java.util.function.Consumer
-import java.util.stream.{IntStream, DoubleStream, LongStream}
+import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import org.neo4j.codegen.ExpressionTemplate._
 import org.neo4j.codegen.MethodReference._
 import org.neo4j.codegen._
 import org.neo4j.collection.primitive.{Primitive, PrimitiveLongIntMap, PrimitiveLongObjectMap}
+import org.neo4j.cypher.internal.codegen.{PrimitiveNodeStream, PrimitiveRelationshipStream}
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription
@@ -58,6 +59,14 @@ object Templates {
   def asList[T](values: Seq[Expression])(implicit manifest: Manifest[T]): Expression = Expression.invoke(
     methodReference(typeRef[util.Arrays], typeRef[util.List[T]], "asList", typeRef[Array[Object]]),
     Expression.newArray(typeRef[T], values: _*))
+
+  def asPrimitiveNodeStream(values: Seq[Expression]): Expression = Expression.invoke(
+    methodReference(typeRef[PrimitiveNodeStream], typeRef[PrimitiveNodeStream], "of", typeRef[Array[Long]]),
+    Expression.newArray(typeRef[Long], values: _*))
+
+  def asPrimitiveRelationshipStream(values: Seq[Expression]): Expression = Expression.invoke(
+    methodReference(typeRef[PrimitiveRelationshipStream], typeRef[PrimitiveRelationshipStream], "of", typeRef[Array[Long]]),
+    Expression.newArray(typeRef[Long], values: _*))
 
   def asLongStream(values: Seq[Expression]): Expression = Expression.invoke(
     methodReference(typeRef[LongStream], typeRef[LongStream], "of", typeRef[Array[Long]]),

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
@@ -46,10 +46,10 @@ public class CompiledOrderabilityUtilsTest
             new Object(),
             new Object[]{1, "foo"},
             new Object[]{1, "foo", 3},
+            new Object[]{1, true, "car"},
             new Object[]{1, 2, "bar"},
             new Object[]{1, 2, "car"},
-            // TODO fails when this is uncommented
-//            new int[]{1, 2, 3},
+            new int[]{1, 2, 3},
             // STRING
             "",
             Character.MIN_VALUE,
@@ -98,24 +98,6 @@ public class CompiledOrderabilityUtilsTest
             Double.POSITIVE_INFINITY,
             Double.NaN
     };
-
-//    // TODO investigate: fails
-//    public static Object[] values = new Object[]{
-//            // OTHER
-//            new Object[]{1, "foo"},
-//            new Object[]{1, "foo", 3},
-//            new Object[]{1, 2, "bar"},
-//            new int[]{1, 2, 3}
-//    };
-
-//    // TODO investigate: passes
-//    public static Object[] values = new Object[]{
-//            // OTHER
-//            new Object[]{1, "foo"},
-//            new Object[]{1, "foo", 3},
-//            new Object[]{1, 2, "bar"},
-//            new Object[]{1, 2, 3}
-//    };
 
     @Test
     public void shouldOrderValuesCorrectly()

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
@@ -1,0 +1,119 @@
+package org.neo4j.cypher.internal.codegen;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.cypher.internal.frontend.v3_2.IncomparableValuesException;
+
+import static java.lang.String.format;
+
+public class CompiledOrderabilityUtilsTest
+{
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    public static Object[] values = new Object[]{
+            // OTHER
+//            PropertyValueComparison.LOWEST_OBJECT,
+//            new Object(),
+
+            // STRING
+            "",
+//            Character.MIN_VALUE,
+            " ",
+            "20",
+            "x",
+            "y",
+//            Character.MIN_HIGH_SURROGATE,
+//            Character.MAX_HIGH_SURROGATE,
+//            Character.MIN_LOW_SURROGATE,
+//            Character.MAX_LOW_SURROGATE,
+//            Character.MAX_VALUE,
+
+            // BOOLEAN
+            false,
+            true,
+
+            // NUMBER
+            Double.NEGATIVE_INFINITY,
+            -Double.MAX_VALUE,
+            Long.MIN_VALUE,
+            Long.MIN_VALUE + 1,
+            Integer.MIN_VALUE,
+            Short.MIN_VALUE,
+            Byte.MIN_VALUE,
+            0,
+            Double.MIN_VALUE,
+            Double.MIN_NORMAL,
+            Float.MIN_VALUE,
+            Float.MIN_NORMAL,
+            1L,
+            1.1d,
+            1.2f,
+            Math.E,
+            Math.PI,
+            (byte) 10,
+            (short) 20,
+            Byte.MAX_VALUE,
+            Short.MAX_VALUE,
+            Integer.MAX_VALUE,
+            9007199254740992D,
+            9007199254740993L,
+            Long.MAX_VALUE,
+            Float.MAX_VALUE,
+            Double.MAX_VALUE,
+            Double.POSITIVE_INFINITY,
+            Double.NaN
+    };
+
+    @Test
+    public void shouldOrderValuesCorrectly()
+    {
+        for ( int i = 2; i < values.length; i++ )
+        {
+            for ( int j = 2; j < values.length; j++ )
+            {
+                Object left = values[i];
+                Object right = values[j];
+
+                int cmpPos = sign( i - j );
+                int cmpVal = sign( compare(  left, right ) );
+
+//                System.out.println( format( "%s (%d), %s (%d) => %d (%d)", left, i, right, j, cmpLeft, i - j ) );
+
+                if ( cmpPos != cmpVal)
+                {
+                    throw new AssertionError( format(
+                            "Comparing %s against %s does not agree with their positions in the sorted list (%d and " +
+                            "%d)",
+                            left, right, i, j
+                    ) );
+                }
+            }
+        }
+    }
+
+    private <T> int compare( T left, T right )
+    {
+        try
+        {
+            int cmp1 = CompiledOrderabilityUtils.compare( left, right );
+            int cmp2 = CompiledOrderabilityUtils.compare( right, left );
+            if ( sign( cmp1 ) != -sign( cmp2 ) )
+            {
+                throw new AssertionError( format( "Comparator is not symmetric on %s and %s", left, right ) );
+            }
+            return cmp1;
+        }
+        catch ( IncomparableValuesException e )
+        {
+            throw new AssertionError( format("Failed to compare %s:%s and %s:%s", left,left.getClass().getName(), right,right.getClass().getName()), e );
+        }
+    }
+
+    private int sign( int value )
+    {
+        return value == 0 ? 0 : (value < 0 ? -1 : +1);
+    }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
@@ -1465,27 +1465,27 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
   test("sort projection with list of floats") {
     /*
     UNWIND [3.0,1.0,2.0,4.0] as x
-    WITH x AS a
-    RETURN a
-    ORDER BY a
+    WITH x, x AS `  FRESHID666`
+    RETURN x
+    ORDER BY `  FRESHID666`
     */
     // given
     val listLiteral = literalFloatList(3.0, 1.0, 2.0, 4.0)
     val unwind = UnwindCollection(SingleRow()(solved), IdName("x"), listLiteral)(solved)
-    val projection = Projection(unwind, Map("a" -> varFor("x")))(solved)
-    val orderBy = Sort(projection, List(Ascending(IdName("a"))))(solved)
-    val plan = ProduceResult(List("a"), orderBy)
+    val projection = Projection(unwind, Map("x" -> varFor("x"), "  FRESHID666" -> varFor("x")))(solved)
+    val orderBy = Sort(projection, List(Ascending(IdName("  FRESHID666"))))(solved)
+    val plan = ProduceResult(List("x"), orderBy)
 
     // when
     val compiled = compileAndExecute(plan)
 
     // then
-    val result = getResult(compiled, "a")
+    val result = getResult(compiled, "x")
     result.toList should equal(List(
-      Map("a" -> 1.0),
-      Map("a" -> 2.0),
-      Map("a" -> 3.0),
-      Map("a" -> 4.0)))
+      Map("x" -> 1.0),
+      Map("x" -> 2.0),
+      Map("x" -> 3.0),
+      Map("x" -> 4.0)))
   }
 
   test("sort projection with list of booleans") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
@@ -1407,8 +1407,8 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     // then
     val result = getResult(compiled, "b", "c")
     result.toList should equal(List(
+      Map("b" -> 2L,"c" -> 2L), // Because we sort Descending on b
       Map("b" -> 1L,"c" -> 1L),
-      Map("b" -> 2L,"c" -> 2L),
       Map("b" -> 3L,"c" -> 3L),
       Map("b" -> 4L,"c" -> 4L)))
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
@@ -1376,7 +1376,8 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
       Map("b" -> 4L,"c" -> 4L)))
   }
 
-  test("sort projection with list of integer maps") {
+  // Expression of Property(Variable(x),PropertyKeyName(a)) not yet supported
+  ignore("sort projection with list of integer maps") {
     /*
     UNWIND [
             {a:3, b:3, c:3, d:3},

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/codegen/CodeGeneratorTest.scala
@@ -1376,8 +1376,7 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
       Map("b" -> 4L,"c" -> 4L)))
   }
 
-  // Expression of Property(Variable(x),PropertyKeyName(a)) not yet supported
-  ignore("sort projection with list of integer maps") {
+  test("sort projection with list of integer maps") {
     /*
     UNWIND [
             {a:3, b:3, c:3, d:3},
@@ -1408,8 +1407,8 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     // then
     val result = getResult(compiled, "b", "c")
     result.toList should equal(List(
-      Map("b" -> 2L,"c" -> 2L),
       Map("b" -> 1L,"c" -> 1L),
+      Map("b" -> 2L,"c" -> 2L),
       Map("b" -> 3L,"c" -> 3L),
       Map("b" -> 4L,"c" -> 4L)))
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructureTest.scala
@@ -90,23 +90,27 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           }
         }),
        Operation("use a LongToList probe table", m => {
-         val table: LongToListTable = LongToListTable(Map("a" -> CodeGenType.primitiveNode), Map("b" -> "a"))
+         val table: LongToListTable =
+           LongToListTable(SimpleTupleDescriptor(Map("a" -> CodeGenType.primitiveNode)),
+                           localMap = Map("b" -> "a"))
          m.declareAndInitialize("a", CodeGenType.primitiveNode)
          m.allocateProbeTable("table", table)
-         val value: Expression = m.newTableValue("value", table.structure)
-         m.updateProbeTable(table.structure, "table", table, Seq("a"), value)
+         val value: Expression = m.newTableValue("value", table.tupleDescriptor)
+         m.updateProbeTable(table.tupleDescriptor, "table", table, Seq("a"), value)
          m.probe("table", table, Seq("a")) { inner =>
            inner.allNodesScan("foo")
          }
        }),
        Operation("use a LongsToList probe table", m => {
-         val table: LongsToListTable = LongsToListTable(Map("a" -> CodeGenType.primitiveNode, "b" -> CodeGenType.primitiveNode),
-                                                        Map("aa" -> "a", "bb" -> "b"))
+         val table: LongsToListTable =
+           LongsToListTable(SimpleTupleDescriptor(Map("a" -> CodeGenType.primitiveNode,
+                                                      "b" -> CodeGenType.primitiveNode)),
+                            localMap = Map("aa" -> "a", "bb" -> "b"))
          m.declareAndInitialize("a", CodeGenType.primitiveNode)
          m.declareAndInitialize("b", CodeGenType.primitiveNode)
          m.allocateProbeTable("table", table)
-         val value: Expression = m.newTableValue("value", table.structure)
-         m.updateProbeTable(table.structure, "table", table, Seq("a", "b"), value)
+         val value: Expression = m.newTableValue("value", table.tupleDescriptor)
+         m.updateProbeTable(table.tupleDescriptor, "table", table, Seq("a", "b"), value)
          m.probe("table", table, Seq("a", "b")) { inner =>
            inner.allNodesScan("foo")
          }

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
@@ -47,4 +47,9 @@ trait AstConstructionTestSupport extends CypherTestSupport {
 
   def literalIntList(intValues: Int*): ListLiteral =
     ListLiteral(intValues.toSeq.map(literalInt))(pos)
+
+  def literalIntMap(keyValues: (String, Int)*): MapExpression =
+    MapExpression(keyValues.map {
+      case (k, v) => (PropertyKeyName(k)(pos), SignedDecimalIntegerLiteral(v.toString)(pos))
+    })(pos)
 }

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AstConstructionTestSupport.scala
@@ -42,11 +42,17 @@ trait AstConstructionTestSupport extends CypherTestSupport {
   def literalInt(intValue: Int): SignedDecimalIntegerLiteral =
     SignedDecimalIntegerLiteral(intValue.toString)(pos)
 
+  def literalFloat(floatValue: Double): DecimalDoubleLiteral =
+    DecimalDoubleLiteral(floatValue.toString)(pos)
+
   def literalList(expressions: Expression*): ListLiteral =
     ListLiteral(expressions.toSeq)(pos)
 
   def literalIntList(intValues: Int*): ListLiteral =
     ListLiteral(intValues.toSeq.map(literalInt))(pos)
+
+  def literalFloatList(floatValues: Double*): ListLiteral =
+    ListLiteral(floatValues.toSeq.map(literalFloat))(pos)
 
   def literalIntMap(keyValues: (String, Int)*): MapExpression =
     MapExpression(keyValues.map {


### PR DESCRIPTION
Support ORDER BY of basic types

Implements full `Sort`, but not yet `TopN` or `Top1`, i.e. not optimized for combination with LIMIT yet.

- Introduces notion of tuples for storage of intermediate rows used in joins, aggregations and sorts.
- Adds a new tuple type that implements `Comparable` for use in sorting.
- Generates specialized comparators for primitive Cypher types integers, floats and booleans
- Support for collections of primitive types
- Support for unconditional blocks in code generator module

Full support for the Cypher orderability CIP is upcoming.