### PR TITLE
Throw exception when calling shortestPath with same start and end node

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -241,76 +241,6 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     }
   }
 
-  test("finds a single path for paths of length one") {
-    /*
-       (a)-(b)-c
-     */
-    val nodeA = createLabeledNode("A")
-    val nodeB = createLabeledNode("B")
-    val nodeC = createLabeledNode("C")
-    relate(nodeA, nodeB)
-    relate(nodeB, nodeC)
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match p = shortestpath((a:A)-[r*..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
-    result should equal(Set(List(nodeA, nodeB)))
-  }
-
-  test("if asked for also return paths of length 0") {
-    /*
-       (a)-(b)-c
-     */
-    val nodeA = createLabeledNode("A")
-    val nodeB = createLabeledNode("B")
-    val nodeC = createLabeledNode("C")
-    relate(nodeA, nodeB)
-    relate(nodeB, nodeC)
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match p = shortestpath((a:A)-[r*0..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
-    result should equal(Set(List(nodeA), List(nodeA, nodeB)))
-  }
-
-  test("if asked for also return paths of length 0, even when no max length is speficied") {
-    /*
-       (a)-(b)-c
-     */
-    val nodeA = createLabeledNode("A")
-    val nodeB = createLabeledNode("B")
-    val nodeC = createLabeledNode("C")
-    relate(nodeA, nodeB)
-    relate(nodeB, nodeC)
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match p = shortestpath((a:A)-[r*0..]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
-    result should equal(Set(List(nodeA), List(nodeA, nodeB), List(nodeA, nodeB, nodeC)))
-  }
-
-  test("we can ask explicitly for paths of minimal length 1") {
-    /*
-       (a)-(b)-c
-     */
-    val nodeA = createLabeledNode("A")
-    val nodeB = createLabeledNode("B")
-    val nodeC = createLabeledNode("C")
-    relate(nodeA, nodeB)
-    relate(nodeB, nodeC)
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match p = shortestpath((a:A)-[r*1..1]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
-    result should equal(Set(List(nodeA, nodeB)))
-  }
-
-  test("finds a single path for non-variable length paths") {
-    /*
-       (a)-(b)-c
-     */
-    val nodeA = createLabeledNode("A")
-    val nodeB = createLabeledNode("B")
-    val nodeC = createLabeledNode("C")
-    relate(nodeA, nodeB)
-    relate(nodeB, nodeC)
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match p = shortestpath((a:A)-[r]->(n)) return nodes(p) as nodes").columnAs[List[Node]]("nodes").toSet
-    result should equal(Set(List(nodeA, nodeB)))
-  }
-
   test("two bound nodes pointing to one") {
     val a = createNode("A")
     val b = createNode("B")
@@ -1825,7 +1755,7 @@ return b
     val query = """WITH [{0}, {1}] AS x, count(*) as y
                   |MATCH (n) WHERE ID(n) IN x
                   |MATCH (m) WHERE ID(m) IN x
-                  |MATCH paths = allShortestPaths((n)-[*..1]-(m))
+                  |MATCH paths = (n)-[*..1]-(m)
                   |RETURN paths""".stripMargin
 
     val result = executeWithAllPlannersAndCompatibilityMode(query, "0" -> node1.getId, "1" -> node2.getId)

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
@@ -19,12 +19,9 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.hamcrest.CoreMatchers._
-import org.junit.Assert._
 import org.neo4j.cypher.internal.RewindableExecutionResult
 import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor3_0
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
-import org.neo4j.graphdb.Node
 
 class ShortestPathComplexQueryAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
 import org.neo4j.graphalgo.impl.path.ShortestPath
 import org.neo4j.graphalgo.impl.path.ShortestPath.DataMonitor
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.graphdb.{Node, Path}
 import org.neo4j.kernel.monitoring.Monitors
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -87,6 +88,8 @@ import scala.collection.mutable
 class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
   val VERBOSE = false // Lots of debug prints
+
+  override def databaseConfig = Map(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "false")
 
   test("shortestPath with same start and end node should return zero length path with no fallback") {
     val start = System.currentTimeMillis

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.internal.{ExecutionEngine, RewindableExecutionResult}
+import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor3_0
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, RunWithConfigTestSupport, ShortestPathCommonEndNodesForbiddenException}
+import org.neo4j.graphdb.RelationshipType
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+
+class ShortestPathSameNodeAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport with RunWithConfigTestSupport {
+
+  def setupModel(db: GraphDatabaseCypherService) {
+    db.inTx {
+      val a = db.createNode()
+      val b = db.createNode()
+      val c = db.createNode()
+      a.createRelationshipTo(b, RelationshipType.withName("KNOWS"))
+      b.createRelationshipTo(c, RelationshipType.withName("KNOWS"))
+    }
+  }
+
+  test("shortest paths with explicit same start and end nodes should throw exception by default") {
+    setupModel(graph)
+    val query = "MATCH p=shortestPath((a)-[*]-(a)) RETURN p"
+    an[ShortestPathCommonEndNodesForbiddenException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+  test("shortest paths with explicit same start and end nodes should throw exception when configured to do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "true") { db =>
+      setupModel(db)
+      val query = "MATCH p=shortestPath((a)-[*]-(a)) RETURN p"
+      val error = intercept[ShortestPathCommonEndNodesForbiddenException](
+        executeUsingCostPlannerOnly(db, query).toList
+      ).getMessage should include("The shortest path algorithm does not work when the start and end nodes are the same")
+    }
+  }
+
+  test("shortest paths with explicit same start and end nodes should not throw exception when configured to not do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "false") { db =>
+      setupModel(db)
+      val query = "MATCH p=shortestPath((a)-[*]-(a)) RETURN p"
+      executeUsingCostPlannerOnly(db, query).toList.length should be(0)
+    }
+  }
+
+  test("shortest paths that discover at runtime that the start and end nodes are the same should throw exception by default") {
+    setupModel(graph)
+    val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*]-(b)) RETURN p"
+    an[ShortestPathCommonEndNodesForbiddenException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+  test("shortest paths that discover at runtime that the start and end nodes are the same should throw exception when configured to do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "true") { db =>
+      setupModel(db)
+      val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*]-(b)) RETURN p"
+      val error = intercept[ShortestPathCommonEndNodesForbiddenException](
+        executeUsingCostPlannerOnly(db, query).toList
+      ).getMessage should include("The shortest path algorithm does not work when the start and end nodes are the same")
+    }
+  }
+
+  test("shortest paths that discover at runtime that the start and end nodes are the same should not throw exception when configured to not do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "false") { db =>
+      setupModel(db)
+      val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*]-(b)) RETURN p"
+      executeUsingCostPlannerOnly(db, query).toList.length should be(6)
+    }
+  }
+
+  test("shortest paths with min length 0 that discover at runtime that the start and end nodes are the same should not throw exception by default") {
+    setupModel(graph)
+    val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*0..]-(b)) RETURN p"
+    executeWithAllPlanners(query).toList.length should be(9)
+  }
+
+  test("shortest paths with min length 0 that discover at runtime that the start and end nodes are the same should throw exception even when when configured to do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "true") { db =>
+      setupModel(db)
+      val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*0..]-(b)) RETURN p"
+      executeUsingCostPlannerOnly(db, query).toList.length should be(9)
+    }
+  }
+
+  test("shortest paths with min length 0 that discover at runtime that the start and end nodes are the same should not throw exception when configured to not do so") {
+    runWithConfig(GraphDatabaseSettings.forbid_shortestpath_common_nodes -> "false") { db =>
+      setupModel(db)
+      val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*0..]-(b)) RETURN p"
+      executeUsingCostPlannerOnly(db, query).toList.length should be(9)
+    }
+  }
+
+  def executeUsingCostPlannerOnly(db: GraphDatabaseCypherService, query: String) =
+    new ExecutionEngine(db).execute(s"CYPHER planner=COST $query", Map.empty[String, Any], db.session()) match {
+      case e: ExecutionResultWrapperFor3_0 => RewindableExecutionResult(e)
+    }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
@@ -66,6 +66,7 @@ case class CypherCompilerConfiguration(queryCacheSize: Int,
                                        idpMaxTableSize: Int,
                                        idpIterationDuration: Long,
                                        errorIfShortestPathFallbackUsedAtRuntime: Boolean,
+                                       errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
                                        nonIndexedLabelWarningThreshold: Long)
 
 object CypherCompilerFactory {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ShortestPathExpression.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsAllN
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.RelationshipSupport
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.frontend.v3_0.SyntaxException
+import org.neo4j.cypher.internal.frontend.v3_0.{ShortestPathCommonEndNodesForbiddenException, SyntaxException}
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
@@ -35,7 +35,7 @@ import scala.collection.JavaConverters._
 import scala.collection.Map
 
 case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
-                                  withFallBack: Boolean = false) extends Expression with PathExtractor {
+                                  withFallBack: Boolean = false, disallowSameNode: Boolean = true) extends Expression with PathExtractor {
   val pathPattern: Seq[Pattern] = Seq(shortestPathPattern)
   val pathVariables = Set(shortestPathPattern.pathName, shortestPathPattern.relIterator.getOrElse(""))
 
@@ -43,13 +43,14 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
     if (anyStartpointsContainNull(ctx)) {
       Stream.empty
     } else {
-      getMatches(ctx)
+      val start = getEndPoint(ctx, shortestPathPattern.left)
+      val end = getEndPoint(ctx, shortestPathPattern.right)
+      if (!shortestPathPattern.allowZeroLength && disallowSameNode && start.equals(end)) throw new ShortestPathCommonEndNodesForbiddenException
+      getMatches(ctx, start, end)
     }
   }
 
