### PR TITLE
Update metrics plugin to resolve all it's external dependency during instantiation.

### DIFF
--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.SimpleLogService;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.metrics.MetricsExtension;
+import org.neo4j.metrics.MetricsSettings;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds;
+import org.neo4j.unsafe.impl.batchimport.Configuration;
+
+public class BatchingNeoStoresIT
+{
+
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    @Test
+    public void startBatchingNeoStoreWithMetricsPluginEnabled() throws Exception
+    {
+        DefaultFileSystemAbstraction fileSystem = fileSystemRule.get();
+        File storeDir = testDirectory.graphDbDir();
+        Config config = Config.defaults()
+                .with( MapUtil.stringMap( MetricsSettings.metricsEnabled.name(), "true" ) );
+        AssertableLogProvider provider = new AssertableLogProvider();
+        SimpleLogService logService = new SimpleLogService( provider, provider );
+
+        try ( BatchingNeoStores batchingNeoStores = BatchingNeoStores
+                .batchingNeoStores( fileSystem, storeDir, RecordFormatSelector.defaultFormat(), Configuration.DEFAULT,
+                        logService, AdditionalInitialIds.EMPTY, config ) )
+        {
+            // empty block
+        }
+        provider.assertNone( AssertableLogProvider.inLog( MetricsExtension.class ).any() );
+    }
+}


### PR DESCRIPTION
Move dependency resolution to plugin construction phase to follow expected dependency
resolution contract: all external dependencies should be resolved during
plugin instantiation, instead of followed lifecycle phases.