### PR TITLE
Added configuration to grant full access to procedures

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -502,6 +502,10 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<File> auth_store =
             pathSetting( "unsupported.dbms.security.auth_store.location", NO_DEFAULT );
 
+    @Description("A comma separated list of procedures that are allowed full access to the database, note that this" +
+            " will enable them to bypass security. Use with care.")
+    public static final Setting<String> procedure_unrestricted = setting( "dbms.security.procedures.unrestricted", Settings.STRING, "" );
+
     // Bolt Settings
 
     @Description("Default network interface to listen for incoming connections. " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -63,7 +63,7 @@ import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.proc.ProcedureAllowedConfig;
+import org.neo4j.kernel.impl.proc.ProcedureConfig;
 import org.neo4j.kernel.impl.proc.ProcedureGDSFactory;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.proc.TerminationGuardProvider;
@@ -350,7 +350,7 @@ public class DataSourceModule
         Procedures procedures = new Procedures(
                 new SpecialBuiltInProcedures( Version.getNeo4jVersion(),
                         platform.databaseInfo.edition.toString() ),
-                pluginDir, internalLog, new ProcedureAllowedConfig( platform.config ) );
+                pluginDir, internalLog, new ProcedureConfig( platform.config ) );
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -362,16 +362,16 @@ public class DataSourceModule
 
         // Register injected public API components
         Log proceduresLog = platform.logging.getUserLog( Procedures.class );
-        procedures.registerComponent( Log.class, ( ctx ) -> proceduresLog );
+        procedures.registerComponent( Log.class, ( ctx ) -> proceduresLog, true );
 
         Guard guard = platform.dependencies.resolveDependency( Guard.class );
-        procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ) );
+        procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ), true );
 
         // Register injected private API components: useful to have available in procedures to access the kernel etc.
         ProcedureGDSFactory gdsFactory = new ProcedureGDSFactory( platform.config, platform.storeDir,
                 platform.dependencies, storeId, this.queryExecutor, editionModule.coreAPIAvailabilityGuard,
                 platform.urlAccessRule );
-        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply );
+        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply, true );
 
         // Below components are not public API, but are made available for internal
         // procedures to call, and to provide temporary workarounds for the following
@@ -380,12 +380,12 @@ public class DataSourceModule
         //  - Group-transaction writes (same pattern as above, but rather than splitting large transactions,
         //                              combine lots of small ones)
         //  - Bleeding-edge performance (KernelTransaction, to bypass overhead of working with Core API)
-        procedures.registerComponent( DependencyResolver.class, ( ctx ) -> platform.dependencies );
-        procedures.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
-        procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade );
+        procedures.registerComponent( DependencyResolver.class, ( ctx ) -> platform.dependencies, false );
+        procedures.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ), false );
+        procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade, false );
 
         // Security procedures
-        procedures.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ) );
+        procedures.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ), true );
 
         // Edition procedures
         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.neo4j.configuration.Description;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.security.URLAccessRule;
@@ -100,10 +99,6 @@ public class GraphDatabaseFacadeFactory
         @Internal
         public static final Setting<String> editionName =
                 setting( "unsupported.dbms.edition", Settings.STRING, Edition.unknown.toString() );
-
-        @Description("A comma separated list of procedures that are allowed full access to the database, note that this" +
-                " will enable them to bypass security. Use with care.")
-        public static final Setting<String> procedure_full_access = setting( "dbms.security.procedures.full_access", Settings.STRING, "" );
     }
 
     protected final DatabaseInfo databaseInfo;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.neo4j.configuration.Description;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.security.URLAccessRule;
@@ -99,6 +100,10 @@ public class GraphDatabaseFacadeFactory
         @Internal
         public static final Setting<String> editionName =
                 setting( "unsupported.dbms.edition", Settings.STRING, Edition.unknown.toString() );
+
+        @Description("A comma separated list of procedures that are allowed full access to the database, note that this" +
+                " will enable them to bypass security. Use with care.")
+        public static final Setting<String> procedure_full_access = setting( "dbms.security.procedures.full_access", Settings.STRING, "" );
     }
 
     protected final DatabaseInfo databaseInfo;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
