### PR TITLE
Preserve parameter type information in compiled runtime

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -364,4 +364,23 @@ public abstract class CompiledConversionUtils
         }
         throw new IllegalArgumentException( format( "Can not be converted to stream: %s", list.getClass().getName() ) );
     }
+
+    public static long unboxNodeOrNull( NodeIdWrapper value )
+    {
+        if ( value == null )
+        {
+            return -1L;
+        }
+        return value.id();
+    }
+
+    public static long unboxRelationshipOrNull( RelationshipIdWrapper value )
+    {
+        if ( value == null )
+        {
+            return -1L;
+        }
+        return value.id();
+    }
+
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -183,22 +183,6 @@ public abstract class CompiledConversionUtils
         }
     }
 
-    public static Object loadPrimitiveListParameter( Object value )
-    {
-        if ( value instanceof Node )
-        {
-            return new NodeIdWrapper( ((Node) value).getId() );
-        }
-        else if ( value instanceof Relationship )
-        {
-            return new RelationshipIdWrapper( ((Relationship) value).getId() );
-        }
-        else
-        {
-            return value;
-        }
-    }
-
     public static final Object materializeAnyResult( NodeManager nodeManager, Object anyValue )
     {
         if ( anyValue instanceof NodeIdWrapper )

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -292,19 +292,19 @@ public abstract class CompiledConversionUtils
         {
             return ((List) list).stream().mapToLong( n -> ((Number) n).longValue() );
         }
-        else if ( list instanceof Object[] )
+        else if ( Object[].class.isAssignableFrom( list.getClass() ) )
         {
             return Arrays.stream( (Object[]) list ).mapToLong( n -> ((Number) n).longValue() );
         }
         else if ( list instanceof byte[] )
         {
             byte[] array = (byte[]) list;
-            return IntStream.range( 0, array.length ).map( i -> array[i] ).mapToLong( i -> i );
+            return IntStream.range( 0, array.length ).mapToLong( i -> array[i] );
         }
         else if ( list instanceof short[] )
         {
             short[] array = (short[]) list;
-            return IntStream.range( 0, array.length ).map( i -> array[i] ).mapToLong( i -> i );
+            return IntStream.range( 0, array.length ).mapToLong( i -> array[i] );
         }
         else if ( list instanceof int[] )
         {
@@ -313,6 +313,54 @@ public abstract class CompiledConversionUtils
         else if ( list instanceof long[] )
         {
             return LongStream.of( (long[]) list );
+        }
+        throw new IllegalArgumentException( format( "Can not be converted to stream: %s", list.getClass().getName() ) );
+    }
+
+    public static DoubleStream toDoubleStream( Object list )
+    {
+        if ( list == null )
+        {
+            return DoubleStream.empty();
+        }
+        else if ( list instanceof List )
+        {
+            return ((List) list).stream().mapToDouble( n -> ((Number) n).doubleValue() );
+        }
+        else if ( Object[].class.isAssignableFrom( list.getClass() ) )
+        {
+            return Arrays.stream( (Object[]) list ).mapToDouble( n -> ((Number) n).doubleValue() );
+        }
+        else if ( list instanceof float[] )
+        {
+            float[] array = (float[]) list;
+            return IntStream.range( 0, array.length ).mapToDouble( i -> array[i] );
+        }
+        else if ( list instanceof double[] )
+        {
+            return DoubleStream.of( (double[]) list );
+        }
+        throw new IllegalArgumentException( format( "Can not be converted to stream: %s", list.getClass().getName() ) );
+    }
+
+    public static IntStream toBooleanStream( Object list )
+    {
+        if ( list == null )
+        {
+            return IntStream.empty();
+        }
+        else if ( list instanceof List )
+        {
+            return ((List) list).stream().mapToInt( n -> ((Number) n).intValue() );
+        }
+        else if ( Object[].class.isAssignableFrom( list.getClass() ) )
+        {
+            return Arrays.stream( (Object[]) list ).mapToInt( n -> ((Number) n).intValue() );
+        }
+        else if ( list instanceof boolean[] )
+        {
+            boolean[] array = (boolean[]) list;
+            return IntStream.range( 0, array.length ).map( i -> (array[i]) ? 1 : 0 );
         }
         throw new IllegalArgumentException( format( "Can not be converted to stream: %s", list.getClass().getName() ) );
     }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtils.java
@@ -24,11 +24,14 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import org.neo4j.cypher.UnorderableValueException;
 import org.neo4j.cypher.internal.frontend.v3_2.IncomparableValuesException;
 import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.helpers.MathUtil;
 
 import static java.lang.String.format;
@@ -124,10 +127,10 @@ public class CompiledOrderabilityUtils
     public enum SuperType
     {
         MAP( 0, FALLBACK_COMPARATOR /*TODO*/ ),
-        NODE( 1, FALLBACK_COMPARATOR /*TODO*/ ),
-        RELATIONSHIP( 2, FALLBACK_COMPARATOR /*TODO*/ ),
+        NODE( 1, NODE_COMPARATOR ),
+        RELATIONSHIP( 2, RELATIONSHIP_COMPARATOR ),
         LIST( 3, LIST_COMPARATOR ),
-        PATH( 4, FALLBACK_COMPARATOR /*TODO*/ ),
+        PATH( 4, PATH_COMPARATOR ),
         STRING( 5, STRING_COMPARATOR ),
         BOOLEAN( 6, BOOLEAN_COMPARATOR ),
         NUMBER( 7, NUMBER_COMPARATOR ),
@@ -185,6 +188,7 @@ public class CompiledOrderabilityUtils
                 }
                 return RELATIONSHIP;
             }
