### PR TITLE
Refactored count-store to use indexId

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.schema_new.index;
 
+import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 
 /**
@@ -26,10 +27,15 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
  */
 public class IndexBoundary
 {
-    public static org.neo4j.kernel.api.schema.IndexDescriptor map( NewIndexDescriptor descriptor )
+    public static IndexDescriptor map( NewIndexDescriptor descriptor )
     {
         LabelSchemaDescriptor labelSchema = (LabelSchemaDescriptor) descriptor.schema();
         return org.neo4j.kernel.api.schema.IndexDescriptorFactory.of(
                 labelSchema.getLabelId(), labelSchema.getPropertyIds()[0] );
+    }
+
+    public static NewIndexDescriptor map( IndexDescriptor descriptor )
+    {
+        return NewIndexDescriptorFactory.forLabel( descriptor.getLabelId(), descriptor.getPropertyKeyId() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
@@ -65,7 +65,14 @@ public class IndexProcedures implements AutoCloseable
         int labelId = getLabelId( index.label() );
         int propertyKeyId = getPropertyKeyId( index.property() );
         //TODO: Support composite indexes
-        triggerSampling( getIndex( labelId, propertyKeyId, index ) );
+        try
+        {
+            triggerSampling( getIndex( labelId, propertyKeyId, index ) );
+        }
+        catch ( IndexNotFoundKernelException e )
+        {
+            throw new ProcedureException( e.status(), e.getMessage(), e );
+        }
     }
 
     public void resampleOutdatedIndexes()
@@ -157,7 +164,7 @@ public class IndexProcedures implements AutoCloseable
         }
     }
 
-    private void triggerSampling( IndexDescriptor index )
+    private void triggerSampling( IndexDescriptor index ) throws IndexNotFoundKernelException
     {
         indexingService.triggerIndexSampling( index, IndexSamplingMode.TRIGGER_REBUILD_ALL );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsAccessor.java
@@ -40,13 +40,13 @@ public interface CountsAccessor extends CountsVisitor.Visitable
      * @param target a register to store the read values in
      * @return the input register for convenience
      */
-    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister target );
+    DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister target );
 
     /**
      * @param target a register to store the read values in
      * @return the input register for convenience
      */
-    DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister target );
+    DoubleLongRegister indexSample( long indexId, DoubleLongRegister target );
 
     interface Updater extends AutoCloseable
     {
@@ -60,11 +60,11 @@ public interface CountsAccessor extends CountsVisitor.Visitable
 
     interface IndexStatsUpdater extends AutoCloseable
     {
-        void replaceIndexUpdateAndSize( IndexDescriptor descriptor, long updates, long size );
+        void replaceIndexUpdateAndSize( long indexId, long updates, long size );
 
-        void replaceIndexSample( IndexDescriptor descriptor, long unique, long size );
+        void replaceIndexSample( long indexId, long unique, long size );
 
-        void incrementIndexUpdates( IndexDescriptor descriptor, long delta );
+        void incrementIndexUpdates( long indexId, long delta );
 
         @Override
         void close();
@@ -94,15 +94,15 @@ public interface CountsAccessor extends CountsVisitor.Visitable
         }
 
         @Override
-        public void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size )
+        public void visitIndexStatistics( long indexId, long updates, long size )
         {
-            stats.replaceIndexUpdateAndSize( descriptor, updates, size );
+            stats.replaceIndexUpdateAndSize( indexId, updates, size );
         }
 
         @Override
-        public void visitIndexSample( IndexDescriptor descriptor, long unique, long size )
+        public void visitIndexSample( long indexId, long unique, long size )
         {
-            stats.replaceIndexSample( descriptor, unique, size );
+            stats.replaceIndexSample( indexId, unique, size );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.state.RecordState;
@@ -68,9 +67,9 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
     }
 
     @Override
-    public DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister target )
+    public DoubleLongRegister indexSample( long indexId, DoubleLongRegister target )
     {
-        counts( indexSampleKey( descriptor ) ).copyTo( target );
+        counts( indexSampleKey( indexId ) ).copyTo( target );
         return target;
     }
 
@@ -84,28 +83,28 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
     }
 
     @Override
-    public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister target )
+    public DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister target )
     {
-        counts( indexStatisticsKey( descriptor ) ).copyTo( target );
+        counts( indexStatisticsKey( indexId ) ).copyTo( target );
         return target;
     }
 
     @Override
-    public void replaceIndexUpdateAndSize( IndexDescriptor descriptor, long updates, long size )
+    public void replaceIndexUpdateAndSize( long indexId, long updates, long size )
     {
-        counts( indexStatisticsKey( descriptor ) ).write( updates, size );
+        counts( indexStatisticsKey( indexId ) ).write( updates, size );
     }
 
     @Override
-    public void incrementIndexUpdates( IndexDescriptor descriptor, long delta )
+    public void incrementIndexUpdates( long indexId, long delta )
     {
-        counts( indexStatisticsKey( descriptor ) ).increment( delta, 0L );
+        counts( indexStatisticsKey( indexId ) ).increment( delta, 0L );
     }
 
     @Override
-    public void replaceIndexSample( IndexDescriptor descriptor, long unique, long size )
+    public void replaceIndexSample( long indexId, long unique, long size )
     {
-        counts( indexSampleKey( descriptor ) ).write( unique, size );
+        counts( indexSampleKey( indexId ) ).write( unique, size );
     }
 
     @Override
@@ -286,15 +285,15 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
             verify( relationshipKey( startLabelId, typeId, endLabelId ), 0, count );
         }
         @Override
-        public void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size )
+        public void visitIndexStatistics( long indexId, long updates, long size )
         {
-            verify( indexStatisticsKey( descriptor ), updates, size );
+            verify( indexStatisticsKey( indexId ), updates, size );
         }
 
         @Override
-        public void visitIndexSample( IndexDescriptor descriptor, long unique, long size )
+        public void visitIndexSample( long indexId, long unique, long size )
         {
-            verify( indexSampleKey( descriptor ), unique, size );
+            verify( indexSampleKey( indexId ), unique, size );
         }
 
         private void verify( CountsKey key, long actualFirst, long actualSecond )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsVisitor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-
 public interface CountsVisitor
 {
     interface Visitable
@@ -32,9 +30,9 @@ public interface CountsVisitor
 
     void visitRelationshipCount( int startLabelId, int typeId, int endLabelId, long count );
 
-    void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size );
+    void visitIndexStatistics( long indexId, long updates, long size );
 
-    void visitIndexSample( IndexDescriptor descriptor, long unique, long size );
+    void visitIndexSample( long indexId, long unique, long size );
 
     public static class Adapter implements CountsVisitor
     {
@@ -51,13 +49,13 @@ public interface CountsVisitor
         }
 
         @Override
-        public void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size )
+        public void visitIndexStatistics( long indexId, long updates, long size )
         {
             // override in subclasses
         }
 
         @Override
-        public void visitIndexSample( IndexDescriptor descriptor, long unique, long size )
+        public void visitIndexSample( long indexId, long unique, long size )
         {
             // override in subclasses
         }
@@ -85,20 +83,20 @@ public interface CountsVisitor
                 }
 
                 @Override
-                public void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size )
+                public void visitIndexStatistics( long indexId, long updates, long size )
                 {
                     for ( CountsVisitor visitor : visitors )
                     {
-                        visitor.visitIndexStatistics( descriptor, updates, size );
+                        visitor.visitIndexStatistics( indexId, updates, size );
                     }
                 }
 
                 @Override