@@ -91,7 +91,7 @@ public class ProcedureJarLoader
         while ( classes.hasNext() )
         {
             Class<?> next = classes.next();
-            target.addAllProcedures( compiler.compileProcedure( next, Optional.empty() ) );
+            target.addAllProcedures( compiler.compileProcedure( next, Optional.empty(), false ) );
             target.addAllFunctions( compiler.compileFunction( next ) );
             target.addAllAggregationFunctions( compiler.compileAggregationFunction( next ) );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -59,11 +59,11 @@ public class Procedures extends LifecycleAdapter
 
     public Procedures()
     {
-        this( new SpecialBuiltInProcedures( "N/A", "N/A" ), null, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+        this( new SpecialBuiltInProcedures( "N/A", "N/A" ), null, NullLog.getInstance(), ProcedureConfig.DEFAULT );
     }
 
     public Procedures( ThrowingConsumer<Procedures,ProcedureException> builtin, File pluginDir, Log log,
-            ProcedureAllowedConfig config )
+            ProcedureConfig config )
     {
         this.builtin = builtin;
         this.pluginDir = pluginDir;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -49,7 +49,8 @@ public class Procedures extends LifecycleAdapter
 {
     private final ProcedureRegistry registry = new ProcedureRegistry();
     private final TypeMappers typeMappers = new TypeMappers();
-    private final ComponentRegistry components = new ComponentRegistry();
+    private final ComponentRegistry safeComponents = new ComponentRegistry();
+    private final ComponentRegistry allComponents = new ComponentRegistry();
     private final ReflectiveProcedureCompiler compiler;
     private final ThrowingConsumer<Procedures, ProcedureException> builtin;
     private final File pluginDir;
@@ -67,7 +68,7 @@ public class Procedures extends LifecycleAdapter
         this.builtin = builtin;
         this.pluginDir = pluginDir;
         this.log = log;
-        this.compiler = new ReflectiveProcedureCompiler( typeMappers, components, log, config );
+        this.compiler = new ReflectiveProcedureCompiler( typeMappers, safeComponents, allComponents, log, config );
     }
 
     /**
@@ -125,7 +126,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      */
     public void registerProcedure( Class<?> proc ) throws KernelException
@@ -134,7 +135,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      * @param overrideCurrentImplementation set to true if procedures within this class should override older procedures with the same name
      */
@@ -144,7 +145,7 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Register a new procedure defined with annotations on a java class.
+     * Register a new internal procedure defined with annotations on a java class.
      * @param proc the procedure class
      * @param overrideCurrentImplementation set to true if procedures within this class should override older procedures with the same name
      * @param warning the warning the procedure should generate when called
@@ -153,7 +154,7 @@ public class Procedures extends LifecycleAdapter
             throws
             KernelException
     {
-        for ( CallableProcedure procedure : compiler.compileProcedure( proc, warning ) )
+        for ( CallableProcedure procedure : compiler.compileProcedure( proc, warning, true ) )
         {
             register( procedure, overrideCurrentImplementation );
         }
@@ -213,13 +214,17 @@ public class Procedures extends LifecycleAdapter
 
     /**
      * Registers a component, these become available in reflective procedures for injection.
-     *
      * @param cls the type of component to be registered (this is what users 'ask' for in their field declaration)
      * @param provider a function that supplies the component, given the context of a procedure invocation
+     * @param safe set to false if this component can bypass security, true if it respects security
      */
-    public <T> void registerComponent( Class<T> cls, ComponentRegistry.Provider<T> provider )
+    public <T> void registerComponent( Class<T> cls, ComponentRegistry.Provider<T> provider, boolean safe )
     {
-        components.register( cls, provider );
+        if ( safe )
+        {
+            safeComponents.register( cls, provider );
+        }
+        allComponents.register( cls, provider );
     }
 
     public ProcedureSignature procedure( QualifiedName name ) throws ProcedureException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -72,10 +72,10 @@ class ReflectiveProcedureCompiler
     private final FieldInjections allFieldInjections;
     private final Log log;
     private final TypeMappers typeMappers;
-    private final ProcedureAllowedConfig config;
+    private final ProcedureConfig config;
 
     ReflectiveProcedureCompiler( TypeMappers typeMappers, ComponentRegistry safeComponents,
-            ComponentRegistry allComponents, Log log, ProcedureAllowedConfig config )
+            ComponentRegistry allComponents, Log log, ProcedureConfig config )
     {
         inputSignatureDeterminer = new MethodSignatureCompiler( typeMappers );
         outputMappers = new OutputMappers( typeMappers );
@@ -201,7 +201,7 @@ class ReflectiveProcedureCompiler
         OutputMapper outputMapper = outputMappers.mapper( method );
         MethodHandle procedureMethod = lookup.unreflect( method );
         List<FieldInjections.FieldSetter> setters;
-        if ( fullAccess )
+        if ( fullAccess || config.fullAccessFor( procName.toString() ) )
         {
             setters = allFieldInjections.setters( procDefinition );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -285,9 +285,9 @@ public class BuiltInProceduresTest
     @Before
     public void setup() throws Exception
     {
-        procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
-        procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ) );
-        procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ) );
+        procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ), false );
+        procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ), false );
+        procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ), false );
 
         procs.registerType( Node.class, new TypeMappers.SimpleConverter( NTNode, Node.class ) );
         procs.registerType( Relationship.class, new TypeMappers.SimpleConverter( NTRelationship, Relationship.class ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -36,7 +36,9 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.BasicContext;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLog;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -45,9 +47,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.helpers.collection.Iterators.asList;
+import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
 
+@SuppressWarnings( "WeakerAccess" )
 public class ProcedureJarLoaderTest
 {
     @Rule
@@ -57,7 +62,7 @@ public class ProcedureJarLoaderTest
 
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
-                    new ComponentRegistry(), NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
+                    registryWithUnsafeAPI(), NullLog.getInstance(), procedureConfig() ), NullLog.getInstance() );
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable
@@ -199,6 +204,40 @@ public class ProcedureJarLoaderTest
         jarloader.loadProcedures( jar );
     }
 