-  private def getMatches(ctx: ExecutionContext)(implicit state: QueryState): Any = {
-    val start = getEndPoint(ctx, shortestPathPattern.left)
-    val end = getEndPoint(ctx, shortestPathPattern.right)
+  private def getMatches(ctx: ExecutionContext, start: Node, end: Node)(implicit state: QueryState): Any = {
     val (expander, nodePredicates) = addPredicates(ctx, makeRelationshipTypeExpander())
     val maybePredicate = if (predicates.isEmpty) None else Some(Ands(NonEmptyList.from(predicates)))
     /* This test is made after a full shortest path candidate has been produced,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
@@ -176,7 +176,9 @@ The Neo4j Team""")
       new LoadCSVBuilder,
       new StartPointBuilder,
       new MatchBuilder,
-      new ShortestPathBuilder,
+      new ShortestPathBuilder(
+        withFallBack = false, // Rule planner does not support exhaustive fallback
+        config.errorIfShortestPathHasCommonNodesAtRuntime),
       new DisconnectedShortestPathEndPointsBuilder
     )
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/ShortestPathBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/ShortestPathBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{PlanBuilder, Execu
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.{PipeMonitor, ShortestPathPipe, Pipe}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 
-class ShortestPathBuilder extends PlanBuilder {
+class ShortestPathBuilder(withFallBack: Boolean, disallowSameNode: Boolean) extends PlanBuilder {
   def apply(plan: ExecutionPlanInProgress, ctx: PlanContext)(implicit pipeMonitor: PipeMonitor) = {
     val q = plan.query
     val p = plan.pipe
@@ -35,7 +35,7 @@ class ShortestPathBuilder extends PlanBuilder {
       case Unsolved(predicate) => predicate
     }
 
-    val shortestPathPipe = new ShortestPathPipe(p, shortestPath, pathPredicates)()
+    val shortestPathPipe = new ShortestPathPipe(p, shortestPath, pathPredicates, withFallBack, disallowSameNode)()
 
     plan.copy(pipe = shortestPathPipe, query = q.copy(patterns = q.patterns.filterNot(_ == item) :+ item.solve))
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ShortestPathPipe.scala
@@ -34,11 +34,11 @@ import scala.collection.JavaConverters._
  * Shortest pipe inserts a single shortest path between two already found nodes
  */
 case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
-                            withFallBack: Boolean = false)
+                            withFallBack: Boolean = false, disallowSameNode: Boolean = true)
                            (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with ListSupport with RonjaPipe {
   private def pathName = shortestPathCommand.pathName
-  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates, withFallBack)
+  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates, withFallBack, disallowSameNode)
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState) =
     input.flatMap(ctx => {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -90,6 +90,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
     val context = LogicalPlanningContext(planContext, logicalPlanProducer, metrics, semanticTable,
       queryGraphSolver, notificationLogger = notificationLogger, useErrorsOverWarnings = config.useErrorsOverWarnings,
       errorIfShortestPathFallbackUsedAtRuntime = config.errorIfShortestPathFallbackUsedAtRuntime,
+      errorIfShortestPathHasCommonNodesAtRuntime = config.errorIfShortestPathHasCommonNodesAtRuntime,
       config = QueryPlannerConfiguration.default.withUpdateStrategy(updateStrategy))
 
     val (periodicCommit, plan) = queryPlanner.plan(unionQuery)(context)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -305,9 +305,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         Eagerly.immutableMapValues[String, ast.Expression, AggregationExpression](aggregatingExpressions, buildExpression(_).asInstanceOf[AggregationExpression])
       )()
 
-    case FindShortestPaths(_, shortestPathPattern, predicates, withFallBack) =>
+    case FindShortestPaths(_, shortestPathPattern, predicates, withFallBack, disallowSameNode) =>
       val legacyShortestPath = shortestPathPattern.expr.asLegacyPatterns(shortestPathPattern.name.map(_.name)).head
-      new ShortestPathPipe(source, legacyShortestPath, predicates.map(toCommandPredicate), withFallBack)()
+      new ShortestPathPipe(source, legacyShortestPath, predicates.map(toCommandPredicate), withFallBack, disallowSameNode)()
 
     case UnwindCollection(_, variable, collection) =>
       UnwindPipe(source, toCommandExpression(collection), variable.name)()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
@@ -36,6 +36,7 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   notificationLogger: InternalNotificationLogger = devNullLogger,
                                   useErrorsOverWarnings: Boolean = false,
                                   errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
+                                  errorIfShortestPathHasCommonNodesAtRuntime: Boolean = false,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
                                   leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
@@ -36,7 +36,7 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   notificationLogger: InternalNotificationLogger = devNullLogger,
                                   useErrorsOverWarnings: Boolean = false,
                                   errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
-                                  errorIfShortestPathHasCommonNodesAtRuntime: Boolean = false,
+                                  errorIfShortestPathHasCommonNodesAtRuntime: Boolean = true,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
                                   leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/FindShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/FindShortestPaths.scala
@@ -23,7 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, P
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
 
 case class FindShortestPaths(left: LogicalPlan, shortestPath: ShortestPathPattern,
-                             predicates: Seq[Expression] = Seq.empty, withFallBack: Boolean = false)
+                             predicates: Seq[Expression] = Seq.empty,
+                             withFallBack: Boolean = false, disallowSameNode: Boolean = true)
                             (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LazyLogicalPlan {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -443,10 +443,10 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
   }
 
   def planShortestPath(inner: LogicalPlan, shortestPaths: ShortestPathPattern, predicates: Seq[Expression],
-                       withFallBack: Boolean)
+                       withFallBack: Boolean, disallowSameNode: Boolean = true)
                       (implicit context: LogicalPlanningContext) = {
     val solved = inner.solved.amendQueryGraph(_.addShortestPath(shortestPaths).addPredicates(predicates: _*))
-    FindShortestPaths(inner, shortestPaths, predicates, withFallBack)(solved)
+    FindShortestPaths(inner, shortestPaths, predicates, withFallBack, disallowSameNode)(solved)
   }
 
   def planEndpointProjection(inner: LogicalPlan, start: IdName, startInScope: Boolean, end: IdName, endInScope: Boolean, patternRel: PatternRelationship)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