+            // TODO is Path really the class that compiled runtime will be using?
             else if ( value instanceof Path )
             {
                 return PATH;
@@ -205,7 +209,7 @@ public class CompiledOrderabilityUtils
     // NOTE: nulls are handled at the top of the public compare() method
     // so the type-specific comparators should not check arguments for null
 
-    private static Comparator FALLBACK_COMPARATOR = new Comparator<Object>()
+    private static Comparator<Object> FALLBACK_COMPARATOR = new Comparator<Object>()
     {
         @Override
         public int compare( Object lhs, Object rhs )
@@ -221,7 +225,7 @@ public class CompiledOrderabilityUtils
         }
     };
 
-    private static Comparator VOID_COMPARATOR = new Comparator<Object>()
+    private static Comparator<Object> VOID_COMPARATOR = new Comparator<Object>()
     {
         @Override
         public int compare( Object lhs, Object rhs )
@@ -230,7 +234,7 @@ public class CompiledOrderabilityUtils
         }
     };
 
-    private static Comparator NUMBER_COMPARATOR = new Comparator<Number>()
+    private static Comparator<Number> NUMBER_COMPARATOR = new Comparator<Number>()
     {
         @Override
         public int compare( Number lhs, Number rhs )
@@ -267,7 +271,7 @@ public class CompiledOrderabilityUtils
         }
     };
 
-    private static Comparator STRING_COMPARATOR = new Comparator<Object>()
+    private static Comparator<Object> STRING_COMPARATOR = new Comparator<Object>()
     {
         @Override
         public int compare( Object lhs, Object rhs )
@@ -285,7 +289,7 @@ public class CompiledOrderabilityUtils
         }
     };
 
-    private static Comparator BOOLEAN_COMPARATOR = new Comparator<Boolean>()
+    private static Comparator<Boolean> BOOLEAN_COMPARATOR = new Comparator<Boolean>()
     {
         @Override
         public int compare( Boolean lhs, Boolean rhs )
@@ -294,13 +298,53 @@ public class CompiledOrderabilityUtils
         }
     };
 