+    @Test
+    public void shouldGiveHelpfulErrorOnUnsafeRestrictedProcedure() throws Throwable
+    {
+        // Given
+        URL jar = createJarFor( ClassWithUnsafeComponent.class );
+
+        // Expect
+        exception.expect( ProcedureException.class );
+        exception.expectMessage( "Unable to set up injection for procedure `ClassWithUnsafeComponent`, the field" +
+                " `api` has type `class org.neo4j.kernel.impl.proc.ProcedureJarLoaderTest$UnsafeAPI` which is not a" +
+                " known injectable component.");
+
+        // When
+        jarloader.loadProcedures( jar );
+    }
+
+    @Test
+    public void shouldLoadUnsafeAllowedProcedureFromJar() throws Throwable
+    {
+        // Given
+        URL jar = createJarFor( ClassWithUnsafeConfiguredComponent.class );
+
+        // When
+        List<CallableProcedure> procedures = jarloader.loadProcedures( jar ).procedures();
+
+        // Then
+        List<ProcedureSignature> signatures = procedures.stream().map( CallableProcedure::signature ).collect( toList() );
+        assertThat( signatures, contains(
+                procedureSignature( "org","neo4j", "kernel", "impl", "proc", "unsafeFullAccessProcedure" ).out( "someNumber", NTInteger ).build() ));
+
+        assertThat( asList( procedures.get( 0 ).apply( new BasicContext(), new Object[0] ) ),
+                contains( IsEqual.equalTo( new Object[]{7331L} )) );
+    }
+
     public URL createJarFor( Class<?> ... targets ) throws IOException
     {
         return new JarBuilder().createJarFor( tmpdir.newFile( new Random().nextInt() + ".jar" ), targets );
@@ -288,5 +327,51 @@ public class ProcedureJarLoaderTest
         {
             return Stream.of( Collections.singletonList( new Output() ));
         }
+    }
+
+    public static class ClassWithUnsafeComponent
+    {
+        @Context
+        public UnsafeAPI api;
+
+        @Procedure
+        public Stream<Output> unsafeProcedure()
+        {
+            return Stream.of( new Output( api.getNumber() ) );
+        }
+    }
+
+    public static class ClassWithUnsafeConfiguredComponent
+    {
+        @Context
+        public UnsafeAPI api;
+
+        @Procedure
+        public Stream<Output> unsafeFullAccessProcedure()
+        {
+            return Stream.of( new Output( api.getNumber() ) );
+        }
+    }
+
+    private static class UnsafeAPI
+    {
+        public long getNumber()
+        {
+            return 7331;
+        }
+    }
+
+    private ComponentRegistry registryWithUnsafeAPI()
+    {
+        ComponentRegistry allComponents = new ComponentRegistry();
+        allComponents.register( UnsafeAPI.class, (ctx) -> new UnsafeAPI() );
+        return allComponents;
+    }
+
+    private ProcedureConfig procedureConfig()
+    {
+        Config config = Config.defaults().with(
+                genericMap( procedure_full_access.name(), "org.neo4j.kernel.impl.proc.unsafeFullAccessProcedure" ) );
+        return new ProcedureConfig( config );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -46,11 +46,11 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
-import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
 
 @SuppressWarnings( "WeakerAccess" )
 public class ProcedureJarLoaderTest
@@ -371,7 +371,7 @@ public class ProcedureJarLoaderTest
     private ProcedureConfig procedureConfig()
     {
         Config config = Config.defaults().with(
-                genericMap( procedure_full_access.name(), "org.neo4j.kernel.impl.proc.unsafeFullAccessProcedure" ) );
+                genericMap( procedure_unrestricted.name(), "org.neo4j.kernel.impl.proc.unsafeFullAccessProcedure" ) );
         return new ProcedureConfig( config );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -57,7 +57,7 @@ public class ProcedureJarLoaderTest
 
     private final ProcedureJarLoader jarloader =
             new ProcedureJarLoader( new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(),
-                    NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
+                    new ComponentRegistry(), NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT ), NullLog.getInstance() );
 
     @Test
     public void shouldLoadProcedureFromJar() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