@@ -57,7 +57,7 @@ case object planShortestPaths {
       planShortestPathsWithFallback(inner, shortestPaths, predicates, safePredicates, needFallbackPredicates, queryGraph)
     }
     else {
-      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates, false)
+      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates, false, context.errorIfShortestPathHasCommonNodesAtRuntime  )
     }
   }
 
@@ -82,7 +82,7 @@ case object planShortestPaths {
     // Plan FindShortestPaths within an Apply with an Optional so we get null rows when
     // the graph algorithm does not find anything (left-hand-side)
     val lhsArgument = lpp.planArgumentRowFrom(inner)
-    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, true)
+    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, true, context.errorIfShortestPathHasCommonNodesAtRuntime)
     val lhsOption = lpp.planOptional(lhsSp, Set.empty)
     val lhs = lpp.planApply(inner, lhsOption)
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -42,7 +42,8 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
-    errorIfShortestPathFallbackUsedAtRuntime = false
+    errorIfShortestPathFallbackUsedAtRuntime = false,
+    errorIfShortestPathHasCommonNodesAtRuntime = true
   )
   val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating,
     typeConverter = IdentityTypeConverter)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/ShortestPathBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/ShortestPathBuilderTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 
 class ShortestPathBuilderTest extends BuilderTest {
 
-  val builder = new ShortestPathBuilder
+  val builder = new ShortestPathBuilder(false, false)
 
   test("should_not_accept_if_no_shortest_paths_exist") {
     val q = PartiallySolvedQuery().

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -183,6 +183,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false,
+    errorIfShortestPathHasCommonNodesAtRuntime = true,
     nonIndexedLabelWarningThreshold = 10000
   )
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -154,3 +154,5 @@ class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException
 }
 
 class ExhaustiveShortestPathForbiddenException(message: String, cause: Throwable) extends CypherExecutionException(message, cause)
