### PR TITLE
Use dependency resolver to resolve FileSystem from KernelContext.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -68,7 +68,6 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
-
 import static org.neo4j.helpers.Service.load;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
@@ -189,7 +188,7 @@ public class ConsistencyCheckService
             Dependencies dependencies = new Dependencies();
             dependencies.satisfyDependencies( consistencyCheckerConfig, fileSystem,
                     new SimpleLogService( logProvider, logProvider ), indexStoreView, pageCache );
-            KernelContext kernelContext = new SimpleKernelContext( fileSystem, storeDir, UNKNOWN, dependencies );
+            KernelContext kernelContext = new SimpleKernelContext( storeDir, UNKNOWN, dependencies );
             KernelExtensions extensions = life.add( new KernelExtensions(
                     kernelContext, (Iterable) load( KernelExtensionFactory.class ), dependencies, ignore() ) );
             life.start();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -194,7 +194,7 @@ public class PlatformModule
         transactionMonitor = dependencies.satisfyDependency( createTransactionStats() );
 
         kernelExtensions = dependencies.satisfyDependency( new KernelExtensions(
-                new SimpleKernelContext( fileSystem, storeDir, databaseInfo, dependencies ),
+                new SimpleKernelContext( storeDir, databaseInfo, dependencies ),
                 externalDependencies.kernelExtensions(), dependencies, UnsatisfiedDependencyStrategies.fail() ) );
 
         urlAccessRule = dependencies.satisfyDependency( URLAccessRules.combined( externalDependencies.urlAccessRules() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/KernelContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/KernelContext.java
@@ -21,13 +21,11 @@ package org.neo4j.kernel.impl.spi;
 
 import java.io.File;
 
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.util.DependencySatisfier;
 
 public interface KernelContext
 {
-    FileSystemAbstraction fileSystem();
 
     File storeDir();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/SimpleKernelContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/spi/SimpleKernelContext.java
@@ -21,30 +21,20 @@ package org.neo4j.kernel.impl.spi;
 
 import java.io.File;
 
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.util.DependencySatisfier;
 
 public class SimpleKernelContext implements KernelContext
 {
-    private final FileSystemAbstraction fileSystem;
     private final File storeDir;
     private final DatabaseInfo databaseInfo;
     private final DependencySatisfier satisfier;
 
-    public SimpleKernelContext( FileSystemAbstraction fileSystem, File storeDir, DatabaseInfo databaseInfo,
-            DependencySatisfier satisfier )
+    public SimpleKernelContext( File storeDir, DatabaseInfo databaseInfo, DependencySatisfier satisfier )
     {
-        this.fileSystem = fileSystem;
         this.storeDir = storeDir;
         this.databaseInfo = databaseInfo;
         this.satisfier = satisfier;
-    }
-
-    @Override
-    public FileSystemAbstraction fileSystem()
-    {
-        return fileSystem;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -51,8 +51,6 @@ import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
-import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -61,8 +59,6 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.index.IndexConfiguration;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -71,6 +67,10 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
+import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.extension.KernelExtensions;
@@ -280,7 +280,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         deps.satisfyDependencies( fileSystem, config, logService, indexStoreView );
 
         KernelExtensions extensions = life.add( new KernelExtensions(
-                new SimpleKernelContext( fileSystem, storeDir, DatabaseInfo.UNKNOWN, deps ),
+                new SimpleKernelContext( storeDir, DatabaseInfo.UNKNOWN, deps ),
                 kernelExtensions, deps, UnsatisfiedDependencyStrategies.ignore() ) );
 
         SchemaIndexProvider provider = extensions.resolveDependency( SchemaIndexProvider.class,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -158,8 +158,7 @@ public class BatchingNeoStores implements AutoCloseable
         dependencies.satisfyDependency( this );
         dependencies.satisfyDependency( logService );
         dependencies.satisfyDependency( IndexStoreView.EMPTY );
-        KernelContext kernelContext = new SimpleKernelContext( fileSystem, storeDir, DatabaseInfo.UNKNOWN,
-                dependencies );
+        KernelContext kernelContext = new SimpleKernelContext( storeDir, DatabaseInfo.UNKNOWN, dependencies );
         @SuppressWarnings( { "unchecked", "rawtypes" } )
         KernelExtensions extensions = life.add( new KernelExtensions(
                 kernelContext, (Iterable) Service.load( KernelExtensionFactory.class ),

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
@@ -20,6 +20,7 @@
 package org.neo4j.index.lucene;
 
 import org.neo4j.index.impl.lucene.legacy.LuceneIndexImplementation;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
@@ -36,6 +37,8 @@ public class LuceneKernelExtensionFactory extends KernelExtensionFactory<LuceneK
         IndexProviders getIndexProviders();
 
         IndexConfigStore getIndexStore();
+
+        FileSystemAbstraction fileSystem();
     }
 
     public LuceneKernelExtensionFactory()
@@ -50,7 +53,7 @@ public class LuceneKernelExtensionFactory extends KernelExtensionFactory<LuceneK
                 context.storeDir(),
                 dependencies.getConfig(),
                 dependencies::getIndexStore,
-                context.fileSystem(),
+                dependencies.fileSystem(),
                 dependencies.getIndexProviders() );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderFactory.java
@@ -46,6 +46,8 @@ public class LuceneSchemaIndexProviderFactory extends
         Config getConfig();
 
         LogService getLogging();
+
+        FileSystemAbstraction fileSystem();
     }
 
     public LuceneSchemaIndexProviderFactory()
@@ -60,7 +62,7 @@ public class LuceneSchemaIndexProviderFactory extends
         LogProvider logging = dependencies.getLogging().getInternalLogProvider();
         boolean ephemeral = config.get( GraphDatabaseFacadeFactory.Configuration.ephemeral );
 
-        FileSystemAbstraction fileSystem = context.fileSystem();
+        FileSystemAbstraction fileSystem = dependencies.fileSystem();
         DirectoryFactory directoryFactory = directoryFactory( ephemeral, fileSystem );
 
         return new LuceneSchemaIndexProvider( fileSystem, directoryFactory, context.storeDir(), logging, config,

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -105,7 +105,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.storemigration.StoreFile.COUNTS_STORE_LEFT;
 import static org.neo4j.kernel.impl.storemigration.StoreFile.COUNTS_STORE_RIGHT;
 
@@ -810,7 +809,7 @@ public class BackupServiceIT
 
         OnlineBackupKernelExtension backup = (OnlineBackupKernelExtension)
                 new OnlineBackupExtensionFactory().newInstance(
-                        new SimpleKernelContext( fileSystem, storeDir, DatabaseInfo.UNKNOWN, dependencies ),
+                        new SimpleKernelContext( storeDir, DatabaseInfo.UNKNOWN, dependencies ),
                         DependenciesProxy.dependencies( dependencies, OnlineBackupExtensionFactory.Dependencies.class )
                 );
         backup.start();
@@ -880,7 +879,7 @@ public class BackupServiceIT
 
         OnlineBackupKernelExtension backup = (OnlineBackupKernelExtension)
                 new OnlineBackupExtensionFactory().newInstance(
-                        new SimpleKernelContext( fileSystem, storeDir, DatabaseInfo.UNKNOWN, dependencies ),
+                        new SimpleKernelContext( storeDir, DatabaseInfo.UNKNOWN, dependencies ),
                         DependenciesProxy.dependencies( dependencies, OnlineBackupExtensionFactory.Dependencies.class )
                 );
 

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
@@ -60,8 +60,7 @@ public class CsvOutputTest
     public void setup()
     {
         File storeDir = directory.directory();
-        kernelContext = new SimpleKernelContext( fileSystemRule.get(), storeDir,
-                DatabaseInfo.UNKNOWN, new Dependencies() );
+        kernelContext = new SimpleKernelContext( storeDir, DatabaseInfo.UNKNOWN, new Dependencies() );
     }
 
     @Test

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -109,7 +109,7 @@ public class StoreMigration
         deps.satisfyDependencies( fs, config );
         deps.satisfyDependencies( legacyIndexProvider );
 
-        KernelContext kernelContext = new SimpleKernelContext( fs, storeDirectory, DatabaseInfo.UNKNOWN, deps );
+        KernelContext kernelContext = new SimpleKernelContext( storeDirectory, DatabaseInfo.UNKNOWN, deps );
         KernelExtensions kernelExtensions = life.add( new KernelExtensions(
                 kernelContext, GraphDatabaseDependencies.newDependencies().kernelExtensions(),
                 deps, ignore() ) );


### PR DESCRIPTION
Remove specific method to provide file system from kernel context.
All component dependencies should be provided by dependency resolver.