### PR TITLE
Add deprecation warning about connectors with arbitrary names

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
@@ -20,6 +20,7 @@
 package org.neo4j.graphdb.config;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
@@ -67,7 +68,8 @@ public interface Setting<T> extends Function<Function<String,String>,T>, Setting
     }
 
     @Override
-    default Map<String,String> validate( Map<String,String> rawConfig ) throws InvalidSettingException
+    default Map<String,String> validate( Map<String,String> rawConfig, Consumer<String> warningConsumer )
+            throws InvalidSettingException
     {
         // Validate setting, if present or default value otherwise
         try

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingValidator.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/SettingValidator.java
@@ -20,6 +20,7 @@
 package org.neo4j.graphdb.config;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 public interface SettingValidator
 {
@@ -27,9 +28,11 @@ public interface SettingValidator
      * Validate one or several setting values, throwing on invalid values.
      *
      * @param settings available to be validated
+     * @param warningConsumer a consumer for configuration warnings
      * @return the set of settings considered valid by this validator
      * @throws InvalidSettingException if invalid value detected
      */
-    Map<String,String> validate( Map<String,String> settings ) throws InvalidSettingException;
+    Map<String,String> validate( Map<String,String> settings, Consumer<String> warningConsumer )
+            throws InvalidSettingException;
 }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -399,10 +399,10 @@ public class Config implements DiagnosticsProvider, Configuration
                 .map( ConfigOptions::settingGroup )
                 .collect( Collectors.toList() );
         validSettings = new IndividualSettingsValidator( warnOnUnknownSettings )
-                .validate( settingValidators, validSettings, log );
+                .validate( settingValidators, validSettings, log, configFile.isPresent() );
         for ( ConfigurationValidator validator : validators )
         {
-            validSettings = validator.validate( settingValidators, validSettings, log );
+            validSettings = validator.validate( settingValidators, validSettings, log, configFile.isPresent() );
         }
         params.clear();
         params.putAll( validSettings );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
@@ -40,11 +40,12 @@ public interface ConfigurationValidator
      * @param settingValidators which are available
      * @param rawConfig to validate
      * @param log for logging with
+     * @param parsingFile true if reading config file, false otherwise
      * @return a Map of valid keys and values.
      * @throws InvalidSettingException in case of invalid values
      */
     @Nonnull
     Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
             @Nonnull Map<String,String> rawConfig,
-            @Nonnull Log log ) throws InvalidSettingException;
+            @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
@@ -172,8 +172,8 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
                     DEPRECATED_CONNECTOR_MSG,
                     nonDefaultConnectors.stream()
                             .sorted()
-                            .map( s -> "  " + s )
-                            .collect( joining( System.lineSeparator() ) ) ) );
+                            .map( s -> format( ">  %s%n", s ) )
+                            .collect( joining() ) ) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorValidator.java
@@ -21,10 +21,12 @@ package org.neo4j.kernel.configuration;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -33,6 +35,8 @@ import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.config.SettingGroup;
 
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.options;
@@ -44,6 +48,10 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
             Arrays.stream( Connector.ConnectorType.values() )
                     .map( Enum::name )
                     .collect( Collectors.toList() );
+    public static final String DEPRECATED_CONNECTOR_MSG =
+            "Warning: connectors with names other than [http,https,bolt] are%n" +
+                    "deprecated and support for them will be removed in a future%n" +
+                    "version of Neo4j. Offending lines in neo4j.conf:%n%n%s";
     protected final Connector.ConnectorType type;
 
     public ConnectorValidator( @Nonnull Connector.ConnectorType type )