+
+class ShortestPathCommonEndNodesForbiddenException(message: String, cause: Throwable) extends CypherExecutionException(message, cause)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -72,6 +72,7 @@ class CypherCompiler(graph: GraphDatabaseQueryService,
                      idpMaxTableSize: Int,
                      idpIterationDuration: Long,
                      errorIfShortestPathFallbackUsedAtRuntime: Boolean,
+                     errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
                      logProvider: LogProvider) {
   import org.neo4j.cypher.internal.CypherCompiler._
 
@@ -85,6 +86,7 @@ class CypherCompiler(graph: GraphDatabaseQueryService,
     idpMaxTableSize = idpMaxTableSize,
     idpIterationDuration = idpIterationDuration,
     errorIfShortestPathFallbackUsedAtRuntime = errorIfShortestPathFallbackUsedAtRuntime,
+    errorIfShortestPathHasCommonNodesAtRuntime = errorIfShortestPathHasCommonNodesAtRuntime,
     nonIndexedLabelWarningThreshold = getNonIndexedLabelWarningThreshold
   )
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -223,13 +223,18 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
       queryService, GraphDatabaseSettings.forbid_exhaustive_shortestpath,
       GraphDatabaseSettings.forbid_exhaustive_shortestpath.getDefaultValue.toBoolean
     )
