### PR TITLE
Single instance backup stress test update

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -30,6 +30,7 @@ import org.neo4j.collection.pool.LinkedQueuePool;
 import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
@@ -167,7 +168,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
         catch ( InterruptedException ie )
         {
             Thread.interrupted();
-            throw new RuntimeException( ie );
+            throw new TransactionFailureException( "Fail to start new transaction.", ie );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -267,6 +267,7 @@ class BackupService
         {
             if ( directoryIsEmpty( fileSystem, targetDirectory ) )
             {
+                TODO:
                 log.info( "Previous backup not found, a new full backup will be performed." );
                 return fullBackup( fileSystem, sourceHostNameOrIp, sourcePort, targetDirectory, consistencyCheck,
                         config, timeout, forensics );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -267,7 +267,6 @@ class BackupService
         {
             if ( directoryIsEmpty( fileSystem, targetDirectory ) )
             {
-                TODO:
                 log.info( "Previous backup not found, a new full backup will be performed." );
                 return fullBackup( fileSystem, sourceHostNameOrIp, sourcePort, targetDirectory, consistencyCheck,
                         config, timeout, forensics );

--- a/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
@@ -1,0 +1,74 @@
+package org.neo4j.backup;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Predicate;
+
+import org.neo4j.function.Predicates;
+import org.neo4j.helper.IsChannelClosedException;
+import org.neo4j.helper.IsConnectionException;
+import org.neo4j.helper.IsConnectionRestByPeer;
+import org.neo4j.helper.IsStoreClosed;
+import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.configuration.Config;
+
+public class BackupHelper
+{
+
+    private static final Predicate<Throwable> isTransientError = Predicates.any(
+                    new IsConnectionException(),
+                    new IsConnectionRestByPeer(),
+                    new IsChannelClosedException(),
+                    new IsStoreClosed() );
+
+    public static BackupResult backup( String host, int port, File targetDirectory )
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        boolean consistent = true;
+        boolean transientFailure = false;
+        boolean failure = false;
+        try
+        {
+            BackupService backupService = new BackupService(outputStream);
+            BackupService.BackupOutcome backupOutcome = backupService.doIncrementalBackupOrFallbackToFull( host, port,
+                    targetDirectory, ConsistencyCheck.FULL, Config.embeddedDefaults(), BackupClient.BIG_READ_TIMEOUT,
+                    false );
+            consistent = backupOutcome.isConsistent();
+        }
+        catch ( Throwable t )
+        {
+            if ( isTransientError.test( t ) )
+            {
+                transientFailure = true;
+            }
+            else
+            {
+                failure = true;
+                throw t;
+            }
+        }
+        finally
+        {
+            if ( !consistent || failure )
+            {
+                flushToStandardOutput( outputStream );
+            }
+            IOUtils.closeAllSilently( outputStream );
+        }
+        return new BackupResult( consistent, transientFailure );
+    }
+
+    private static void flushToStandardOutput( ByteArrayOutputStream outputStream )
+    {
+        try
+        {
+            outputStream.writeTo( System.out );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupHelper.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.backup;
 
 import java.io.ByteArrayOutputStream;

--- a/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.backup;
 
 public class BackupResult

--- a/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupResult.java
@@ -1,0 +1,23 @@
+package org.neo4j.backup;
+
+public class BackupResult
+{
+    private final boolean consistent;
+    private final boolean transientErrorOnBackup;
+
+    public BackupResult( boolean consistent, boolean transientErrorOnBackup )
+    {
+        this.consistent = consistent;
+        this.transientErrorOnBackup = transientErrorOnBackup;
+    }
+
+    public boolean isConsistent()
+    {
+        return consistent;
+    }
+
+    public boolean isTransientErrorOnBackup()
+    {
+        return transientErrorOnBackup;
+    }
+}

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupLoad.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupLoad.java
@@ -51,7 +51,7 @@ class BackupLoad extends RepeatUntilCallable
         {
             throw new RuntimeException( "Inconsistent backup" );
         }
-        if (backupResult.isTransientErrorOnBackup())
+        if ( backupResult.isTransientErrorOnBackup() )
         {
             LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 10 ) );
         }

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
@@ -35,6 +35,7 @@ import java.util.function.BooleanSupplier;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.ThreadTestUtils;
 
@@ -50,7 +51,6 @@ import static org.neo4j.helper.DatabaseConfiguration.configureBackup;
 import static org.neo4j.helper.DatabaseConfiguration.configureTxLogRotationAndPruning;
 import static org.neo4j.helper.StressTestingHelper.ensureExistsAndEmpty;
 import static org.neo4j.helper.StressTestingHelper.fromEnv;
-import static org.neo4j.helper.StressTestingHelper.prettyPrintStackTrace;
 
 /**
  * Notice the class name: this is _not_ going to be run as part of the main build.
@@ -110,9 +110,9 @@ public class BackupServiceStressTesting
                     new StartStop( keepGoingSupplier, onFailure, graphDatabaseBuilder::newGraphDatabase, dbRef ) );
 
             long timeout = durationInMinutes + 5;
-            assertNull( prettyPrintStackTrace( workload.get() ), workload.get( timeout, MINUTES ) );
-            assertNull( prettyPrintStackTrace( backupWorker.get() ), backupWorker.get( timeout, MINUTES ) );
-            assertNull( prettyPrintStackTrace( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( workload.get() ), workload.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( backupWorker.get() ), backupWorker.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES ) );
 
             service.shutdown();
             if ( !service.awaitTermination( 30, TimeUnit.SECONDS ) )

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/BackupServiceStressTesting.java
@@ -35,8 +35,6 @@ import java.util.function.BooleanSupplier;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.io.fs.DefaultFileSystemAbstraction;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.ThreadTestUtils;
 
@@ -77,8 +75,12 @@ public class BackupServiceStressTesting
         boolean enableIndexes =
                 parseBoolean( fromEnv( "BACKUP_SERVICE_STRESS_ENABLE_INDEXES", DEFAULT_ENABLE_INDEXES ) );
 
-        File storeDirectory = ensureExistsAndEmpty( new File( directory, "store" ) );
-        File workDirectory = ensureExistsAndEmpty( new File( directory, "work" ) );
+        File store = new File( directory, "store" );
+        File work = new File( directory, "work" );
+        FileUtils.deleteRecursively( store );
+        FileUtils.deleteRecursively( work );
+        File storeDirectory = ensureExistsAndEmpty( store );
+        File workDirectory = ensureExistsAndEmpty( work );
 
         final Map<String,String> config =
                 configureBackup( configureTxLogRotationAndPruning( new HashMap<>(), txPrune ), backupHostname,

--- a/stresstests/src/test/java/org/neo4j/backup/stresstests/StartStop.java
+++ b/stresstests/src/test/java/org/neo4j/backup/stresstests/StartStop.java
@@ -20,6 +20,7 @@
 package org.neo4j.backup.stresstests;
 
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
@@ -48,7 +49,7 @@ class StartStop extends RepeatUntilCallable
     {
         GraphDatabaseService db = dbRef.get();
         db.shutdown();
-        LockSupport.parkNanos( 5_000_000_000L );
+        LockSupport.parkNanos( TimeUnit.SECONDS.toNanos( 5 ) );
         boolean replaced = dbRef.compareAndSet( db, factory.newInstance() );
         assertTrue( replaced );
     }

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
@@ -38,6 +38,7 @@ import java.util.function.IntFunction;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.SocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -59,7 +60,6 @@ import static org.neo4j.function.Suppliers.untilTimeExpired;
 import static org.neo4j.helper.DatabaseConfiguration.configureTxLogRotationAndPruning;
 import static org.neo4j.helper.StressTestingHelper.ensureExistsAndEmpty;
 import static org.neo4j.helper.StressTestingHelper.fromEnv;
-import static org.neo4j.helper.StressTestingHelper.prettyPrintStackTrace;
 
 public class BackupStoreCopyInteractionStressTesting
 {
@@ -149,9 +149,9 @@ public class BackupStoreCopyInteractionStressTesting
                             backupAddress ) );
 
             long timeout = durationInMinutes + 5;
-            assertNull( prettyPrintStackTrace( workload.get() ), workload.get( timeout, MINUTES ) );
-            assertNull( prettyPrintStackTrace( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES  ) );
-            assertNull( prettyPrintStackTrace( backupWorker.get() ), backupWorker.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( workload.get() ), workload.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES  ) );
+            assertNull( Exceptions.stringify( backupWorker.get() ), backupWorker.get( timeout, MINUTES ) );
         }
         finally
         {

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupStoreCopyInteractionStressTesting.java
@@ -35,10 +35,11 @@ import java.util.function.BooleanSupplier;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
@@ -55,7 +56,6 @@ import static org.neo4j.function.Suppliers.untilTimeExpired;
 import static org.neo4j.helper.DatabaseConfiguration.configureTxLogRotationAndPruning;
 import static org.neo4j.helper.StressTestingHelper.ensureExistsAndEmpty;
 import static org.neo4j.helper.StressTestingHelper.fromEnv;
-import static org.neo4j.helper.StressTestingHelper.prettyPrintStackTrace;
 
 public class CatchupStoreCopyInteractionStressTesting
 {
@@ -128,9 +128,9 @@ public class CatchupStoreCopyInteractionStressTesting
             Future<Throwable> catchUpWorker = service.submit( new CatchUpLoad( keepGoing, onFailure, cluster ) );
 
             long timeout = durationInMinutes + 5;
-            assertNull( prettyPrintStackTrace( workload.get() ), workload.get( timeout, MINUTES ) );
-            assertNull( prettyPrintStackTrace( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES ) );
-            assertNull( prettyPrintStackTrace( catchUpWorker.get() ), catchUpWorker.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( workload.get() ), workload.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( startStopWorker.get() ), startStopWorker.get( timeout, MINUTES ) );
+            assertNull( Exceptions.stringify( catchUpWorker.get() ), catchUpWorker.get( timeout, MINUTES ) );
         }
         finally
         {

--- a/stresstests/src/test/java/org/neo4j/helper/StressTestingHelper.java
+++ b/stresstests/src/test/java/org/neo4j/helper/StressTestingHelper.java
@@ -20,8 +20,6 @@
 package org.neo4j.helper;
 
 import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import static java.lang.System.getenv;
 import static org.junit.Assert.assertEquals;
@@ -53,15 +51,4 @@ public class StressTestingHelper
         return environmentVariableValue == null ? defaultValue : environmentVariableValue;
     }
 
-    public static String prettyPrintStackTrace( Throwable throwable )
-    {
-        if ( throwable == null )
-        {
-            return "";
-        }
-
-        StringWriter stringWriter = new StringWriter();
-        throwable.printStackTrace( new PrintWriter( stringWriter ) );
-        return stringWriter.toString();
-    }
 }


### PR DESCRIPTION
Avoid log pollution for cases when backup is consistent and no error occur.
Update timeouts to use TimeUnits
Use standard exception stringification.