@@ -75,7 +83,7 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
         // Do not allow invalid settings under 'dbms.connector.**'
         if ( parts.length != 4 )
         {
-            throw new InvalidSettingException( String.format( "Invalid connector setting: %s", key ) );
+            throw new InvalidSettingException( format( "Invalid connector setting: %s", key ) );
         }
 
         /*if ( !subSettings().contains( parts[3] ) )
@@ -104,14 +112,14 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
         // If this is a connector not called bolt or http, then we require the type
         if ( typeValue == null )
         {
-            throw new InvalidSettingException( String.format( "Missing mandatory value for '%s'",
+            throw new InvalidSettingException( format( "Missing mandatory value for '%s'",
                     typeKey ) );
         }
 
         if ( !validTypes.contains( typeValue ) )
         {
             throw new InvalidSettingException(
-                    String.format( "'%s' must be one of %s; not '%s'",
+                    format( "'%s' must be one of %s; not '%s'",
                             typeKey, String.join( ", ", validTypes ), typeValue ) );
         }
 
@@ -128,7 +136,7 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
 
     @Override
     @Nonnull
-    public Map<String,String> validate( @Nonnull Map<String,String> rawConfig )
+    public Map<String,String> validate( @Nonnull Map<String,String> rawConfig, @Nonnull Consumer<String> warningConsumer )
             throws InvalidSettingException
     {
         final HashMap<String,String> result = new HashMap<>();
@@ -136,10 +144,37 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
         ownedEntries( rawConfig ).forEach( s ->
                 result.putAll( getSettingFor( s.getKey(), rawConfig )
                         .orElseThrow( () -> new InvalidSettingException(
-                                String.format( "Invalid connector setting: %s", s.getKey() ) ) )
-                        .validate( rawConfig ) ) );
+                                format( "Invalid connector setting: %s", s.getKey() ) ) )
+                        .validate( rawConfig, warningConsumer ) ) );
+
+        warnAboutDeprecatedConnectors( result, warningConsumer );
 
         return result;
+    }
+
+    private void warnAboutDeprecatedConnectors( @Nonnull Map<String,String> connectorSettings,
+            @Nonnull Consumer<String> warningConsumer )
+    {
+        final HashSet<String> nonDefaultConnectors = new HashSet<>();
+        connectorSettings.entrySet().stream()
+                .map( Entry::getKey )
+                .filter( settingKey ->
+                {
+                    String name = settingKey.split( "\\." )[2];
+                    return !( name.equalsIgnoreCase( "http" ) || name.equalsIgnoreCase( "https" ) || name
+                            .equalsIgnoreCase( "bolt" ) );
+                } )
+                .forEach( nonDefaultConnectors::add );
+
+        if ( !nonDefaultConnectors.isEmpty() )
+        {
+            warningConsumer.accept( format(
+                    DEPRECATED_CONNECTOR_MSG,
+                    nonDefaultConnectors.stream()
+                            .sorted()
+                            .map( s -> "  " + s )
+                            .collect( joining( System.lineSeparator() ) ) ) );
+        }
     }
 
     @Override
@@ -151,7 +186,7 @@ public abstract class ConnectorValidator implements SettingGroup<Object>
         ownedEntries( params ).forEach( s ->
                 result.putAll( getSettingFor( s.getKey(), params )
                         .orElseThrow( () -> new InvalidSettingException(
-                                String.format( "Invalid connector setting: %s", s.getKey() ) ) )
+                                format( "Invalid connector setting: %s", s.getKey() ) ) )
                         .values( params ) ) );
 
         return result;

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnectorValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnectorValidator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.configuration;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 
@@ -39,6 +40,11 @@ import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class HttpConnectorValidator extends ConnectorValidator
 {
+    private static final Consumer<String> nullConsumer = s ->
+    {
+
+    };
+
     public HttpConnectorValidator()
     {
         super( HTTP );
@@ -92,7 +98,7 @@ public class HttpConnectorValidator extends ConnectorValidator
             @Nonnull Setting<?> setting,
             @Nonnull Map<String,String> rawConfig )
     {
-        Map<String,String> result = setting.validate( rawConfig );
+        Map<String,String> result = setting.validate( rawConfig, nullConsumer );
 
         Optional<?> encryption = Optional.ofNullable( setting.apply( rawConfig::get ) );
 
@@ -163,9 +169,10 @@ public class HttpConnectorValidator extends ConnectorValidator
             }
 
             @Override
-            public Map<String,String> validate( Map<String,String> rawConfig ) throws InvalidSettingException
+            public Map<String,String> validate( Map<String,String> rawConfig, Consumer<String> warningConsumer )
+                    throws InvalidSettingException
             {
-                Map<String,String> result = s.validate( rawConfig );
+                Map<String,String> result = s.validate( rawConfig, warningConsumer );
                 assertEncryption( name, s, rawConfig );
                 return result;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
@@ -60,7 +60,7 @@ public class IndividualSettingsValidator implements ConfigurationValidator
             @Nonnull Log log ) throws InvalidSettingException
     {
         Map<String,String> validConfig = settingValidators.stream()
-                .map( it -> it.validate( rawConfig ) )
+                .map( it -> it.validate( rawConfig, log::warn ) )
                 .flatMap( map -> map.entrySet().stream() )
                 .collect( Collectors.toMap( Entry::getKey, Entry::getValue ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/IndividualSettingsValidator.java
@@ -29,7 +29,6 @@ import javax.annotation.Nonnull;
 
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.SettingValidator;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.logging.Log;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.strict_config_validation;
@@ -57,10 +56,16 @@ public class IndividualSettingsValidator implements ConfigurationValidator
     @Nonnull
     public Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
             @Nonnull Map<String,String> rawConfig,
-            @Nonnull Log log ) throws InvalidSettingException
+            @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException
     {
         Map<String,String> validConfig = settingValidators.stream()
-                .map( it -> it.validate( rawConfig, log::warn ) )
+                .map( it -> it.validate( rawConfig, msg ->
+                {
+                    if ( parsingFile )
+                    {
+                        log.warn( msg );
+                    }
+                } ) )
                 .flatMap( map -> map.entrySet().stream() )
                 .collect( Collectors.toMap( Entry::getKey, Entry::getValue ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ServerConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ServerConfigurationValidator.java
@@ -45,7 +45,7 @@ public class ServerConfigurationValidator implements ConfigurationValidator
     @Nonnull
     public Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
             @Nonnull Map<String,String> rawConfig,
-            @Nonnull Log log ) throws InvalidSettingException
+            @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException
     {
         Pattern pattern = Pattern.compile(
                 Pattern.quote( "dbms.connector." ) + "([^\\.]+)\\.(.+)" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.configuration;
 
+import java.util.function.Consumer;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,10 +29,13 @@ import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.kernel.configuration.BoltConnector.EncryptionLevel;
 
-import static java.util.Collections.emptyMap;
-import static org.junit.Assert.*;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.Connector.ConnectorType.BOLT;
+import static org.neo4j.kernel.configuration.ConnectorValidator.DEPRECATED_CONNECTOR_MSG;
 
 
 public class BoltConnectorValidatorTest
@@ -38,12 +44,19 @@ public class BoltConnectorValidatorTest
 
     @Rule
     public ExpectedException expected = ExpectedException.none();
+    private Consumer<String> warningConsumer;
+
+    @Before
+    public void setup()
+    {
+        warningConsumer = mock( Consumer.class );
+    }
 
     @Test
     public void doesNotValidateUnrelatedStuff() throws Exception
     {
         assertEquals( 0, cv.validate( stringMap( "dbms.connector.http.enabled", "true",
-                "dbms.blabla.boo", "123" ) ).size() );
+                "dbms.blabla.boo", "123" ), warningConsumer ).size() );
     }
 
     @Test
@@ -52,7 +65,7 @@ public class BoltConnectorValidatorTest
         String boltEnabled = "dbms.connector.bolt.enabled";
 
         assertEquals( stringMap( boltEnabled, "true" ),
-                cv.validate( stringMap( boltEnabled, "true" ) ) );
+                cv.validate( stringMap( boltEnabled, "true" ), warningConsumer ) );
     }
 
     @Test
@@ -62,12 +75,12 @@ public class BoltConnectorValidatorTest
         String randomType = "dbms.connector.bla.type";
 
         assertEquals( stringMap( randomEnabled, "true", randomType, BOLT.name() ),
-                cv.validate( stringMap( randomEnabled, "true", randomType, BOLT.name() ) ) );
+                cv.validate( stringMap( randomEnabled, "true", randomType, BOLT.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Missing mandatory value for 'dbms.connector.bla.type'" );
 
-        cv.validate( stringMap( randomEnabled, "true" ) );
+        cv.validate( stringMap( randomEnabled, "true" ), warningConsumer );
     }
 
     @Test
@@ -79,7 +92,20 @@ public class BoltConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "dbms.connector.bla.type' must be one of BOLT, HTTP; not 'woo'" );
 
-        cv.validate( stringMap( randomEnabled, "true", randomType, "woo" ) );
+        cv.validate( stringMap( randomEnabled, "true", randomType, "woo" ), warningConsumer );
+    }
+
+    @Test
+    public void warnsWhenNameIsNotBolt() throws Exception
+    {
+        String randomEnabled = "dbms.connector.bla.enabled";
+        String randomType = "dbms.connector.bla.type";
+
+        cv.validate( stringMap( randomEnabled, "true", randomType, "BOLT" ), warningConsumer );
+
+        verify( warningConsumer ).accept(
+                format( DEPRECATED_CONNECTOR_MSG,
+                        format( "  %s%n  %s", randomEnabled, randomType ) ) );
     }
 
     @Test
@@ -90,7 +116,7 @@ public class BoltConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Invalid connector setting: dbms.connector.bla.0.enabled" );
 
-        cv.validate( stringMap( invalidSetting, "true" ) );
+        cv.validate( stringMap( invalidSetting, "true" ), warningConsumer );
     }
 
     @Test
@@ -101,7 +127,7 @@ public class BoltConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Invalid connector setting: dbms.connector.bolt.foobar" );
 
-        cv.validate( stringMap( invalidSetting, "true" ) );
+        cv.validate( stringMap( invalidSetting, "true" ), warningConsumer );
     }
 
     @Test
@@ -110,32 +136,32 @@ public class BoltConnectorValidatorTest
         String key = "dbms.connector.bolt.tls_level";
 
         assertEquals( stringMap( key, EncryptionLevel.DISABLED.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.DISABLED.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.DISABLED.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, EncryptionLevel.OPTIONAL.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.OPTIONAL.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.OPTIONAL.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, EncryptionLevel.REQUIRED.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.REQUIRED.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.REQUIRED.name() ), warningConsumer ) );
 
         key = "dbms.connector.bla.tls_level";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, EncryptionLevel.DISABLED.name(), type, BOLT.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.DISABLED.name(), type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.DISABLED.name(), type, BOLT.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, EncryptionLevel.OPTIONAL.name(), type, BOLT.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.OPTIONAL.name(), type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.OPTIONAL.name(), type, BOLT.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, EncryptionLevel.REQUIRED.name(), type, BOLT.name() ),
-                cv.validate( stringMap( key, EncryptionLevel.REQUIRED.name(), type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, EncryptionLevel.REQUIRED.name(), type, BOLT.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage(
                 "Bad value 'BOBO' for setting 'dbms.connector.bla.tls_level': must be one of [REQUIRED, OPTIONAL, " +
                         "DISABLED] case sensitive" );
 
-        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ), warningConsumer );
     }
 
     @Test
@@ -144,24 +170,24 @@ public class BoltConnectorValidatorTest
         String key = "dbms.connector.bolt.address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.address\" must be in the format \"hostname:port\" or " +
                 "\":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ), warningConsumer );
     }
 
     @Test
@@ -170,24 +196,24 @@ public class BoltConnectorValidatorTest
         String key = "dbms.connector.bolt.listen_address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.listen_address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.listen_address\" must be in the format " +
                 "\"hostname:port\" or \":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ), warningConsumer );
     }
 
     @Test
@@ -196,24 +222,24 @@ public class BoltConnectorValidatorTest
         String key = "dbms.connector.bolt.advertised_address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.advertised_address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, BOLT.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, BOLT.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.advertised_address\" must be in the format " +
                 "\"hostname:port\" or \":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, BOLT.name() ), warningConsumer );
     }
 
     @Test
@@ -224,6 +250,6 @@ public class BoltConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "'dbms.connector.bla.type' must be one of BOLT, HTTP; not 'BOBO'" );
 
-        cv.validate( stringMap( type, "BOBO" ) );
+        cv.validate( stringMap( type, "BOBO" ), warningConsumer );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/BoltConnectorValidatorTest.java
@@ -105,7 +105,7 @@ public class BoltConnectorValidatorTest
 
         verify( warningConsumer ).accept(
                 format( DEPRECATED_CONNECTOR_MSG,
-                        format( "  %s%n  %s", randomEnabled, randomType ) ) );
+                        format( ">  %s%n>  %s%n", randomEnabled, randomType ) ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -197,7 +198,7 @@ public class ConfigTest
             @Nonnull
             @Override
             public Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
-                    @Nonnull Map<String,String> rawConfig, @Nonnull Log log ) throws InvalidSettingException
+                    @Nonnull Map<String,String> rawConfig, @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException
             {
                 return rawConfig;
             }
@@ -211,6 +212,6 @@ public class ConfigTest
         second.with( stringMap( "third.jibberish", "baah" ) );
 
         // Then
-        verify( validator, times( 3 ) ).validate( any(), any(), any() );
+        verify( validator, times( 3 ) ).validate( any(), any(), any(), anyBoolean() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.configuration;
 
+import java.util.function.Consumer;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,10 +28,13 @@ import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.kernel.configuration.HttpConnector.Encryption;
 
-import static java.util.Collections.emptyMap;
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.Connector.ConnectorType.HTTP;
+import static org.neo4j.kernel.configuration.ConnectorValidator.DEPRECATED_CONNECTOR_MSG;
 
 public class HttpConnectorValidatorTest
 {
@@ -38,11 +43,13 @@ public class HttpConnectorValidatorTest
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
+    Consumer<String> warningConsumer = mock( Consumer.class );
+
     @Test
     public void doesNotValidateUnrelatedStuff() throws Exception
     {
         assertEquals( 0, cv.validate( stringMap( "dbms.connector.bolt.enabled", "true",
-                "dbms.blabla.boo", "123" ) ).size() );
+                "dbms.blabla.boo", "123" ), warningConsumer ).size() );
     }
 
     @Test
@@ -52,10 +59,10 @@ public class HttpConnectorValidatorTest
         String httpsEnabled = "dbms.connector.https.enabled";
 
         assertEquals( stringMap( httpEnabled, "true" ),
-                cv.validate( stringMap( httpEnabled, "true" ) ) );
+                cv.validate( stringMap( httpEnabled, "true" ), warningConsumer ) );
 
         assertEquals( stringMap( httpsEnabled, "true" ),
-                cv.validate( stringMap( httpsEnabled, "true" ) ) );
+                cv.validate( stringMap( httpsEnabled, "true" ), warningConsumer ) );
     }
 
     @Test
@@ -65,12 +72,25 @@ public class HttpConnectorValidatorTest
         String randomType = "dbms.connector.bla.type";
 
         assertEquals( stringMap( randomEnabled, "true", randomType, HTTP.name() ),
-                cv.validate( stringMap( randomEnabled, "true", randomType, HTTP.name() ) ) );
+                cv.validate( stringMap( randomEnabled, "true", randomType, HTTP.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Missing mandatory value for 'dbms.connector.bla.type'" );
 
-        cv.validate( stringMap( randomEnabled, "true" ) );
+        cv.validate( stringMap( randomEnabled, "true" ), warningConsumer );
+    }
+
+    @Test
+    public void warnsWhenNameIsNotHttpOrHttps() throws Exception
+    {
+        String randomEnabled = "dbms.connector.bla.enabled";
+        String randomType = "dbms.connector.bla.type";
+
+        cv.validate( stringMap( randomEnabled, "true", randomType, "HTTP" ), warningConsumer );
+
+        verify( warningConsumer ).accept(
+                format( DEPRECATED_CONNECTOR_MSG,
+                        format( "  %s%n  %s", randomEnabled, randomType ) ) );
     }
 
     @Test
@@ -81,7 +101,7 @@ public class HttpConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Invalid connector setting: dbms.connector.bla.0.enabled" );
 
-        cv.validate( stringMap( invalidSetting, "true" ) );
+        cv.validate( stringMap( invalidSetting, "true" ), warningConsumer );
     }
 
     @Test
@@ -92,7 +112,7 @@ public class HttpConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Invalid connector setting: dbms.connector.http.foobar" );
 
-        cv.validate( stringMap( invalidSetting, "true" ) );
+        cv.validate( stringMap( invalidSetting, "true" ), warningConsumer );
     }
 
     @Test
@@ -103,18 +123,18 @@ public class HttpConnectorValidatorTest
 
         assertEquals( stringMap( key, Encryption.NONE.name(),
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, Encryption.NONE.name(), type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, Encryption.NONE.name(), type, HTTP.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, Encryption.TLS.name(),
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, Encryption.TLS.name(), type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, Encryption.TLS.name(), type, HTTP.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage(
                 "Bad value 'BOBO' for setting 'dbms.connector.bla.encryption': must be one of [NONE, TLS] case " +
                         "sensitive" );
 
-        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ), warningConsumer );
     }
 
     @Test
@@ -123,12 +143,12 @@ public class HttpConnectorValidatorTest
         String key = "dbms.connector.https.encryption";
 
         assertEquals( stringMap( key, Encryption.TLS.name() ),
-                cv.validate( stringMap( key, Encryption.TLS.name() ) ) );
+                cv.validate( stringMap( key, Encryption.TLS.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage(
                 "'dbms.connector.https.encryption' is only allowed to be 'TLS'; not 'NONE'" );
-        cv.validate( stringMap( key, Encryption.NONE.name() ) );
+        cv.validate( stringMap( key, Encryption.NONE.name() ), warningConsumer );
     }
 
     @Test
@@ -137,12 +157,12 @@ public class HttpConnectorValidatorTest
         String key = "dbms.connector.http.encryption";
 
         assertEquals( stringMap( key, Encryption.NONE.name() ),
-                cv.validate( stringMap( key, Encryption.NONE.name() ) ) );
+                cv.validate( stringMap( key, Encryption.NONE.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage(
                 "'dbms.connector.http.encryption' is only allowed to be 'NONE'; not 'TLS'" );
-        cv.validate( stringMap( key, Encryption.TLS.name() ) );
+        cv.validate( stringMap( key, Encryption.TLS.name() ), warningConsumer );
     }
 
     @Test
@@ -151,24 +171,24 @@ public class HttpConnectorValidatorTest
         String key = "dbms.connector.http.address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.address\" must be in the format \"hostname:port\" or " +
                 "\":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ), warningConsumer );
     }
 
     @Test
@@ -177,24 +197,24 @@ public class HttpConnectorValidatorTest
         String key = "dbms.connector.http.listen_address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.listen_address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.listen_address\" must be in the format " +
                 "\"hostname:port\" or \":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ), warningConsumer );
     }
 
     @Test
@@ -203,24 +223,24 @@ public class HttpConnectorValidatorTest
         String key = "dbms.connector.http.advertised_address";
 
         assertEquals( stringMap( key, "localhost:123" ),
-                cv.validate( stringMap( key, "localhost:123" ) ) );
+                cv.validate( stringMap( key, "localhost:123" ), warningConsumer ) );
 
         key = "dbms.connector.bla.advertised_address";
         String type = "dbms.connector.bla.type";
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         assertEquals( stringMap( key, "localhost:123",
                 type, HTTP.name() ),
-                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ) ) );
+                cv.validate( stringMap( key, "localhost:123", type, HTTP.name() ), warningConsumer ) );
 
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "Setting \"dbms.connector.bla.advertised_address\" must be in the format " +
                 "\"hostname:port\" or \":port\". \"BOBO\" does not conform to these formats" );
 
-        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ) );
+        cv.validate( stringMap( key, "BOBO", type, HTTP.name() ), warningConsumer );
     }
 
     @Test
@@ -231,6 +251,6 @@ public class HttpConnectorValidatorTest
         expected.expect( InvalidSettingException.class );
         expected.expectMessage( "'dbms.connector.bla.type' must be one of BOLT, HTTP; not 'BOBO'" );
 
-        cv.validate( stringMap( type, "BOBO" ) );
+        cv.validate( stringMap( type, "BOBO" ), warningConsumer );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/HttpConnectorValidatorTest.java
@@ -90,7 +90,7 @@ public class HttpConnectorValidatorTest
 
         verify( warningConsumer ).accept(
                 format( DEPRECATED_CONNECTOR_MSG,
-                        format( "  %s%n  %s", randomEnabled, randomType ) ) );
+                        format( ">  %s%n>  %s%n", randomEnabled, randomType ) ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/IndividualSettingsValidatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/IndividualSettingsValidatorTest.java
@@ -62,7 +62,7 @@ public class IndividualSettingsValidatorTest
 
         final Map<String,String> result = iv.validate( singletonList( strict_config_validation ),
                 fullConfig,
-                log );
+                log, false );
 
         assertEquals( fullConfig, result );
         verify( log ).warn( "Unknown config option: %s", "dbms.jibber.jabber" );
@@ -84,7 +84,7 @@ public class IndividualSettingsValidatorTest
 
         iv.validate( singletonList( strict_config_validation ),
                 fullConfig,
-                log );
+                log, false );
     }
 
     @Test
@@ -97,7 +97,7 @@ public class IndividualSettingsValidatorTest
 
         final Map<String,String> result = iv.validate( singletonList( strict_config_validation ),
                 fullConfig,
-                log );
+                log, false );
 
         assertEquals( fullConfig, result );
         verifyNoMoreInteractions( log );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusterConfigurationValidator.java
@@ -39,7 +39,7 @@ public class CausalClusterConfigurationValidator implements ConfigurationValidat
     @Override
     @Nonnull
     public Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
-            @Nonnull Map<String,String> rawConfig, @Nonnull Log log ) throws InvalidSettingException
+            @Nonnull Map<String,String> rawConfig, @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException
     {
         // Make sure mode is CC
         Mode mode = ClusterSettings.mode.apply( rawConfig::get );

--- a/enterprise/cluster/src/main/java/org/neo4j/configuration/HaConfigurationValidator.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/configuration/HaConfigurationValidator.java
@@ -41,7 +41,7 @@ public class HaConfigurationValidator implements ConfigurationValidator
     @Override
     @Nonnull
     public Map<String,String> validate( @Nonnull Collection<SettingValidator> settingValidators,
-            @Nonnull Map<String,String> rawConfig, @Nonnull Log log ) throws InvalidSettingException
+            @Nonnull Map<String,String> rawConfig, @Nonnull Log log, boolean parsingFile ) throws InvalidSettingException
     {
         // Make sure mode is HA
         Mode mode = ClusterSettings.mode.apply( rawConfig::get );


### PR DESCRIPTION
This time in java, it still needs a little work because this is the actual output:

```
$ bin/neo4j console
Starting Neo4j.
WARNING: Max 1024 open files allowed, minimum of 40000 recommended. See the Neo4j manual.
2017-02-01 16:02:24.962+0000 WARN  Warning: connectors with names other than [http,https,bolt] are
deprecated and support for them will be removed in a future
version of Neo4j. Offending lines in neo4j.conf:

>  dbms.connector.jonas.enabled
>  dbms.connector.jonas.type

2017-02-01 16:02:25.004+0000 INFO  No SSL certificate found, generating a self-signed certificate..
2017-02-01 16:02:25.450+0000 INFO  Starting...
2017-02-01 16:02:25.465+0000 WARN  Warning: connectors with names other than [http,https,bolt] are
deprecated and support for them will be removed in a future
version of Neo4j. Offending lines in neo4j.conf:

>  dbms.connector.jonas.enabled
>  dbms.connector.jonas.type

2017-02-01 16:02:25.661+0000 WARN  Warning: connectors with names other than [http,https,bolt] are
deprecated and support for them will be removed in a future
version of Neo4j. Offending lines in neo4j.conf:

>  dbms.connector.jonas.enabled
>  dbms.connector.jonas.type

2017-02-01 16:02:26.047+0000 INFO  Bolt enabled on localhost:7687.
2017-02-01 16:02:26.055+0000 WARN  Warning: connectors with names other than [http,https,bolt] are
deprecated and support for them will be removed in a future
version of Neo4j. Offending lines in neo4j.conf:

>  dbms.connector.jonas.enabled
>  dbms.connector.jonas.type

2017-02-01 16:02:26.059+0000 INFO  Initiating metrics...
2017-02-01 16:02:26.128+0000 WARN  Warning: connectors with names other than [http,https,bolt] are
deprecated and support for them will be removed in a future
version of Neo4j. Offending lines in neo4j.conf:

>  dbms.connector.jonas.enabled
>  dbms.connector.jonas.type

2017-02-01 16:02:28.222+0000 INFO  Started.
2017-02-01 16:02:28.347+0000 INFO  Mounted REST API at: /db/manage
2017-02-01 16:02:28.925+0000 INFO  Remote interface available at http://localhost:7474/
```