### PR TITLE
Restrict access to unsecured components

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -362,16 +362,16 @@ public class DataSourceModule
 
         // Register injected public API components
         Log proceduresLog = platform.logging.getUserLog( Procedures.class );
-        procedures.registerComponent( Log.class, ( ctx ) -> proceduresLog );
+        procedures.registerComponent( Log.class, ( ctx ) -> proceduresLog, true );
 
         Guard guard = platform.dependencies.resolveDependency( Guard.class );
-        procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ) );
+        procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ), true );
 
         // Register injected private API components: useful to have available in procedures to access the kernel etc.
         ProcedureGDSFactory gdsFactory = new ProcedureGDSFactory( platform.config, platform.storeDir,
                 platform.dependencies, storeId, this.queryExecutor, editionModule.coreAPIAvailabilityGuard,
                 platform.urlAccessRule );
-        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply );
+        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply, true );
 
         // Below components are not public API, but are made available for internal
         // procedures to call, and to provide temporary workarounds for the following
@@ -380,12 +380,12 @@ public class DataSourceModule
         //  - Group-transaction writes (same pattern as above, but rather than splitting large transactions,
         //                              combine lots of small ones)
         //  - Bleeding-edge performance (KernelTransaction, to bypass overhead of working with Core API)
-        procedures.registerComponent( DependencyResolver.class, ( ctx ) -> platform.dependencies );
-        procedures.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
-        procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade );
+        procedures.registerComponent( DependencyResolver.class, ( ctx ) -> platform.dependencies, false );
+        procedures.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ), false );
+        procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade, false );
 
         // Security procedures
-        procedures.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ) );
+        procedures.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ), true );
 
         // Edition procedures
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
@@ -91,7 +91,7 @@ public class ProcedureJarLoader
         while ( classes.hasNext() )
         {
             Class<?> next = classes.next();
-            target.addAllProcedures( compiler.compileProcedure( next, Optional.empty() ) );
+            target.addAllProcedures( compiler.compileProcedure( next, Optional.empty(), false ) );
             target.addAllFunctions( compiler.compileFunction( next ) );
             target.addAllAggregationFunctions( compiler.compileAggregationFunction( next ) );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -49,7 +49,8 @@ public class Procedures extends LifecycleAdapter
 {
     private final ProcedureRegistry registry = new ProcedureRegistry();
     private final TypeMappers typeMappers = new TypeMappers();
-    private final ComponentRegistry components = new ComponentRegistry();
+    private final ComponentRegistry safeComponents = new ComponentRegistry();
+    private final ComponentRegistry allComponents = new ComponentRegistry();
     private final ReflectiveProcedureCompiler compiler;
     private final ThrowingConsumer<Procedures, ProcedureException> builtin;
     private final File pluginDir;
@@ -67,7 +68,7 @@ public class Procedures extends LifecycleAdapter
         this.builtin = builtin;
         this.pluginDir = pluginDir;
         this.log = log;
-        this.compiler = new ReflectiveProcedureCompiler( typeMappers, components, log, config );
+        this.compiler = new ReflectiveProcedureCompiler( typeMappers, safeComponents, allComponents, log, config );
     }
 
     /**
@@ -125,7 +126,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      */
     public void registerProcedure( Class<?> proc ) throws KernelException
@@ -134,7 +135,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      * @param overrideCurrentImplementation set to true if procedures within this class should override older procedures with the same name
      */
@@ -144,7 +145,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      * @param overrideCurrentImplementation set to true if procedures within this class should override older procedures with the same name
      * @param warning the warning the procedure should generate when called
@@ -153,7 +154,7 @@ public class Procedures extends LifecycleAdapter
             throws
             KernelException
     {
-        for ( CallableProcedure procedure : compiler.compileProcedure( proc, warning ) )
+        for ( CallableProcedure procedure : compiler.compileProcedure( proc, warning, true ) )
         {
             register( procedure, overrideCurrentImplementation );
         }
@@ -213,13 +214,17 @@ public class Procedures extends LifecycleAdapter
 
     /**
      * Registers a component, these become available in reflective procedures for injection.
-     *
      * @param cls the type of component to be registered (this is what users 'ask' for in their field declaration)
      * @param provider a function that supplies the component, given the context of a procedure invocation
+     * @param safe set to false if this component can bypass security, true if it respects security
      */
-    public <T> void registerComponent( Class<T> cls, ComponentRegistry.Provider<T> provider )
+    public <T> void registerComponent( Class<T> cls, ComponentRegistry.Provider<T> provider, boolean safe )
     {
-        components.register( cls, provider );
+        if ( safe )
+        {
+            safeComponents.register( cls, provider );
+        }
+        allComponents.register( cls, provider );
     }
 
     public ProcedureSignature procedure( QualifiedName name ) throws ProcedureException

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -285,9 +285,9 @@ public class BuiltInProceduresTest
     @Before
     public void setup() throws Exception
     {
-        procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
-        procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ) );
-        procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ) );
+        procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ), false );
+        procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ), false );
+        procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ), false );
 
         procs.registerType( Node.class, new TypeMappers.SimpleConverter( NTNode, Node.class ) );
         procs.registerType( Relationship.class, new TypeMappers.SimpleConverter( NTRelationship, Relationship.class ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -57,7 +57,7 @@ public class ProcedureJarLoaderTest
 
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
-                    NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
+                    new ComponentRegistry(), NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
+@SuppressWarnings( "WeakerAccess" )
 public class ReflectiveProcedureTest
 {
     @Rule
@@ -67,7 +68,8 @@ public class ReflectiveProcedureTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, components,
+                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -77,7 +79,7 @@ public class ReflectiveProcedureTest
         Log log = spy( Log.class );
         components.register( Log.class, (ctx) -> log );
         CallableProcedure procedure =
-                procedureCompiler.compileProcedure( LoggingProcedure.class, Optional.empty() ).get( 0 );
+                procedureCompiler.compileProcedure( LoggingProcedure.class, Optional.empty(), true ).get( 0 );
 
         // When
         procedure.apply( new BasicContext(), new Object[0] );
@@ -273,12 +275,12 @@ public class ReflectiveProcedureTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log,
-                ProcedureAllowedConfig.DEFAULT );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
+                components, log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableProcedure> procs =
-                procedureCompiler.compileProcedure( ProcedureWithDeprecation.class, Optional.empty() );
+                procedureCompiler.compileProcedure( ProcedureWithDeprecation.class, Optional.empty(), true );
 
         // Then
         verify( log ).warn( "Use of @Procedure(deprecatedBy) without @Deprecated in badProc" );
@@ -524,6 +526,6 @@ public class ReflectiveProcedureTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return procedureCompiler.compileProcedure( clazz, Optional.empty() );
+        return procedureCompiler.compileProcedure( clazz, Optional.empty(), true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -215,7 +215,8 @@ public class ReflectiveProcedureWithArgumentsTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), NullLog.getInstance(),
-                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty() );
+        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), new ComponentRegistry(),
+                NullLog.getInstance(),
+                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -69,7 +69,8 @@ public class ReflectiveUserAggregationFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(),
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
+                NullLog.getInstance(),
                 ProcedureAllowedConfig.DEFAULT );
     }
 
