### PR TITLE
Provide more detailed error messages when ordering by mixed types

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, IncomparableValuesException, NewPlannerTestSupport, SyntaxException}
 import org.neo4j.graphdb.Node
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
@@ -293,5 +293,19 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     val result2 = executeWithCostPlannerOnly(query2).toList
 
     result1.size should equal(result2.size)
+  }
+
+  test("should provide sensible error message when aggregating by min on mixed types") {
+    withEachPlanner { execute =>
+      val exception = intercept[IncomparableValuesException](execute("UNWIND {things} AS thing RETURN min(thing)", Seq("things" -> List("1", 2))))
+      exception.getMessage should startWith("Cannot perform MIN on mixed types.")
+    }
+  }
+
+  test("should provide sensible error message when aggregating by max on mixed types") {
+    withEachPlanner { execute =>
+      val exception = intercept[IncomparableValuesException](execute("UNWIND {things} AS thing RETURN max(thing)", Seq("things" -> List("1", 2))))
+      exception.getMessage should startWith("Cannot perform MAX on mixed types.")
+    }
   }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/OrderByAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/OrderByAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CustomMatchers
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, IncomparableValuesException, NewPlannerTestSupport, SyntaxException}
 
 class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers with NewPlannerTestSupport {
 
@@ -125,5 +125,19 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
     val expected = List(Map("floats" -> 1.3), Map("floats" -> 1.5), Map("floats" -> 999.99))
     executeWithAllPlanners(query).toList should equal(expected)
     executeWithAllPlanners(s"$query DESC").toList should equal(expected.reverse)
+  }
+
+  test("should provide sensible error message when ordering by mixed types") {
+    withEachPlanner { execute =>
+      val exception = intercept[IncomparableValuesException](execute("UNWIND {things} AS thing RETURN thing ORDER BY thing", Seq("things" -> List("1", 2))))
+      exception.getMessage should startWith("Cannot perform ORDER BY on mixed types.")
+    }
+  }
+
+  test("should provide sensible error message when ordering by list values") {
+    withEachPlanner { execute =>
+      val exception = intercept[IncomparableValuesException](execute("UNWIND {things} AS thing RETURN thing ORDER BY thing", Seq("things" -> List(List("a"),List("b")))))
+      exception.getMessage should startWith("Cannot perform ORDER BY on lists, consider using UNWIND.")
+    }
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/predicates/ComparablePredicate.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/predicates/ComparablePredicate.scala
@@ -36,7 +36,7 @@ abstract sealed class ComparablePredicate(val left: Expression, val right: Expre
     if (l == null || r == null)
       return None
 
-    val comparisonResult: Int = compare(l, r)(state)
+    val comparisonResult: Int = compare(None, l, r)(state)
 
     Some(compare(comparisonResult))
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LegacySortPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LegacySortPipe.scala
@@ -52,7 +52,7 @@ trait ExecutionContextComparer extends Comparer {
     case head :: tail => {
       val aVal = head(a)
       val bVal = head(b)
-      signum(compare(aVal, bVal)) match {
+      signum(compare(Some("ORDER BY"), aVal, bVal)) match {
         case 1 => !head.ascending
         case -1 => head.ascending
         case 0 => compareBy(a, b, tail)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SortPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SortPipe.scala
@@ -47,7 +47,7 @@ case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
       val aVal = a(column)
       val bVal = b(column)
 
-      Math.signum(compare(aVal, bVal)) match {
+      Math.signum(compare(Some("ORDER BY"), aVal, bVal)) match {
         case 1 => sort.isInstanceOf[Descending]
         case -1 => sort.isInstanceOf[Ascending]
         case 0 => compareBy(a, b, tail)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TopPipe.scala
@@ -47,7 +47,7 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
       val v2 = b._1
       var i = 0
       while (i < sortItemsCount) {
-        val res = signum(comparer.compare(v1(i), v2(i)))
+        val res = signum(comparer.compare(Some("ORDER BY"), v1(i), v2(i)))
         if (res != 0) {
           val sortItem = sortItems(i)
           return if (sortItem.ascending) res else -res

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/MaxFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/MaxFunction.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.frontend.v2_3.SyntaxException
 trait MinMax extends AggregationFunction with Comparer {
   def value: Expression
   def keep(comparisonResult: Int): Boolean
+  def name: String
 
   private var biggestSeen: Any = null
 
@@ -43,7 +44,7 @@ trait MinMax extends AggregationFunction with Comparer {
   private def checkIfLargest(value: Any)(implicit qtx: QueryState) {
     if (biggestSeen == null) {
       biggestSeen = value
-    } else if (keep(compare(biggestSeen, value))) {
+    } else if (keep(compare(Some(name), biggestSeen, value))) {
       biggestSeen = value
     }
   }
@@ -51,8 +52,10 @@ trait MinMax extends AggregationFunction with Comparer {
 
 class MaxFunction(val value: Expression) extends AggregationFunction with MinMax {
   def keep(comparisonResult: Int) = comparisonResult < 0
+  override def name: String = "MAX"
 }
 
 class MinFunction(val value: Expression) extends AggregationFunction with MinMax {
   def keep(comparisonResult: Int) = comparisonResult > 0
+  override def name: String = "MIN"
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -135,9 +135,10 @@ class ArithmeticException(message: String, cause: Throwable) extends CypherExcep
   val status = Status.Statement.ArithmeticError
 }
 
-class IncomparableValuesException(lhs: String, rhs: String, cause: Throwable)
-  extends SyntaxException(s"Don't know how to compare that. Left: ${lhs}; Right: ${rhs}", cause) {
-  def this(lhs: String, rhs: String) = this(lhs, rhs, null)
+class IncomparableValuesException(details: Option[String], lhs: String, rhs: String, cause: Throwable)
+  extends SyntaxException(s"${details.getOrElse("Don't know how to compare that.")} Left: ${lhs}; Right: ${rhs}", cause) {
+  def this(lhs: String, rhs: String, cause: Throwable) = this(None, lhs, rhs, null)
+  def this(lhs: String, rhs: String) = this(None, lhs, rhs, null)
 }
 
 class PeriodicCommitInOpenTransactionException(cause: Throwable)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -66,7 +66,7 @@ object exceptionHandlerFor2_3 extends MapToPublicExceptions[CypherException] {
     throw new ProfilerStatisticsNotReadyException(cause)
   }
 
-  def incomparableValuesException(lhs: String, rhs: String, cause: Throwable) = new IncomparableValuesException(lhs, rhs, cause)
+  def incomparableValuesException(details: Option[String], lhs: String, rhs: String, cause: Throwable): CypherException = new IncomparableValuesException(details, lhs, rhs, cause)
 
   def unknownLabelException(s: String, cause: Throwable) = new UnknownLabelException(s, cause)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NewPlannerTestSupport.scala
@@ -196,6 +196,10 @@ trait NewPlannerTestSupport extends CypherTestSupport {
   override def execute(queryText: String, params: (String, Any)*) =
     fail("Don't use execute together with NewPlannerTestSupport")
 
+  def withEachPlanner(body: ((String, Seq[(String, Any)]) => InternalExecutionResult) => Any) = {
+    List(executeWithRulePlanner _, executeWithCostPlannerOnly _).foreach(body)
+  }
+
   def executeWithRulePlanner(queryText: String, params: (String, Any)*) = {
     val plannerWatcher: (List[NewPlannerMonitorCall]) => Unit = unexpectedlyUsedNewPlanner(queryText)
     val runtimeWatcher: (List[NewRuntimeMonitorCall]) => Unit = unexpectedlyUsedNewRuntime(queryText)

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/CypherException.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/CypherException.scala
@@ -111,8 +111,10 @@ class ArithmeticException(message: String, cause: Throwable = null) extends Cyph
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.arithmeticException(message, this)
 }
 
-class IncomparableValuesException(lhs: String, rhs: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.incomparableValuesException(lhs, rhs, this)
+class IncomparableValuesException(details: Option[String], lhs: String, rhs: String) extends CypherException {
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.incomparableValuesException(details, lhs, rhs, this)
+  def this(operator: String, lhs: String, rhs: String) = this(Some(operator), lhs, rhs)
+  def this(lhs: String, rhs: String) = this(None, lhs, rhs)
 }
 
 class PeriodicCommitInOpenTransactionException extends CypherException {

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/spi/MapToPublicExceptions.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/spi/MapToPublicExceptions.scala
@@ -32,7 +32,7 @@ trait MapToPublicExceptions[T <: Throwable] {
 
   def loadExternalResourceException(message: String, cause: Throwable): T
 
-  def incomparableValuesException(lhs: String, rhs: String, cause: Throwable): T
+  def incomparableValuesException(operator: Option[String], lhs: String, rhs: String, cause: Throwable): T
 
   def arithmeticException(message: String, cause: Throwable): T
 


### PR DESCRIPTION
Also for when aggregating with MIN or MAX on mixed types, or when ordering by list values.