### PR TITLE
Convert Cypher parameter types

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationFunctionCallSupportAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationFunctionCallSupportAcceptanceTest.scala
@@ -28,7 +28,7 @@ class AggregationFunctionCallSupportAcceptanceTest extends ProcedureCallAcceptan
   test("should return correctly typed map result (even if converting to and from scala representation internally)") {
     val value = new util.HashMap[String, Any]()
     value.put("name", "Cypher")
-    value.put("level", 9001)
+    value.put("level", 9001L)
 
     registerUserAggregationFunction(value)
 

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
@@ -28,7 +28,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
   test("should return correctly typed map result (even if converting to and from scala representation internally)") {
     val value = new util.HashMap[String, Any]()
     value.put("name", "Cypher")
-    value.put("level", 9001)
+    value.put("level", 9001L)
 
     registerUserFunction(value)
 

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -67,4 +67,113 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with NewPlan
       r.hasProperty("name") should equal(false)
     }
   }
+
+  test("parameters should be transformed to cypher types") {
+    def echo(any: Any): AnyRef = {
+      executeScalarWithAllPlannersAndCompatibilityMode[AnyRef]("RETURN {p} AS p", "p" -> any)
+    }
+
+    echo(42.asInstanceOf[Byte]) shouldBe a[java.lang.Long]
+    echo(42.asInstanceOf[Short]) shouldBe a[java.lang.Long]
+    echo(42) shouldBe a[java.lang.Long]
+    echo(42L) shouldBe a[java.lang.Long]
+    echo(42.0f) shouldBe a[java.lang.Double]
+  }
+
+  test("array parameters should be transformed to cypher types") {
+    def echo(any: Any): Array[_] = {
+      executeWithAllPlannersAndRuntimesAndCompatibilityMode("RETURN {p} AS p", "p" -> any)
+        .columnAs[Array[_]]("p").next()
+    }
+
+    def echoNoCompatibility(any: Any): Array[_] = {
+      executeWithAllPlanners("RETURN {p} AS p", "p" -> any)
+        .columnAs[Array[_]]("p").next()
+    }
+
+    // Arrays of primitives
+    echo(Array[Byte](42.asInstanceOf[Byte])).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[Short](42.asInstanceOf[Short])).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[Int](42)).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[Long](42L)).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[Float](42.0F)).foreach(_ shouldBe a[java.lang.Double])
+    echo(Array[Double](42.0D)).foreach(_ shouldBe a[java.lang.Double])
+    echoNoCompatibility(Array[Char]('a')).foreach(_ shouldBe a[java.lang.String])
+
+    // Arrays of boxed values
+    echo(Array[java.lang.Byte](42.asInstanceOf[Byte])).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[java.lang.Short](42.asInstanceOf[Short])).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[java.lang.Integer](42)).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[java.lang.Long](42L)).foreach(_ shouldBe a[java.lang.Long])
+    echo(Array[java.lang.Float](42.0F)).foreach(_ shouldBe a[java.lang.Double])
+    echo(Array[java.lang.Double](42.0D)).foreach(_ shouldBe a[java.lang.Double])
+    echo(Array[java.lang.String]("a")).foreach(_ shouldBe a[java.lang.String])
+    echoNoCompatibility(Array[java.lang.Character]('a')).foreach(_ shouldBe a[java.lang.String])
+
+    // Nested array
+    echo(Array[Array[Byte]](Array(42.asInstanceOf[Byte]))).foreach { x =>
+      x shouldBe a[Array[AnyRef]]
+      x.asInstanceOf[Array[_]].foreach(_ shouldBe a[java.lang.Long])
+    }
+  }
+
+  test("list parameters should be transformed to cypher types") {
+    def echo(any: Any): Iterable[_] = {
+      executeWithAllPlannersAndRuntimesAndCompatibilityMode("RETURN {p} AS p", "p" -> any)
+        .columnAs[Iterable[_]]("p").next()
+    }
+
+    def echoNoCompatibility(any: Any): Iterable[_] = {
+      executeWithAllPlanners("RETURN {p} AS p", "p" -> any)
+        .columnAs[Iterable[_]]("p").next()
+    }
+
+    // Lists
+    echo(java.util.Arrays.asList[java.lang.Byte](42.asInstanceOf[Byte])).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Arrays.asList[java.lang.Short](42.asInstanceOf[Short])).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Arrays.asList[java.lang.Integer](42)).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Arrays.asList[java.lang.Long](42L)).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Arrays.asList[java.lang.Float](42.0F)).foreach(_ shouldBe a[java.lang.Double])
+    echo(java.util.Arrays.asList[java.lang.Double](42.0D)).foreach(_ shouldBe a[java.lang.Double])
+    echo(java.util.Arrays.asList[java.lang.String]("a")).foreach(_ shouldBe a[java.lang.String])
+    echoNoCompatibility(java.util.Arrays.asList[java.lang.Character]('a')).foreach(_ shouldBe a[java.lang.String])
+
+    // Nested list
+    echo(java.util.Arrays.asList[java.util.List[java.lang.Byte]](
+      java.util.Arrays.asList[java.lang.Byte](42.asInstanceOf[Byte])))
+      .foreach { x =>
+        x shouldBe a[Iterable[AnyRef]]
+        x.asInstanceOf[Iterable[_]].foreach(_ shouldBe a[java.lang.Long])
+      }
+  }
+
+  test("map parameters should be transformed to cypher types") {
+    def echo(any: Any): Iterable[_] = {
+      executeWithAllPlannersAndRuntimesAndCompatibilityMode("RETURN {p} AS p", "p" -> any)
+        .columnAs[Map[_, _]]("p").next().values
+    }
+
+    def echoNoCompatibility(any: Any): Iterable[_] = {
+      executeWithAllPlanners("RETURN {p} AS p", "p" -> any)
+        .columnAs[Map[_, _]]("p").next().values
+    }
+
+    // Maps
+    echo(java.util.Collections.singletonMap("k", 42.asInstanceOf[Byte])).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Collections.singletonMap("k", 42.asInstanceOf[Short])).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Collections.singletonMap("k", 42)).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Collections.singletonMap("k", 42L)).foreach(_ shouldBe a[java.lang.Long])
+    echo(java.util.Collections.singletonMap("k", 42.0F)).foreach(_ shouldBe a[java.lang.Double])
+    echo(java.util.Collections.singletonMap("k", 42.0D)).foreach(_ shouldBe a[java.lang.Double])
+    echo(java.util.Collections.singletonMap("k", "a")).foreach(_ shouldBe a[java.lang.String])
+    echoNoCompatibility(java.util.Collections.singletonMap("k", 'a')).foreach(_ shouldBe a[java.lang.String])
+
+    // Nested map
+    echo(java.util.Collections.singletonMap("k",
+      java.util.Collections.singletonMap("k", 42.asInstanceOf[Byte])))
+      .foreach { x =>
+        x shouldBe a[Map[_, _]]
+        x.asInstanceOf[Map[_, _]].values.foreach(_ shouldBe a[java.lang.Long])
+      }
+  }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -194,8 +194,8 @@ public abstract class CompiledConversionUtils
         }
         else if ( anyValue instanceof Map )
         {
-            ((Map) anyValue).replaceAll( (k, v) -> materializeAnyResult( nodeManager, v ) );
-            return anyValue;
+            return ((Map<String,Object>) anyValue).entrySet().stream().collect(
+                    Collectors.toMap( k -> k.getKey(), v -> materializeAnyResult( nodeManager, v.getValue() ) ) );
         }
         else
         {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/typeConversions.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/typeConversions.scala
@@ -40,9 +40,14 @@ object typeConversions extends RuntimeTypeConverter {
     case seq: Seq[_] => seq.map(asPrivateType)
     case javaMap: java.util.Map[_, _] => Eagerly.immutableMapValues(javaMap.asScala, asPrivateType)
     case javaIterable: java.lang.Iterable[_] => javaIterable.asScala.map(asPrivateType)
-    case arr: Array[Any] => arr.map(asPrivateType)
+    case arr: Array[_] => arr.map(asPrivateType)
     case point: spatial.Point => asPrivatePoint(point)
     case geometry: spatial.Geometry => asPrivateGeometry(geometry)
+    case float: Float => float.toDouble
+    case double: Double => double
+    case number: Number => number.longValue()
+    case char: Char => String.valueOf(char)
+    case character: Character => character.toString
     case value => value
   }
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherUpdateMapTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/CypherUpdateMapTest.java
@@ -52,7 +52,7 @@ public class CypherUpdateMapTest
         Node node1 = getNodeByIdInTx( 0 );
 
         assertThat( node1, inTxS( hasProperty( "key1" ).withValue( "value1" ) ) );
-        assertThat( node1, inTxS( hasProperty( "key2" ).withValue( 1234 ) ) );
+        assertThat( node1, inTxS( hasProperty( "key2" ).withValue( 1234L ) ) );
 
         db.execute(
                 "MATCH (n:Reference) SET n = {data} RETURN n",
@@ -65,7 +65,7 @@ public class CypherUpdateMapTest
 
         assertThat( node2, inTxS( not( hasProperty( "key1" ) ) ) );
         assertThat( node2, inTxS( not( hasProperty( "key2" ) ) ) );
-        assertThat( node2, inTxS( hasProperty( "key3" ).withValue(5678) ) );
+        assertThat( node2, inTxS( hasProperty( "key3" ).withValue(5678L) ) );
     }
 
     public <T> Matcher<? super T> inTxS( final Matcher<T> inner )


### PR DESCRIPTION
Fixes #7115 - Can't use Long safely as procedure argument type

- Converts Float to Double
- Converts all other Number types to Long
- Converts Character to String (this breaks backward compatibility tests)
- Converts values of Array, List and Map recursively
(including primitive arrays)
- Fix issue with materialization of Map results in compiled runtime

NOTE: This means that you can no longer use Cypher in embedded Neo4j to
store non-Cypher type property values.