+@SuppressWarnings( "WeakerAccess" )
 public class ReflectiveProcedureTest
 {
     @Rule
@@ -67,7 +68,8 @@ public class ReflectiveProcedureTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, components,
+                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -77,7 +79,7 @@ public class ReflectiveProcedureTest
         Log log = spy( Log.class );
         components.register( Log.class, (ctx) -> log );
         CallableProcedure procedure =
-                procedureCompiler.compileProcedure( LoggingProcedure.class, Optional.empty() ).get( 0 );
+                procedureCompiler.compileProcedure( LoggingProcedure.class, Optional.empty(), true ).get( 0 );
 
         // When
         procedure.apply( new BasicContext(), new Object[0] );
@@ -273,12 +275,12 @@ public class ReflectiveProcedureTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log,
-                ProcedureAllowedConfig.DEFAULT );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
+                components, log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableProcedure> procs =
-                procedureCompiler.compileProcedure( ProcedureWithDeprecation.class, Optional.empty() );
+                procedureCompiler.compileProcedure( ProcedureWithDeprecation.class, Optional.empty(), true );
 
         // Then
         verify( log ).warn( "Use of @Procedure(deprecatedBy) without @Deprecated in badProc" );
@@ -524,6 +526,6 @@ public class ReflectiveProcedureTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return procedureCompiler.compileProcedure( clazz, Optional.empty() );
+        return procedureCompiler.compileProcedure( clazz, Optional.empty(), true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -69,7 +69,7 @@ public class ReflectiveProcedureTest
     {
         components = new ComponentRegistry();
         procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, components,
-                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+                NullLog.getInstance(), ProcedureConfig.DEFAULT );
     }
 
     @Test
@@ -276,7 +276,7 @@ public class ReflectiveProcedureTest
         // Given
         Log log = mock(Log.class);
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
-                components, log, ProcedureAllowedConfig.DEFAULT );
+                components, log, ProcedureConfig.DEFAULT );
 
         // When
         List<CallableProcedure> procs =

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -215,7 +215,8 @@ public class ReflectiveProcedureWithArgumentsTest
 
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
-        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), NullLog.getInstance(),
-                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty() );
+        return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), new ComponentRegistry(),
+                NullLog.getInstance(),
+                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -216,7 +216,6 @@ public class ReflectiveProcedureWithArgumentsTest
     private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
         return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry(), new ComponentRegistry(),
-                NullLog.getInstance(),
-                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), true );
+                NullLog.getInstance(), ProcedureConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), true );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -70,8 +70,7 @@ public class ReflectiveUserAggregationFunctionTest
     {
         components = new ComponentRegistry();
         procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
-                NullLog.getInstance(),
-                ProcedureAllowedConfig.DEFAULT );
+                NullLog.getInstance(), ProcedureConfig.DEFAULT );
     }
 
     @Test