+    val errorIfShortestPathHasCommonNodesAtRuntime = optGraphSetting[java.lang.Boolean](
+      queryService, GraphDatabaseSettings.forbid_shortestpath_common_nodes,
+      GraphDatabaseSettings.forbid_shortestpath_common_nodes.getDefaultValue.toBoolean
+    )
+
     if (((version != CypherVersion.v2_3) || (version != CypherVersion.v3_0)) && (planner == CypherPlanner.greedy || planner == CypherPlanner.idp || planner == CypherPlanner.dp)) {
       val message = s"Cannot combine configurations: ${GraphDatabaseSettings.cypher_parser_version.name}=${version.name} " +
         s"with ${GraphDatabaseSettings.cypher_planner.name} = ${planner.name}"
       log.error(message)
       throw new IllegalStateException(message)
     }
-    new CypherCompiler(queryService, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime, logProvider)
+    new CypherCompiler(queryService, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime, errorIfShortestPathHasCommonNodesAtRuntime, logProvider)
   }
 
   private def getPlanCacheSize: Int =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -167,6 +167,9 @@ object exceptionHandlerFor3_0 extends MapToPublicExceptions[CypherException] {
   override def shortestPathFallbackDisableRuntimeException(message: String, cause: Throwable): CypherException =
     throw new ExhaustiveShortestPathForbiddenException(message, cause)
 
+  override def shortestPathCommonEndNodesForbiddenException(message: String, cause: Throwable): CypherException =
+    throw new ShortestPathCommonEndNodesForbiddenException(message, cause)
+
   def invalidSemanticException(message: String, cause: Throwable) = throw new InvalidSemanticsException(message, cause)
 
   def parameterWrongTypeException(message: String, cause: Throwable) = throw new ParameterWrongTypeException(message, cause)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -111,6 +111,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
+        errorIfShortestPathHasCommonNodesAtRuntime = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       Clock.systemUTC(),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
@@ -19,8 +19,9 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
-import org.neo4j.graphdb.{GraphDatabaseService, QueryExecutionException}
+import org.neo4j.graphdb.QueryExecutionException
 import org.neo4j.kernel.api.exceptions.Status
 
 import scala.collection.JavaConverters._
@@ -136,7 +137,6 @@ class CypherCompatibilityTest extends ExecutionEngineFunSuite with RunWithConfig
     }
   }
 