-                public void visitIndexSample( IndexDescriptor descriptor, long unique, long size )
+                public void visitIndexSample( long indexId, long unique, long size )
                 {
                     for ( CountsVisitor visitor : visitors )
                     {
-                        visitor.visitIndexSample( descriptor, unique, size );
+                        visitor.visitIndexSample( indexId, unique, size );
                     }
                 }
             };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1160,13 +1160,14 @@ public class StateHandlingStatementOperations implements
 
     @Override
     public DoubleLongRegister indexUpdatesAndSize( KernelStatement statement, IndexDescriptor index,
-            DoubleLongRegister target )
+            DoubleLongRegister target ) throws IndexNotFoundKernelException
     {
         return storeLayer.indexUpdatesAndSize( index, target );
     }
 
     @Override
     public DoubleLongRegister indexSample( KernelStatement statement, IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException
     {
         return storeLayer.indexSample( index, target );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
@@ -121,11 +121,11 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
     }
 
     @Override
-    protected IndexPopulation createPopulation( IndexPopulator populator,
+    protected IndexPopulation createPopulation( IndexPopulator populator, long indexId,
             IndexDescriptor descriptor, IndexConfiguration config, SchemaIndexProvider.Descriptor providerDescriptor,
             FlippableIndexProxy flipper, FailedIndexProxyFactory failedIndexProxyFactory, String indexUserDescription )
     {
-        return new BatchingIndexPopulation( populator, descriptor, config, providerDescriptor, flipper,
+        return new BatchingIndexPopulation( populator, indexId, descriptor, config, providerDescriptor, flipper,
                 failedIndexProxyFactory, indexUserDescription );
     }
 
@@ -339,11 +339,12 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
      */
     private class BatchingIndexPopulation extends IndexPopulation
     {
-        BatchingIndexPopulation( IndexPopulator populator, IndexDescriptor descriptor, IndexConfiguration config,
-                SchemaIndexProvider.Descriptor providerDescriptor, FlippableIndexProxy flipper,
-                FailedIndexProxyFactory failedIndexProxyFactory, String indexUserDescription )
+        BatchingIndexPopulation( IndexPopulator populator, long indexId, IndexDescriptor descriptor,
+                IndexConfiguration config, SchemaIndexProvider.Descriptor providerDescriptor,
+                FlippableIndexProxy flipper, FailedIndexProxyFactory failedIndexProxyFactory,
+                String indexUserDescription )
         {
-            super( populator, descriptor, config, providerDescriptor, flipper, failedIndexProxyFactory,
+            super( populator, indexId, descriptor, config, providerDescriptor, flipper, failedIndexProxyFactory,
                     indexUserDescription );
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexCountsRemover.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexCountsRemover.java
@@ -24,16 +24,16 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 public class IndexCountsRemover
 {
     private final IndexStoreView storeView;
-    private final IndexDescriptor descriptor;
+    private final long indexId;
 
-    public IndexCountsRemover( final IndexStoreView storeView, final IndexDescriptor descriptor )
+    public IndexCountsRemover( final IndexStoreView storeView, final long indexId )
     {
         this.storeView = storeView;
-        this.descriptor = descriptor;
+        this.indexId = indexId;
     }
 
     public void remove()
     {
-        storeView.replaceIndexCounts( descriptor, 0, 0, 0 );
+        storeView.replaceIndexCounts( indexId, 0, 0, 0 );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -36,16 +36,18 @@ public final class IndexMap implements Cloneable
 {
     private final Map<Long, IndexProxy> indexesById;
     private final Map<IndexDescriptor, IndexProxy> indexesByDescriptor;
+    private final Map<IndexDescriptor, Long> indexIdsByDescriptor;
 
     public IndexMap()
     {
-        this( new HashMap<>(), new HashMap<>() );
+        this( new HashMap<>(), new HashMap<>(), new HashMap<>() );
     }
 
-    private IndexMap( Map<Long, IndexProxy> indexesById, Map<IndexDescriptor, IndexProxy> indexesByDescriptor )
+    private IndexMap( Map<Long, IndexProxy> indexesById, Map<IndexDescriptor, IndexProxy> indexesByDescriptor, Map<IndexDescriptor, Long> indexIdsByDescriptor )
     {
         this.indexesById = indexesById;
         this.indexesByDescriptor = indexesByDescriptor;
+        this.indexIdsByDescriptor = indexIdsByDescriptor;
     }
 
     public IndexProxy getIndexProxy( long indexId )
@@ -58,10 +60,16 @@ public final class IndexMap implements Cloneable
         return indexesByDescriptor.get( descriptor );
     }
 
+    public long getIndexId( IndexDescriptor descriptor )
+    {
+        return indexIdsByDescriptor.get( descriptor );
+    }
+
     public void putIndexProxy( long indexId, IndexProxy indexProxy )
     {
         indexesById.put( indexId, indexProxy );
         indexesByDescriptor.put( indexProxy.getDescriptor(), indexProxy );
+        indexIdsByDescriptor.put( indexProxy.getDescriptor(), indexId );
     }
 
     public IndexProxy removeIndexProxy( long indexId )
@@ -90,7 +98,8 @@ public final class IndexMap implements Cloneable
     @Override
     public IndexMap clone()
     {
-        return new IndexMap( cloneMap( indexesById ), cloneMap( indexesByDescriptor ) );
+        return new IndexMap( cloneMap( indexesById ), cloneMap( indexesByDescriptor ),
+                cloneMap( indexIdsByDescriptor ) );
     }
 
     private <K, V> Map<K, V> cloneMap( Map<K, V> map )
@@ -103,6 +112,11 @@ public final class IndexMap implements Cloneable
     public Iterator<IndexDescriptor> descriptors()
     {
         return indexesByDescriptor.keySet().iterator();
+    }
+
+    public Iterator<Long> indexIds()
+    {
+        return indexesById.keySet().iterator();
     }
 
     public int size()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
@@ -52,16 +52,26 @@ public class IndexMapReference implements IndexMapSnapshotProvider
         return proxy;
     }
 
-    public IndexProxy getOnlineIndexProxy( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public long getIndexId( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    {
+        IndexProxy proxy = indexMap.getIndexProxy( descriptor );
+        if ( proxy == null )
+        {
+            throw new IndexNotFoundKernelException( "No index for " + descriptor + " exists." );
+        }
+        return indexMap.getIndexId( descriptor );
+    }
+
+    public long getOnlineIndexId( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         IndexProxy proxy = getIndexProxy( descriptor );
         switch ( proxy.getState() )
         {
-            case ONLINE:
-                return proxy;
+        case ONLINE:
+            return indexMap.getIndexId( descriptor );
 
-            default:
-                throw new IndexNotFoundKernelException( "Expected index on " + descriptor + " to be online.");
+        default:
+            throw new IndexNotFoundKernelException( "Expected index on " + descriptor + " to be online.");
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -75,6 +75,7 @@ public class IndexPopulationJob implements Runnable
      * @param failedIndexProxyFactory {@link FailedIndexProxyFactory} to use after an unsuccessful population.
      */
     public void addPopulator( IndexPopulator populator,
+            long indexId,
             IndexDescriptor descriptor,
             IndexConfiguration config,
             SchemaIndexProvider.Descriptor providerDescriptor,
@@ -83,7 +84,7 @@ public class IndexPopulationJob implements Runnable
             FailedIndexProxyFactory failedIndexProxyFactory )
     {
         assert storeScan == null : "Population have already started, too late to add populators at this point";
-        this.multiPopulator.addPopulator( populator, descriptor, providerDescriptor, config, flipper,
+        this.multiPopulator.addPopulator( populator, indexId, descriptor, providerDescriptor, config, flipper,
                 failedIndexProxyFactory, indexUserDescription );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxyCreator.java
@@ -77,14 +77,14 @@ public class IndexProxyCreator
                 providerDescriptor,
                 populator,
                 indexUserDescription,
-                new IndexCountsRemover( storeView, descriptor ),
+                new IndexCountsRemover( storeView, ruleId ),
                 logProvider
         );
 
         PopulatingIndexProxy populatingIndex =
                 new PopulatingIndexProxy( descriptor, config, providerDescriptor, populationJob );
 
-        populationJob.addPopulator( populator, descriptor, config, providerDescriptor, indexUserDescription,
+        populationJob.addPopulator( populator, ruleId, descriptor, config, providerDescriptor, indexUserDescription,
                 flipper, failureDelegateFactory );
 
         flipper.flipTo( populatingIndex );
@@ -92,7 +92,7 @@ public class IndexProxyCreator
         // Prepare for flipping to online mode
         flipper.setFlipTarget( () -> {
             monitor.populationCompleteOn( descriptor );
-            OnlineIndexProxy onlineProxy = new OnlineIndexProxy(
+            OnlineIndexProxy onlineProxy = new OnlineIndexProxy(ruleId,
                     descriptor, config, onlineAccessorFromProvider( providerDescriptor, ruleId,
                     config, samplingConfig ), storeView, providerDescriptor, true
             );
@@ -127,7 +127,7 @@ public class IndexProxyCreator
             IndexAccessor onlineAccessor =
                     onlineAccessorFromProvider( providerDescriptor, ruleId, config, samplingConfig );
             IndexProxy proxy;
-            proxy = new OnlineIndexProxy( descriptor, config, onlineAccessor, storeView, providerDescriptor, false );
+            proxy = new OnlineIndexProxy( ruleId, descriptor, config, onlineAccessor, storeView, providerDescriptor, false );
             proxy = new ContractCheckingIndexProxy( proxy, true );
             return proxy;
         }
@@ -158,7 +158,7 @@ public class IndexProxyCreator
                 indexUserDescription,
                 indexPopulator,
                 populationFailure,
-                new IndexCountsRemover( storeView, descriptor ),
+                new IndexCountsRemover( storeView, ruleId ),
                 logProvider
         );
         proxy = new ContractCheckingIndexProxy( proxy, true );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -57,13 +57,13 @@ public interface IndexStoreView extends PropertyAccessor
      */
     void nodeAsUpdates( long nodeId, Collection<NodePropertyUpdate> target );
 
-    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister output );
+    DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister output );
 
-    DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister output );
+    DoubleLongRegister indexSample( long indexId, DoubleLongRegister output );
 
-    void replaceIndexCounts( IndexDescriptor descriptor, long uniqueElements, long maxUniqueElements, long indexSize );
+    void replaceIndexCounts( long indexId, long uniqueElements, long maxUniqueElements, long indexSize );
 
-    void incrementIndexUpdates( IndexDescriptor descriptor, long updatesDelta );
+    void incrementIndexUpdates( long indexId, long updatesDelta );
 
     StoreScan EMPTY_SCAN = new StoreScan()
     {
@@ -114,7 +114,7 @@ public interface IndexStoreView extends PropertyAccessor
         }
 
         @Override
-        public void replaceIndexCounts( IndexDescriptor descriptor, long uniqueElements, long maxUniqueElements,
+        public void replaceIndexCounts( long indexId, long uniqueElements, long maxUniqueElements,
                 long indexSize )
         {
         }
@@ -125,19 +125,19 @@ public interface IndexStoreView extends PropertyAccessor
         }
 
         @Override
-        public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister output )
+        public DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister output )
         {
             return output;
         }
 
         @Override
-        public DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister output )
+        public DoubleLongRegister indexSample( long indexId, DoubleLongRegister output )
         {
             return output;
         }
 
         @Override
-        public void incrementIndexUpdates( IndexDescriptor descriptor, long updatesDelta )
+        public void incrementIndexUpdates( long indexId, long updatesDelta )
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -371,17 +371,17 @@ public class IndexingService extends LifecycleAdapter
 
     public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( descriptor );
+        final long indexId = indexMapRef.getOnlineIndexId( descriptor );
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
-        storeView.indexUpdatesAndSize( indexProxy.getDescriptor(), output );
+        storeView.indexUpdatesAndSize( indexId, output );
         return output;
     }
 
     public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( descriptor );
+        final long indexId = indexMapRef.getOnlineIndexId( descriptor );
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
-        storeView.indexSample( indexProxy.getDescriptor(), output );
+        storeView.indexSample( indexId, output );
         long unique = output.readFirst();
         long size = output.readSecond();
         if ( size == 0 )
@@ -624,10 +624,11 @@ public class IndexingService extends LifecycleAdapter
     }
 
     public void triggerIndexSampling( IndexDescriptor descriptor, IndexSamplingMode mode )
+            throws IndexNotFoundKernelException
     {
         String description = descriptor.userDescription( tokenNameLookup );
         log.info( "Manual trigger for sampling index " + description + " [" + mode + "]" );
-        samplingController.sampleIndex( descriptor, mode );
+        samplingController.sampleIndex( indexMapRef.getIndexId( descriptor ), mode );
     }
 
     private void awaitIndexFuture( Future<Void> future ) throws Exception
@@ -680,6 +681,11 @@ public class IndexingService extends LifecycleAdapter
     public IndexProxy getIndexProxy( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         return indexMapRef.getIndexProxy( descriptor );
+    }
+
+    public long getIndexId( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    {
+        return indexMapRef.getIndexId( descriptor );
     }
 
     public void validateIndex( long indexId ) throws IndexNotFoundKernelException, ConstraintVerificationFailedKernelException, IndexPopulationFailedKernelException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -39,6 +39,7 @@ import static org.neo4j.helpers.FutureAdapter.VOID;
 
 public class OnlineIndexProxy implements IndexProxy
 {
+    private final long indexId;
     private final IndexDescriptor descriptor;
     final IndexAccessor accessor;
     private final IndexStoreView storeView;
@@ -72,17 +73,18 @@ public class OnlineIndexProxy implements IndexProxy
     //   slightly more costly, but shouldn't make that big of a difference hopefully.
     private final boolean forcedIdempotentMode;
 
-    public OnlineIndexProxy( IndexDescriptor descriptor, IndexConfiguration configuration, IndexAccessor accessor,
-                             IndexStoreView storeView, SchemaIndexProvider.Descriptor providerDescriptor,
-                             boolean forcedIdempotentMode )
+    public OnlineIndexProxy( long indexId, IndexDescriptor descriptor, IndexConfiguration configuration,
+            IndexAccessor accessor, IndexStoreView storeView, SchemaIndexProvider.Descriptor providerDescriptor,
+            boolean forcedIdempotentMode )
     {
+        this.indexId = indexId;
         this.descriptor = descriptor;
         this.storeView = storeView;
         this.providerDescriptor = providerDescriptor;
         this.accessor = accessor;
         this.configuration = configuration;
         this.forcedIdempotentMode = forcedIdempotentMode;
-        this.indexCountsRemover = new IndexCountsRemover( storeView, descriptor );
+        this.indexCountsRemover = new IndexCountsRemover( storeView, indexId );
     }
 
     @Override
@@ -98,7 +100,7 @@ public class OnlineIndexProxy implements IndexProxy
 
     private IndexUpdater updateCountingUpdater( final IndexUpdater indexUpdater )
     {
-        return new UpdateCountingIndexUpdater( storeView, descriptor, indexUpdater );
+        return new UpdateCountingIndexUpdater( storeView, indexId, indexUpdater );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJob.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index.sampling;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-
 public interface IndexSamplingJob extends Runnable
 {
-    IndexDescriptor descriptor();
+    long indexId();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobFactory.java
@@ -23,5 +23,5 @@ import org.neo4j.kernel.impl.api.index.IndexProxy;
 
 public interface IndexSamplingJobFactory
 {
-    IndexSamplingJob create( IndexProxy indexProxy );
+    IndexSamplingJob create( long indexId, IndexProxy indexProxy);
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
@@ -35,18 +35,18 @@ import static org.neo4j.kernel.api.index.InternalIndexState.ONLINE;
 
 class OnlineIndexSamplingJob implements IndexSamplingJob
 {
-    private final IndexDescriptor indexDescriptor;
+    private final long indexId;
     private final IndexProxy indexProxy;
     private final IndexStoreView storeView;
     private final Log log;
     private final String indexUserDescription;
 
-    public OnlineIndexSamplingJob( IndexProxy indexProxy,
+    public OnlineIndexSamplingJob( long indexId, IndexProxy indexProxy,
             IndexStoreView storeView,
             String indexUserDescription,
             LogProvider logProvider )
     {
-        this.indexDescriptor = indexProxy.getDescriptor();
+        this.indexId = indexId;
         this.indexProxy = indexProxy;
         this.storeView = storeView;
         this.log = logProvider.getLog( getClass() );
@@ -54,9 +54,9 @@ class OnlineIndexSamplingJob implements IndexSamplingJob
     }
 
     @Override
-    public IndexDescriptor descriptor()
+    public long indexId()
     {
-        return indexDescriptor;
+        return indexId;
     }
 
     @Override
@@ -74,7 +74,7 @@ class OnlineIndexSamplingJob implements IndexSamplingJob
                     // check again if the index is online before saving the counts in the store
                     if ( indexProxy.getState() == ONLINE )
                     {
-                        storeView.replaceIndexCounts( indexDescriptor, sample.uniqueValues(), sample.sampleSize(),
+                        storeView.replaceIndexCounts( indexId, sample.uniqueValues(), sample.sampleSize(),
                                 sample.indexSize() );
                         durationLogger.markAsFinished();
                         log.info(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobFactory.java
@@ -38,9 +38,9 @@ public class OnlineIndexSamplingJobFactory implements IndexSamplingJobFactory
     }
 
     @Override
-    public IndexSamplingJob create( IndexProxy indexProxy )
+    public IndexSamplingJob create( long indexId, IndexProxy indexProxy )
     {
         final String indexUserDescription = indexProxy.getDescriptor().userDescription( nameLookup );
-        return new OnlineIndexSamplingJob( indexProxy, storeView, indexUserDescription, logProvider );
+        return new OnlineIndexSamplingJob( indexId, indexProxy, storeView, indexUserDescription, logProvider );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
@@ -31,14 +31,14 @@ import org.neo4j.kernel.impl.api.index.IndexStoreView;
 public class UpdateCountingIndexUpdater implements IndexUpdater
 {
     private final IndexStoreView storeView;
-    private final IndexDescriptor descriptor;
+    private final long indexId;
     private final IndexUpdater delegate;
     private long updates;
 
-    public UpdateCountingIndexUpdater( IndexStoreView storeView, IndexDescriptor descriptor, IndexUpdater delegate )
+    public UpdateCountingIndexUpdater( IndexStoreView storeView, long indexId, IndexUpdater delegate )
     {
         this.storeView = storeView;
-        this.descriptor = descriptor;
+        this.indexId = indexId;
         this.delegate = delegate;
     }
 
@@ -53,7 +53,7 @@ public class UpdateCountingIndexUpdater implements IndexUpdater
     public void close() throws IOException, IndexEntryConflictException
     {
         delegate.close();
-        storeView.incrementIndexUpdates( descriptor, updates );
+        storeView.incrementIndexUpdates( indexId, updates );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/CountsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/CountsOperations.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.register.Register.DoubleLongRegister;
@@ -38,7 +39,8 @@ public interface CountsOperations
     long countsForRelationshipWithoutTxState( KernelStatement statement, int startLabelId, int typeId, int endLabelId );
 
     DoubleLongRegister indexUpdatesAndSize( KernelStatement statement, IndexDescriptor index,
-            DoubleLongRegister target );
+            DoubleLongRegister target ) throws IndexNotFoundKernelException;
 
-    DoubleLongRegister indexSample( KernelStatement statement, IndexDescriptor index, DoubleLongRegister target );
+    DoubleLongRegister indexSample( KernelStatement statement, IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -411,12 +411,14 @@ public class CacheLayer implements StoreReadLayer
 
     @Override
     public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException
     {
         return diskLayer.indexUpdatesAndSize( index, target );
     }
 
     @Override
     public DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException
     {
         return diskLayer.indexSample( index, target );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -502,14 +502,21 @@ public class DiskLayer implements StoreReadLayer
 
     @Override
     public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister target )
+            throws IndexNotFoundKernelException
     {
-        return counts.indexUpdatesAndSize( descriptor, target );
+        return counts.indexUpdatesAndSize( tryGetIndexId( descriptor ), target );
     }
 
     @Override
     public DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister target )
+            throws IndexNotFoundKernelException
     {
-        return counts.indexSample( descriptor, target );
+        return counts.indexSample( tryGetIndexId( descriptor ), target );
+    }
+
+    private long tryGetIndexId(IndexDescriptor descriptor) throws IndexNotFoundKernelException
+    {
+        return indexService.getIndexId( descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotDeserializer.java
@@ -69,15 +69,13 @@ public class CountsSnapshotDeserializer
                 break;
 
             case INDEX_SAMPLE:
-                descriptor = IndexDescriptorFactory.of( readNodePropertyDescriptor( channel ) );
-                key = indexSampleKey( descriptor );
+                key = indexSampleKey( channel.getLong() );
                 value = new long[]{channel.getLong(), channel.getLong()};
                 map.put( key, value );
                 break;
 
             case INDEX_STATISTICS:
-                descriptor = IndexDescriptorFactory.of( readNodePropertyDescriptor( channel ) );
-                key = indexStatisticsKey( descriptor );
+                key = indexStatisticsKey( channel.getLong() );
                 value = new long[]{channel.getLong(), channel.getLong()};
                 map.put( key, value );
                 break;
@@ -90,24 +88,5 @@ public class CountsSnapshotDeserializer
             }
         }
         return new CountsSnapshot( txid, map );
-    }
-
-    private static NodePropertyDescriptor readNodePropertyDescriptor( ReadableClosableChannel channel ) throws IOException
-    {
-        int labelId = channel.getInt();
-        short length = channel.getShort();
-        if ( length > 1 )
-        {
-            int[] propertyKeyIds = new int[length];
-            for ( int i = 0; i < length; i++ )
-            {
-                propertyKeyIds[i] = channel.getInt();
-            }
-            return new NodeMultiPropertyDescriptor( labelId, propertyKeyIds );
-        }
-        else
-        {
-            return new NodePropertyDescriptor( labelId, channel.getInt() );
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotSerializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotSerializer.java
@@ -85,7 +85,7 @@ public class CountsSnapshotSerializer
                 }
                 IndexSampleKey indexSampleKey = (IndexSampleKey) key;
                 channel.put( INDEX_SAMPLE.code );
-                writeIndexDescription( channel, indexSampleKey.descriptor() );
+                channel.putLong( indexSampleKey.indexId() );
                 channel.putLong( value[0] );
                 channel.putLong( value[1] );
                 break;
@@ -98,7 +98,7 @@ public class CountsSnapshotSerializer
                 }
                 IndexStatisticsKey indexStatisticsKey = (IndexStatisticsKey) key;
                 channel.put( INDEX_STATISTICS.code );
-                writeIndexDescription( channel, indexStatisticsKey.descriptor() );
+                channel.putLong( indexStatisticsKey.indexId() );
                 channel.putLong( value[0] );
                 channel.putLong( value[1] );
                 break;
@@ -109,25 +109,6 @@ public class CountsSnapshotSerializer
             default:
                 throw new IllegalArgumentException( "The read CountsKey has an unknown type." );
             }
-        }
-    }
-
-    private static void writeIndexDescription( FlushableChannel channel, IndexDescriptor descriptor ) throws IOException
-    {
-        channel.putInt( descriptor.getLabelId() );
-        if ( descriptor.isComposite() )
-        {
-            int[] propertyKeyIds = descriptor.getPropertyKeyIds();
-            channel.putShort( (short) propertyKeyIds.length );
-            for ( int prop : propertyKeyIds )
-            {
-                channel.putInt( prop );
-            }
-        }
-        else
-        {
-            channel.putShort( (short) 1 );
-            channel.putInt( descriptor.getPropertyKeyId() );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -77,7 +77,7 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
 {
     /** The format specifier for the current version of the store file format. */
     private static final byte[] FORMAT = {'N', 'e', 'o', 'C', 'o', 'u', 'n', 't',
-                                          'S', 't', 'o', 'r', 'e', /**/0, 1, 'V'};
+                                          'S', 't', 'o', 'r', 'e', /**/0, 2, 'V'};
     @SuppressWarnings("unchecked")
     private static final HeaderField<?>[] HEADER_FIELDS = new HeaderField[]{FileVersion.FILE_VERSION};
     public static final String LEFT = ".a", RIGHT = ".b";
@@ -184,16 +184,16 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
     }
 
     @Override
-    public Register.DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor,
+    public Register.DoubleLongRegister indexUpdatesAndSize( long indexId,
                                                             Register.DoubleLongRegister target )
     {
-        return get( indexStatisticsKey( descriptor ), target );
+        return get( indexStatisticsKey( indexId ), target );
     }
 
     @Override
-    public Register.DoubleLongRegister indexSample( IndexDescriptor descriptor, Register.DoubleLongRegister target )
+    public Register.DoubleLongRegister indexSample( long indexId, Register.DoubleLongRegister target )
     {
-        return get( indexSampleKey( descriptor ), target );
+        return get( indexSampleKey( indexId ), target );
     }
 
     public Optional<CountsAccessor.Updater> apply( long txId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -184,8 +184,7 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
     }
 
     @Override
-    public Register.DoubleLongRegister indexUpdatesAndSize( long indexId,
-                                                            Register.DoubleLongRegister target )
+    public Register.DoubleLongRegister indexUpdatesAndSize( long indexId, Register.DoubleLongRegister target )
     {
         return get( indexStatisticsKey( indexId ), target );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
@@ -98,11 +98,11 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
      * For key format, see {@link KeyFormat#visitIndexStatistics(IndexDescriptor, long, long)}
      */
     @Override
-    public void replaceIndexUpdateAndSize( IndexDescriptor descriptor, long updates, long size )
+    public void replaceIndexUpdateAndSize( long indexId, long updates, long size )
     {
         try
         {
-            updater.apply( indexStatisticsKey( descriptor ), new Write( updates, size ) );
+            updater.apply( indexStatisticsKey( indexId ), new Write( updates, size ) );
         }
         catch ( IOException e )
         {
@@ -121,11 +121,11 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
      * For key format, see {@link KeyFormat#visitIndexSample(IndexDescriptor, long, long)}
      */
     @Override
-    public void replaceIndexSample( IndexDescriptor descriptor, long unique, long size )
+    public void replaceIndexSample( long indexId, long unique, long size )
     {
         try
         {
-            updater.apply( indexSampleKey( descriptor ), new Write( unique, size ) );
+            updater.apply( indexSampleKey( indexId ), new Write( unique, size ) );
         }
         catch ( IOException e )
         {
@@ -135,14 +135,14 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
 
     /**
      * For key format, see {@link KeyFormat#visitIndexStatistics(IndexDescriptor, long, long)}
-     * For value format, see {@link CountsUpdater#replaceIndexUpdateAndSize(IndexDescriptor, long, long)}
+     * For value format, see {@link CountsUpdater#replaceIndexUpdateAndSize(long, long, long)}
      */
     @Override
-    public void incrementIndexUpdates( IndexDescriptor descriptor, long delta )
+    public void incrementIndexUpdates( long indexId, long delta )
     {
         try
         {
-            updater.apply( indexStatisticsKey( descriptor ), incrementFirstBy( delta ) );
+            updater.apply( indexStatisticsKey( indexId ), incrementFirstBy( delta ) );
         }
         catch ( IOException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/CountsKeyFactory.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.store.counts.keys;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-
 public class CountsKeyFactory
 {
     public static NodeKey nodeKey( int labelId )
@@ -33,13 +31,13 @@ public class CountsKeyFactory
         return new RelationshipKey( startLabelId, typeId, endLabelId );
     }
 
-    public static IndexStatisticsKey indexStatisticsKey( IndexDescriptor descriptor )
+    public static IndexStatisticsKey indexStatisticsKey( long indexId )
     {
-        return new IndexStatisticsKey( descriptor );
+        return new IndexStatisticsKey( indexId );
     }
 
-    public static IndexSampleKey indexSampleKey( IndexDescriptor descriptor )
+    public static IndexSampleKey indexSampleKey( long indexId )
     {
-        return new IndexSampleKey( descriptor );
+        return new IndexSampleKey( indexId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexKey.java
@@ -24,25 +24,24 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 
 abstract class IndexKey implements CountsKey
 {
-    private final IndexDescriptor descriptor;
+    private final long indexId;
     private final CountsKeyType type;
 
-    IndexKey( IndexDescriptor descriptor, CountsKeyType type )
+    IndexKey( long indexId, CountsKeyType type )
     {
-        this.descriptor = descriptor;
+        this.indexId = indexId;
         this.type = type;
     }
 
-    public IndexDescriptor descriptor()
+    public long indexId()
     {
-        return descriptor;
+        return indexId;
     }
 
     @Override
     public String toString()
     {
-        String propertyText = descriptor.descriptor().propertyIdText();
-        return String.format( "IndexKey[%s (%s {%s})]", type.name(), label( descriptor.getLabelId() ), propertyText );
+        return String.format( "IndexKey[%s:%d]", type.name(), indexId );
     }
 
     @Override
@@ -54,7 +53,7 @@ abstract class IndexKey implements CountsKey
     @Override
     public int hashCode()
     {
-        return 31 * descriptor.hashCode() + type.hashCode();
+        return 31 * (int) indexId + type.hashCode();
     }
 
     @Override
@@ -68,9 +67,7 @@ abstract class IndexKey implements CountsKey
         {
             return false;
         }
-
-        IndexKey indexKey = (IndexKey) other;
-        return indexKey.descriptor.equals( descriptor );
+        return ((IndexKey) other).indexId() == indexId;
     }
 
     @Override
@@ -78,8 +75,7 @@ abstract class IndexKey implements CountsKey
     {
         if ( other instanceof IndexKey )
         {
-            IndexKey that = (IndexKey) other;
-            return this.descriptor.descriptor().compareTo( that.descriptor.descriptor() );
+            return (int) (indexId - ((IndexKey) other).indexId());
         }
         return recordType().ordinal() - other.recordType().ordinal();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexSampleKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexSampleKey.java
@@ -24,15 +24,15 @@ import org.neo4j.kernel.impl.api.CountsVisitor;
 
 public final class IndexSampleKey extends IndexKey
 {
-    IndexSampleKey( IndexDescriptor descriptor )
+    IndexSampleKey( long indexId )
     {
-        super( descriptor, CountsKeyType.INDEX_SAMPLE );
+        super( indexId, CountsKeyType.INDEX_SAMPLE );
     }
 
     @Override
     public void accept( CountsVisitor visitor, long unique, long size )
     {
-        visitor.visitIndexSample( descriptor(), unique, size );
+        visitor.visitIndexSample( indexId(), unique, size );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexStatisticsKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/keys/IndexStatisticsKey.java
@@ -24,15 +24,15 @@ import org.neo4j.kernel.impl.api.CountsVisitor;
 
 public final class IndexStatisticsKey extends IndexKey
 {
-    IndexStatisticsKey( IndexDescriptor descriptor )
+    IndexStatisticsKey( long indexId )
     {
-        super( descriptor, CountsKeyType.INDEX_STATISTICS );
+        super( indexId, CountsKeyType.INDEX_STATISTICS );
     }
 
     @Override
     public void accept( CountsVisitor visitor, long updates, long size )
     {
-        visitor.visitIndexStatistics( descriptor(), updates, size );
+        visitor.visitIndexStatistics( indexId(), updates, size );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreView.java
@@ -24,7 +24,6 @@ import java.util.function.IntPredicate;
 
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.api.properties.Property;
@@ -67,35 +66,34 @@ public class NeoStoreIndexStoreView implements IndexStoreView
     }
 
     @Override
-    public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister output )
+    public DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister output )
     {
-        return counts.indexUpdatesAndSize( descriptor, output );
+        return counts.indexUpdatesAndSize( indexId, output );
     }
 
     @Override
-    public void replaceIndexCounts( IndexDescriptor descriptor,
-                                    long uniqueElements, long maxUniqueElements, long indexSize )
+    public void replaceIndexCounts( long indexId, long uniqueElements, long maxUniqueElements, long indexSize )
     {
         try ( CountsAccessor.IndexStatsUpdater updater = counts.updateIndexCounts() )
         {
-            updater.replaceIndexSample( descriptor, uniqueElements, maxUniqueElements );
-            updater.replaceIndexUpdateAndSize( descriptor, 0L, indexSize );
+            updater.replaceIndexSample( indexId, uniqueElements, maxUniqueElements );
+            updater.replaceIndexUpdateAndSize( indexId, 0L, indexSize );
         }
     }
 
     @Override
-    public void incrementIndexUpdates( IndexDescriptor descriptor, long updatesDelta )
+    public void incrementIndexUpdates( long indexId, long updatesDelta )
     {
         try ( CountsAccessor.IndexStatsUpdater updater = counts.updateIndexCounts() )
         {
-            updater.incrementIndexUpdates( descriptor, updatesDelta );
+            updater.incrementIndexUpdates( indexId, updatesDelta );
         }
     }
 
     @Override
-    public DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister output )
+    public DoubleLongRegister indexSample( long indexId, DoubleLongRegister output )
     {
-        return counts.indexSample( descriptor, output );
+        return counts.indexSample( indexId, output );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -373,9 +373,11 @@ public interface StoreReadLayer
 
     int relationshipTypeCount();
 
-    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target );
+    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException;
 
-    DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target );
+    DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target )
+            throws IndexNotFoundKernelException;
 
     boolean nodeExists( long id );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
@@ -119,7 +119,8 @@ public class ResampleIndexProcedureTest
     }
 
     @Test
-    public void shouldTriggerResampling() throws SchemaRuleNotFoundException, ProcedureException
+    public void shouldTriggerResampling()
+            throws SchemaRuleNotFoundException, ProcedureException, IndexNotFoundKernelException
     {
         IndexDescriptor index = IndexDescriptorFactory.of( 123, 456 );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( index );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
@@ -292,14 +292,18 @@ public class BatchingMultipleIndexPopulatorTest
     {
         IndexPopulator populator = mock( IndexPopulator.class );
         IndexDescriptor descriptor = IndexDescriptorFactory.of( id, id );
+        long indexId = id;
 
         IndexProxyFactory indexProxyFactory = mock( IndexProxyFactory.class );
         FailedIndexProxyFactory failedIndexProxyFactory = mock( FailedIndexProxyFactory.class );
         FlippableIndexProxy flipper = new FlippableIndexProxy();
         flipper.setFlipTarget( indexProxyFactory );
 
-        batchingPopulator.addPopulator( populator, descriptor, new SchemaIndexProvider.Descriptor( "foo", "1" ),
-                IndexConfiguration.NON_UNIQUE, flipper, failedIndexProxyFactory, "testIndex" );
+        batchingPopulator.addPopulator(
+                populator, indexId, descriptor,
+                new SchemaIndexProvider.Descriptor( "foo", "1" ),
+                IndexConfiguration.NON_UNIQUE, flipper,
+                failedIndexProxyFactory, "testIndex" );
 
         return populator;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -654,7 +654,7 @@ public class IndexPopulationJobTest
                                                       LogProvider logProvider,
                                                       boolean constraint ) throws TransactionFailureException
     {
-        return newIndexPopulationJob( 
+        return newIndexPopulationJob(
                 mock( FailedIndexProxyFactory.class ), populator, flipper, storeView, logProvider, constraint );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -39,13 +39,12 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -65,16 +64,13 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
-import org.neo4j.kernel.impl.coreapi.schema.IndexDefinitionImpl;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
-import org.neo4j.kernel.impl.coreapi.schema.PropertyNameUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.AssertableLogProvider.LogMatcherBuilder;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.register.Register.DoubleLongRegister;
-import org.neo4j.register.Registers;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.OtherThreadExecutor;
@@ -106,6 +102,7 @@ import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.api.index.IndexingService.NO_MONITOR;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.neo4j.register.Registers.newDoubleLongRegister;
 
 public class IndexPopulationJobTest
 {
@@ -156,7 +153,7 @@ public class IndexPopulationJobTest
         String value = "Taylor";
         long nodeId = createNode( map( name, value ), FIRST );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy(), false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
 
         // WHEN
         job.run();
@@ -183,7 +180,7 @@ public class IndexPopulationJobTest
         createNode( map( name, value ), FIRST );
         stateHolder.apply( MapUtil.stringMap( "key", "original_value" ) );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy(), false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
 
         // WHEN
         job.run();
@@ -203,7 +200,7 @@ public class IndexPopulationJobTest
         createNode( map( age, 31 ), FIRST );
         long node4 = createNode( map( age, 35, name, value ), FIRST );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy(), false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
 
         // WHEN
         job.run();
@@ -237,7 +234,7 @@ public class IndexPopulationJobTest
         int propertyKeyId = getPropertyKeyForName( name );
         NodeChangingWriter populator = new NodeChangingWriter( changeNode, propertyKeyId, value1, changedValue,
                 labelId );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy(), false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
         populator.setJob( job );
 
         // WHEN
@@ -262,7 +259,7 @@ public class IndexPopulationJobTest
         long node3 = createNode( map( name, value3 ), FIRST );
         int propertyKeyId = getPropertyKeyForName( name );
         NodeDeletingWriter populator = new NodeDeletingWriter( node2, propertyKeyId, value2, labelId );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, new FlippableIndexProxy(), false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
         populator.setJob( job );
 
         // WHEN
@@ -285,7 +282,7 @@ public class IndexPopulationJobTest
         FlippableIndexProxy index = new FlippableIndexProxy();
 
         createNode( map( name, "Taylor" ), FIRST );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, failingPopulator, index, false );
+        IndexPopulationJob job = newIndexPopulationJob( failingPopulator, index, false );
 
         // WHEN
         job.run();
@@ -308,7 +305,7 @@ public class IndexPopulationJobTest
                 Matchers.<Visitor<NodeLabelUpdate,RuntimeException>>any()) )
                 .thenReturn(storeScan );
 
-        final IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, storeView,
+        final IndexPopulationJob job = newIndexPopulationJob( populator, index, storeView,
                 NullLogProvider.getInstance(), false );
 
         OtherThreadExecutor<Void> populationJobRunner = cleanup.add( new OtherThreadExecutor<>(
@@ -345,7 +342,7 @@ public class IndexPopulationJobTest
         AssertableLogProvider logProvider = new AssertableLogProvider();
         FlippableIndexProxy index = mock( FlippableIndexProxy.class );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, indexStoreView, logProvider, false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, index, indexStoreView, logProvider, false );
 
         // When
         job.run();
@@ -366,7 +363,7 @@ public class IndexPopulationJobTest
         AssertableLogProvider logProvider = new AssertableLogProvider();
         FlippableIndexProxy index = mock( FlippableIndexProxy.class );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, indexStoreView, logProvider, false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, index, indexStoreView, logProvider, false );
 
         Throwable failure = new IllegalStateException( "not successful" );
         doThrow( failure ).when( populator ).create();
@@ -388,7 +385,7 @@ public class IndexPopulationJobTest
         FailedIndexProxyFactory failureDelegateFactory = mock( FailedIndexProxyFactory.class );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
         IndexPopulationJob job =
-                newIndexPopulationJob( FIRST, name, failureDelegateFactory, populator,
+                newIndexPopulationJob( failureDelegateFactory, populator,
                         new FlippableIndexProxy(), indexStoreView, NullLogProvider.getInstance(), false );
 
         IllegalStateException failure = new IllegalStateException( "not successful" );
@@ -414,7 +411,7 @@ public class IndexPopulationJobTest
         LogProvider logProvider = NullLogProvider.getInstance();
         FlippableIndexProxy index = mock( FlippableIndexProxy.class );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, indexStoreView, logProvider, false );
+        IndexPopulationJob job = newIndexPopulationJob( populator, index, indexStoreView, logProvider, false );
 
         String failureMessage = "not successful";
         IllegalStateException failure = new IllegalStateException( failureMessage );
@@ -440,7 +437,7 @@ public class IndexPopulationJobTest
         LogProvider logProvider = NullLogProvider.getInstance();
         FlippableIndexProxy index = new FlippableIndexProxy( mock( IndexProxy.class ) );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
-        IndexPopulationJob job = newIndexPopulationJob( FIRST, name, populator, index, indexStoreView, logProvider, true );
+        IndexPopulationJob job = newIndexPopulationJob( populator, index, indexStoreView, logProvider, true );
 
         IndexEntryConflictException failure = new PreexistingIndexEntryConflictException( "duplicate value", 0, 1 );
         doThrow( failure ).when( populator ).verifyDeferredConstraints( indexStoreView );
@@ -644,38 +641,37 @@ public class IndexPopulationJobTest
         return new InMemoryIndexProvider().getPopulator( 21, descriptor, indexConfig, samplingConfig );
     }
 
-    private IndexPopulationJob newIndexPopulationJob( Label label, String propertyKey, IndexPopulator populator,
+    private IndexPopulationJob newIndexPopulationJob( IndexPopulator populator,
                                                       FlippableIndexProxy flipper, boolean constraint )
                                                               throws TransactionFailureException
     {
-        return newIndexPopulationJob( label, propertyKey, populator, flipper, indexStoreView,
+        return newIndexPopulationJob( populator, flipper, indexStoreView,
                 NullLogProvider.getInstance(), constraint );
     }
 
-    private IndexPopulationJob newIndexPopulationJob( Label label, String propertyKey,
-                                                      IndexPopulator populator,
+    private IndexPopulationJob newIndexPopulationJob( IndexPopulator populator,
                                                       FlippableIndexProxy flipper, IndexStoreView storeView,
                                                       LogProvider logProvider,
                                                       boolean constraint ) throws TransactionFailureException
     {
-        return newIndexPopulationJob( label, propertyKey,
+        return newIndexPopulationJob( 
                 mock( FailedIndexProxyFactory.class ), populator, flipper, storeView, logProvider, constraint );
     }
 
-    private IndexPopulationJob newIndexPopulationJob( Label label, String propertyKey,
-                                                      FailedIndexProxyFactory failureDelegateFactory,
+    private IndexPopulationJob newIndexPopulationJob( FailedIndexProxyFactory failureDelegateFactory,
                                                       IndexPopulator populator,
                                                       FlippableIndexProxy flipper, IndexStoreView storeView,
                                                       LogProvider logProvider, boolean constraint )
                                                               throws TransactionFailureException
     {
-        IndexDescriptor descriptor = indexDescriptor( label, propertyKey );
+        IndexDescriptor descriptor = indexDescriptor( FIRST, name );
+        long indexId = 0;
         flipper.setFlipTarget( mock( IndexProxyFactory.class ) );
 
         MultipleIndexPopulator multiPopulator = new MultipleIndexPopulator( storeView, logProvider );
         IndexPopulationJob job = new IndexPopulationJob( storeView, multiPopulator, NO_MONITOR, stateHolder::clear );
-        job.addPopulator( populator, descriptor, IndexConfiguration.of( constraint ), PROVIDER_DESCRIPTOR,
-                format( ":%s(%s)", label.name(), propertyKey ), flipper, failureDelegateFactory );
+        job.addPopulator( populator, indexId, descriptor, IndexConfiguration.of( constraint ), PROVIDER_DESCRIPTOR,
+                format( ":%s(%s)", FIRST.name(), name ), flipper, failureDelegateFactory );
         return job;
     }
 
@@ -684,12 +680,11 @@ public class IndexPopulationJobTest
         try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() );
               Statement statement = tx.acquireStatement() )
         {
-            IndexDefinition indexDefinition = new IndexDefinitionImpl( actions, label, propertyKey, false );
-            NodePropertyDescriptor descriptor =
-                    IndexDescriptorFactory.getTokens( statement.readOperations(), indexDefinition );
-            IndexDescriptor index = IndexDescriptorFactory.of( descriptor );
+            int labelId = statement.readOperations().labelGetForName( label.name() );
+            int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
+            IndexDescriptor descriptor = IndexDescriptorFactory.of( labelId, propertyKeyId );
             tx.success();
-            return index;
+            return descriptor;
         }
     }
 
@@ -700,9 +695,17 @@ public class IndexPopulationJobTest
         {
             int labelId = statement.readOperations().labelGetForName( label.name() );
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
-            DoubleLongRegister result =
-                    statement.readOperations().indexUpdatesAndSize( IndexDescriptorFactory.of( labelId, propertyKeyId ),
-                            Registers.newDoubleLongRegister() );
+            DoubleLongRegister result = newDoubleLongRegister(0, 0);
+            try
+            {
+                result = statement.readOperations()
+                        .indexUpdatesAndSize( IndexDescriptorFactory.of( labelId, propertyKeyId ),
+                                newDoubleLongRegister() );
+            }
+            catch (IndexNotFoundKernelException e)
+            {
+                // Tests ignore this
+            }
             tx.success();
             return result;
         }
@@ -713,10 +716,18 @@ public class IndexPopulationJobTest
         try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() );
               Statement statement = tx.acquireStatement() )
         {
-            DoubleLongRegister result = Registers.newDoubleLongRegister();
             int labelId = statement.readOperations().labelGetForName( label.name() );
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
-            statement.readOperations().indexSample( IndexDescriptorFactory.of( labelId, propertyKeyId ), result );
+            DoubleLongRegister result = newDoubleLongRegister(0, 0);
+            try
+            {
+                result = statement.readOperations()
+                        .indexSample( IndexDescriptorFactory.of( labelId, propertyKeyId ), newDoubleLongRegister() );
+            }
+            catch (IndexNotFoundKernelException e)
+            {
+                // Tests ignore this
+            }
             tx.success();
             return result;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -38,6 +38,8 @@ import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
@@ -45,6 +47,7 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
@@ -194,14 +197,10 @@ public class IndexStatisticsIT
 
     private long indexId(IndexDescriptor index)
     {
-        for ( SchemaRule rule : neoStores().getSchemaStore() )
-        {
-            if ( rule.descriptor().equals( index.descriptor() ) )
-            {
-                return rule.getId();
-            }
-        }
-        return -1;
+        SchemaStorage storage = new SchemaStorage( neoStores().getSchemaStore() );
+        LabelSchemaDescriptor descriptor =
+                SchemaDescriptorFactory.forLabel( index.getLabelId(), index.getPropertyKeyId() );
+        return storage.indexGetForSchema( descriptor ).getId();
     }
 
     private void resetIndexCounts( long indexId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -195,7 +195,7 @@ public class IndexStatisticsIT
         }
     }
 
-    private long indexId(IndexDescriptor index)
+    private long indexId( IndexDescriptor index )
     {
         SchemaStorage storage = new SchemaStorage( neoStores().getSchemaStore() );
         LabelSchemaDescriptor descriptor =

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -502,7 +502,7 @@ public class IndexStatisticsTest
         }
     }
 
-    private long indexId(IndexDescriptor index)
+    private long indexId( IndexDescriptor index )
     {
         SchemaStorage storage = new SchemaStorage( neoStores().getSchemaStore() );
         LabelSchemaDescriptor descriptor =

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -54,11 +54,13 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
+import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
+import org.neo4j.storageengine.api.schema.SchemaRule;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
@@ -174,6 +176,7 @@ public class IndexStatisticsTest
         // given
         createSomePersons();
         IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        long indexId = indexId( index );
 
         // when
         dropIndex( index );
@@ -186,12 +189,12 @@ public class IndexStatisticsTest
         }
         catch ( IndexNotFoundKernelException e )
         {
-            DoubleLongRegister actual = getTracker().indexSample( index, Registers.newDoubleLongRegister() );
+            DoubleLongRegister actual = getTracker().indexSample( indexId, Registers.newDoubleLongRegister() );
             assertDoubleLongEquals( 0L, 0L, actual );
         }
 
         // and then index size and index updates are zero on disk
-        DoubleLongRegister actual = getTracker().indexUpdatesAndSize( index, Registers.newDoubleLongRegister() );
+        DoubleLongRegister actual = getTracker().indexUpdatesAndSize( indexId, Registers.newDoubleLongRegister() );
         assertDoubleLongEquals( 0L, 0L, actual );
     }
 
@@ -494,6 +497,24 @@ public class IndexStatisticsTest
             tx.success();
             return index;
         }
+    }
+
+    private long indexId(IndexDescriptor index)
+    {
+        for ( SchemaRule rule : neoStores().getSchemaStore() )
+        {
+            if ( rule.descriptor().equals( index.descriptor() ) )
+            {
+                return rule.getId();
+            }
+        }
+        return -1;
+    }
+
+    private NeoStores neoStores()
+    {
+        return ( (GraphDatabaseAPI) db ).getDependencyResolver().resolveDependency( RecordStorageEngine.class )
+                .testAccessNeoStores();
     }
 
     private IndexDescriptor awaitOnline( IndexDescriptor index ) throws KernelException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -52,9 +52,12 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -501,14 +504,10 @@ public class IndexStatisticsTest
 
     private long indexId(IndexDescriptor index)
     {
-        for ( SchemaRule rule : neoStores().getSchemaStore() )
-        {
-            if ( rule.descriptor().equals( index.descriptor() ) )
-            {
-                return rule.getId();
-            }
-        }
-        return -1;
+        SchemaStorage storage = new SchemaStorage( neoStores().getSchemaStore() );
+        LabelSchemaDescriptor descriptor =
+                SchemaDescriptorFactory.forLabel( index.getLabelId(), index.getPropertyKeyId() );
+        return storage.indexGetForSchema( descriptor ).getId();
     }
 
     private NeoStores neoStores()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -525,7 +525,7 @@ public class IndexingServiceTest
         IndexSamplingMode mode = TRIGGER_REBUILD_ALL;
         IndexDescriptor descriptor = IndexDescriptorFactory.of( 0, 1 );
         IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData(),
-                indexRule( indexId, descriptor.descriptor(), PROVIDER_DESCRIPTOR ) );
+                indexRule( indexId, descriptor.getLabelId(), descriptor.getPropertyKeyId(), PROVIDER_DESCRIPTOR ) );
         life.init();
         life.start();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -158,7 +158,7 @@ public class IndexingServiceTest
     public void setUp()
     {
         when( populator.sampleResult() ).thenReturn( new IndexSample() );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) )
+        when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
                 .thenAnswer( invocation -> invocation.getArguments()[1] );
     }
 
@@ -385,7 +385,7 @@ public class IndexingServiceTest
         when(mockLookup.labelGetName( 2 )).thenReturn( "LabelTwo" );
         when(mockLookup.propertyKeyGetName( 1 )).thenReturn( "propertyOne" );
         when(mockLookup.propertyKeyGetName( 2 )).thenReturn( "propertyTwo" );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) ).thenReturn( newDoubleLongRegister( 32L, 32L ) );
+        when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) ).thenReturn( newDoubleLongRegister( 32L, 32L ) );
 
         logProvider.clear();
 
@@ -444,7 +444,7 @@ public class IndexingServiceTest
         when( indexAccessor.snapshotFiles()).thenAnswer( newResourceIterator( theFile ) );
         when( indexProvider.getInitialState( indexId ) ).thenReturn( ONLINE );
         when( indexProvider.getInitialState( indexId2 ) ).thenReturn( ONLINE );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) )
+        when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
                 .thenReturn( newDoubleLongRegister( 32L, 32L ) );
 
         life.start();
@@ -476,7 +476,7 @@ public class IndexingServiceTest
         when( indexAccessor.snapshotFiles() ).thenAnswer( newResourceIterator( theFile ) );
         when( indexProvider.getInitialState( indexId ) ).thenReturn( POPULATING );
         when( indexProvider.getInitialState( indexId2 ) ).thenReturn( ONLINE );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) ).thenReturn( newDoubleLongRegister( 32L, 32L ) );
+        when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) ).thenReturn( newDoubleLongRegister( 32L, 32L ) );
         life.start();
 
         // WHEN
@@ -521,9 +521,13 @@ public class IndexingServiceTest
     public void shouldLogTriggerSamplingOnAnIndexes() throws Exception
     {
         // given
-        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData() );
+        long indexId = 0;
         IndexSamplingMode mode = TRIGGER_REBUILD_ALL;
         IndexDescriptor descriptor = IndexDescriptorFactory.of( 0, 1 );
+        IndexingService indexingService = newIndexingServiceWithMockedDependencies( populator, accessor, withData(),
+                indexRule( indexId, descriptor.descriptor(), PROVIDER_DESCRIPTOR ) );
+        life.init();
+        life.start();
 
         // when
         indexingService.triggerIndexSampling( descriptor, mode );
@@ -754,7 +758,7 @@ public class IndexingServiceTest
                 .nodeAsUpdates( eq( nodeId ), any( Collection.class ) );
         DoubleLongRegister register = mock( DoubleLongRegister.class );
         when( register.readSecond() ).thenReturn( 42L );
-        when( storeView.indexSample( any( IndexDescriptor.class ), any( DoubleLongRegister.class ) ) )
+        when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
                 .thenReturn( register );
         // For some reason the usual accessor returned null from newUpdater, even when told to return the updater
         // so spying on a real object instead.
@@ -1004,6 +1008,7 @@ public class IndexingServiceTest
                                                                       IndexingService.Monitor monitor,
                                                                       IndexRule... rules ) throws IOException
     {
+        when( indexProvider.getInitialState( anyLong() ) ).thenReturn( ONLINE );
         when( indexProvider.getProviderDescriptor() ).thenReturn( PROVIDER_DESCRIPTOR );
         when( indexProvider.getPopulator( anyLong(), any( IndexDescriptor.class ), any( IndexConfiguration.class ),
                 any( IndexSamplingConfig.class ) ) ).thenReturn( populator );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
@@ -159,14 +159,11 @@ public class MultipleIndexPopulatorTest
     @Test
     public void testFailByPopulation() throws IOException
     {
-        IndexDescriptor descriptor1 = IndexDescriptorFactory.of( 1, 1 );
-        IndexDescriptor descriptor2 = IndexDescriptorFactory.of( 2, 2 );
-
         IndexPopulator populator1 = createIndexPopulator();
         IndexPopulator populator2 = createIndexPopulator();
 
-        addPopulator( populator1, descriptor1 );
-        IndexPopulation population2 = addPopulator( populator2, descriptor2 );
+        addPopulator( populator1, 1 );
+        IndexPopulation population2 = addPopulator( populator2, 2 );
 
         multipleIndexPopulator.fail( population2, getPopulatorException() );
 
@@ -177,14 +174,11 @@ public class MultipleIndexPopulatorTest
     @Test
     public void testFailByPopulationRemovesPopulator() throws IOException
     {
-        IndexDescriptor descriptor1 = IndexDescriptorFactory.of( 1, 1 );
-        IndexDescriptor descriptor2 = IndexDescriptorFactory.of( 2, 2 );
-
         IndexPopulator populator1 = createIndexPopulator();
         IndexPopulator populator2 = createIndexPopulator();
 
-        IndexPopulation population1 = addPopulator( populator1, descriptor1 );
-        IndexPopulation population2 = addPopulator( populator2, descriptor2 );
+        IndexPopulation population1 = addPopulator( populator1, 1 );
+        IndexPopulation population2 = addPopulator( populator2, 2 );
 
         multipleIndexPopulator.fail( population1, getPopulatorException() );
         multipleIndexPopulator.fail( population2, getPopulatorException() );
@@ -197,12 +191,11 @@ public class MultipleIndexPopulatorTest
     @Test
     public void testFailByNonExistingPopulation() throws IOException
     {
-        IndexDescriptor descriptor = IndexDescriptorFactory.of( 1, 1 );
         IndexPopulation nonExistingPopulation = mock( IndexPopulation.class );
 
         IndexPopulator populator = createIndexPopulator();
 
-        addPopulator( populator, descriptor );
+        addPopulator( populator, 1 );
 
         multipleIndexPopulator.fail( nonExistingPopulation, getPopulatorException() );
 
@@ -254,8 +247,8 @@ public class MultipleIndexPopulatorTest
         IndexPopulator indexPopulator1 = createIndexPopulator();
         IndexPopulator indexPopulator2 = createIndexPopulator();
 
-        FlippableIndexProxy flipper1 = addPopulator( indexPopulator1, 1 );
-        FlippableIndexProxy flipper2 = addPopulator( indexPopulator2, 2 );
+        FlippableIndexProxy flipper1 = addPopulator( indexPopulator1, 1 ).flipper;
+        FlippableIndexProxy flipper2 = addPopulator( indexPopulator2, 2 ).flipper;
 
         multipleIndexPopulator.flipAfterPopulation();
 
@@ -291,7 +284,7 @@ public class MultipleIndexPopulatorTest
         multipleIndexPopulator.cancel();
 
         verify( indexStoreView, times( 2 ) )
-                .replaceIndexCounts( any( IndexDescriptor.class ), eq( 0L ), eq( 0L ), eq( 0L ) );
+                .replaceIndexCounts( anyLong(), eq( 0L ), eq( 0L ), eq( 0L ) );
         verify( indexPopulator1 ).close( false );
         verify( indexPopulator2 ).close( false );
     }
@@ -319,7 +312,7 @@ public class MultipleIndexPopulatorTest
 
         verify( indexPopulator2 ).close( true );
         verify( indexPopulator2 ).sampleResult();
-        verify( indexStoreView ).replaceIndexCounts( any( IndexDescriptor.class ), anyLong(), anyLong(), anyLong() );
+        verify( indexStoreView ).replaceIndexCounts( anyLong(), anyLong(), anyLong(), anyLong() );
     }
 
     @Test
@@ -445,47 +438,38 @@ public class MultipleIndexPopulatorTest
         verify( populator ).close( false );
     }
 
-    private void addPopulator( IndexPopulator indexPopulator, int id, FlippableIndexProxy flippableIndexProxy,
+    private IndexPopulation addPopulator( IndexPopulator indexPopulator, int id, FlippableIndexProxy flippableIndexProxy,
             FailedIndexProxyFactory failedIndexProxyFactory )
     {
-        addPopulator(multipleIndexPopulator, indexPopulator, id, flippableIndexProxy, failedIndexProxyFactory );
+        return addPopulator(multipleIndexPopulator, indexPopulator, id, flippableIndexProxy, failedIndexProxyFactory );
     }
 
-    private void addPopulator( MultipleIndexPopulator multipleIndexPopulator, IndexPopulator indexPopulator, int id,
+    private IndexPopulation addPopulator( MultipleIndexPopulator multipleIndexPopulator, IndexPopulator indexPopulator, int id,
             FlippableIndexProxy flippableIndexProxy, FailedIndexProxyFactory failedIndexProxyFactory )
     {
-        IndexDescriptor descriptor = mock( IndexDescriptor.class );
-        when( descriptor.getLabelId() ).thenReturn( id );
-        when( descriptor.getPropertyKeyId() ).thenReturn( id );
-        addPopulator( multipleIndexPopulator, descriptor, indexPopulator, flippableIndexProxy,
-                failedIndexProxyFactory );
-    }
-
-    private IndexPopulation addPopulator(IndexPopulator indexPopulator, IndexDescriptor descriptor )
-    {
-        return addPopulator( multipleIndexPopulator, indexPopulator, descriptor );
+        return addPopulator( multipleIndexPopulator, id, IndexDescriptorFactory.of( id, id ), indexPopulator,
+                flippableIndexProxy, failedIndexProxyFactory );
     }
 
     private IndexPopulation addPopulator( MultipleIndexPopulator multipleIndexPopulator, IndexPopulator indexPopulator,
-            IndexDescriptor descriptor )
+            long indexId, IndexDescriptor descriptor )
     {
-        return addPopulator( multipleIndexPopulator, descriptor, indexPopulator, mock( FlippableIndexProxy.class ),
-                mock( FailedIndexProxyFactory.class ) );
+        return addPopulator( multipleIndexPopulator, indexId, descriptor, indexPopulator,
+                mock( FlippableIndexProxy.class ), mock( FailedIndexProxyFactory.class ) );
     }
 
-    private IndexPopulation addPopulator(MultipleIndexPopulator multipleIndexPopulator, IndexDescriptor descriptor,
-            IndexPopulator indexPopulator,
+    private IndexPopulation addPopulator(MultipleIndexPopulator multipleIndexPopulator, long indexId,
+            IndexDescriptor descriptor, IndexPopulator indexPopulator,
             FlippableIndexProxy flippableIndexProxy, FailedIndexProxyFactory failedIndexProxyFactory )
     {
-        return multipleIndexPopulator.addPopulator( indexPopulator, descriptor,
+        return multipleIndexPopulator.addPopulator( indexPopulator, indexId, descriptor,
                 mock( SchemaIndexProvider.Descriptor.class ), IndexConfiguration.NON_UNIQUE,
                 flippableIndexProxy, failedIndexProxyFactory, "userIndexDescription" );
     }
 
-    private FlippableIndexProxy addPopulator( IndexPopulator indexPopulator, int id )
+    private IndexPopulation addPopulator( IndexPopulator indexPopulator, int id )
     {
         FlippableIndexProxy indexProxy = mock( FlippableIndexProxy.class );
-        addPopulator( indexPopulator, id, indexProxy, mock( FailedIndexProxyFactory.class ) );
-        return indexProxy;
+        return addPopulator( indexPopulator, id, indexProxy, mock( FailedIndexProxyFactory.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorUpdatesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorUpdatesTest.java
@@ -112,8 +112,7 @@ public class MultipleIndexPopulatorUpdatesTest
         IndexUpdater indexUpdater = mock( IndexUpdater.class );
         when( populator.newPopulatingUpdater( storeView ) ).thenReturn( indexUpdater );
 
-        IndexDescriptor descriptor = IndexDescriptorFactory.of( 1, 1 );
-        addPopulator( indexPopulator, populator, descriptor );
+        addPopulator( indexPopulator, populator, 1, IndexDescriptorFactory.of( 1, 1 ) );
 
         indexPopulator.create();
         StoreScan<IndexPopulationFailedKernelException> storeScan = indexPopulator.indexAllNodes();
@@ -148,18 +147,19 @@ public class MultipleIndexPopulatorUpdatesTest
         return populator;
     }
 
-    private MultipleIndexPopulator.IndexPopulation addPopulator( MultipleIndexPopulator multipleIndexPopulator, IndexPopulator indexPopulator,
-            IndexDescriptor descriptor )
+    private MultipleIndexPopulator.IndexPopulation addPopulator( MultipleIndexPopulator multipleIndexPopulator,
+            IndexPopulator indexPopulator, long indexId, IndexDescriptor descriptor )
     {
-        return addPopulator( multipleIndexPopulator, descriptor, indexPopulator, mock( FlippableIndexProxy.class ),
+        return addPopulator( multipleIndexPopulator, indexId, descriptor, indexPopulator, mock( FlippableIndexProxy.class ),
                 mock( FailedIndexProxyFactory.class ) );
     }
 
-    private MultipleIndexPopulator.IndexPopulation addPopulator(MultipleIndexPopulator multipleIndexPopulator, IndexDescriptor descriptor,
+    private MultipleIndexPopulator.IndexPopulation addPopulator( MultipleIndexPopulator multipleIndexPopulator,
+            long indexId, IndexDescriptor descriptor,
             IndexPopulator indexPopulator,
             FlippableIndexProxy flippableIndexProxy, FailedIndexProxyFactory failedIndexProxyFactory )
     {
-        return multipleIndexPopulator.addPopulator( indexPopulator, descriptor,
+        return multipleIndexPopulator.addPopulator( indexPopulator, indexId, descriptor,
                 mock( SchemaIndexProvider.Descriptor.class ), IndexConfiguration.NON_UNIQUE,
                 flippableIndexProxy, failedIndexProxyFactory, "userIndexDescription" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxyTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class OnlineIndexProxyTest
 {
+    private final long indexId = 1;
     private final IndexDescriptor descriptor = IndexDescriptorFactory.of( 1, 2 );
     private final IndexConfiguration config = IndexConfiguration.NON_UNIQUE;
     private final SchemaIndexProvider.Descriptor providerDescriptor = mock( SchemaIndexProvider.Descriptor.class );
@@ -45,7 +46,7 @@ public class OnlineIndexProxyTest
     public void shouldRemoveIndexCountsWhenTheIndexItselfIsDropped() throws IOException
     {
         // given
-        OnlineIndexProxy index = new OnlineIndexProxy( descriptor, config, accessor,
+        OnlineIndexProxy index = new OnlineIndexProxy( indexId, descriptor, config, accessor,
                 storeView, providerDescriptor, false );
 
         // when
@@ -53,7 +54,7 @@ public class OnlineIndexProxyTest
 
         // then
         verify( accessor ).drop();
-        verify( storeView ).replaceIndexCounts( descriptor, 0L, 0L, 0L );
+        verify( storeView ).replaceIndexCounts( indexId, 0L, 0L, 0L );
         verifyNoMoreInteractions( accessor, storeView );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingJobTrackerTest.java
@@ -53,6 +53,9 @@ public class IndexSamplingJobTrackerTest
     IndexDescriptor index11 = IndexDescriptorFactory.of( descriptor11 );
     IndexDescriptor index12 = IndexDescriptorFactory.of( descriptor12 );
     IndexDescriptor index22 = IndexDescriptorFactory.of( descriptor22 );
+    long indexId11 = 0;
+    long indexId12 = 1;
+    long indexId22 = 2;
 
     @Test
     public void shouldNotRunASampleJobWhichIsAlreadyRunning() throws Throwable
@@ -70,8 +73,6 @@ public class IndexSamplingJobTrackerTest
         assertTrue( jobTracker.canExecuteMoreSamplingJobs() );
         IndexSamplingJob job = new IndexSamplingJob()
         {
-            private final IndexDescriptor descriptor = index12;
-
             @Override
             public void run()
             {
@@ -82,9 +83,9 @@ public class IndexSamplingJobTrackerTest
             }
 
             @Override
-            public IndexDescriptor descriptor()
+            public long indexId()
             {
-                return descriptor;
+                return indexId12;
             }
         };
 
@@ -114,8 +115,6 @@ public class IndexSamplingJobTrackerTest
 
         jobTracker.scheduleSamplingJob( new IndexSamplingJob()
         {
-            private final IndexDescriptor descriptor = index12;
-
             @Override
             public void run()
             {
@@ -124,9 +123,9 @@ public class IndexSamplingJobTrackerTest
             }
 
             @Override
-            public IndexDescriptor descriptor()
+            public long indexId()
             {
-                return descriptor;
+                return indexId12;
             }
         } );
 
@@ -179,9 +178,9 @@ public class IndexSamplingJobTrackerTest
         jobTracker.scheduleSamplingJob( new IndexSamplingJob()
         {
             @Override
-            public IndexDescriptor descriptor()
+            public long indexId()
             {
-                return IndexDescriptorFactory.of( descriptor11 );
+                return indexId11;
             }
 
             @Override
@@ -198,9 +197,9 @@ public class IndexSamplingJobTrackerTest
             jobTracker.scheduleSamplingJob( new IndexSamplingJob()
             {
                 @Override
-                public IndexDescriptor descriptor()
+                public long indexId()
                 {
-                    return index22;
+                    return indexId22;
                 }
 
                 @Override
@@ -261,8 +260,8 @@ public class IndexSamplingJobTrackerTest
         final CountDownLatch latch1 = new CountDownLatch( 1 );
         final CountDownLatch latch2 = new CountDownLatch( 1 );
 
-        WaitingIndexSamplingJob job1 = new WaitingIndexSamplingJob( index11, latch1 );
-        WaitingIndexSamplingJob job2 = new WaitingIndexSamplingJob( index22, latch1 );
+        WaitingIndexSamplingJob job1 = new WaitingIndexSamplingJob( indexId11, latch1 );
+        WaitingIndexSamplingJob job2 = new WaitingIndexSamplingJob( indexId22, latch1 );
 
         jobTracker.scheduleSamplingJob( job1 );
         jobTracker.scheduleSamplingJob( job2 );
@@ -299,8 +298,8 @@ public class IndexSamplingJobTrackerTest
         final CountDownLatch latch1 = new CountDownLatch( 1 );
         final CountDownLatch latch2 = new CountDownLatch( 1 );
 
-        WaitingIndexSamplingJob job1 = new WaitingIndexSamplingJob( index11, latch1 );
-        WaitingIndexSamplingJob job2 = new WaitingIndexSamplingJob( index22, latch1 );
+        WaitingIndexSamplingJob job1 = new WaitingIndexSamplingJob( indexId11, latch1 );
+        WaitingIndexSamplingJob job2 = new WaitingIndexSamplingJob( indexId22, latch1 );
 
         jobTracker.scheduleSamplingJob( job1 );
         jobTracker.scheduleSamplingJob( job2 );
@@ -331,21 +330,21 @@ public class IndexSamplingJobTrackerTest
 
     private static class WaitingIndexSamplingJob implements IndexSamplingJob
     {
-        final IndexDescriptor descriptor;
+        final long indexId;
         final CountDownLatch latch;
 
         volatile boolean executed;
 
-        WaitingIndexSamplingJob( IndexDescriptor descriptor, CountDownLatch latch )
+        WaitingIndexSamplingJob( long indexId, CountDownLatch latch )
         {
-            this.descriptor = descriptor;
+            this.indexId = indexId;
             this.latch = latch;
         }
 
         @Override
-        public IndexDescriptor descriptor()
+        public long indexId()
         {
-            return descriptor;
+            return indexId;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJobTest.java
@@ -48,14 +48,14 @@ public class OnlineIndexSamplingJobTest
     public void shouldSampleTheIndexAndStoreTheValueWhenTheIndexIsOnline()
     {
         // given
-        OnlineIndexSamplingJob job = new OnlineIndexSamplingJob( indexProxy, indexStoreView, "Foo", logProvider );
+        OnlineIndexSamplingJob job = new OnlineIndexSamplingJob( indexId, indexProxy, indexStoreView, "Foo", logProvider );
         when( indexProxy.getState() ).thenReturn( ONLINE );
 
         // when
         job.run();
 
         // then
-        verify( indexStoreView ).replaceIndexCounts( indexDescriptor, indexUniqueValues, indexSize, indexSize );
+        verify( indexStoreView ).replaceIndexCounts( indexId, indexUniqueValues, indexSize, indexSize );
         verifyNoMoreInteractions( indexStoreView );
     }
 
@@ -63,7 +63,7 @@ public class OnlineIndexSamplingJobTest
     public void shouldSampleTheIndexButDoNotStoreTheValuesIfTheIndexIsNotOnline()
     {
         // given
-        OnlineIndexSamplingJob job = new OnlineIndexSamplingJob( indexProxy, indexStoreView, "Foo", logProvider );
+        OnlineIndexSamplingJob job = new OnlineIndexSamplingJob( indexId, indexProxy, indexStoreView, "Foo", logProvider );
         when( indexProxy.getState() ).thenReturn( FAILED );
 
         // when
@@ -74,6 +74,7 @@ public class OnlineIndexSamplingJobTest
     }
 
     private final LogProvider logProvider = NullLogProvider.getInstance();
+    private final long indexId = 1;
     private final IndexProxy indexProxy = mock( IndexProxy.class );
     private final IndexStoreView indexStoreView = mock( IndexStoreView.class );
     private final IndexDescriptor indexDescriptor = IndexDescriptorFactory.of( 1, 2 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CountsOracle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CountsOracle.java
@@ -56,14 +56,14 @@ public class CountsOracle
         state.addRelationship( start.labels, type, end.labels );
     }
 
-    public void indexUpdatesAndSize( IndexDescriptor descriptor, long updates, long size )
+    public void indexUpdatesAndSize( long indexId, long updates, long size )
     {
-        state.replaceIndexUpdateAndSize( descriptor, updates, size );
+        state.replaceIndexUpdateAndSize( indexId, updates, size );
     }
 
-    public void indexSampling( IndexDescriptor descriptor, long unique, long size )
+    public void indexSampling( long indexId, long unique, long size )
     {
-        state.replaceIndexSample( descriptor, unique, size );
+        state.replaceIndexSample( indexId, unique, size );
     }
 
     public void update( CountsTracker target, long txId )
@@ -110,19 +110,19 @@ public class CountsOracle
             }
 
             @Override
-            public void visitIndexStatistics( IndexDescriptor descriptor, long updates, long size )
+            public void visitIndexStatistics( long indexId, long updates, long size )
             {
                 Register.DoubleLongRegister output =
-                        tracker.indexUpdatesAndSize( descriptor, newDoubleLongRegister() );
+                        tracker.indexUpdatesAndSize( indexId, newDoubleLongRegister() );
                 assertEquals( "Should be able to read visited state.", output.readFirst(), updates );
                 assertEquals( "Should be able to read visited state.", output.readSecond(), size );
             }
 
             @Override
-            public void visitIndexSample( IndexDescriptor descriptor, long unique, long size )
+            public void visitIndexSample( long indexId, long unique, long size )
             {
                 Register.DoubleLongRegister output =
-                        tracker.indexSample( descriptor, newDoubleLongRegister() );
+                        tracker.indexSample( indexId, newDoubleLongRegister() );
                 assertEquals( "Should be able to read visited state.", output.readFirst(), unique );
                 assertEquals( "Should be able to read visited state.", output.readSecond(), size );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/CountsStoreMapGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/CountsStoreMapGenerator.java
@@ -62,8 +62,7 @@ public class CountsStoreMapGenerator
     {
         for ( int i = 0; i < num; i++ )
         {
-            IndexDescriptor descriptor = IndexDescriptorFactory.of( i, i );
-            map.put( CountsKeyFactory.indexSampleKey( descriptor ), new long[]{i, i} );
+            map.put( CountsKeyFactory.indexSampleKey( i ), new long[]{i, i} );
         }
     }
 
@@ -71,8 +70,7 @@ public class CountsStoreMapGenerator
     {
         for ( int i = 0; i < num; i++ )
         {
-            IndexDescriptor descriptor = IndexDescriptorFactory.of( i, i );
-            map.put( CountsKeyFactory.indexStatisticsKey( descriptor ), new long[]{i, i} );
+            map.put( CountsKeyFactory.indexStatisticsKey( i ), new long[]{i, i} );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreCountsSnapshotSerializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreCountsSnapshotSerializerTest.java
@@ -148,15 +148,14 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
     public void correctlySerializesIndexSample() throws IOException
     {
         //GIVEN
+        long indexId = 1;
         int serializedLength = Long.BYTES + Integer.BYTES //Serialization Prefix
-                + Byte.BYTES + Short.BYTES + (2 * Integer.BYTES) +
+                + Byte.BYTES + Long.BYTES +
                 (2 * Long.BYTES); //A single INDEX_SAMPLE from count store.
-        writeAndSerializeIndexSample( 1, 1, 1 );
+        writeAndSerializeIndexSample( indexId, 1 );
         initializeBuffers( serializedLength );
         expectedBytes.put( INDEX_SAMPLE.code );
-        expectedBytes.putInt( 1 );
-        expectedBytes.putShort( (short)1 );
-        expectedBytes.putInt( 1 );
+        expectedBytes.putLong( indexId );
         expectedBytes.putLong( 1 );
         expectedBytes.putLong( 1 );
         expectedBytes.position( 0 );
@@ -171,15 +170,14 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
     public void correctlySerializesIndexStatistics() throws IOException
     {
         //GIVEN
+        long indexId = 1;
         int serializedLength = Long.BYTES + Integer.BYTES //Serialization Prefix
-                + Byte.BYTES + Short.BYTES + (2 * Integer.BYTES) +
+                + Byte.BYTES + Long.BYTES +
                 (2 * Long.BYTES); //A single INDEX_STATISTICS from count store.
-        writeAndSerializeIndexStatistics( 1, 1, 1 );
+        writeAndSerializeIndexStatistics( indexId, 1 );
         initializeBuffers( serializedLength );
         expectedBytes.put( INDEX_STATISTICS.code );
-        expectedBytes.putInt( 1 );
-        expectedBytes.putShort( (short)1 );
-        expectedBytes.putInt( 1 );
+        expectedBytes.putLong( indexId );
         expectedBytes.putLong( 1 );
         expectedBytes.putLong( 1 );
         expectedBytes.position( 0 );
@@ -213,7 +211,7 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
     public void throwsExceptionOnWrongValueLengthForIndexSample() throws IOException
     {
         Map<CountsKey,long[]> brokenMap = new ConcurrentHashMap<>();
-        brokenMap.put( indexSampleKey( 1, 1 ), new long[]{1} );
+        brokenMap.put( indexSampleKey( 1 ), new long[]{1} );
         CountsSnapshot brokenSnapshot = new CountsSnapshot( 1, brokenMap );
         serialize( logChannel, brokenSnapshot );
     }
@@ -222,7 +220,7 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
     public void throwsExceptionOnWrongValueLengthForIndexStatistics() throws IOException
     {
         Map<CountsKey,long[]> brokenMap = new ConcurrentHashMap<>();
-        brokenMap.put( indexStatisticsKey( 1, 1 ), new long[]{1} );
+        brokenMap.put( indexStatisticsKey( 1 ), new long[]{1} );
         CountsSnapshot brokenSnapshot = new CountsSnapshot( 1, brokenMap );
         serialize( logChannel, brokenSnapshot );
     }
@@ -234,21 +232,14 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
                 new CountsKeyType[]{EMPTY, ENTITY_NODE, ENTITY_RELATIONSHIP, INDEX_STATISTICS, INDEX_SAMPLE} );
     }
 
-    public static IndexSampleKey indexSampleKey( int labelId, int propertyKeyId )
+    public static IndexSampleKey indexSampleKey( long indexId )
     {
-        //TODO: Consider enhancing stests for composite indexes
-        return CountsKeyFactory.indexSampleKey( indexFor( labelId, propertyKeyId ) );
+        return CountsKeyFactory.indexSampleKey( indexId );
     }
 
-    public static IndexStatisticsKey indexStatisticsKey( int labelId, int propertyKeyId )
+    public static IndexStatisticsKey indexStatisticsKey( long indexId)
     {
-        //TODO: Consider enhancing stests for composite indexes
-        return CountsKeyFactory.indexStatisticsKey( indexFor( labelId, propertyKeyId ) );
-    }
-
-    private static IndexDescriptor indexFor( int labelId, int propertyKeyId )
-    {
-        return IndexDescriptorFactory.of( labelId, propertyKeyId );
+        return CountsKeyFactory.indexStatisticsKey( indexId );
     }
 
     private void initializeBuffers( int serializedLength )
@@ -282,19 +273,19 @@ public class InMemoryCountsStoreCountsSnapshotSerializerTest
         serialize( logChannel, countsSnapshot );
     }
 
-    private void writeAndSerializeIndexSample( int labelId, int propertyKeyId, long count )
+    private void writeAndSerializeIndexSample( long indexId, long count )
             throws IOException
     {
         countsSnapshot.getMap()
-                .put( indexSampleKey( labelId, propertyKeyId ), new long[]{count, count} );
+                .put( indexSampleKey( indexId ), new long[]{count, count} );
         serialize( logChannel, countsSnapshot );
     }
 
-    private void writeAndSerializeIndexStatistics( int labelId, int propertyKeyId, long count )
+    private void writeAndSerializeIndexStatistics( long indexId, long count )
             throws IOException
     {
         countsSnapshot.getMap()
-                .put( indexStatisticsKey( labelId, propertyKeyId ), new long[]{count, count} );
+                .put( indexStatisticsKey( indexId ), new long[]{count, count} );
         serialize( logChannel, countsSnapshot );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreSnapshotDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreSnapshotDeserializerTest.java
@@ -155,19 +155,17 @@ public class InMemoryCountsStoreSnapshotDeserializerTest
     public void correctlyDeserializeIndexSample() throws IOException
     {
         //GIVEN
+        long indexId = 1;
         serializedBytes = ByteBuffer.allocate( 1000 );
         InMemoryClosableChannel logChannel = new InMemoryClosableChannel( serializedBytes.array(), false );
         writeSimpleHeader( logChannel );
         logChannel.put( INDEX_SAMPLE.code );
-        logChannel.putInt( 1 );
-        logChannel.putShort( (short) 1 );
-        logChannel.putInt( 1 );
+        logChannel.putLong( indexId );
         logChannel.putLong( 1 );
         logChannel.putLong( 1 );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 1 );
 
         //WHEN
-        IndexSampleKey expectedNode = CountsKeyFactory.indexSampleKey( index );
+        IndexSampleKey expectedNode = CountsKeyFactory.indexSampleKey( indexId );
         CountsSnapshot countsSnapshot = deserialize( logChannel );
 
         //THEN
@@ -179,19 +177,17 @@ public class InMemoryCountsStoreSnapshotDeserializerTest
     public void correctlyDeserializeIndexStatistics() throws IOException
     {
         //GIVEN
+        long indexId = 1;
         serializedBytes = ByteBuffer.allocate( 1000 );
         InMemoryClosableChannel logChannel = new InMemoryClosableChannel( serializedBytes.array(), false );
         writeSimpleHeader( logChannel );
         logChannel.put( INDEX_STATISTICS.code );
-        logChannel.putInt( 1 );
-        logChannel.putShort( (short) 1 );
-        logChannel.putInt( 1 );
+        logChannel.putLong( indexId );
         logChannel.putLong( 1 );
         logChannel.putLong( 1 );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 1 );
 
         //WHEN
-        IndexStatisticsKey expectedNode = CountsKeyFactory.indexStatisticsKey( index );
+        IndexStatisticsKey expectedNode = CountsKeyFactory.indexStatisticsKey( indexId );
         CountsSnapshot countsSnapshot = deserialize( logChannel );
 
         //THEN

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
@@ -426,13 +426,13 @@ public class CountsRotationTest
             }
 
             @Override
-            public void visitIndexStatistics( IndexDescriptor index, long updates, long size) {
-                records.add( Pair.of( CountsKeyFactory.indexStatisticsKey( index ), size ) );
+            public void visitIndexStatistics( long indexId, long updates, long size) {
+                records.add( Pair.of( CountsKeyFactory.indexStatisticsKey( indexId ), size ) );
             }
 
             @Override
-            public void visitIndexSample( IndexDescriptor index, long unique, long size) {
-                records.add( Pair.of( CountsKeyFactory.indexSampleKey( index ), size ) );
+            public void visitIndexSample( long indexId, long unique, long size) {
+                records.add( Pair.of( CountsKeyFactory.indexSampleKey( indexId ), size ) );
             }
         } );
         return records;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
@@ -78,14 +78,14 @@ public class CountsTrackerTest
     {
         // given
         CountsTracker tracker = resourceManager.managed( newTracker() );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 1 );
+        long indexId = 0;
         CountsOracle oracle = new CountsOracle();
         {
             CountsOracle.Node a = oracle.node( 1 );
             CountsOracle.Node b = oracle.node( 1 );
             oracle.relationship( a, 1, b );
-            oracle.indexSampling( index, 2, 2 );
-            oracle.indexUpdatesAndSize( index, 10, 2 );
+            oracle.indexSampling( indexId, 2, 2 );
+            oracle.indexUpdatesAndSize( indexId, 10, 2 );
         }
 
         // when
@@ -103,11 +103,11 @@ public class CountsTrackerTest
         // when
         try ( CountsAccessor.IndexStatsUpdater updater = tracker.updateIndexCounts() )
         {
-            updater.incrementIndexUpdates( index, 2 );
+            updater.incrementIndexUpdates( indexId, 2 );
         }
 
         // then
-        oracle.indexUpdatesAndSize( index, 12, 2 );
+        oracle.indexUpdatesAndSize( indexId, 12, 2 );
         oracle.verify( tracker );
 
         // when
@@ -274,7 +274,7 @@ public class CountsTrackerTest
         File before = tracker.currentFile();
         try ( CountsAccessor.IndexStatsUpdater updater = tracker.updateIndexCounts() )
         {
-            updater.incrementIndexUpdates( IndexDescriptorFactory.of( 7, 8 ), 100 );
+            updater.incrementIndexUpdates( 7, 100 );
         }
 
         // when
@@ -367,9 +367,9 @@ public class CountsTrackerTest
         oracle.relationship( n1, 1, n3 );
         oracle.relationship( n1, 1, n2 );
         oracle.relationship( n0, 1, n3 );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 2 );
-        oracle.indexUpdatesAndSize( index, 0L, 50L );
-        oracle.indexSampling( index, 25L, 50L );
+        long indexId = 2;
+        oracle.indexUpdatesAndSize( indexId, 0L, 50L );
+        oracle.indexSampling( indexId, 25L, 50L );
         return oracle;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScanTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScanTest.java
@@ -158,7 +158,7 @@ public class LabelScanViewNodeStoreScanTest
 
     private MultipleIndexPopulator.IndexPopulation getPopulation( LabelScanTestMultipleIndexPopulator indexPopulator )
     {
-        return indexPopulator.createPopulation( mock( IndexPopulator.class ), null, null, null, null, null, null );
+        return indexPopulator.createPopulation( mock( IndexPopulator.class ), 1, null, null, null, null, null, null );
     }
 
     private LabelScanViewNodeStoreScan<Exception> getLabelScanViewStoreScan( int[] labelIds )
@@ -176,13 +176,13 @@ public class LabelScanViewNodeStoreScanTest
         }
 
         @Override
-        public IndexPopulation createPopulation( IndexPopulator populator,
+        public IndexPopulation createPopulation( IndexPopulator populator, long indexId,
                 IndexDescriptor descriptor, IndexConfiguration config,
                 SchemaIndexProvider.Descriptor providerDescriptor,
                 FlippableIndexProxy flipper, FailedIndexProxyFactory failedIndexProxyFactory,
                 String indexUserDescription )
         {
-            return super.createPopulation( populator, descriptor, config, providerDescriptor, flipper,
+            return super.createPopulation( populator, indexId, descriptor, config, providerDescriptor, flipper,
                             failedIndexProxyFactory,
                             indexUserDescription );
         }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema.IndexState;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
@@ -194,7 +195,14 @@ public class Schema extends TransactionProvidingApp
             throw new ShellException( "No property associated with '" + property + "' was found" );
         }
 
-        indexingService.triggerIndexSampling( IndexDescriptorFactory.of( labelKey, propertyKey ), samplingMode );
+        try
+        {
+            indexingService.triggerIndexSampling( IndexDescriptorFactory.of( labelKey, propertyKey ), samplingMode );
+        }
+        catch ( IndexNotFoundKernelException e )
+        {
+            throw new ShellException( e.getMessage() );
+        }
     }
 
     private IndexSamplingMode getSamplingMode( boolean forceSample )

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/IndexSamplingManagerBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/IndexSamplingManagerBean.java
@@ -26,6 +26,7 @@ import org.neo4j.jmx.impl.ManagementBeanProvider;
 import org.neo4j.jmx.impl.ManagementData;
 import org.neo4j.jmx.impl.Neo4jMBean;
 import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -127,8 +128,15 @@ public final class IndexSamplingManagerBean extends ManagementBeanProvider
                 throw new IllegalArgumentException( "No property or label key was found associated with " +
                         propertyKey + " and " + labelKey );
             }
-            state.indexingService.triggerIndexSampling( IndexDescriptorFactory.of( labelKeyId, propertyKeyId ),
-                    getIndexSamplingMode( forceSample ) );
+            try
+            {
+                state.indexingService.triggerIndexSampling( IndexDescriptorFactory.of( labelKeyId, propertyKeyId ),
+                        getIndexSamplingMode( forceSample ) );
+            }
+            catch ( IndexNotFoundKernelException e )
+            {
+                throw new IllegalArgumentException( e.getMessage() );
+            }
         }
 
         private IndexSamplingMode getIndexSamplingMode( boolean forceSample )

--- a/enterprise/management/src/test/java/org/neo4j/management/impl/IndexSamplingManagerBeanTest.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/impl/IndexSamplingManagerBeanTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
@@ -64,7 +65,7 @@ public class IndexSamplingManagerBeanTest
     }
 
     @Test
-    public void samplingTriggeredWhenIdsArePresent()
+    public void samplingTriggeredWhenIdsArePresent() throws IndexNotFoundKernelException
     {
         // Given
         IndexSamplingManagerBean.StoreAccess storeAccess = new IndexSamplingManagerBean.StoreAccess();
@@ -79,7 +80,7 @@ public class IndexSamplingManagerBeanTest
     }
 
     @Test
-    public void forceSamplingTriggeredWhenIdsArePresent()
+    public void forceSamplingTriggeredWhenIdsArePresent() throws IndexNotFoundKernelException
     {
         // Given
         IndexSamplingManagerBean.StoreAccess storeAccess = new IndexSamplingManagerBean.StoreAccess();

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,14 +32,12 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CountsVisitor;
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.SchemaStore;
+import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
@@ -47,12 +46,11 @@ import org.neo4j.kernel.impl.store.kvstore.Headers;
 import org.neo4j.kernel.impl.store.kvstore.MetadataVisitor;
 import org.neo4j.kernel.impl.store.kvstore.ReadableBuffer;
 import org.neo4j.kernel.impl.store.kvstore.UnknownKey;
+import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
-import org.neo4j.storageengine.api.EntityType;
 import org.neo4j.storageengine.api.Token;
-import org.neo4j.storageengine.api.schema.SchemaRule;
 
 import static org.neo4j.io.pagecache.impl.muninn.StandalonePageCacheFactory.createPageCache;
 
@@ -84,7 +82,8 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
                 StoreFactory factory = new StoreFactory( path, pages, fs, NullLogProvider.getInstance() );
 
                 NeoStores neoStores = factory.openAllNeoStores();
-                neoStores.getCounts().accept( new DumpCountsStore( out, neoStores ) );
+                SchemaStorage schemaStorage = new SchemaStorage( neoStores.getSchemaStore() );
+                neoStores.getCounts().accept( new DumpCountsStore( out, neoStores, schemaStorage ) );
             }
             else
             {
@@ -107,26 +106,26 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
         this( out, Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList() );
     }
 
-    DumpCountsStore( PrintStream out, NeoStores neoStores )
+    DumpCountsStore( PrintStream out, NeoStores neoStores, SchemaStorage schemaStorage )
     {
-        this( out, allSchemaRulesFrom( neoStores.getSchemaStore() ),
+        this( out, getAllIndexesFrom( schemaStorage ),
               allTokensFrom( neoStores.getLabelTokenStore() ),
               allTokensFrom( neoStores.getRelationshipTypeTokenStore() ),
               allTokensFrom( neoStores.getPropertyKeyTokenStore() ) );
     }
 
     private final PrintStream out;
-    private final Map<Long,IndexDescriptor> schemaRules;
+    private final Map<Long,NewIndexDescriptor> indexes;
     private final List<Token> labels;
     private final List<RelationshipTypeToken> relationshipTypes;
     private final List<Token> propertyKeys;
 
-    private DumpCountsStore( PrintStream out, Map<Long,IndexDescriptor> schemaRules, List<Token> labels,
+    private DumpCountsStore( PrintStream out, Map<Long,NewIndexDescriptor> indexes, List<Token> labels,
             List<RelationshipTypeToken> relationshipTypes,
             List<Token> propertyKeys )
     {
         this.out = out;
-        this.schemaRules = schemaRules;
+        this.indexes = indexes;
         this.labels = labels;
         this.relationshipTypes = relationshipTypes;
         this.propertyKeys = propertyKeys;
@@ -161,17 +160,17 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
     @Override
     public void visitIndexStatistics( long indexId, long updates, long size )
     {
-        IndexDescriptor index = schemaRules.get( indexId );
+        NewIndexDescriptor index = indexes.get( indexId );
         out.printf( "\tIndexStatistics[(%s {%s})]:\tupdates=%d, size=%d%n",
-                label( index.getLabelId() ), propertyKey( index.descriptor().getPropertyKeyId() ), updates, size );
+                label( index.schema().getLabelId() ), propertyKeys( index.schema().getPropertyIds() ), updates, size );
     }
 
     @Override
     public void visitIndexSample( long indexId, long unique, long size )
     {
-        IndexDescriptor index = schemaRules.get( indexId );
+        NewIndexDescriptor index = indexes.get( indexId );
         out.printf( "\tIndexSample[(%s {%s})]:\tunique=%d, size=%d%n",
-                label( index.getLabelId() ), propertyKey( index.descriptor().getPropertyKeyId() ), unique, size );
+                label( index.schema().getLabelId() ), propertyKeys( index.schema().getPropertyIds() ), unique, size );
     }
 
     @Override
@@ -190,9 +189,18 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
         return token( new StringBuilder(), labels, ":", "label", id ).toString();
     }
 
-    private String propertyKey( int id )
+    private String propertyKeys( int[] ids )
     {
-        return token( new StringBuilder(), propertyKeys, "", "key", id ).toString();
+        StringBuilder builder = new StringBuilder();
+        for ( int i = 0; i < ids.length; i++ )
+        {
+            if ( i > 0 )
+            {
+                builder.append( "," );
+            }
+            token( builder, propertyKeys, "", "key", ids[i] );
+        }
+        return builder.toString();
     }
 
     private String relationshipType( int id )
@@ -242,17 +250,16 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
         }
     }
 
-    private static Map<Long,IndexDescriptor> allSchemaRulesFrom( SchemaStore store )
+    private static Map<Long,NewIndexDescriptor> getAllIndexesFrom( SchemaStorage storage )
     {
-        HashMap<Long,IndexDescriptor> rules = new HashMap<>();
-        for ( SchemaRule rule : store )
+        HashMap<Long,NewIndexDescriptor> indexes = new HashMap<>();
+        Iterator<IndexRule> indexRules = storage.indexesGetAll();
+        while ( indexRules.hasNext() )
         {
-            if ( rule.descriptor().entityType() == EntityType.NODE )
-            {
-                rules.put( rule.getId(), IndexDescriptorFactory.of( (NodePropertyDescriptor) rule.descriptor() ) );
-            }
+            IndexRule rule = indexRules.next();
+            indexes.put( rule.getId(), rule.getIndexDescriptor() );
         }
-        return rules;
+        return indexes;
     }
 
     private static class VisitableCountsTracker extends CountsTracker


### PR DESCRIPTION
The count store used to store the label+property key ids in the key fields for index statistics. However, this made it dependent on the definition of the index, and made it hard to support alternative definitions, including the concept of a composite index with multiple properties. This PR changes it to use only the indexId value and so it can support any index definition, including those we have not yet imagined. It also frees up a few bytes for future use in case we want them for things like histograms.