@@ -344,8 +343,8 @@ public class ReflectiveUserAggregationFunctionTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(),
- components, new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
+                new ComponentRegistry(), log, ProcedureConfig.DEFAULT );
 
         // When
         List<CallableUserAggregationFunction> funcs = procedureCompiler.compileAggregationFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -69,7 +69,8 @@ public class ReflectiveUserAggregationFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(),
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
+                NullLog.getInstance(),
                 ProcedureAllowedConfig.DEFAULT );
     }
 
@@ -344,7 +345,7 @@ public class ReflectiveUserAggregationFunctionTest
         // Given
         Log log = mock(Log.class);
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(),
- components, log, ProcedureAllowedConfig.DEFAULT );
+ components, new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableUserAggregationFunction> funcs = procedureCompiler.compileAggregationFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -65,7 +65,8 @@ public class ReflectiveUserFunctionTest
     public void setUp() throws Exception
     {
         components = new ComponentRegistry();
-        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+        procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
+                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
     }
 
     @Test
@@ -249,7 +250,8 @@ public class ReflectiveUserFunctionTest
     {
         // Given
         Log log = mock(Log.class);
-        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, log, ProcedureAllowedConfig.DEFAULT );
+        ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
+                new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
 
         // When
         List<CallableUserFunction> funcs = procedureCompiler.compileFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -66,7 +66,7 @@ public class ReflectiveUserFunctionTest
     {
         components = new ComponentRegistry();
         procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components, new ComponentRegistry(),
-                NullLog.getInstance(), ProcedureAllowedConfig.DEFAULT );
+                NullLog.getInstance(), ProcedureConfig.DEFAULT );
     }
 
     @Test
@@ -251,7 +251,7 @@ public class ReflectiveUserFunctionTest
         // Given
         Log log = mock(Log.class);
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
-                new ComponentRegistry(), log, ProcedureAllowedConfig.DEFAULT );
+                new ComponentRegistry(), log, ProcedureConfig.DEFAULT );
 
         // When
         List<CallableUserFunction> funcs = procedureCompiler.compileFunction( FunctionWithDeprecation.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -184,6 +184,6 @@ public class ResourceInjectionTest
         allComponents.register( MyUnsafeAPI.class, (ctx) -> new MyUnsafeAPI() );
 
         return new ReflectiveProcedureCompiler( new TypeMappers(), safeComponents, allComponents, NullLog.getInstance(),
-                ProcedureAllowedConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), safe );
+                ProcedureConfig.DEFAULT ).compileProcedure( clazz, Optional.empty(), safe );
     }
 }

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsAlternativeCoreAPI.java
@@ -46,7 +46,7 @@ public class MyExtensionThatAddsAlternativeCoreAPI
     {
         dependencies.procedures().registerComponent( MyCoreAPI.class,
                 ( ctx ) -> new MyCoreAPI( dependencies.getGraphDatabaseAPI(), dependencies.txBridge(),
-                        dependencies.logService().getUserLog( MyCoreAPI.class ) ) );
+                        dependencies.logService().getUserLog( MyCoreAPI.class ) ), true );
         return new LifecycleAdapter();
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyExtensionThatAddsInjectable.java
@@ -42,7 +42,7 @@ public class MyExtensionThatAddsInjectable
     public Lifecycle newInstance( KernelContext context,
             Dependencies dependencies ) throws Throwable
     {
-        dependencies.procedures().registerComponent( SomeService.class, ( ctx ) -> new SomeService() );
+        dependencies.procedures().registerComponent( SomeService.class, ( ctx ) -> new SomeService(), true );
         return new LifecycleAdapter();
     }
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -59,7 +59,7 @@ public class CommunitySecurityModule extends SecurityModule
 
         dependencies.lifeSupport().add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 
-        procedures.registerComponent( UserManager.class, ctx -> authManager );
+        procedures.registerComponent( UserManager.class, ctx -> authManager, false );
         procedures.registerProcedure( AuthProcedures.class );
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -99,16 +99,16 @@ public class EnterpriseSecurityModule extends SecurityModule
         life.add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 
         // Register procedures