@@ -344,7 +345,7 @@ public class ReflectiveUserAggregationFunctionTest
         // Given
         Log log = mock(Log.class);
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(),
- components, log, ProcedureAllowedConfig.DEFAULT );
+ components, new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableUserAggregationFunction> funcs = procedureCompiler.compileAggregationFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -65,7 +65,8 @@ public class ReflectiveUserFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
+                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -249,7 +250,8 @@ public class ReflectiveUserFunctionTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log, ProcedureAllowedConfig.DEFAULT );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
+                new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableUserFunction> funcs = procedureCompiler.compileFunction( FunctionWithDeprecation.class );

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
@@ -46,7 +46,7 @@ public class MyExtensionThatAddsAlternativeCoreAPI
     {
         dependencies.procedures().registerComponent( MyCoreAPI.class,
                 ( ctx ) -> new MyCoreAPI( dependencies.getGraphDatabaseAPI(), dependencies.txBridge(),
-                        dependencies.logService().getUserLog( MyCoreAPI.class ) ) );
+                        dependencies.logService().getUserLog( MyCoreAPI.class ) ), true );
         return new LifecycleAdapter();
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
@@ -42,7 +42,7 @@ public class MyExtensionThatAddsInjectable
     public Lifecycle newInstance( KernelContext context,
             Dependencies dependencies ) throws Throwable
     {
-        dependencies.procedures().registerComponent( SomeService.class, ( ctx ) -> new SomeService() );
+        dependencies.procedures().registerComponent( SomeService.class, ( ctx ) -> new SomeService(), true );
         return new LifecycleAdapter();
     }
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -59,7 +59,7 @@ public class CommunitySecurityModule extends SecurityModule
 
         dependencies.lifeSupport().add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 
-        procedures.registerComponent( UserManager.class, ctx -> authManager );
+        procedures.registerComponent( UserManager.class, ctx -> authManager, false );
         procedures.registerProcedure( AuthProcedures.class );
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -99,16 +99,16 @@ public class EnterpriseSecurityModule extends SecurityModule
         life.add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 
         // Register procedures
-        procedures.registerComponent( SecurityLog.class, ( ctx ) -> securityLog );
-        procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager );
+        procedures.registerComponent( SecurityLog.class, ( ctx ) -> securityLog, false );
+        procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager, false );
         procedures.registerComponent( EnterpriseSecurityContext.class,
-                ctx -> asEnterprise( ctx.get( SECURITY_CONTEXT ) ) );
+                ctx -> asEnterprise( ctx.get( SECURITY_CONTEXT ) ), true );
 
         if ( config.get( SecuritySettings.native_authentication_enabled )
              || config.get( SecuritySettings.native_authorization_enabled ) )
         {
             procedures.registerComponent( EnterpriseUserManager.class,
-                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( SECURITY_CONTEXT ) ) ) );
+                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( SECURITY_CONTEXT ) ) ), true );
             if ( config.get( SecuritySettings.auth_providers ).size() > 1 )
             {
                 procedures.registerProcedure( UserManagementProcedures.class, true,
@@ -121,7 +121,7 @@ public class EnterpriseSecurityModule extends SecurityModule
         }
         else
         {
-            procedures.registerComponent( EnterpriseUserManager.class, ctx -> EnterpriseUserManager.NOOP );
+            procedures.registerComponent( EnterpriseUserManager.class, ctx -> EnterpriseUserManager.NOOP, true );
         }
 
         procedures.registerProcedure( SecurityProcedures.class, true );


### PR DESCRIPTION
Internal procedures should have access to all components while
external procedures should not be allowed to access components
that could let them bypass security.