### PR TITLE
Separate compilation phases

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/java/org/neo4j/cypher/internal/compiler/v3_2/CompilationPhaseTracer.java
+++ b/community/cypher/cypher-compiler-3.2/src/main/java/org/neo4j/cypher/internal/compiler/v3_2/CompilationPhaseTracer.java
@@ -48,6 +48,7 @@ public interface CompilationPhaseTracer
             return NONE_PHASE;
         }
     };
+
     CompilationPhaseEvent NONE_PHASE = () -> {
     };
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ASTRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ASTRewriter.scala
@@ -21,13 +21,13 @@ package org.neo4j.cypher.internal.compiler.v3_2
 
 import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters._
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.{ApplyRewriter, RewriterCondition, RewriterStepSequencer}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{NotEquals, Statement, UnaliasedReturnItem}
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.{ApplyRewriter, RewriterCondition, RewriterStepSequencer}
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, SemanticState}
 
 class ASTRewriter(rewriterSequencer: (String) => RewriterStepSequencer, shouldExtractParameters: Boolean = true) {
 
-  import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStep._
+  import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStep._
 
   def rewrite(queryText: String, statement: Statement, semanticState: SemanticState): (Statement, Map[String, Any], Set[RewriterCondition]) = {
     val (extractParameters, extractedParameters) = if (shouldExtractParameters)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
-object BuildCompiledExecutionPlan extends Phase {
+object BuildCompiledExecutionPlan extends Phase[Context] {
 
   override def phase = CODE_GENERATION
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.CODE_GENERATION
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.CODE_GENERATION
 import org.neo4j.cypher.internal.compiler.v3_2.codegen._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.ExecutionPlanBuilder.DescriptionProvider

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildCompiledExecutionPlan.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
-object BuildCompiledExecutionPlan extends Phase[Context] {
+object BuildCompiledExecutionPlan extends Phase[CompilerContext] {
 
   override def phase = CODE_GENERATION
 
@@ -39,7 +39,7 @@ object BuildCompiledExecutionPlan extends Phase[Context] {
 
   override def postConditions = Set.empty// Can't yet guarantee that we can build an execution plan
 
-  override def process(from: CompilationState, context: Context): CompilationState =
+  override def process(from: CompilationState, context: CompilerContext): CompilationState =
     try {
       val codeGen = new CodeGenerator(context.codeStructure, context.clock, context.codeGenConfiguration)
       val compiled: CompiledPlan = codeGen.generate(from.logicalPlan, context.planContext, from.semanticTable, from.plannerName)
@@ -50,7 +50,7 @@ object BuildCompiledExecutionPlan extends Phase[Context] {
         from.copy(maybeExecutionPlan = None)
     }
 
-  private def createExecutionPlan(context: Context, compiled: CompiledPlan) = new ExecutionPlan {
+  private def createExecutionPlan(context: CompilerContext, compiled: CompiledPlan) = new ExecutionPlan {
     private val fingerprint = context.createFingerprintReference(compiled.fingerprint)
 
     override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.PeriodicCommitInOpenTransactionException
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
-object BuildInterpretedExecutionPlan extends Phase {
+object BuildInterpretedExecutionPlan extends Phase[Context] {
   override def phase = PIPE_BUILDING
 
   override def description = "create interpreted execution plan"

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{PipeInfo, _}
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.Pipe
@@ -29,6 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.profiler.Profiler
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext, QueryContext, UpdateCountingQueryContext}
 import org.neo4j.cypher.internal.frontend.v3_2.PeriodicCommitInOpenTransactionException
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 
 object BuildInterpretedExecutionPlan extends Phase[CompilerContext] {
   override def phase = PIPE_BUILDING

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
@@ -30,14 +30,14 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.PeriodicCommitInOpenTransactionException
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
-object BuildInterpretedExecutionPlan extends Phase[Context] {
+object BuildInterpretedExecutionPlan extends Phase[CompilerContext] {
   override def phase = PIPE_BUILDING
 
   override def description = "create interpreted execution plan"
 
   override def postConditions = Set(Contains[ExecutionPlan])
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val logicalPlan = from.logicalPlan
     val idMap = LogicalPlanIdentificationBuilder(logicalPlan)
     val executionPlanBuilder = new PipeExecutionPlanBuilder(context.clock, context.monitors)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
@@ -35,6 +35,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.{CheckForUnresolvedTokens
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.{InputPosition, SemanticState}
 
 case class CypherCompiler(createExecutionPlan: Transformer[CompilerContext],
@@ -152,7 +153,6 @@ case class CypherCompiler(createExecutionPlan: Transformer[CompilerContext],
       monitors, metrics, queryGraphSolver, config, updateStrategy, clock, structure, codeGenConfiguration)
   }
 }
-
 
 case class CypherCompilerConfiguration(queryCacheSize: Int,
                                        statsDivergenceThreshold: Double,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
@@ -32,9 +32,9 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter.PlanRewriter
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CheckForUnresolvedTokens, ResolveTokens, UnionQuery}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, InternalNotificationLogger, Monitors}
 
 case class CypherCompiler(createExecutionPlan: Transformer[CompilerContext],

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
@@ -27,8 +27,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp._
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 
 object CypherCompilerFactory {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
@@ -29,6 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp._
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 
 object CypherCompilerFactory {
   val monitorTag = "cypher3.2"

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.InvalidArgumentException
 import org.neo4j.cypher.internal.frontend.v3_2.notification.RuntimeUnsupportedNotification
 
 object RuntimeBuilder {
-  def create(runtimeName: Option[RuntimeName], useErrorsOverWarnings: Boolean): Transformer[Context] = runtimeName match {
+  def create(runtimeName: Option[RuntimeName], useErrorsOverWarnings: Boolean): Transformer[CompilerContext] = runtimeName match {
     case None | Some(InterpretedRuntimeName) =>
       BuildInterpretedExecutionPlan
 
@@ -37,7 +37,7 @@ object RuntimeBuilder {
     case Some(CompiledRuntimeName) =>
       BuildCompiledExecutionPlan andThen
       If(_.maybeExecutionPlan.isEmpty)(
-        Do { (c:Context) => c.notificationLogger.log(RuntimeUnsupportedNotification) } andThen
+        Do { (c:CompilerContext) => c.notificationLogger.log(RuntimeUnsupportedNotification) } andThen
         BuildInterpretedExecutionPlan
       )
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.InvalidArgumentException
 import org.neo4j.cypher.internal.frontend.v3_2.notification.RuntimeUnsupportedNotification
 
 object RuntimeBuilder {
-  def create(runtimeName: Option[RuntimeName], useErrorsOverWarnings: Boolean): Transformer = runtimeName match {
+  def create(runtimeName: Option[RuntimeName], useErrorsOverWarnings: Boolean): Transformer[Context] = runtimeName match {
     case None | Some(InterpretedRuntimeName) =>
       BuildInterpretedExecutionPlan
 
@@ -37,7 +37,7 @@ object RuntimeBuilder {
     case Some(CompiledRuntimeName) =>
       BuildCompiledExecutionPlan andThen
       If(_.maybeExecutionPlan.isEmpty)(
-        Do(_.notificationLogger.log(RuntimeUnsupportedNotification)) andThen
+        Do { (c:Context) => c.notificationLogger.log(RuntimeUnsupportedNotification) } andThen
         BuildInterpretedExecutionPlan
       )
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/aggregationsAreIsolated.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/aggregationsAreIsolated.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{hasAggregateButIsNotAggregate, Expression}
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 
 case object aggregationsAreIsolated extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNamedPathOnlyForShortestPath.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNamedPathOnlyForShortestPath.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{NamedPatternPart, ShortestPaths}
 
 case object containsNamedPathOnlyForShortestPath extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNoNodesOfType.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNoNodesOfType.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
 import org.neo4j.cypher.internal.frontend.v3_2.ast.ASTNode
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 
 import scala.reflect.ClassTag
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNoReturnAll.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/containsNoReturnAll.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.ReturnItems
 
 case object containsNoReturnAll extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noDuplicatesInReturnItems.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noDuplicatesInReturnItems.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.ReturnItems
 
 case object noDuplicatesInReturnItems extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noReferenceEqualityAmongVariables.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noReferenceEqualityAmongVariables.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.Ref
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Variable
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 
 case object noReferenceEqualityAmongVariables extends Condition {
   def apply(that: Any): Seq[String] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noUnnamedPatternElementsInMatch.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noUnnamedPatternElementsInMatch.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Match, NodePattern, RelationshipPattern}
 
 case object noUnnamedPatternElementsInMatch extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noUnnamedPatternElementsInPatternComprehension.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/noUnnamedPatternElementsInPatternComprehension.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 
 case object noUnnamedPatternElementsInPatternComprehension extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/normalizedEqualsArguments.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/normalizedEqualsArguments.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Equals, Expression, FunctionInvocation, Property, functions}
 
 case object normalizedEqualsArguments extends Condition {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/orderByOnlyOnVariables.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/conditions/orderByOnlyOnVariables.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.conditions
 
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Variable, OrderBy, SortItem}
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.Condition
 
 case object orderByOnlyOnVariables extends Condition {
   def apply(that: Any): Seq[String] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizer.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v3_2._
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{Condition, Context}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{Condition, CompilerContext}
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_2.Rewritable._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
@@ -31,7 +31,7 @@ case object CNFNormalizer extends StatementRewriter {
 
   override def description: String = "normalize boolean predicates into conjunctive normal form"
 
-  override def instance(context: Context): Rewriter = {
+  override def instance(context: CompilerContext): Rewriter = {
     implicit val monitor = context.monitors.newMonitor[AstRewritingMonitor]()
     inSequence(
       deMorganRewriter(),

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizer.scala
@@ -20,18 +20,19 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v3_2._
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{Condition, CompilerContext}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilerContext, Condition}
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_2.Rewritable._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp, inSequence}
 
 case object CNFNormalizer extends StatementRewriter {
 
   override def description: String = "normalize boolean predicates into conjunctive normal form"
 
-  override def instance(context: CompilerContext): Rewriter = {
+  override def instance(context: BaseContext): Rewriter = {
     implicit val monitor = context.monitors.newMonitor[AstRewritingMonitor]()
     inSequence(
       deMorganRewriter(),

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/Namespacer.scala
@@ -19,16 +19,17 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 import org.neo4j.cypher.internal.frontend.v3_2.{Ref, Rewriter, SemanticTable, bottomUp, _}
 
 object Namespacer extends Phase[BaseContext] {
   type VariableRenamings = Map[Ref[Variable], Variable]
 
-  import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+  import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 
   override def phase: CompilationPhase = AST_REWRITE
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/Namespacer.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, Context, Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Ref, Rewriter, SemanticTable, bottomUp, _}
 
-object Namespacer extends Phase {
+object Namespacer extends Phase[BaseContext] {
   type VariableRenamings = Map[Ref[Variable], Variable]
 
   import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
@@ -34,7 +34,7 @@ object Namespacer extends Phase {
 
   override def description: String = "rename variables so they are all unique"
 
-  override def process(from: CompilationState, ignored: Context): CompilationState = {
+  override def process(from: CompilationState, ignored: BaseContext): CompilationState = {
     val ambiguousNames = shadowedNames(from.semantics.scopeTree)
     val variableDefinitions: Map[SymbolUse, SymbolUse] = from.semantics.scopeTree.allVariableDefinitions
     val protectedVariables = returnAliases(from.statement)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
@@ -47,7 +47,7 @@ case object rewriteEqualityToInPredicate extends StatementRewriter {
   override def postConditions: Set[Condition] = Set.empty
 }
 
-trait StatementRewriter extends Phase {
+trait StatementRewriter extends Phase[Context] {
   override def phase: CompilationPhase = AST_REWRITE
 
   def instance(context: Context): Rewriter

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/rewriteEqualityToInPredicate.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, Context, Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp}
 
@@ -29,7 +29,7 @@ case object rewriteEqualityToInPredicate extends StatementRewriter {
 
   override def description: String = "normalize equality predicates into IN comparisons"
 
-  override def instance(ignored: Context): Rewriter = bottomUp(Rewriter.lift {
+  override def instance(ignored: CompilerContext): Rewriter = bottomUp(Rewriter.lift {
     // id(a) = value => id(a) IN [value]
     case predicate@Equals(func@FunctionInvocation(_, _, _, IndexedSeq(idExpr)), idValueExpr)
       if func.function == functions.Id =>
@@ -47,12 +47,12 @@ case object rewriteEqualityToInPredicate extends StatementRewriter {
   override def postConditions: Set[Condition] = Set.empty
 }
 
-trait StatementRewriter extends Phase[Context] {
+trait StatementRewriter extends Phase[CompilerContext] {
   override def phase: CompilationPhase = AST_REWRITE
 
-  def instance(context: Context): Rewriter
+  def instance(context: CompilerContext): Rewriter
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val rewritten = from.statement.endoRewrite(instance(context))
     from.copy(maybeStatement = Some(rewritten))
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{CSVResources, QueryContext}
 import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionMode, ExplainMode, _}
 import org.neo4j.cypher.internal.frontend.v3_2.CypherException
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 
 import scala.collection.mutable
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionResultBuilder.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.executionplan
 
-import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionMode, InternalNotificationLogger}
+import org.neo4j.cypher.internal.compiler.v3_2.ExecutionMode
 import org.neo4j.cypher.internal.compiler.v3_2.pipes._
 import org.neo4j.cypher.internal.compiler.v3_2.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_2.CypherException
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 
 trait ExecutionResultBuilder {
   def setQueryContext(context: QueryContext)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.executionplan.procs
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_2.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast._
 /**
   * This planner takes on queries that requires no planning such as procedures and schema commands
   */
-case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase {
+case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[Context] {
 
   override def phase: CompilationPhase = PIPE_BUILDING
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.Compilatio
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_2.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, Context, Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast._
 /**
   * This planner takes on queries that requires no planning such as procedures and schema commands
   */
-case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[Context] {
+case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[CompilerContext] {
 
   override def phase: CompilationPhase = PIPE_BUILDING
 
@@ -40,7 +40,7 @@ case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[Context] {
 
   override def postConditions: Set[Condition] = Set.empty
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val maybeExecutionPlan: Option[ExecutionPlan] = from.statement match {
       // Global call: CALL foo.bar.baz("arg1", 2)
       case Query(None, SingleQuery(Seq(resolved@ResolvedCall(signature, args, _, _, _)))) =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.ASTRewriter
 import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters._
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.{RewriterCondition, RewriterStepSequencer, Condition => Rewriter_Condition}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.NotEquals
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.{RewriterCondition, RewriterStepSequencer}
 import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, inSequence}
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
@@ -27,11 +27,11 @@ import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.{RewriterCondit
 import org.neo4j.cypher.internal.frontend.v3_2.ast.NotEquals
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, inSequence}
 
-case class AstRewriting(sequencer: String => RewriterStepSequencer, shouldExtractParams: Boolean) extends Phase {
+case class AstRewriting(sequencer: String => RewriterStepSequencer, shouldExtractParams: Boolean) extends Phase[BaseContext] {
 
   private val astRewriter = new ASTRewriter(sequencer, shouldExtractParams)
 
-  override def process(in: CompilationState, context: Context): CompilationState = {
+  override def process(in: CompilationState, context: BaseContext): CompilationState = {
 
     val (rewrittenStatement, extractedParams, postConditions) = astRewriter.rewrite(in.queryText, in.statement, in.semantics)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
@@ -62,7 +62,7 @@ case class AstRewriting(sequencer: String => RewriterStepSequencer, shouldExtrac
 }
 
 object LateAstRewriting extends StatementRewriter {
-  override def instance(context: Context): Rewriter = inSequence(
+  override def instance(context: CompilerContext): Rewriter = inSequence(
     collapseMultipleInPredicates,
     nameUpdatingClauses,
     projectNamedPaths,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
@@ -63,7 +63,7 @@ case class AstRewriting(sequencer: String => RewriterStepSequencer, shouldExtrac
 }
 
 object LateAstRewriting extends StatementRewriter {
-  override def instance(context: CompilerContext): Rewriter = inSequence(
+  override def instance(context: BaseContext): Rewriter = inSequence(
     collapseMultipleInPredicates,
     nameUpdatingClauses,
     projectNamedPaths,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/AstRewriting.scala
@@ -20,11 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
 import org.neo4j.cypher.internal.compiler.v3_2.ASTRewriter
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters._
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.{RewriterCondition, RewriterStepSequencer, Condition => Rewriter_Condition}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.NotEquals
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, inSequence}
 
 case class AstRewriting(sequencer: String => RewriterStepSequencer, shouldExtractParams: Boolean) extends Phase[BaseContext] {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilationPhases.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilationPhases.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.phases
+
+import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.{CNFNormalizer, Namespacer, rewriteEqualityToInPredicate}
+import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticState
+import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
+
+object CompilationPhases {
+
+  def parsing(sequencer: String => RewriterStepSequencer): Transformer[BaseContext] =
+    Parsing.adds[Statement] andThen
+      SyntaxDeprecationWarnings andThen
+      PreparatoryRewriting andThen
+      SemanticAnalysis(warn = true).adds[SemanticState] andThen
+      AstRewriting(sequencer, shouldExtractParams = true)
+
+  def lateAstRewriting: Transformer[BaseContext] =
+    SemanticAnalysis(warn = false) andThen
+      Namespacer andThen
+      rewriteEqualityToInPredicate andThen
+      CNFNormalizer andThen
+      LateAstRewriting
+
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilationPhases.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilationPhases.scala
@@ -20,9 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.{CNFNormalizer, Namespacer, rewriteEqualityToInPredicate}
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticState
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 object CompilationPhases {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{GeneratedQuery, Pl
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition}
 
 case class CompilerContext(exceptionCreator: (String, InputPosition) => CypherException,
@@ -45,8 +46,3 @@ case class CompilerContext(exceptionCreator: (String, InputPosition) => CypherEx
                            codeStructure: CodeStructure[GeneratedQuery],
                            codeGenConfiguration: CodeGenConfiguration) extends BaseContext
 
-trait BaseContext {
-  def tracer: CompilationPhaseTracer
-  def notificationLogger: InternalNotificationLogger
-  def exceptionCreator: (String, InputPosition) => CypherException
-}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{GeneratedQuery, Pl
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
-import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger, Monitors}
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition}
 
 case class CompilerContext(exceptionCreator: (String, InputPosition) => CypherException,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CompilerContext.scala
@@ -30,20 +30,20 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGr
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition}
 
-case class Context(exceptionCreator: (String, InputPosition) => CypherException,
-                   tracer: CompilationPhaseTracer,
-                   notificationLogger: InternalNotificationLogger,
-                   planContext: PlanContext,
-                   typeConverter: RuntimeTypeConverter,
-                   createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
-                   monitors: Monitors,
-                   metrics: Metrics,
-                   queryGraphSolver: QueryGraphSolver,
-                   config: CypherCompilerConfiguration,
-                   updateStrategy: UpdateStrategy,
-                   clock: Clock,
-                   codeStructure: CodeStructure[GeneratedQuery],
-                   codeGenConfiguration: CodeGenConfiguration) extends BaseContext
+case class CompilerContext(exceptionCreator: (String, InputPosition) => CypherException,
+                           tracer: CompilationPhaseTracer,
+                           notificationLogger: InternalNotificationLogger,
+                           planContext: PlanContext,
+                           typeConverter: RuntimeTypeConverter,
+                           createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
+                           monitors: Monitors,
+                           metrics: Metrics,
+                           queryGraphSolver: QueryGraphSolver,
+                           config: CypherCompilerConfiguration,
+                           updateStrategy: UpdateStrategy,
+                           clock: Clock,
+                           codeStructure: CodeStructure[GeneratedQuery],
+                           codeGenConfiguration: CodeGenConfiguration) extends BaseContext
 
 trait BaseContext {
   def tracer: CompilationPhaseTracer

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Context.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Context.scala
@@ -43,4 +43,10 @@ case class Context(exceptionCreator: (String, InputPosition) => CypherException,
                    updateStrategy: UpdateStrategy,
                    clock: Clock,
                    codeStructure: CodeStructure[GeneratedQuery],
-                   codeGenConfiguration: CodeGenConfiguration)
+                   codeGenConfiguration: CodeGenConfiguration) extends BaseContext
+
+trait BaseContext {
+  def tracer: CompilationPhaseTracer
+  def notificationLogger: InternalNotificationLogger
+  def exceptionCreator: (String, InputPosition) => CypherException
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CreatePlannerQuery.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CreatePlannerQuery.scala
@@ -19,11 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.UnionQuery
 import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Query
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 object CreatePlannerQuery extends Phase[BaseContext] {
   override def phase = LOGICAL_PLANNING

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CreatePlannerQuery.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/CreatePlannerQuery.scala
@@ -25,14 +25,14 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.UnionQuery
 import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Query
 
-object CreatePlannerQuery extends Phase {
+object CreatePlannerQuery extends Phase[BaseContext] {
   override def phase = LOGICAL_PLANNING
 
   override def description = "from the normalized ast, create the corresponding PlannerQuery"
 
   override def postConditions = Set(Contains[UnionQuery])
 
-  override def process(from: CompilationState, context: Context): CompilationState = from.statement match {
+  override def process(from: CompilationState, context: BaseContext): CompilationState = from.statement match {
     case query: Query =>
       val unionQuery: UnionQuery = toUnionQuery(query, from.semanticTable)
       from.copy(maybeUnionQuery = Some(unionQuery))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/DeprecationWarnings.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/DeprecationWarnings.scala
@@ -28,8 +28,8 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast.{FunctionInvocation, Function
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{DeprecatedFunctionNotification, DeprecatedProcedureNotification, InternalNotification, ProcedureWarningNotification}
 
 
-object SyntaxDeprecationWarnings extends VisitorPhase {
-  override def visit(value: CompilationState, context: Context): Unit = {
+object SyntaxDeprecationWarnings extends VisitorPhase[BaseContext] {
+  override def visit(value: CompilationState, context: BaseContext): Unit = {
     val warnings = findDeprecations(value.statement)
 
     warnings.foreach(context.notificationLogger.log)
@@ -46,8 +46,8 @@ object SyntaxDeprecationWarnings extends VisitorPhase {
   override def description = "find deprecated Cypher constructs and generate warnings for them"
 }
 
-object ProcedureDeprecationWarnings extends VisitorPhase {
-  override def visit(value: CompilationState, context: Context): Unit = {
+object ProcedureDeprecationWarnings extends VisitorPhase[BaseContext] {
+  override def visit(value: CompilationState, context: BaseContext): Unit = {
     val warnings = findDeprecations(value.statement)
 
     warnings.foreach(context.notificationLogger.log)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/DeprecationWarnings.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/DeprecationWarnings.scala
@@ -19,14 +19,14 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.DEPRECATION_WARNINGS
 import org.neo4j.cypher.internal.compiler.v3_2.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.replaceAliasedFunctionInvocations.aliases
 import org.neo4j.cypher.internal.compiler.v3_2.spi.ProcedureSignature
 import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{FunctionInvocation, FunctionName, Statement, UnresolvedCall}
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{DeprecatedFunctionNotification, DeprecatedProcedureNotification, InternalNotification, ProcedureWarningNotification}
-
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.DEPRECATION_WARNINGS
 
 object SyntaxDeprecationWarnings extends VisitorPhase[BaseContext] {
   override def visit(value: CompilationState, context: BaseContext): Unit = {
@@ -66,8 +66,8 @@ object ProcedureDeprecationWarnings extends VisitorPhase[BaseContext] {
   override def description = "find calls to deprecated procedures and generate warnings for them"
 }
 
-object ProcedureWarnings extends VisitorPhase {
-  override def visit(value: CompilationState, context: Context): Unit = {
+object ProcedureWarnings extends VisitorPhase[BaseContext] {
+  override def visit(value: CompilationState, context: BaseContext): Unit = {
     val warnings = findWarnings(value.statement)
 
     warnings.foreach(context.notificationLogger.log)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Parsing.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Parsing.scala
@@ -23,10 +23,10 @@ import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.Compilatio
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
 
-case object Parsing extends Phase {
+case object Parsing extends Phase[BaseContext] {
   private val parser = new CypherParser
 
-  override def process(in: CompilationState, ignored: Context): CompilationState =
+  override def process(in: CompilationState, ignored: BaseContext): CompilationState =
     in.copy(maybeStatement = Some(parser.parse(in.queryText, in.startPosition)))
 
   override val phase = PARSING

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Phase.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/Phase.scala
@@ -21,10 +21,11 @@ package org.neo4j.cypher.internal.compiler.v3_2.phases
 
 import org.neo4j.cypher.internal.compiler.v3_2.AssertionRunner
 import org.neo4j.cypher.internal.compiler.v3_2.AssertionRunner.Thunk
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.closing
 import org.neo4j.cypher.internal.frontend.v3_2.InternalException
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 import scala.reflect.ClassTag
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/PreparatoryRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/PreparatoryRewriting.scala
@@ -23,9 +23,9 @@ import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.Compilatio
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.{expandCallWhere, normalizeReturnClauses, normalizeWithClauses, replaceAliasedFunctionInvocations}
 import org.neo4j.cypher.internal.frontend.v3_2.inSequence
 
-case object PreparatoryRewriting extends Phase {
+case object PreparatoryRewriting extends Phase[BaseContext] {
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: BaseContext): CompilationState = {
 
     val rewrittenStatement = from.statement.endoRewrite(inSequence(
       normalizeReturnClauses(context.exceptionCreator),

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/PreparatoryRewriting.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/PreparatoryRewriting.scala
@@ -19,9 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.{expandCallWhere, normalizeReturnClauses, normalizeWithClauses, replaceAliasedFunctionInvocations}
 import org.neo4j.cypher.internal.frontend.v3_2.inSequence
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 case object PreparatoryRewriting extends Phase[BaseContext] {
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp}
 
 // Given a way to lookup procedure signatures, this phase rewrites unresolved calls into resolved calls
-case object RewriteProcedureCalls extends Phase {
+case object RewriteProcedureCalls extends Phase[Context] {
 
   // Current procedure calling syntax allows simplified short-hand syntax for queries
   // that only consist of a standalone procedure call. In all other cases attempts to

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions.containsNoNodesOfType
 import org.neo4j.cypher.internal.compiler.v3_2.ast.{ResolvedCall, ResolvedFunctionInvocation}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/RewriteProcedureCalls.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp}
 
 // Given a way to lookup procedure signatures, this phase rewrites unresolved calls into resolved calls
-case object RewriteProcedureCalls extends Phase[Context] {
+case object RewriteProcedureCalls extends Phase[CompilerContext] {
 
   // Current procedure calling syntax allows simplified short-hand syntax for queries
   // that only consist of a standalone procedure call. In all other cases attempts to
@@ -66,7 +66,7 @@ case object RewriteProcedureCalls extends Phase[Context] {
 
   override def description = "resolve procedure calls"
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val rewrittenStatement = from.statement.endoRewrite(rewriter(context.planContext))
     from.copy(maybeStatement = Some(rewrittenStatement))
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/SemanticAnalysis.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/SemanticAnalysis.scala
@@ -19,11 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.phases
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.SEMANTIC_CHECK
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.SEMANTIC_CHECK
 import org.neo4j.cypher.internal.compiler.v3_2.SemanticChecker
 import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions.containsNoNodesOfType
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticState
 import org.neo4j.cypher.internal.frontend.v3_2.ast.UnaliasedReturnItem
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 case class SemanticAnalysis(warn: Boolean) extends Phase[BaseContext] {
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/SemanticAnalysis.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/phases/SemanticAnalysis.scala
@@ -25,9 +25,9 @@ import org.neo4j.cypher.internal.compiler.v3_2.ast.conditions.containsNoNodesOfT
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticState
 import org.neo4j.cypher.internal.frontend.v3_2.ast.UnaliasedReturnItem
 
-case class SemanticAnalysis(warn: Boolean) extends Phase {
+case class SemanticAnalysis(warn: Boolean) extends Phase[BaseContext] {
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: BaseContext): CompilationState = {
     val semanticState = SemanticChecker.check(from.statement, context.exceptionCreator)
     if (warn) semanticState.notifications.foreach(context.notificationLogger.log)
     from.copy(maybeSemantics = Some(semanticState))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
@@ -20,13 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v3_2.planner
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Context, VisitorPhase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{BaseContext, CompilationState, Context, VisitorPhase}
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{InternalNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification}
 
-object CheckForUnresolvedTokens extends VisitorPhase {
+object CheckForUnresolvedTokens extends VisitorPhase[BaseContext] {
 
-  override def visit(value: CompilationState, context: Context): Unit = {
+  override def visit(value: CompilationState, context: BaseContext): Unit = {
     val table = value.semanticTable
     def isEmptyLabel(label: String) = !table.resolvedLabelIds.contains(label)
     def isEmptyRelType(relType: String) = !table.resolvedRelTypeNames.contains(relType)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{BaseContext, CompilationState, CompilerContext, VisitorPhase}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, CompilerContext, VisitorPhase}
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{InternalNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.BaseContext
 
 object CheckForUnresolvedTokens extends VisitorPhase[BaseContext] {
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokens.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2.planner
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{BaseContext, CompilationState, Context, VisitorPhase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{BaseContext, CompilationState, CompilerContext, VisitorPhase}
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{InternalNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification}
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.compiler.v3_2.spi.TokenContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Query, _}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.TokenContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Query, _}
 import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, PropertyKeyId, RelTypeId, SemanticTable}
 
-object ResolveTokens extends VisitorPhase[Context] {
+object ResolveTokens extends VisitorPhase[CompilerContext] {
   def resolve(ast: Query)(implicit semanticTable: SemanticTable, tokenContext: TokenContext) {
     ast.fold(()) {
       case token: PropertyKeyName =>
@@ -65,7 +65,7 @@ object ResolveTokens extends VisitorPhase[Context] {
 
   override def description = "resolve token ids for labels, property keys and relationship types"
 
-  override def visit(value: CompilationState, context: Context): Unit = value.statement match {
+  override def visit(value: CompilationState, context: CompilerContext): Unit = value.statement match {
     case q: Query => resolve(q)(value.semanticTable, context.planContext)
     case _ =>
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ResolveTokens.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.TokenContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Query, _}
 import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, PropertyKeyId, RelTypeId, SemanticTable}
 
-object ResolveTokens extends VisitorPhase {
+object ResolveTokens extends VisitorPhase[Context] {
   def resolve(ast: Query)(implicit semanticTable: SemanticTable, tokenContext: TokenContext) {
     ast.fold(()) {
       case token: PropertyKeyName =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -35,10 +35,11 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{Limit => LimitPlan, LoadCSV => LoadCSVPlan, Skip => SkipPlan, _}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CantHandleQueryException, logical}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{InstrumentedGraphStatistics, PlanContext}
-import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionContext, Monitors, pipes, ast => compilerAst}
+import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionContext, pipes, ast => compilerAst}
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.Eagerly
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 import org.neo4j.cypher.internal.ir.v3_2.{IdName, PeriodicCommit, VarPatternLength}
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlanningContext.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Variable
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, IdName, StrictnessMode}
 
 case class LogicalPlanningContext(planContext: PlanContext,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
@@ -192,7 +192,7 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
 
 }
 
-trait PlannerQueryRewriter extends Phase {
+trait PlannerQueryRewriter extends Phase[Context] {
   override def phase: CompilationPhase = LOGICAL_PLANNING
 
   def instance(context: Context): Rewriter

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, Context, Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{AggregatingQueryProjection, QueryGraph, RegularPlannerQuery, _}
 import org.neo4j.cypher.internal.frontend.v3_2.Rewritable._
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, FunctionInvocation, _}
@@ -38,7 +38,7 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
 
   override def postConditions: Set[Condition] = Set.empty
 
-  override def instance(ignored: Context): Rewriter = topDown(Rewriter.lift {
+  override def instance(ignored: CompilerContext): Rewriter = topDown(Rewriter.lift {
     case RegularPlannerQuery(graph, proj@AggregatingQueryProjection(distinctExpressions, aggregations, _), tail)
       if validAggregations(aggregations) =>
 
@@ -192,12 +192,12 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
 
 }
 
-trait PlannerQueryRewriter extends Phase[Context] {
+trait PlannerQueryRewriter extends Phase[CompilerContext] {
   override def phase: CompilationPhase = LOGICAL_PLANNING
 
-  def instance(context: Context): Rewriter
+  def instance(context: CompilerContext): Rewriter
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val query: UnionQuery = from.unionQuery
     val rewritten = query.endoRewrite(instance(context))
     from.copy(maybeUnionQuery = Some(rewritten))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{AggregatingQueryProjection, QueryGraph, RegularPlannerQuery, _}
 import org.neo4j.cypher.internal.frontend.v3_2.Rewritable._

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{LogicalPla
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.ir.v3_2.PeriodicCommit
 
-case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = PlanSingleQuery()) extends Phase[Context] {
+case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = PlanSingleQuery()) extends Phase[CompilerContext] {
 
   override def phase = LOGICAL_PLANNING
 
@@ -34,7 +34,7 @@ case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, 
 
   override def postConditions = Set(Contains[LogicalPlan])
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val logicalPlanProducer = LogicalPlanProducer(context.metrics.cardinality)
     val logicalPlanningContext = LogicalPlanningContext(
       planContext = context.planContext,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{LogicalPlan, ProduceResult}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/QueryPlanner.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{LogicalPla
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.ir.v3_2.PeriodicCommit
 
-case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = PlanSingleQuery()) extends Phase {
+case class QueryPlanner(planSingleQuery: LogicalPlanningFunction1[PlannerQuery, LogicalPlan] = PlanSingleQuery()) extends Phase[Context] {
 
   override def phase = LOGICAL_PLANNING
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, Context, Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
@@ -36,7 +36,7 @@ case class PlanRewriter(rewriterSequencer: String => RewriterStepSequencer) exte
 
   override def postConditions: Set[Condition] = Set.empty
 
-  override def instance(context: Context) = fixedPoint(rewriterSequencer("LogicalPlanRewriter")(
+  override def instance(context: CompilerContext) = fixedPoint(rewriterSequencer("LogicalPlanRewriter")(
     fuseSelections,
     unnestApply,
     cleanUpEager,
@@ -48,12 +48,12 @@ case class PlanRewriter(rewriterSequencer: String => RewriterStepSequencer) exte
   ).rewriter)
 }
 
-trait LogicalPlanRewriter extends Phase[Context] {
+trait LogicalPlanRewriter extends Phase[CompilerContext] {
   override def phase: CompilationPhase = LOGICAL_PLANNING
 
-  def instance(context: Context): Rewriter
+  def instance(context: CompilerContext): Rewriter
 
-  override def process(from: CompilationState, context: Context): CompilationState = {
+  override def process(from: CompilationState, context: CompilerContext): CompilationState = {
     val rewritten = from.logicalPlan.endoRewrite(instance(context))
     from.copy(maybeLogicalPlan = Some(rewritten))
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -48,7 +48,7 @@ case class PlanRewriter(rewriterSequencer: String => RewriterStepSequencer) exte
   ).rewriter)
 }
 
-trait LogicalPlanRewriter extends Phase {
+trait LogicalPlanRewriter extends Phase[Context] {
   override def phase: CompilationPhase = LOGICAL_PLANNING
 
   def instance(context: Context): Rewriter

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
 
-import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
-import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
-import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, Condition, CompilerContext, Phase}
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
+import org.neo4j.cypher.internal.compiler.v3_2.phases.{CompilationState, CompilerContext, Condition, Phase}
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
 
 /*
  * Rewriters that live here are required to adhere to the contract of

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/PlanContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/PlanContext.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.spi
 
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 
 /**

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/NotImplementedPlanContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/NotImplementedPlanContext.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_2
 
 import org.neo4j.cypher.internal.compiler.v3_2.spi._
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 
 class NotImplementedPlanContext extends PlanContext {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/CNFNormalizerTest.scala
@@ -22,8 +22,9 @@ package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.compiler.v3_2.{AstRewritingMonitor, Monitors}
+import org.neo4j.cypher.internal.compiler.v3_2.AstRewritingMonitor
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class CNFNormalizerTest extends CypherFunSuite with PredicateTestSupport {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/NamespacerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/NamespacerTest.scala
@@ -24,9 +24,9 @@ import org.neo4j.cypher.internal.compiler.v3_2.helpers.StatementHelper._
 import org.neo4j.cypher.internal.compiler.v3_2.parser.ParserFixture.parser
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{AstConstructionTestSupport, Statement}
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class NamespacerTest extends CypherFunSuite with AstConstructionTestSupport {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.execution.FakeIdMap
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.SingleRow
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{QueryContext, QueryTransactionalContext}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.Cardinality
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokensTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/CheckForUnresolvedTokensTest.scala
@@ -21,9 +21,10 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner
 
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.compiler.v3_2.{IDPPlannerName, RecordingNotificationLogger}
+import org.neo4j.cypher.internal.compiler.v3_2.IDPPlannerName
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Query
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{InternalNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.RecordingNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{InputPosition, LabelId, PropertyKeyId, RelTypeId, SemanticTable}
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
@@ -193,7 +193,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     Do(rewriteStuff _) andThen
     CreatePlannerQuery
 
-  private def rewriteStuff(input: CompilationState, context: Context): CompilationState = {
+  private def rewriteStuff(input: CompilationState, context: CompilerContext): CompilationState = {
     val newStatement = input.statement.endoRewrite(namePatternPredicatePatternElements)
     input.copy(maybeStatement = Some(newStatement))
   }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
@@ -37,6 +37,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSeq
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{InternalNotificationLogger, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.ir.v3_2._

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
@@ -37,7 +37,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSeq
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
-import org.neo4j.cypher.internal.frontend.v3_2.phases.{InternalNotificationLogger, devNullLogger}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{InternalNotificationLogger, Monitors, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.ir.v3_2._

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
@@ -32,10 +32,10 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext, ProcedureSignature, _}
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer.newPlain
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer.newPlain
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_2.phases.{InternalNotificationLogger, Monitors, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
@@ -31,10 +31,10 @@ import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{LogicalPlanningContext, _}
 import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer.newPlain
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer.newPlain
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
@@ -36,6 +36,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSeq
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
 import org.neo4j.cypher.internal.frontend.v3_2.parser.CypherParser
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.frontend.v3_2.{Foldable, PropertyKeyId, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, IdName, PeriodicCommit}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
@@ -145,12 +145,12 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
     //
     // cf. QueryPlanningStrategy
     //
-    private def namePatternPredicates(input: CompilationState, context: Context): CompilationState = {
+    private def namePatternPredicates(input: CompilationState, context: CompilerContext): CompilationState = {
       val newStatement = input.statement.endoRewrite(namePatternPredicatePatternElements)
       input.copy(maybeStatement = Some(newStatement))
     }
 
-    private def removeApply(input: CompilationState, context: Context): CompilationState = {
+    private def removeApply(input: CompilationState, context: CompilerContext): CompilationState = {
       val newPlan = input.logicalPlan.endoRewrite(fixedPoint(unnestApply))
       input.copy(maybeLogicalPlan = Some(newPlan))
     }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilderTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.execution
 
-import org.neo4j.cypher.internal.compiler.v3_2.Monitors
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.{FakePipe, Pipe}
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.Cardinality
 import org.neo4j.time.Clocks

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/DefaultQueryPlannerTest.scala
@@ -21,13 +21,13 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{times, verify, when}
-import org.neo4j.cypher.internal.compiler.v3_2.devNullLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{ASTAnnotationMap, Expression, Hint}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{ExpressionTypeInfo, SemanticTable}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/PickBestPlanUsingHintsAndCostTest.scala
@@ -19,11 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_2.devNullLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.{LogicalPlanProducer, pickBestPlanUsingHintsAndCost}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, LogicalPlanningTestSupport2, PlannerQuery}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{LabelName, PropertyKeyName, UsingIndexHint}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.Cost
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/PlanEventHorizonTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{ProcedureCall, Projection, SingleRow}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, ProcedureCallProjection, RegularPlannerQuery, RegularQueryProjection}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.SignedDecimalIntegerLiteral
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{DummyPosition, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_2.Cardinality

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/idp/ExpandSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/idp/ExpandSolverStepTest.scala
@@ -20,13 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp
 
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.CardinalityModel
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{LogicalPlanningContext, Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, LogicalPlanConstructionTestSupport, PlannerQuery, QueryGraph}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{SemanticDirection, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, IdName, PatternRelationship, SimplePatternLength}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/idp/JoinSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/idp/JoinSolverStepTest.scala
@@ -20,13 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp
 
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.CardinalityModel
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{LogicalPlanningContext, Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{SemanticDirection, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, IdName, PatternRelationship, SimplePatternLength}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/ExtractBestPlanTest.scala
@@ -24,9 +24,10 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v3_2.{IndexDescriptor, RecordingNotificationLogger}
+import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.notification.{IndexHintUnfulfillableNotification, JoinHintUnfulfillableNotification}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.RecordingNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{IndexHintException, JoinHintException, SemanticDirection}
 import org.neo4j.cypher.internal.ir.v3_2.{IdName, PatternRelationship, VarPatternLength}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/countStorePlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/countStorePlannerTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{LogicalPlan, NodeCountFromCountStore, RelationshipCountFromCountStore}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{LogicalPlanningContext, Metrics, QueryGraphProducer, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{AggregatingQueryProjection, LogicalPlanningTestSupport}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{AstConstructionTestSupport, FunctionInvocation, FunctionName, Variable}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.IdName
 import org.scalatest.matchers.{MatchResult, Matcher}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.test_helpers
 
 import java.time.Clock
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.NO_TRACING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_TRACING
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.CodeStructure
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, InternalNotificationLogger, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition, InternalException}
 import org.scalatest.mock.MockitoSugar
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compiler.v3_2.test_helpers
 
 import java.time.Clock
 
-import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_TRACING
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.CodeStructure
@@ -30,7 +29,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
-import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, InternalNotificationLogger, devNullLogger}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_TRACING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, InternalNotificationLogger, Monitors, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition, InternalException}
 import org.scalatest.mock.MockitoSugar
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/test_helpers/ContextHelper.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.spi.CodeStructure
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{GeneratedQuery, PlanFingerprint, PlanFingerprintReference}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.RuntimeTypeConverter
-import org.neo4j.cypher.internal.compiler.v3_2.phases.Context
+import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition, InternalException}
@@ -47,7 +47,7 @@ object ContextHelper extends MockitoSugar {
              updateStrategy: UpdateStrategy = mock[UpdateStrategy],
              clock: Clock = Clock.systemUTC(),
              codeStructure: CodeStructure[GeneratedQuery] = mock[CodeStructure[GeneratedQuery]],
-             codeGenConfiguration: CodeGenConfiguration = CodeGenConfiguration()): Context =
-    Context(exceptionCreator, tracer, notificationLogger, planContext, typeConverter, createFingerprintReference,
+             codeGenConfiguration: CodeGenConfiguration = CodeGenConfiguration()): CompilerContext =
+    CompilerContext(exceptionCreator, tracer, notificationLogger, planContext, typeConverter, createFingerprintReference,
       monitors, metrics, queryGraphSolver, config, updateStrategy, clock, codeStructure, codeGenConfiguration)
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/CompilationTracer.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/CompilationTracer.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.tracing;
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer;
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer;
 
 public interface CompilationTracer
 {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/TimingCompilationTracer.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/tracing/TimingCompilationTracer.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer;
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer;
 
 public class TimingCompilationTracer implements CompilationTracer
 {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -26,7 +26,8 @@ import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
-import org.neo4j.cypher.{InvalidArgumentException, _}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
+import org.neo4j.cypher.{InvalidArgumentException, SyntaxException, _}
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.graphdb.impl.notification.NotificationCode.{CREATE_UNIQUE_UNAVAILABLE_FALLBACK, RULE_PLANNER_UNAVAILABLE_FALLBACK}
 import org.neo4j.kernel.GraphDatabaseQueryService

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{RuntimeJavaValueConverter, RuntimeScalaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_2.prettifier.Prettifier
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
 import org.neo4j.cypher.internal.tracing.{CompilationTracer, TimingCompilationTracer}
 import org.neo4j.graphdb.config.Setting

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal
 
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
 
 import scala.util.Try

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -23,11 +23,12 @@ import java.util.Collections.emptyList
 
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compatibility._
+import org.neo4j.cypher.internal.compiler.v2_3
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{EntityAccessor, ExecutionPlan => ExecutionPlan_v2_3}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{PlanContext, QueryContext}
 import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v2_3.{InfoLogger, ExplainMode => ExplainModev2_3, NormalMode => NormalModev2_3, ProfileMode => ProfileModev2_3, _}
-import org.neo4j.cypher.internal.compiler.{v2_3, v3_2}
+import org.neo4j.cypher.internal.frontend.v3_2
 import org.neo4j.cypher.internal.spi.v2_3.{TransactionBoundGraphStatistics, TransactionBoundPlanContext, TransactionBoundQueryContext}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
 import org.neo4j.graphdb.{Node, Relationship}
@@ -70,8 +71,7 @@ trait Compatibility {
         preParsedQuery.planner.name,
         Some(as2_3(preParsedQuery.offset)), tracer))
     new ParsedQuery {
-      override def plan(transactionalContext: TransactionalContextWrapper, tracer: v3_2.CompilationPhaseTracer): (org
-      .neo4j.cypher.internal.ExecutionPlan, Map[String, Any]) = exceptionHandler.runSafely {
+      def plan(transactionalContext: TransactionalContextWrapper, tracer: v3_2.phases.CompilationPhaseTracer): (org.neo4j.cypher.internal.ExecutionPlan, Map[String, Any]) = exceptionHandler.runSafely {
         val planContext: PlanContext = new TransactionBoundPlanContext(transactionalContext)
         val (planImpl, extractedParameters) = compiler.planPreparedQuery(preparedQueryForV_2_3.get, planContext, as2_3(tracer))
 
@@ -111,7 +111,6 @@ trait Compatibility {
     }
 
     def isPeriodicCommit = inner.isPeriodicCommit
-
 
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean =
       inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
@@ -23,9 +23,11 @@ import org.neo4j.cypher.InternalException
 import org.neo4j.cypher.internal.compiler.v2_3
 import org.neo4j.cypher.internal.compiler.v2_3.CompilationPhaseTracer.CompilationPhaseEvent
 import org.neo4j.cypher.internal.compiler.v2_3.{CypherCompilerConfiguration => CypherCompilerConfiguration2_3}
-import org.neo4j.cypher.internal.compiler.v3_2.{CompilationPhaseTracer, CypherCompilerConfiguration}
+import org.neo4j.cypher.internal.compiler.v3_2.CypherCompilerConfiguration
+import org.neo4j.cypher.internal.frontend
 import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition => InputPosition2_3}
-import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
+import org.neo4j.cypher.internal.frontend.v3_2.{InputPosition, phases}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, TransactionalContext}
 
 object helpers {
@@ -43,21 +45,21 @@ object helpers {
       override def beginPhase(phase: v2_3.CompilationPhaseTracer.CompilationPhase) = {
         val wrappedPhase =
           if (phase == v2_3.CompilationPhaseTracer.CompilationPhase.AST_REWRITE)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+            CompilationPhaseTracer.CompilationPhase.AST_REWRITE
           else if (phase == v2_3.CompilationPhaseTracer.CompilationPhase
             .CODE_GENERATION)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.CODE_GENERATION
+            phases.CompilationPhaseTracer.CompilationPhase.CODE_GENERATION
           else if (phase == v2_3.CompilationPhaseTracer.CompilationPhase
             .LOGICAL_PLANNING)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
+            phases.CompilationPhaseTracer.CompilationPhase.LOGICAL_PLANNING
           else if (phase == v2_3.CompilationPhaseTracer.CompilationPhase.PARSING)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.PARSING
+            phases.CompilationPhaseTracer.CompilationPhase.PARSING
           else if (phase == v2_3.CompilationPhaseTracer.CompilationPhase
             .PIPE_BUILDING)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
+            phases.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
           else if (phase == v2_3.CompilationPhaseTracer.CompilationPhase
             .SEMANTIC_CHECK)
-            org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.SEMANTIC_CHECK
+            phases.CompilationPhaseTracer.CompilationPhase.SEMANTIC_CHECK
           else throw new InternalException(s"Cannot handle $phase in 2.3")
 
         val wrappedEvent = tracer.beginPhase(wrappedPhase)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -21,16 +21,16 @@ package org.neo4j.cypher.internal.compatibility.v3_1
 
 import java.util.Collections.emptyList
 
-import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compatibility._
 import org.neo4j.cypher.internal.compatibility.v3_1.helpers._
+import org.neo4j.cypher.internal.compiler.v3_1
 import org.neo4j.cypher.internal.compiler.v3_1.executionplan.{ExecutionPlan => ExecutionPlan_v3_1}
 import org.neo4j.cypher.internal.compiler.v3_1.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_1.{CompilationPhaseTracer, InfoLogger, ExplainMode => ExplainModev3_1, NormalMode => NormalModev3_1, ProfileMode => ProfileModev3_1, _}
-import org.neo4j.cypher.internal.compiler.{v3_1, v3_2}
 import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_1.{TransactionalContextWrapper => TransactionalContextWrapperV3_1, _}
 import org.neo4j.cypher.internal.spi.v3_2.{TransactionalContextWrapper => TransactionalContextWrapperV3_2}
+import org.neo4j.cypher.internal.{frontend, _}
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.ExecutingQuery.PlannerInfo
 import org.neo4j.kernel.api.{IndexUsage, KernelAPI}
@@ -67,7 +67,7 @@ trait Compatibility {
         preParsedQuery.planner.name,
         Some(as3_1(preParsedQuery.offset)), tracer))
     new ParsedQuery {
-      override def plan(transactionalContext: TransactionalContextWrapperV3_2, tracer: v3_2.CompilationPhaseTracer):
+      override def plan(transactionalContext: TransactionalContextWrapperV3_2, tracer: frontend.v3_2.phases.CompilationPhaseTracer):
         (ExecutionPlan, Map[String, Any]) =
         exceptionHandler.runSafely {
           val tc = TransactionalContextWrapperV3_1(transactionalContext.tc)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
@@ -23,10 +23,11 @@ import org.neo4j.cypher.InternalException
 import org.neo4j.cypher.internal.compiler.v3_1
 import org.neo4j.cypher.internal.compiler.v3_1.CompilationPhaseTracer.{CompilationPhaseEvent, CompilationPhase => v3_1Phase}
 import org.neo4j.cypher.internal.compiler.v3_1.{CypherCompilerConfiguration => CypherCompilerConfiguration3_1}
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.{CompilationPhase => v3_2Phase}
-import org.neo4j.cypher.internal.compiler.v3_2.{CompilationPhaseTracer, CypherCompilerConfiguration}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.{CompilationPhase => v3_2Phase}
+import org.neo4j.cypher.internal.compiler.v3_2.CypherCompilerConfiguration
 import org.neo4j.cypher.internal.frontend.v3_1.{InputPosition => InputPosition3_1}
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, TransactionalContext}
 
 object helpers {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{LegacyNodeIndexUsa
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_2.{InfoLogger, ExplainMode => ExplainModev3_2, NormalMode => NormalModev3_2, ProfileMode => ProfileModev3_2, _}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, RecordingNotificationLogger}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_2._
 import org.neo4j.kernel.api.ExecutingQuery.PlannerInfo

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
@@ -24,8 +24,8 @@ import org.neo4j.cypher.internal.compatibility._
 import org.neo4j.cypher.internal.compiler.v3_2
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{LegacyNodeIndexUsage, LegacyRelationshipIndexUsage, SchemaIndexScanUsage, SchemaIndexSeekUsage, ExecutionPlan => ExecutionPlan_v3_2}
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
-import org.neo4j.cypher.internal.compiler.v3_2.{InfoLogger, ExplainMode => ExplainModev3_2, NormalMode => NormalModev3_2, ProfileMode => ProfileModev3_2, _}
+import org.neo4j.cypher.internal.compiler.v3_2.{InfoLogger, ExplainMode => ExplainModev3_2, NormalMode => NormalModev3_2, ProfileMode => ProfileModev3_2}
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.{CompilationPhaseTracer, RecordingNotificationLogger}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_2._
@@ -44,7 +44,7 @@ trait Compatibility {
   val kernelAPI: KernelAPI
 
   protected val rewriterSequencer: (String) => RewriterStepSequencer = {
-    import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer._
+    import RewriterStepSequencer._
     import org.neo4j.helpers.Assertion._
 
     if (assertionsEnabled()) newValidating else newPlain

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/WrappedMonitors.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/WrappedMonitors.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_2
 
-import org.neo4j.cypher.internal.compiler.v3_2.Monitors
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Monitors
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
 
 import scala.reflect.ClassTag

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/ExceptionTranslatingPlanContext.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.spi.v3_2
 
-import org.neo4j.cypher.internal.compiler.v3_2.InternalNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 
 class ExceptionTranslatingPlanContext(inner: PlanContext) extends PlanContext with ExceptionTranslationSupport {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContext.scala
@@ -23,8 +23,9 @@ import java.util.Optional
 
 import org.neo4j.cypher.MissingIndexException
 import org.neo4j.cypher.internal.LastCommittedTxIdProvider
-import org.neo4j.cypher.internal.compiler.v3_2.{IndexDescriptor, InternalNotificationLogger}
+import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_2.spi._
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.CypherType
 import org.neo4j.cypher.internal.frontend.v3_2.{CypherExecutionException, symbols}
 import org.neo4j.kernel.api.constraints.UniquenessConstraint

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_2.notification.CartesianProductNotification
+import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 import org.neo4j.logging.NullLog

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -27,8 +27,8 @@ import org.neo4j.cypher.internal.compatibility.v3_2.{StringInfoLogger, WrappedMo
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.notification.CartesianProductNotification
 import org.neo4j.cypher.internal.frontend.v3_2.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -23,7 +23,7 @@ import java.io.{File, PrintWriter}
 import java.util.concurrent.TimeUnit
 
 import org.neo4j.cypher.internal.ExecutionEngine
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.CreateTempFileTestSupport
 import org.neo4j.cypher.internal.tracing.TimingCompilationTracer
 import org.neo4j.cypher.internal.tracing.TimingCompilationTracer.QueryEvent

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -23,7 +23,8 @@ import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp.DefaultIDPSolverConfig
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
-import org.neo4j.cypher.internal.compiler.v3_2.{CypherCompilerConfiguration, devNullLogger}
+import org.neo4j.cypher.internal.compiler.v3_2.CypherCompilerConfiguration
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.helpers.GraphIcing
 import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -26,8 +26,8 @@ import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_2.{CypherCompilerFactory, InfoLogger, _}
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -22,12 +22,13 @@ package org.neo4j.cypher.internal.compiler
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD}
 import org.neo4j.cypher.internal.compatibility.v3_2.WrappedMonitors
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.NO_TRACING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_TRACING
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_2.{CypherCompilerFactory, InfoLogger, _}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 
 import scala.concurrent.duration._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CompilerComparisonTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer.newPlain
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 import org.neo4j.cypher.internal.spi.v3_2.{TransactionBoundPlanContext, TransactionBoundQueryContext, TransactionalContextWrapper}
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CompilerComparisonTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical._
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer.newPlain
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer.newPlain
 import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 import org.neo4j.cypher.internal.spi.v3_2.{TransactionBoundPlanContext, TransactionBoundQueryContext, TransactionalContextWrapper}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -27,8 +27,8 @@ import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
-import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -23,12 +23,13 @@ import java.time.{Clock, Instant, ZoneOffset}
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.v3_2.{StringInfoLogger, WrappedMonitors}
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.NO_TRACING
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.NO_TRACING
 import org.neo4j.cypher.internal.compiler.v3_2.codegen.CodeGenConfiguration
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_2.codegen.GeneratedQueryStructure
 import org.neo4j.graphdb.config.Setting

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ActualCostCalculationTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.commands.SingleQueryExpression
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{Literal, Property, Variable}
 import org.neo4j.cypher.internal.compiler.v3_2.commands.predicates.Equals
 import org.neo4j.cypher.internal.compiler.v3_2.commands.values.TokenType.{Label => _, _}
-import org.neo4j.cypher.internal.compiler.v3_2.devNullLogger
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, PropertyKeyId, SemanticDirection, ast}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.spi.v3_2
 
 import java.util.Collections
 
-import org.neo4j.cypher.internal.compiler.v3_2.devNullLogger
+import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, RelTypeId}
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.Cardinality

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/tracing/TimingCompilationTracerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/tracing/TimingCompilationTracerTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import org.mockito.Mockito.verify
-import org.neo4j.cypher.internal.compiler.v3_2.CompilationPhaseTracer.CompilationPhase.{LOGICAL_PLANNING, PARSING}
+import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer.CompilationPhase.{LOGICAL_PLANNING, PARSING}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{closing, using}
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.tracing.CompilationTracer.NO_COMPILATION_TRACING

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterCondition.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterCondition.scala
@@ -17,15 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
-
-import org.neo4j.cypher.internal.compiler.v3_2.helpers.ListSupport
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 final case class RewriterCondition(name: String, condition: Any => Seq[String])
-  extends (Any => Option[RewriterConditionFailure]) with ListSupport {
+  extends (Any => Option[RewriterConditionFailure]) {
 
-  def apply(input: Any): Option[RewriterConditionFailure] =
-    condition(input).asNonEmptyOption.map(RewriterConditionFailure(name, _))
+  def apply(input: Any): Option[RewriterConditionFailure] = {
+    val conditions = condition(input)
+    if (conditions.isEmpty) None else Some(RewriterConditionFailure(name, conditions))
+  }
 }
 
 case class RewriterConditionFailure(name: String, problems: Seq[String])

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStep.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStep.scala
@@ -17,10 +17,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 
-sealed trait RewriterTask
-final case class RunConditions(previousName: Option[String], conditions: Set[RewriterCondition]) extends RewriterTask
-final case class RunRewriter(name: String, rewriter: Rewriter) extends RewriterTask
+object RewriterStep {
+   implicit def namedProductRewriter(p: Product with Rewriter): ApplyRewriter = ApplyRewriter(p.productPrefix, p)
+
+   def enableCondition(p: Condition) = EnableRewriterCondition(RewriterCondition(p.name, p))
+   def disableCondition(p: Condition) = DisableRewriterCondition(RewriterCondition(p.name, p))
+ }
+
+sealed trait RewriterStep
+final case class ApplyRewriter(name: String, rewriter: Rewriter) extends RewriterStep
+final case class EnableRewriterCondition(cond: RewriterCondition) extends RewriterStep
+final case class DisableRewriterCondition(cond: RewriterCondition) extends RewriterStep
+
+trait Condition extends (Any => Seq[String]) {
+   def name: String
+}

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStepSequencer.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStepSequencer.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2._
 

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTask.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTask.scala
@@ -17,22 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 
-object RewriterStep {
-   implicit def namedProductRewriter(p: Product with Rewriter): ApplyRewriter = ApplyRewriter(p.productPrefix, p)
-
-   def enableCondition(p: Condition) = EnableRewriterCondition(RewriterCondition(p.name, p))
-   def disableCondition(p: Condition) = DisableRewriterCondition(RewriterCondition(p.name, p))
- }
-
-sealed trait RewriterStep
-final case class ApplyRewriter(name: String, rewriter: Rewriter) extends RewriterStep
-final case class EnableRewriterCondition(cond: RewriterCondition) extends RewriterStep
-final case class DisableRewriterCondition(cond: RewriterCondition) extends RewriterStep
-
-trait Condition extends (Any => Seq[String]) {
-   def name: String
-}
+sealed trait RewriterTask
+final case class RunConditions(previousName: Option[String], conditions: Set[RewriterCondition]) extends RewriterTask
+final case class RunRewriter(name: String, rewriter: Rewriter) extends RewriterTask

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTaskBuilder.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTaskBuilder.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTaskProcessor.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterTaskProcessor.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2.{InternalException, Rewriter}
 

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/BaseContext.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/BaseContext.scala
@@ -25,4 +25,5 @@ trait BaseContext {
   def tracer: CompilationPhaseTracer
   def notificationLogger: InternalNotificationLogger
   def exceptionCreator: (String, InputPosition) => CypherException
+  def monitors: Monitors
 }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/BaseContext.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/BaseContext.scala
@@ -17,38 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2;
+package org.neo4j.cypher.internal.frontend.v3_2.phases
 
-public interface CompilationPhaseTracer
-{
-    enum CompilationPhase
-    {
-        PARSING,
-        DEPRECATION_WARNINGS,
-        SEMANTIC_CHECK,
-        AST_REWRITE,
-        LOGICAL_PLANNING,
-        CODE_GENERATION,
-        PIPE_BUILDING,
-    }
+import org.neo4j.cypher.internal.frontend.v3_2.{CypherException, InputPosition}
 
-    CompilationPhaseEvent beginPhase( CompilationPhase phase );
-
-    interface CompilationPhaseEvent extends AutoCloseable
-    {
-        @Override
-        void close();
-    }
-
-    CompilationPhaseTracer NO_TRACING = new CompilationPhaseTracer()
-    {
-        @Override
-        public CompilationPhaseEvent beginPhase( CompilationPhase phase )
-        {
-            return NONE_PHASE;
-        }
-    };
-
-    CompilationPhaseEvent NONE_PHASE = () -> {
-    };
+trait BaseContext {
+  def tracer: CompilationPhaseTracer
+  def notificationLogger: InternalNotificationLogger
+  def exceptionCreator: (String, InputPosition) => CypherException
 }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/InternalNotificationLogger.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/InternalNotificationLogger.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2
+package org.neo4j.cypher.internal.frontend.v3_2.phases
 
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
@@ -31,8 +31,8 @@ sealed trait InternalNotificationLogger {
 }
 
 /**
- * A null implementation that discards all notifications.
- */
+  * A null implementation that discards all notifications.
+  */
 case object devNullLogger extends InternalNotificationLogger {
   override def log(notification: InternalNotification) {}
 
@@ -40,8 +40,8 @@ case object devNullLogger extends InternalNotificationLogger {
 }
 
 /**
- * NotificationLogger that records all notifications for later retrieval.
- */
+  * NotificationLogger that records all notifications for later retrieval.
+  */
 class RecordingNotificationLogger extends InternalNotificationLogger {
   private val builder = Set.newBuilder[InternalNotification]
 
@@ -49,4 +49,3 @@ class RecordingNotificationLogger extends InternalNotificationLogger {
 
   def notifications = builder.result()
 }
-

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/Monitors.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/Monitors.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2
+package org.neo4j.cypher.internal.frontend.v3_2.phases
 
 import scala.reflect.ClassTag
 

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStepSequencerTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/rewriting/RewriterStepSequencerTest.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_2.tracing.rewriters
+package org.neo4j.cypher.internal.frontend.v3_2.helpers.rewriting
 
 import org.neo4j.cypher.internal.frontend.v3_2.Rewriter
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite


### PR DESCRIPTION
This PR is a first step in an attempt to split up the compiler phases into several pieces: frontend, ir, and planning. We'd like to put the frontend steps into the frontend module, making it possible to use these phases without pulling in all the dependencies from the other module(s).

- Makes Transformer generic in its context
- Splits up `Context` into `BaseContext` (frontend) and `CompilerContext` (compiler)
- Moves the first two compiler pipeline phases out of `CypherCompiler`
- Moves many classes over to the frontend module