-        procedures.registerComponent( SecurityLog.class, ( ctx ) -> securityLog );
-        procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager );
+        procedures.registerComponent( SecurityLog.class, ( ctx ) -> securityLog, false );
+        procedures.registerComponent( EnterpriseAuthManager.class, ctx -> authManager, false );
         procedures.registerComponent( EnterpriseSecurityContext.class,
-                ctx -> asEnterprise( ctx.get( SECURITY_CONTEXT ) ) );
+                ctx -> asEnterprise( ctx.get( SECURITY_CONTEXT ) ), true );
 
         if ( config.get( SecuritySettings.native_authentication_enabled )
              || config.get( SecuritySettings.native_authorization_enabled ) )
         {
             procedures.registerComponent( EnterpriseUserManager.class,
-                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( SECURITY_CONTEXT ) ) ) );
+                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( SECURITY_CONTEXT ) ) ), true );
             if ( config.get( SecuritySettings.auth_providers ).size() > 1 )
             {
                 procedures.registerProcedure( UserManagementProcedures.class, true,
@@ -121,7 +121,7 @@ public class EnterpriseSecurityModule extends SecurityModule
         }
         else
         {
-            procedures.registerComponent( EnterpriseUserManager.class, ctx -> EnterpriseUserManager.NOOP );
+            procedures.registerComponent( EnterpriseUserManager.class, ctx -> EnterpriseUserManager.NOOP, true );
         }
 
         procedures.registerProcedure( SecurityProcedures.class, true );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -43,8 +43,8 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.setting;
-import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
-import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES;
+import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
+import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_ROLES;
 
 /**
  * Settings for security module

--- a/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
@@ -25,8 +25,8 @@ import org.neo4j.kernel.configuration.Config;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
-import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
 import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
 import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_ROLES;
 
@@ -141,7 +141,7 @@ public class ProcedureConfigTest
     @Test
     public void shouldAllowFullAccessForProcedures()
     {
-        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+        Config config = Config.defaults().with( genericMap( procedure_unrestricted.name(),
                 "test.procedure.name" ) );
         ProcedureConfig procConfig = new ProcedureConfig( config );
 
@@ -152,7 +152,7 @@ public class ProcedureConfigTest
     @Test
     public void shouldAllowFullAccessForSeveralProcedures()
     {
-        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+        Config config = Config.defaults().with( genericMap( procedure_unrestricted.name(),
                 "test.procedure.name, test.procedure.otherName" ) );
         ProcedureConfig procConfig = new ProcedureConfig( config );
 
@@ -164,7 +164,7 @@ public class ProcedureConfigTest
     @Test
     public void shouldAllowFullAcsessForSeveralProceduresOddNames()
     {
-        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+        Config config = Config.defaults().with( genericMap( procedure_unrestricted.name(),
                 "test\\.procedure.name, test*rocedure.otherName" ) );
         ProcedureConfig procConfig = new ProcedureConfig( config );
 
@@ -176,7 +176,7 @@ public class ProcedureConfigTest
     @Test
     public void shouldAllowFullAccessWildcardProceduresNames()
     {
-        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+        Config config = Config.defaults().with( genericMap( procedure_unrestricted.name(),
                 " test.procedure.*  ,     test.*.otherName" ) );
         ProcedureConfig procConfig = new ProcedureConfig( config );
 

--- a/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/kernel/impl/proc/ProcedureConfigTest.java
@@ -26,10 +26,11 @@ import org.neo4j.kernel.configuration.Config;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
-import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
-import static org.neo4j.kernel.impl.proc.ProcedureAllowedConfig.PROC_ALLOWED_SETTING_ROLES;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
+import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_DEFAULT_NAME;
+import static org.neo4j.kernel.impl.proc.ProcedureConfig.PROC_ALLOWED_SETTING_ROLES;
 
-public class ProcedureAllowedConfigTest
+public class ProcedureConfigTest
 {
     private static final String[] EMPTY = new String[]{};
 
@@ -42,16 +43,15 @@ public class ProcedureAllowedConfigTest
     public void shouldHaveEmptyDefaultConfigs()
     {
         Config config = Config.defaults();
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "x" ), equalTo( EMPTY ) );
     }
 
     @Test
     public void shouldHaveConfigsWithDefaultProcedureAllowed()
     {
-        Config config = Config.defaults()
-                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1" ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        Config config = Config.defaults().with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "x" ), equalTo( arrayOf( "role1" ) ) );
     }
 
@@ -59,9 +59,9 @@ public class ProcedureAllowedConfigTest
     public void shouldHaveConfigsWithExactMatchProcedureAllowed()
     {
         Config config = Config.defaults()
-                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1",
-                        PROC_ALLOWED_SETTING_ROLES, "xyz:anotherRole" ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1", PROC_ALLOWED_SETTING_ROLES,
+                        "xyz:anotherRole" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( arrayOf( "anotherRole" ) ) );
         assertThat( procConfig.rolesFor( "abc" ), equalTo( arrayOf( "role1" ) ) );
     }
@@ -70,9 +70,9 @@ public class ProcedureAllowedConfigTest
     public void shouldHaveConfigsWithWildcardProcedureAllowed()
     {
         Config config = Config.defaults()
-                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1",
-                        PROC_ALLOWED_SETTING_ROLES, "xyz*:anotherRole" ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "role1", PROC_ALLOWED_SETTING_ROLES,
+                        "xyz*:anotherRole" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyzabc" ), equalTo( arrayOf( "anotherRole" ) ) );
         assertThat( procConfig.rolesFor( "abcxyz" ), equalTo( arrayOf( "role1" ) ) );
     }
@@ -80,9 +80,8 @@ public class ProcedureAllowedConfigTest
     @Test
     public void shouldHaveConfigsWithWildcardProcedureAllowedAndNoDefault()
     {
-        Config config = Config.defaults()
-                .with( genericMap( PROC_ALLOWED_SETTING_ROLES, "xyz*:anotherRole" ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        Config config = Config.defaults().with( genericMap( PROC_ALLOWED_SETTING_ROLES, "xyz*:anotherRole" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyzabc" ), equalTo( arrayOf( "anotherRole" ) ) );
         assertThat( procConfig.rolesFor( "abcxyz" ), equalTo( EMPTY ) );
     }
@@ -90,12 +89,9 @@ public class ProcedureAllowedConfigTest
     @Test
     public void shouldHaveConfigsWithMultipleWildcardProcedureAllowedAndNoDefault()
     {
-        Config config = Config.defaults()
-                .with( genericMap(
-                        PROC_ALLOWED_SETTING_ROLES,
-                        "apoc.convert.*:apoc_reader;apoc.load.json:apoc_writer;apoc.trigger.add:TriggerHappy"
-                ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+        Config config = Config.defaults().with( genericMap( PROC_ALLOWED_SETTING_ROLES,
+                "apoc.convert.*:apoc_reader;apoc.load.json:apoc_writer;apoc.trigger.add:TriggerHappy" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( EMPTY ) );
         assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "apoc_reader" ) ) );
         assertThat( procConfig.rolesFor( "apoc.convert.json" ), equalTo( arrayOf( "apoc_reader" ) ) );
@@ -112,12 +108,9 @@ public class ProcedureAllowedConfigTest
     public void shouldHaveConfigsWithOverlappingMatchingWildcards()
     {
         Config config = Config.defaults()
-                .with( genericMap(
-                        PROC_ALLOWED_SETTING_DEFAULT_NAME, "default",
-                        PROC_ALLOWED_SETTING_ROLES,
-                        "apoc.*:apoc;apoc.load.*:loader;apoc.trigger.*:trigger;apoc.trigger.add:TriggerHappy"
-                ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
+                .with( genericMap( PROC_ALLOWED_SETTING_DEFAULT_NAME, "default", PROC_ALLOWED_SETTING_ROLES,
+                        "apoc.*:apoc;apoc.load.*:loader;apoc.trigger.*:trigger;apoc.trigger.add:TriggerHappy" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyz" ), equalTo( arrayOf( "default" ) ) );
         assertThat( procConfig.rolesFor( "apoc.convert.xml" ), equalTo( arrayOf( "apoc" ) ) );
         assertThat( procConfig.rolesFor( "apoc.load.xml" ), equalTo( arrayOf( "apoc", "loader" ) ) );
@@ -131,10 +124,67 @@ public class ProcedureAllowedConfigTest
     {
         Config config = Config.defaults().with( genericMap( PROC_ALLOWED_SETTING_ROLES,
                 "xyz*:role1,role2,  role3  ,    role4   ;    abc:  role3   ,role1" ) );
-        ProcedureAllowedConfig procConfig = new ProcedureAllowedConfig( config );
-
+        ProcedureConfig procConfig = new ProcedureConfig( config );
         assertThat( procConfig.rolesFor( "xyzabc" ), equalTo( arrayOf( "role1", "role2", "role3", "role4" ) ) );
         assertThat( procConfig.rolesFor( "abc" ), equalTo( arrayOf( "role3", "role1" ) ) );
         assertThat( procConfig.rolesFor( "abcxyz" ), equalTo( EMPTY ) );
+    }
+
+    @Test
+    public void shouldNotAllowFullAccessDefault()
+    {
+        Config config = Config.defaults();
+        ProcedureConfig procConfig = new ProcedureConfig( config );
+        assertThat( procConfig.fullAccessFor( "x" ), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldAllowFullAccessForProcedures()
+    {
+        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+                "test.procedure.name" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
+
+        assertThat( procConfig.fullAccessFor( "xyzabc" ), equalTo( false ) );
+        assertThat( procConfig.fullAccessFor( "test.procedure.name" ), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldAllowFullAccessForSeveralProcedures()
+    {
+        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+                "test.procedure.name, test.procedure.otherName" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
+
+        assertThat( procConfig.fullAccessFor( "xyzabc" ), equalTo( false ) );
+        assertThat( procConfig.fullAccessFor( "test.procedure.name" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test.procedure.otherName" ), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldAllowFullAcsessForSeveralProceduresOddNames()
+    {
+        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+                "test\\.procedure.name, test*rocedure.otherName" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
+
+        assertThat( procConfig.fullAccessFor( "xyzabc" ), equalTo( false ) );
+        assertThat( procConfig.fullAccessFor( "test\\.procedure.name" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test*procedure.otherName" ), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldAllowFullAccessWildcardProceduresNames()
+    {
+        Config config = Config.defaults().with( genericMap( procedure_full_access.name(),
+                " test.procedure.*  ,     test.*.otherName" ) );
+        ProcedureConfig procConfig = new ProcedureConfig( config );
+
+        assertThat( procConfig.fullAccessFor( "xyzabc" ), equalTo( false ) );
+        assertThat( procConfig.fullAccessFor( "test.procedure.name" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test.procedure.otherName" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test.other.otherName" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test.other.cool.otherName" ), equalTo( true ) );
+        assertThat( procConfig.fullAccessFor( "test.other.name" ), equalTo( false ) );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -52,7 +52,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Iterators;
@@ -75,9 +74,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.plugin_dir;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.helpers.collection.MapUtil.map;
-import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 import static org.neo4j.procedure.Mode.SCHEMA;
 import static org.neo4j.procedure.Mode.WRITE;
@@ -476,8 +476,8 @@ public class ProcedureIT
                 .setInternalLogProvider( logProvider )
                 .setUserLogProvider( logProvider )
                 .newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .setConfig( procedure_full_access, "org.neo4j.procedure.*" )
+                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .setConfig( procedure_unrestricted, "org.neo4j.procedure.*" )
                 .newGraphDatabase();
 
         // When
@@ -1137,8 +1137,8 @@ public class ProcedureIT
         new JarBuilder().createJarFor( plugins.newFile( "myFunctions.jar" ), ClassWithFunctions.class );
         db = new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .setConfig( procedure_full_access, "org.neo4j.procedure.*" )
+                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .setConfig( procedure_unrestricted, "org.neo4j.procedure.*" )
                 .newGraphDatabase();
     }
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -60,7 +60,6 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.proc.JarBuilder;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -78,6 +77,7 @@ import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.procedure_full_access;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 import static org.neo4j.procedure.Mode.SCHEMA;
 import static org.neo4j.procedure.Mode.WRITE;
@@ -477,6 +477,7 @@ public class ProcedureIT
                 .setUserLogProvider( logProvider )
                 .newImpermanentDatabaseBuilder()
                 .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .setConfig( procedure_full_access, "org.neo4j.procedure.*" )
                 .newGraphDatabase();
 
         // When
@@ -1137,8 +1138,8 @@ public class ProcedureIT
         db = new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .setConfig( procedure_full_access, "org.neo4j.procedure.*" )
                 .newGraphDatabase();
-
     }
 
     @After


### PR DESCRIPTION
Procedures that need to access internal APIs such as `DependencyResolver` and `GraphDatabaseAPI` need to be added in the configuration, otherwise they will fail to compile.

changelog: Restrict access to unsecured components and add a configuration option to allow trusted procedures full access.