### PR TITLE
Added a validator for dbms.security.auth_provider(s)

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidator.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.configuration;
+
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.graphdb.config.SettingValidator;
+import org.neo4j.kernel.configuration.ConfigurationValidator;
+import org.neo4j.logging.Log;
+
+
+public class SecurityConfigurationValidator implements ConfigurationValidator
+{
+    @Override
+    public Map<String,String> validate( Collection<SettingValidator> settingValidators, Map<String,String> rawConfig,
+            Log log ) throws InvalidSettingException
+    {
+        String provider = SecuritySettings.auth_provider.apply( rawConfig::get );
+        List<String> providers = SecuritySettings.auth_providers.apply( rawConfig::get );
+
+        validateServerId( provider, providers );
+
+        return rawConfig;
+    }
+
+    private static void validateServerId( String provider, List<String> providers )
+    {
+        if ( providers.size() > 1 || !providers.contains( provider ) )
+        {
+            throw new InvalidSettingException( String.format( "Using both SecuritySettings.auth_provider and SecuritySettings.auth_providers and they " +
+                    "do not match: auth_provider = %s , auth_provider = %s", provider, providers ) );
+        }
+
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidatorTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidatorTest.java
@@ -33,8 +33,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class SecurityConfigurationValidatorTest
 {
-
-
     @Test
     public void shouldWarnIfUsingSeveralConfigs() throws Throwable
     {
@@ -48,7 +46,7 @@ public class SecurityConfigurationValidatorTest
         }
         catch ( InvalidSettingException invalid )
         {
-            assertEquals( "Using both auth_provider and auth_providers and they do not match:" +
+            assertEquals( "Using both SecuritySettings.auth_provider and SecuritySettings.auth_providers and they do not match:" +
                     " auth_provider = native , auth_provider = [native, LDAP]", invalid.getMessage() );
         }
     }
@@ -65,7 +63,7 @@ public class SecurityConfigurationValidatorTest
         }
         catch ( InvalidSettingException invalid )
         {
-            assertEquals( "Using both auth_provider and auth_providers and they do not match:" +
+            assertEquals( "Using both SecuritySettings.auth_provider and SecuritySettings.auth_providers and they do not match:" +
                     " auth_provider = native , auth_provider = [LDAP]", invalid.getMessage() );
         }
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidatorTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/configuration/SecurityConfigurationValidatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.configuration;
+
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class SecurityConfigurationValidatorTest
+{
+
+
+    @Test
+    public void shouldWarnIfUsingSeveralConfigs() throws Throwable
+    {
+        try
+        {
+            Config.embeddedDefaults( (stringMap( SecuritySettings.auth_providers.name(), "native, LDAP",
+                    SecuritySettings.auth_provider.name(), "native" )),
+                    Collections.singleton( new SecurityConfigurationValidator() ) );
+
+            fail();
+        }
+        catch ( InvalidSettingException invalid )
+        {
+            assertEquals( "Using both auth_provider and auth_providers and they do not match:" +
+                    " auth_provider = native , auth_provider = [native, LDAP]", invalid.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldWarnIfUsingConflictingConfigs() throws Throwable
+    {
+        try
+        {
+            Config.embeddedDefaults(
+                    (stringMap( SecuritySettings.auth_providers.name(), "LDAP", SecuritySettings.auth_provider.name(),
+                            "native" )), Collections.singleton( new SecurityConfigurationValidator() ) );
+            fail();
+        }
+        catch ( InvalidSettingException invalid )
+        {
+            assertEquals( "Using both auth_provider and auth_providers and they do not match:" +
+                    " auth_provider = native , auth_provider = [LDAP]", invalid.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldNotWarnIfUsingAgreeingConfigs() throws Throwable
+    {
+        Config.embeddedDefaults(
+                (stringMap( SecuritySettings.auth_providers.name(), "native", SecuritySettings.auth_provider.name(),
+                        "native" )), Collections.singleton( new SecurityConfigurationValidator() ) );
+
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -28,6 +28,7 @@ import org.neo4j.configuration.HaConfigurationValidator;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.ConfigurationValidator;
+import org.neo4j.kernel.configuration.ServerConfigurationValidator;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.CommunityBootstrapper;
 import org.neo4j.server.NeoServer;
@@ -48,6 +49,7 @@ public class EnterpriseBootstrapper extends CommunityBootstrapper
         ArrayList<ConfigurationValidator> validators = new ArrayList<>();
         validators.addAll( super.configurationValidators() );
         validators.add( new HaConfigurationValidator() );
+        validators.add( new ServerConfigurationValidator() );
         validators.add( new CausalClusterConfigurationValidator() );
         return validators;
     }


### PR DESCRIPTION
changelog: Now dbms.security.auth_provider` and `dbms.security.auth_providers` can not be set to different things at the same time.