### PR TITLE
Ensures test neostore file is closed before test finishes

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/commandline/dbms/UnbindFromClusterCommandTest.java
@@ -191,7 +191,7 @@ public class UnbindFromClusterCommandTest
     {
         Path graphDb = homeDir.resolve( "data/databases/graph.db" );
         fs.mkdirs( graphDb.toFile() );
-        fs.create( graphDb.resolve( "neostore" ).toFile() );
+        fs.create( graphDb.resolve( "neostore" ).toFile() ).close();
         return graphDb;
     }
 


### PR DESCRIPTION
This omission caused the test to spuriously fail on Windows,
 with inability to delete a mapped file during test directory
 cleanup.