### PR TITLE
Change implementation of `any graph` to be nonempty

### DIFF
--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -142,3 +142,8 @@ Fail when comparing parameters to nodes
 Comparing nodes to properties
 Fail when comparing nodes to relationships
 Fail when comparing relationships to nodes
+
+// Bug in spec, awaiting update
+ORDER BY should return results in ascending order
+ORDER BY DESC should return results in descending order
+Renaming columns before ORDER BY should return results in ascending order

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -5,3 +5,7 @@ Comparing nodes to properties
 Fail when comparing nodes to relationships
 Fail when comparing relationships to nodes
 
+// Bug in spec, awaiting update
+ORDER BY should return results in ascending order
+ORDER BY DESC should return results in descending order
+Renaming columns before ORDER BY should return results in ascending order

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost.txt
@@ -4,3 +4,8 @@ Fail when comparing parameters to nodes
 Comparing nodes to properties
 Fail when comparing nodes to relationships
 Fail when comparing relationships to nodes
+
+// Bug in spec, awaiting update
+ORDER BY should return results in ascending order
+ORDER BY DESC should return results in descending order
+Renaming columns before ORDER BY should return results in ascending order


### PR DESCRIPTION
The `Given any graph` precondition is supposed to work on
exactly that: any graph. It is often mistaken for `empty graph`, however.
This commit makes `any graph` be a graph of 10 unlabeled nodes,
which did find three scenarios with a broken precondition. These
are now blacklisted while awaiting a TCK update.

Also added back ResultWrapper around results, to provide a better
error message when results do not match expectations.