-    private static Comparator LIST_COMPARATOR = new Comparator<Object>()
+    private static Comparator<NodeIdWrapper> NODE_COMPARATOR = new Comparator<NodeIdWrapper>()
+    {
+        @Override
+        public int compare( NodeIdWrapper lhs, NodeIdWrapper rhs )
+        {
+            return Long.compare( lhs.id(), rhs.id() );
+        }
+    };
+
+    private static Comparator<RelationshipIdWrapper> RELATIONSHIP_COMPARATOR = new Comparator<RelationshipIdWrapper>()
+    {
+        @Override
+        public int compare( RelationshipIdWrapper lhs, RelationshipIdWrapper rhs )
+        {
+            return Long.compare( lhs.id(), rhs.id() );
+        }
+    };
+
+    // TODO test
+    private static Comparator<Path> PATH_COMPARATOR = new Comparator<Path>()
+    {
+        @Override
+        public int compare( Path lhs, Path rhs )
+        {
+            Iterator<PropertyContainer> lhsIter = lhs.iterator();
+            Iterator<PropertyContainer> rhsIter = lhs.iterator();
+            while ( lhsIter.hasNext() && rhsIter.hasNext() )
+            {
+                int result = CompiledOrderabilityUtils.compare( lhsIter.next(), rhsIter.next() );
+                if ( 0 != result )
+                {
+                    return result;
+                }
+            }
+            return (lhsIter.hasNext()) ? 1
+                                       : (rhsIter.hasNext()) ? -1
+                                                             : 0;
+        }
+    };
+
+    private static Comparator<Object> LIST_COMPARATOR = new Comparator<Object>()
     {
         @Override
         public int compare( Object lhs, Object rhs )
         {
-            Iterator lhsIter = (lhs.getClass().isArray()) ? arrayToIterator( lhs ) : ((List) lhs).iterator();
-            Iterator rhsIter = (rhs.getClass().isArray()) ? arrayToIterator( rhs ) : ((List) rhs).iterator();
+            Iterator lhsIter = toIterator( lhs );
+            Iterator rhsIter = toIterator( rhs );
             while ( lhsIter.hasNext() && rhsIter.hasNext() )
             {
                 int result = CompiledOrderabilityUtils.compare( lhsIter.next(), rhsIter.next() );
@@ -314,28 +358,32 @@ public class CompiledOrderabilityUtils
                                                              : 0;
         }
 
-        private Iterator arrayToIterator( Object o )
+        private Iterator toIterator( Object o )
         {
             Class clazz = o.getClass();
-            if ( clazz.equals( Object[].class ) )
+            if ( Iterable.class.isAssignableFrom( clazz) )
+            {
+                return ((Iterable) o).iterator();
+            }
+            else if ( Object[].class.isAssignableFrom( clazz) )
             {
                 return Arrays.stream( (Object[]) o ).iterator();
             }
             else if ( clazz.equals( int[].class ) )
             {
-                return Arrays.stream( (int[]) o ).iterator();
-            }
-            else if ( clazz.equals( Integer[].class ) )
-            {
-                return Arrays.stream( (Integer[]) o ).iterator();
+                return IntStream.of( (int[]) o ).iterator();
             }
             else if ( clazz.equals( long[].class ) )
             {
-                return Arrays.stream( (long[]) o ).iterator();
+                return LongStream.of( (long[]) o ).iterator();
             }
-            else if ( clazz.equals( Long[].class ) )
+            else if ( clazz.equals( float[].class ) )
             {
-                return Arrays.stream( (Long[]) o ).iterator();
+                return IntStream.range( 0, ((float[]) o).length ).mapToObj( i -> ((float[]) o)[i] ).iterator();
+            }
+            else if ( clazz.equals( double[].class ) )
+            {
+                return DoubleStream.of( (double[]) o ).iterator();
             }
             else if ( clazz.equals( String[].class ) )
             {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveNodeStream.java
@@ -19,8 +19,14 @@
  */
 package org.neo4j.cypher.internal.codegen;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.stream.LongStream;
+
+import org.neo4j.graphdb.Node;
+
+import static java.lang.String.format;
 
 public class PrimitiveNodeStream extends PrimitiveEntityStream<NodeIdWrapper>
 {
@@ -34,10 +40,29 @@ public class PrimitiveNodeStream extends PrimitiveEntityStream<NodeIdWrapper>
         return new PrimitiveNodeStream( LongStream.of( array ) );
     }
 
+    public static PrimitiveNodeStream of( Object list )
+    {
+        if ( list == null )
+        {
+            return empty;
+        }
+        if ( list instanceof List )
+        {
+            return new PrimitiveNodeStream( ((List<Node>) list).stream().mapToLong( Node::getId ) );
+        }
+        else if ( list instanceof Node[] )
+        {
+            return new PrimitiveNodeStream( Arrays.stream( (Node[]) list ).mapToLong( Node::getId ) );
+        }
+        throw new IllegalArgumentException( format( "Can not convert to stream: %s", list.getClass().getName() ) );
+    }
+
     @Override
     // This method is only used when we do not know the element type at compile time, so it has to box the elements
     public Iterator<NodeIdWrapper> iterator()
     {
         return inner.mapToObj( NodeIdWrapper::new ).iterator();
     }
+
+    private static final PrimitiveNodeStream empty = new PrimitiveNodeStream( LongStream.empty() );
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/PrimitiveRelationshipStream.java
@@ -19,8 +19,14 @@
  */
 package org.neo4j.cypher.internal.codegen;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.stream.LongStream;
+
+import org.neo4j.graphdb.Relationship;
+
+import static java.lang.String.format;
 
 public class PrimitiveRelationshipStream extends PrimitiveEntityStream<RelationshipIdWrapper>
 {
@@ -34,10 +40,31 @@ public class PrimitiveRelationshipStream extends PrimitiveEntityStream<Relations
         return new PrimitiveRelationshipStream( LongStream.of( array ) );
     }
 
+    public static PrimitiveRelationshipStream of( Object list )
+    {
+        if ( null == list )
+        {
+            return empty;
+        }
+        else if ( list instanceof List )
+        {
+            return new PrimitiveRelationshipStream(
+                    ((List<Relationship>) list).stream().mapToLong( Relationship::getId ) );
+        }
+        else if ( list instanceof Relationship[] )
+        {
+            return new PrimitiveRelationshipStream(
+                    Arrays.stream( (Relationship[]) list ).mapToLong( Relationship::getId ) );
+        }
+        throw new IllegalArgumentException( format( "Can not convert to stream: %s", list.getClass().getName() ) );
+    }
+
     @Override
     // This method is only used when we do not know the element type at compile time, so it has to box the elements
     public Iterator<RelationshipIdWrapper> iterator()
     {
         return inner.mapToObj( RelationshipIdWrapper::new ).iterator();
     }
+
+    private static final PrimitiveRelationshipStream empty = new PrimitiveRelationshipStream( LongStream.empty() );
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -140,6 +140,11 @@ class IncomparableValuesException(lhs: String, rhs: String, cause: Throwable)
   def this(lhs: String, rhs: String) = this(lhs, rhs, null)
 }
 
+class UnorderableValueException(value: String, cause: Throwable)
+  extends CypherTypeException(s"Do not know how to order $value", cause) {
+  def this(value: String) = this(value, null)
+}
+
 class PeriodicCommitInOpenTransactionException(cause: Throwable)
   extends InvalidSemanticsException("Executing stream that use periodic commit in an open transaction is not possible.", cause) {
   def this() = this(null)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/exceptionHandler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/exceptionHandler.scala
@@ -35,6 +35,7 @@ object exceptionHandler extends MapToPublicExceptions[CypherException] {
 
   def incomparableValuesException(lhs: String, rhs: String, cause: Throwable) = new IncomparableValuesException(lhs, rhs, cause)
 
+  def unorderableValueException(value: String, cause: Throwable) = new UnorderableValueException(value, cause)
 
   def patternException(message: String, cause: Throwable) = new PatternException(message, cause)
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
@@ -44,26 +44,35 @@ public class CompiledOrderabilityUtilsTest
 
             // NODE
             new NodeIdWrapper( 1 ),
-            //new NodeIdWrapper( 2 ), TODO: FIXME
+            new NodeIdWrapper( 2 ),
 
             // RELATIONSHIP
             new RelationshipIdWrapper( 1 ),
-            //new RelationshipIdWrapper( 2 ), TODO: FIXME
+            new RelationshipIdWrapper( 2 ),
 
             // LIST
+            new String[]{"boo"},
             new String[]{"foo"},
+            new boolean[]{false},
+            new Boolean[]{true},
             new Object[]{1, "foo"},
             new Object[]{1, "foo", 3},
             new Object[]{1, true, "car"},
             new Object[]{1, 2, "bar"},
             new Object[]{1, 2, "car"},
-            new int[]   {1, 2, 3},
-            new Object[]{1,  2, 3L, Double.NEGATIVE_INFINITY},
-            new long[]  {1,  2, 3,  Long.MIN_VALUE},
-            new int[]   {1,  2, 3,  Integer.MIN_VALUE},
-            new Object[]{1L, 2, 3,  Double.NaN},
-            new Object[]{1L, 2, 3,  new NodeIdWrapper(-1)},
-            new int[]   {2},
+            new int[]{1, 2, 3},
+            new Object[]{1, 2, 3L, Double.NEGATIVE_INFINITY},
+            new long[]{1, 2, 3, Long.MIN_VALUE},
+            new int[]{1, 2, 3, Integer.MIN_VALUE},
+            new Object[]{1L, 2, 3, Double.NaN},
+            new Object[]{1L, 2, 3, new NodeIdWrapper(-1)},
+            new Long[]{1L, 2L, 4L},
+            new int[]{2},
+            new Integer[]{3},
+            new double[]{4D},
+            new Double[]{5D},
+            new float[]{6},
+            new Float[]{7F},
             new Object[]{new RelationshipIdWrapper(-1)},
 
             // TODO: PATH

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledOrderabilityUtilsTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 import org.neo4j.cypher.internal.frontend.v3_2.IncomparableValuesException;
-import org.neo4j.kernel.impl.api.PropertyValueComparison;
 
 import static java.lang.String.format;
 
@@ -38,23 +38,43 @@ public class CompiledOrderabilityUtilsTest
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    // TODO add acceptance tests too
-
     public static Object[] values = new Object[]{
-            // OTHER
-            PropertyValueComparison.LOWEST_OBJECT,
-            new Object(),
+            // MAP
+            new HashMap<Long,Long>(),
+
+            // NODE
+            new NodeIdWrapper( 1 ),
+            //new NodeIdWrapper( 2 ), TODO: FIXME
+
+            // RELATIONSHIP
+            new RelationshipIdWrapper( 1 ),
+            //new RelationshipIdWrapper( 2 ), TODO: FIXME
+
+            // LIST
+            new String[]{"foo"},
             new Object[]{1, "foo"},
             new Object[]{1, "foo", 3},
             new Object[]{1, true, "car"},
             new Object[]{1, 2, "bar"},
             new Object[]{1, 2, "car"},
-            new int[]{1, 2, 3},
+            new int[]   {1, 2, 3},
+            new Object[]{1,  2, 3L, Double.NEGATIVE_INFINITY},
+            new long[]  {1,  2, 3,  Long.MIN_VALUE},
+            new int[]   {1,  2, 3,  Integer.MIN_VALUE},
+            new Object[]{1L, 2, 3,  Double.NaN},
+            new Object[]{1L, 2, 3,  new NodeIdWrapper(-1)},
+            new int[]   {2},
+            new Object[]{new RelationshipIdWrapper(-1)},
+
+            // TODO: PATH
+
             // STRING
             "",
             Character.MIN_VALUE,
             " ",
             "20",
+            "X",
+            "Y",
             "x",
             "y",
             Character.MIN_HIGH_SURROGATE,
@@ -96,7 +116,10 @@ public class CompiledOrderabilityUtilsTest
             Float.MAX_VALUE,
             Double.MAX_VALUE,
             Double.POSITIVE_INFINITY,
-            Double.NaN
+            Double.NaN,
+
+            // VOID
+            null,
     };
 
     @Test
@@ -126,6 +149,11 @@ public class CompiledOrderabilityUtilsTest
 
     private String toString( Object o )
     {
+        if ( o == null )
+        {
+            return "null";
+        }
+
         Class clazz = o.getClass();
         if ( clazz.equals( Object[].class ) )
         {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -119,6 +119,21 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
 
+  test("should keep different cache entries for different literal types") {
+    runQuery("WITH 1 as x RETURN x")      // miss
+    runQuery("WITH 2 as x RETURN x")      // hit
+    runQuery("WITH 1.0 as x RETURN x")    // miss
+    runQuery("WITH 2.0 as x RETURN x")    // hit
+    runQuery("WITH 'foo' as x RETURN x")  // miss
+    runQuery("WITH 'bar' as x RETURN x")  // hit
+    runQuery("WITH {p} as x RETURN x")    // miss
+    runQuery("WITH {k} as x RETURN x")    // miss, a little surprising but not harmful
+    runQuery("WITH [1,2] as x RETURN x")  // miss
+    runQuery("WITH [3] as x RETURN x")    // hit
+
+    counter.counts should equal(CacheCounts(hits = 4, misses = 6, flushes = 1))
+  }
+
   test("should not care about white spaces") {
     runQuery("return 42")
     runQuery("\treturn          42")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -23,6 +23,14 @@ import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QuerySt
 
 class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with NewRuntimeTestSupport with QueryStatisticsTestSupport {
 
+  test("should be able to send in an array of nodes via parameter") {
+    // given
+    val node = createLabeledNode("Person")
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("WITH {param} as p RETURN p", "param" -> Array(node))
+    val outputP = result.next.get("p").get
+    outputP should equal(Array(node))
+  }
+
   // Not TCK material below; sending graph types or characters as parameters is not supported
 
   ignore("should not erase the type of an empty array sent as parameter") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -65,14 +65,6 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with NewRunt
     result.toList should equal(List(Map("b" -> node)))
   }
 
-  test("should be able to send in an array of nodes via parameter") {
-    // given
-    val node = createLabeledNode("Person")
-
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("WITH {param} as p RETURN p", "param" -> Array(node))
-    result.toList should equal(List(Map("p" -> Array(node))))
-  }
-
   test("should be able to send in relationship via parameter") {
     // given
     val rel = relate(createLabeledNode("Person"), createLabeledNode("Person"))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -65,6 +65,14 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with NewRunt
     result.toList should equal(List(Map("b" -> node)))
   }
 
+  test("should be able to send in an array of nodes via parameter") {
+    // given
+    val node = createLabeledNode("Person")
+
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("WITH {param} as p RETURN p", "param" -> Array(node))
+    result.toList should equal(List(Map("p" -> Array(node))))
+  }
+
   test("should be able to send in relationship via parameter") {
     // given
     val rel = relate(createLabeledNode("Person"), createLabeledNode("Person"))

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenContext.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenContext.scala
@@ -51,6 +51,8 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
 
   def hasVariable(queryVariable: String): Boolean = variables.isDefinedAt(queryVariable)
 
+  def isProjectedVariable(queryVariable: String): Boolean = projectedVariables.contains(queryVariable)
+
   def variableQueryVariables(): Set[String] = variables.keySet.toSet
 
   // We need to keep track of variables that are exposed by a QueryHorizon,

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenContext.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenContext.scala
@@ -49,6 +49,8 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
 
   def getVariable(queryVariable: String): Variable = variables(queryVariable)
 
+  def hasVariable(queryVariable: String): Boolean = variables.isDefinedAt(queryVariable)
+
   def variableQueryVariables(): Set[String] = variables.keySet.toSet
 
   // We need to keep track of variables that are exposed by a QueryHorizon,
@@ -58,9 +60,9 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
     projectedVariables.put(queryVariable, variable)
   }
 
-  // We need to clear projected variables that are no longer exposed by a QueryHorizon, e.g a regular Projection
-  def clearProjectedVariables(): Unit = {
-    projectedVariables.clear()
+  // We need to keep only the projected variables that are exposed by a QueryHorizon, e.g a regular Projection
+  def retainProjectedVariables(queryVariablesToRetain: Set[String]): Unit = {
+    projectedVariables.retain((key, _) => queryVariablesToRetain.contains(key))
   }
 
   def getProjectedVariables: Map[String, Variable] = projectedVariables.toMap

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -86,9 +86,12 @@ object LogicalPlanConverter {
                                        (e: ast.Expression) => ExpressionConverter.createExpression(e)(context))
       context.retainProjectedVariables(projection.expressions.keySet)
       val vars = columns.collect {
-        case (name, expr) if !context.hasVariable(name) =>
+        case (name, expr) if !context.isProjectedVariable(name) =>
           val variable = Variable(context.namer.newVarName(), expr.codeGenType(context), expr.nullable(context))
-          context.addVariable(name, variable)
+          if (context.hasVariable(name))
+            context.updateVariable(name, variable)
+          else
+            context.addVariable(name, variable)
           context.addProjectedVariable(name, variable)
           variable -> expr
       }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -84,9 +84,9 @@ object LogicalPlanConverter {
       val projectionOpName = context.registerOperator(projection)
       val columns = immutableMapValues(projection.expressions,
                                        (e: ast.Expression) => ExpressionConverter.createExpression(e)(context))
-      context.clearProjectedVariables()
-      val vars = columns.map {
-        case (name, expr) =>
+      context.retainProjectedVariables(projection.expressions.keySet)
+      val vars = columns.collect {
+        case (name, expr) if !context.hasVariable(name) =>
           val variable = Variable(context.namer.newVarName(), expr.codeGenType(context), expr.nullable(context))
           context.addVariable(name, variable)
           context.addProjectedVariable(name, variable)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/IndexSeek.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/IndexSeek.scala
@@ -36,7 +36,7 @@ case class IndexSeek(opName: String, labelName: String, propName: String, descri
   }
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-      generator.indexSeek(iterVar, descriptorVar, expression.generateExpression(generator))
+      generator.indexSeek(iterVar, descriptorVar, expression.generateExpression(generator), expression.codeGenType)
       generator.incrementDbHits()
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/IndexUniqueSeek.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/IndexUniqueSeek.scala
@@ -39,7 +39,7 @@ case class IndexUniqueSeek(opName: String, labelName: String, propName: String, 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.trace(opName) { body =>
       body.incrementDbHits()
-      body.indexUniqueSeek(node.name, descriptorVar, expression.generateExpression(body))
+      body.indexUniqueSeek(node.name, descriptorVar, expression.generateExpression(body), expression.codeGenType)
       body.ifNotStatement(body.isNull(node.name, CodeGenType.primitiveNode)) { ifBody =>
         ifBody.incrementRows()
         inner.body(ifBody)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/Projection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/Projection.scala
@@ -38,14 +38,8 @@ case class Projection(projectionOpName: String, variables: Map[Variable, CodeGen
       body.incrementRows()
       variables.foreach {
         case (variable, expr) =>
-          if (variable.codeGenType.isPrimitive) {
-            body.declare(variable.name, variable.codeGenType)
-            body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
-          }
-          else {
-            body.declare(variable.name, variable.codeGenType)
-            body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
-          }
+          body.declare(variable.name, variable.codeGenType)
+          body.assign(variable.name, variable.codeGenType, expr.generateExpression(body))
       }
       action.body(body)
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/SeekNodeById.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/SeekNodeById.scala
@@ -28,7 +28,7 @@ case class SeekNodeById(opName: String, nodeVar: Variable, expression: CodeGenEx
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.trace(opName) { body =>
       body.incrementDbHits()
-      body.nodeIdSeek(nodeVar.name, expression.generateExpression(body)) { seekBody =>
+      body.nodeIdSeek(nodeVar.name, expression.generateExpression(body), expression.codeGenType) { seekBody =>
         seekBody.incrementRows()
         action.body(seekBody)
       }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.functions.functionConverter
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.helpers.LiteralTypeSupport
 import org.neo4j.cypher.internal.compiler.v3_2.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_2.ast
 import org.neo4j.cypher.internal.frontend.v3_2.ast.PropertyKeyName
@@ -131,7 +132,8 @@ object ExpressionConverter {
       case ast.Property(variable@ast.Variable(name), PropertyKeyName(propKeyName)) =>
         MapProperty(context.getVariable(name), propKeyName)
 
-      case ast.Parameter(name, _) => expressions.Parameter(name, context.namer.newVarName())
+      case ast.Parameter(name, cypherType) =>
+        expressions.Parameter(name, context.namer.newVarName(), LiteralTypeSupport.deriveCodeGenType(cypherType))
 
       case lit: ast.IntegerLiteral => Literal(lit.value)
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Parameter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Parameter.scala
@@ -22,15 +22,15 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
 
-case class Parameter(key: String, variableName: String) extends CodeGenExpression {
+case class Parameter(key: String, variableName: String, cType: CodeGenType = CodeGenType.Any) extends CodeGenExpression {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
-    generator.expectParameter(key, variableName)
+    generator.expectParameter(key, variableName, cType)
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext): E =
     structure.loadVariable(variableName)
 
-  override def nullable(implicit context: CodeGenContext) = true
+  override def nullable(implicit context: CodeGenContext) = cType.canBeNullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType.Any
+  override def codeGenType(implicit context: CodeGenContext) = cType
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -61,6 +61,7 @@ trait MethodStructure[E] {
   def constantExpression(value: Object): E
   def asMap(map: Map[String, E]): E
   def asList(values: Seq[E]): E
+  def asPrimitiveStream(values: E, codeGenType: CodeGenType): E
   def asPrimitiveStream(values: Seq[E], codeGenType: CodeGenType): E
 
   def declarePrimitiveIterator(name: String, iterableCodeGenType: CodeGenType): Unit
@@ -123,7 +124,7 @@ trait MethodStructure[E] {
   def toFloat(expression:E): E
 
   // parameters
-  def expectParameter(key: String, variableName: String): Unit
+  def expectParameter(key: String, variableName: String, codeGenType: CodeGenType): Unit
 
   // map
   def mapGetExpression(mapName: String, key: String): E

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -155,8 +155,8 @@ trait MethodStructure[E] {
   def relationshipGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
   def relationshipGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
   def lookupPropertyKey(propName: String, propVar: String)
-  def indexSeek(iterVar: String, descriptorVar: String, value: E): Unit
-  def indexUniqueSeek(name: String, descriptorVar: String, value: E)
+  def indexSeek(iterVar: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
+  def indexUniqueSeek(name: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
   def relType(relIdVar: String, typeVar: String): Unit
   def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
   def createRelExtractor(extractorName: String): Unit

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -151,7 +151,7 @@ trait MethodStructure[E] {
   def hasNextRelationship(iterVar: String): E
   def nodeGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
   def nodeGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
-  def nodeIdSeek(nodeIdVar: String, expression: E)(block: MethodStructure[E] => Unit): Unit
+  def nodeIdSeek(nodeIdVar: String, expression: E, codeGenType: CodeGenType)(block: MethodStructure[E] => Unit): Unit
   def relationshipGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
   def relationshipGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
   def lookupPropertyKey(propName: String, propVar: String)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/helpers/LiteralTypeSupport.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/helpers/LiteralTypeSupport.scala
@@ -40,11 +40,16 @@ object LiteralTypeSupport {
   def deriveCodeGenType(obj: Any): CodeGenType = deriveCodeGenType(deriveCypherType(obj))
 
   def deriveCodeGenType(ct: CypherType): CodeGenType = ct match {
-    case CTInteger => CodeGenType(CTInteger, IntType)
-    case CTFloat => CodeGenType(CTFloat, expressions.FloatType)
-    case CTBoolean => CodeGenType(CTBoolean, BoolType)
-    case CTNode => CodeGenType(CTNode, IntType)
-    case CTRelationship => CodeGenType(CTRelationship, IntType)
-    case _ => CodeGenType(ct, ReferenceType)
+    case ListType(innerCt) => CodeGenType(CTList(innerCt), ListReferenceType(toRepresentationType(innerCt)))
+    case _ => CodeGenType(ct, toRepresentationType(ct))
+  }
+
+  private def toRepresentationType(ct: CypherType): RepresentationType = ct match {
+    case CTInteger => IntType
+    case CTFloat => expressions.FloatType
+    case CTBoolean => BoolType
+    case CTNode => IntType
+    case CTRelationship => IntType
+    case _ => ReferenceType
   }
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1300,8 +1300,15 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     }
   }
 
-  override def nodeIdSeek(nodeIdVar: String, expression: Expression)(block: MethodStructure[Expression] => Unit) = {
-    generator.assign(typeRef[Long], nodeIdVar, invoke(Methods.mathCastToLong, expression))
+  override def nodeIdSeek(nodeIdVar: String, expression: Expression, codeGenType: CodeGenType)(block: MethodStructure[Expression] => Unit) = {
+    codeGenType match {
+      case CodeGenType(symbols.CTInteger, IntType) =>
+        generator.assign(typeRef[Long], nodeIdVar, expression)
+      case CodeGenType(symbols.CTInteger, ReferenceType) =>
+        generator.assign(typeRef[Long], nodeIdVar, invoke(Methods.mathCastToLong, expression))
+      case _ =>
+        throw new IllegalArgumentException(s"CodeGenType $codeGenType can not be converted to long")
+    }
     using(generator.ifStatement(
       gt(generator.load(nodeIdVar), constant(-1L)),
       invoke(readOperations, nodeExists, generator.load(nodeIdVar))

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -412,8 +412,8 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def unbox(expression: Expression, codeGenType: CodeGenType) = codeGenType match {
     case c if c.isPrimitive => expression
-    case CodeGenType(symbols.CTNode, ReferenceType) => invoke(expression, Methods.unboxNode)
-    case CodeGenType(symbols.CTRelationship, ReferenceType) => invoke(expression, Methods.unboxRel)
+    case CodeGenType(symbols.CTNode, ReferenceType) => invoke(Methods.unboxNode, expression)
+    case CodeGenType(symbols.CTRelationship, ReferenceType) => invoke(Methods.unboxRel, expression)
     case _ => Expression.unbox(expression)
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -492,8 +492,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def asPrimitiveStream(publicTypeList: Expression, codeGenType: CodeGenType) = {
     codeGenType match {
-      // PrimitiveNodeStream.of( (List<Node>) publicTypeList )
-
       case CodeGenType(ListType(CTNode), ListReferenceType(IntType)) =>
         Expression.invoke(methodReference(typeRef[PrimitiveNodeStream], typeRef[PrimitiveNodeStream], "of", typeRef[Object]), publicTypeList)
       case CodeGenType(ListType(CTRelationship), ListReferenceType(IntType)) =>
@@ -503,15 +501,17 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
         // short[]
         // int[]
         // long[]
-        // Object[] -> Arrays.stream((Object[]) o).mapToLong(((Number)o).longValue());
+        // Object[]
         Expression.invoke(methodReference(typeRef[CompiledConversionUtils], typeRef[LongStream], "toLongStream", typeRef[Object]), publicTypeList)
-        // TODO
-//      case CodeGenType(_, ListReferenceType(FloatType)) =>
-//        Templates.asDoubleStream(values)
-//      case CodeGenType(_, ListReferenceType(BoolType)) =>
-//        // There are no primitive streams for booleans, so we use an IntStream with value conversions
-//        // 0 = false, 1 = true
-//        Templates.asIntStream(values.map(Expression.ternary(_, Expression.constant(1), Expression.constant(0))))
+      case CodeGenType(_, ListReferenceType(FloatType)) =>
+        // float[]
+        // double[]
+        // Object[]
+        Expression.invoke(methodReference(typeRef[CompiledConversionUtils], typeRef[DoubleStream], "toDoubleStream", typeRef[Object]), publicTypeList)
+      case CodeGenType(_, ListReferenceType(BoolType)) =>
+        // boolean[]
+        // Object[]
+        Expression.invoke(methodReference(typeRef[CompiledConversionUtils], typeRef[IntStream], "toBooleanStream", typeRef[Object]), publicTypeList)
       case _ =>
         throw new IllegalArgumentException(s"CodeGenType $codeGenType not supported as primitive stream")
     }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1348,18 +1348,20 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     )
   }
 
-  override def indexSeek(iterVar: String, descriptorVar: String, value: Expression) = {
+  override def indexSeek(iterVar: String, descriptorVar: String, value: Expression, codeGenType: CodeGenType) = {
     val local = generator.declare(typeRef[PrimitiveLongIterator], iterVar)
+    val boxedValue = if (codeGenType.isPrimitive) Expression.box(value) else value
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
-      body.assign(local, invoke(readOperations, nodesGetFromIndexLookup, generator.load(descriptorVar), value))
+      body.assign(local, invoke(readOperations, nodesGetFromIndexLookup, generator.load(descriptorVar), boxedValue))
     }
   }
 
-  override def indexUniqueSeek(nodeVar: String, descriptorVar: String, value: Expression) = {
+  override def indexUniqueSeek(nodeVar: String, descriptorVar: String, value: Expression, codeGenType: CodeGenType) = {
     val local = generator.declare(typeRef[Long], nodeVar)
+    val boxedValue = if (codeGenType.isPrimitive) Expression.box(value) else value
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
       body.assign(local,
-                  invoke(readOperations, nodeGetUniqueFromIndexLookup, generator.load(descriptorVar), value))
+                  invoke(readOperations, nodeGetUniqueFromIndexLookup, generator.load(descriptorVar), boxedValue))
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
@@ -106,6 +106,6 @@ object Methods {
   val unboxBoolean = method[java.lang.Boolean, Boolean]("booleanValue")
   val unboxLong = method[java.lang.Long, Long]("longValue")
   val unboxDouble = method[java.lang.Double, Double]("doubleValue")
-  val unboxNode = method[NodeIdWrapper, Long]("id")
-  val unboxRel = method[RelationshipIdWrapper, Long]("id")
+  val unboxNode = method[CompiledConversionUtils, Long]("unboxNodeOrNull", typeRef[NodeIdWrapper])
+  val unboxRel = method[CompiledConversionUtils, Long]("unboxRelationshipOrNull", typeRef[RelationshipIdWrapper])
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
@@ -106,6 +106,6 @@ object Methods {
   val unboxBoolean = method[java.lang.Boolean, Boolean]("booleanValue")
   val unboxLong = method[java.lang.Long, Long]("longValue")
   val unboxDouble = method[java.lang.Double, Double]("doubleValue")
-  val unboxNode = method[NodeProxy, Long]("getNodeId")
-  val unboxRel = method[RelationshipProxy, Long]("getRelationshipId")
+  val unboxNode = method[NodeIdWrapper, Long]("id")
+  val unboxRel = method[RelationshipIdWrapper, Long]("id")
 }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
@@ -624,6 +624,27 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     result.toSet should equal(Set(Map("a" -> "BAR")))
   }
 
+  test("project primitive parameters") {
+
+    val plan = ProduceResult(List("a", "r1", "x", "y", "z"),
+      Projection(SingleRow()(solved), Map("a" -> Parameter("FOO_NODE", CTNode)(pos),
+                                          "r1" -> Parameter("FOO_REL",  CTRelationship)(pos),
+                                          "x" -> Parameter("FOO1", CTInteger)(pos),
+                                          "y" -> Parameter("FOO2", CTFloat)(pos),
+                                          "z" -> Parameter("FOO3", CTBoolean)(pos)))(solved))
+
+    val compiled = compileAndExecute(plan, Map("FOO_NODE" -> aNode,
+                                               "FOO_REL" -> relMap(11L).relationship,
+                                               "FOO1" -> 42L.asInstanceOf[AnyRef],
+                                               "FOO2" -> 3.14d.asInstanceOf[AnyRef],
+                                               "FOO3" -> true.asInstanceOf[AnyRef]))
+
+    //then
+    val result = getResult(compiled, "a", "r1", "x", "y", "z")
+    result.toSet should equal(Set(Map("a" -> aNode, "r1" -> relMap(11L).relationship,
+                                      "x" -> 42L, "y" -> 3.14d, "z" -> true)))
+  }
+
   test("project nodes") {
     val scan = AllNodesScan(IdName("a"), Set.empty)(solved)
     val plan = ProduceResult(List("a"), plans.Projection(scan, Map("a" -> varFor("a")))(solved))

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
@@ -624,6 +624,16 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     result.toSet should equal(Set(Map("a" -> "BAR")))
   }
 
+  test("project null parameters") {
+
+    val plan = ProduceResult(List("a"), Projection(SingleRow()(solved), Map("a" -> Parameter("FOO", CTAny)(pos)))(solved))
+    val compiled = compileAndExecute(plan, Map("FOO" -> null))
+
+    //then
+    val result = getResult(compiled, "a")
+    result.toSet should equal(Set(Map("a" -> null)))
+  }
+
   test("project primitive parameters") {
 
     val plan = ProduceResult(List("a", "r1", "x", "y", "z"),
@@ -643,6 +653,20 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     val result = getResult(compiled, "a", "r1", "x", "y", "z")
     result.toSet should equal(Set(Map("a" -> aNode, "r1" -> relMap(11L).relationship,
                                       "x" -> 42L, "y" -> 3.14d, "z" -> true)))
+  }
+
+  test("project null primitive node and relationship parameters") {
+
+    val plan = ProduceResult(List("a", "r1"),
+      Projection(SingleRow()(solved), Map("a" -> Parameter("FOO_NODE", CTNode)(pos),
+                                          "r1" -> Parameter("FOO_REL",  CTRelationship)(pos)))(solved))
+
+    val compiled = compileAndExecute(plan, Map("FOO_NODE" -> null,
+                                               "FOO_REL" -> null))
+
+    //then
+    val result = getResult(compiled, "a", "r1")
+    result.toSet should equal(Set(Map("a" -> null, "r1" -> null)))
   }
 
   test("project nodes") {


### PR DESCRIPTION
This is needed for micro-benchmarking with lists of primitive types.

Also
- Fixes some more orderability cases
- Fixes unnecessary projection of variables
