### PR TITLE
fix cluster state test on windows

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/ClusterStateDirectoryTest.java
@@ -63,7 +63,7 @@ public class ClusterStateDirectoryTest
         File oldClusterStateFile = new File( oldStateDir, fileName );
 
         fs.mkdirs( oldStateDir );
-        fs.create( oldClusterStateFile );
+        fs.create( oldClusterStateFile ).close();
 
         // when
         ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDir, false );
@@ -86,7 +86,7 @@ public class ClusterStateDirectoryTest
         File oldClusterStateFile = new File( oldStateDir, fileName );
 
         fs.mkdirs( oldStateDir );
-        fs.create( oldClusterStateFile );
+        fs.create( oldClusterStateFile ).close();
 
         // when
         ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDir, false );


### PR DESCRIPTION
Seems create also opens the file, and it needs to be closed.