-
   test("should not fail nor generate a warning if asked to execute query without specifying runtime, knowing that compiled is default but will fallback silently to interpreted") {
     runWithConfig() {
       db =>
@@ -154,14 +154,14 @@ class CypherCompatibilityTest extends ExecutionEngineFunSuite with RunWithConfig
     }
   }
 
-  private def assertProfiled(db: GraphDatabaseService, q: String) {
+  private def assertProfiled(db: GraphDatabaseCypherService, q: String) {
     val result = db.execute(q)
     result.resultAsString()
     assert(result.getExecutionPlanDescription.hasProfilerStatistics, s"$q was not profiled as expected")
     assert(result.getQueryExecutionType.requestedExecutionPlanDescription(), s"$q was not flagged for planDescription")
   }
 
-  private def assertExplained(db: GraphDatabaseService, q: String) {
+  private def assertExplained(db: GraphDatabaseCypherService, q: String) {
     val result = db.execute(q)
     result.resultAsString()
     assert(!result.getExecutionPlanDescription.hasProfilerStatistics, s"$q was not explained as expected")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -254,6 +254,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
-    errorIfShortestPathFallbackUsedAtRuntime = false
+    errorIfShortestPathFallbackUsedAtRuntime = false,
+    errorIfShortestPathHasCommonNodesAtRuntime = true
   )
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RunWithConfigTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RunWithConfigTestSupport.scala
@@ -21,18 +21,18 @@ package org.neo4j.cypher
 
 import java.util
 
-import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.test.TestGraphDatabaseFactory
 
 import scala.collection.JavaConverters._
 
 trait RunWithConfigTestSupport {
-  def runWithConfig(m: (Setting[_], String)*)(run: GraphDatabaseService => Unit) = {
+  def runWithConfig(m: (Setting[_], String)*)(run: GraphDatabaseCypherService => Unit) = {
     val config: util.Map[Setting[_], String] = m.toMap.asJava
     val graph = new TestGraphDatabaseFactory().newImpermanentDatabase(config)
     try {
-      run(graph)
+      run(new GraphDatabaseCypherService(graph))
     } finally {
       graph.shutdown()
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -192,6 +192,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
+        errorIfShortestPathHasCommonNodesAtRuntime = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock = CLOCK,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -57,7 +57,8 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     idpMaxTableSize = 128,
     idpIterationDuration = 1000,
     nonIndexedLabelWarningThreshold = 10000,
-    errorIfShortestPathFallbackUsedAtRuntime = true
+    errorIfShortestPathFallbackUsedAtRuntime = true,
+    errorIfShortestPathHasCommonNodesAtRuntime = true
   )
 
   val compilers = Seq[(String, GraphDatabaseQueryService => CypherCompiler)](

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -49,6 +49,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
+        errorIfShortestPathHasCommonNodesAtRuntime = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock,

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/CypherException.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/CypherException.scala
@@ -155,10 +155,10 @@ class ShortestPathCommonEndNodesForbiddenException extends CypherExecutionExcept
 object ShortestPathCommonEndNodesForbiddenException {
   val ERROR_MSG: String =
     s"""The shortest path algorithm does not work when the start and end nodes are the same. This can happen if you
-        |perform a shortestPath search after a cartesian product that might have the same start and end nodes for some
-        |of the rows passed to shortestPath. If would rather not experience this exception, and can accept the
-        |possibility of missing results for those rows, disable this in the Neo4j configuration. If you cannot accept
-        |missing results, and really want the shortestPath between two common nodes, then re-write the query using
-        |a normal cypher variable length pattern expression followed by sorting by path length and limiting to one
-        |result.""".stripMargin
+       |perform a shortestPath search after a cartesian product that might have the same start and end nodes for some
+       |of the rows passed to shortestPath. If you would rather not experience this exception, and can accept the
+       |possibility of missing results for those rows, disable this in the Neo4j configuration by setting
+       |`cypher.forbid_shortestpath_common_node` to false. If you cannot accept missing results, and really want the
+       |shortestPath between two common nodes, then re-write the query using a standard Cypher variable length pattern
+       |expression followed by ordering by path length and limiting to one result.""".stripMargin
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/CypherException.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/CypherException.scala
@@ -146,3 +146,19 @@ object ExhaustiveShortestPathForbiddenException {
        |start filtering.""".stripMargin
 }
 
+class ShortestPathCommonEndNodesForbiddenException extends CypherExecutionException(
+  ShortestPathCommonEndNodesForbiddenException.ERROR_MSG, null) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
+    mapper.shortestPathCommonEndNodesForbiddenException(message, this)
+}
+
+object ShortestPathCommonEndNodesForbiddenException {
+  val ERROR_MSG: String =
+    s"""The shortest path algorithm does not work when the start and end nodes are the same. This can happen if you
+        |perform a shortestPath search after a cartesian product that might have the same start and end nodes for some
+        |of the rows passed to shortestPath. If would rather not experience this exception, and can accept the
+        |possibility of missing results for those rows, disable this in the Neo4j configuration. If you cannot accept
+        |missing results, and really want the shortestPath between two common nodes, then re-write the query using
+        |a normal cypher variable length pattern expression followed by sorting by path length and limiting to one
+        |result.""".stripMargin
+}

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/spi/MapToPublicExceptions.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/spi/MapToPublicExceptions.scala
@@ -67,4 +67,7 @@ trait MapToPublicExceptions[T <: Throwable] {
   def cypherExecutionException(message: String, cause: Throwable): T
 
   def shortestPathFallbackDisableRuntimeException(message: String, cause: Throwable): T
+
+  def shortestPathCommonEndNodesForbiddenException(message: String, cause: Throwable): T
+
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -147,13 +147,13 @@ public abstract class GraphDatabaseSettings
 
     @Description( "This setting is associated with performance optimization. The shortest path algorithm does not " +
                   "work when the start and end nodes are the same. With this setting set to `false` no path will " +
-                  "by returned when that happens. The default value of `true` will instead throw an exception. " +
+                  "be returned when that happens. The default value of `true` will instead throw an exception. " +
                   "This can happen if you perform a shortestPath search after a cartesian product that might have " +
-                  "the same start and end nodes for some of the rows passed to shortestPath. If is it preferable " +
+                  "the same start and end nodes for some of the rows passed to shortestPath. If it is preferable " +
                   "to not experience this exception, and acceptable for results to be missing for those rows, then " +
                   "set this to `false`. If you cannot accept missing results, and really want the shortestPath " +
-                  "between two common nodes, then re-write the query using a normal cypher variable length pattern " +
-                  "expression followed by sorting by path length and limiting to one result." )
+                  "between two common nodes, then re-write the query using a standard Cypher variable length pattern " +
+                  "expression followed by ordering by path length and limiting to one result." )
     public static final Setting<Boolean> forbid_shortestpath_common_nodes = setting(
             "cypher.forbid_shortestpath_common_nodes", BOOLEAN, TRUE );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -145,6 +145,18 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> forbid_exhaustive_shortestpath = setting(
             "cypher.forbid_exhaustive_shortestpath", BOOLEAN, FALSE );
 
+    @Description( "This setting is associated with performance optimization. The shortest path algorithm does not " +
+                  "work when the start and end nodes are the same. With this setting set to `false` no path will " +
+                  "by returned when that happens. The default value of `true` will instead throw an exception. " +
+                  "This can happen if you perform a shortestPath search after a cartesian product that might have " +
+                  "the same start and end nodes for some of the rows passed to shortestPath. If is it preferable " +
+                  "to not experience this exception, and acceptable for results to be missing for those rows, then " +
+                  "set this to `false`. If you cannot accept missing results, and really want the shortestPath " +
+                  "between two common nodes, then re-write the query using a normal cypher variable length pattern " +
+                  "expression followed by sorting by path length and limiting to one result." )
+    public static final Setting<Boolean> forbid_shortestpath_common_nodes = setting(
+            "cypher.forbid_shortestpath_common_nodes", BOOLEAN, TRUE );
+
     @Description( "Set this to specify the default runtime for the default language version." )
     @Internal
     public static final Setting<String> cypher_runtime = setting(


### PR DESCRIPTION
The shortest path algorithm does not work when the start and end nodes are the same. This can happen if you perform a shortestPath search after a cartesian product that might have the same start and end nodes for some of the rows passed to shortestPath. If you would rather not experience this exception, and can accept the possibility of missing results for those rows, disable this in the Neo4j configuration. If you cannot accept missing results, and really want the shortestPath between two common nodes, then re-write the query using a normal cypher variable length pattern expression followed by sorting by path length and limiting to one result.