### PR TITLE
Fixes GBPTree page allocation order at creation

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -31,6 +31,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.cursor.RawCursor;
@@ -321,8 +322,14 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
     private void initializeAfterCreation( Layout<KEY,VALUE> layout ) throws IOException
     {
-        // Write meta
+        // Initialize meta
         writeMeta( layout, pagedFile );
+
+        // Initialize state
+        try ( PageCursor cursor = pagedFile.io( 0 /*ignored*/, PagedFile.PF_SHARED_WRITE_LOCK ) )
+        {
+            TreeStatePair.initializeStatePages( cursor );
+        }
 
         // Initialize index root node to a leaf node.
         try ( PageCursor cursor = openRootCursor( PagedFile.PF_SHARED_WRITE_LOCK ) )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -262,7 +262,7 @@ class TreeState
     @Override
     public String toString()
     {
-        return String.format( "pageId=%d, stableGeneration=%d, unstableGeneration=%d, rootId=%d, rootGen=%d" +
+        return String.format( "pageId=%d, stableGeneration=%d, unstableGeneration=%d, rootId=%d, rootGen=%d, " +
                 "lastId=%d, freeListWritePageId=%d, freeListReadPageId=%d, freeListWritePos=%d, freeListReadPos=%d, " +
                 "valid=%b",
                 pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
@@ -35,6 +35,20 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.checkOutOfBounds;
 class TreeStatePair
 {
     /**
+     * Initialize state pages because new pages are expected to be allocated directly after
+     * the existing highest allocated page. Otherwise there'd be a hole between meta and root pages
+     * until they would have been written, which isn't guaranteed to be handled correctly by the page cache.
+     *
+     * @param cursor {@link PageCursor} assumed to be opened with write capabilities.
+     * @throws IOException on {@link PageCursor} error.
+     */
+    static void initializeStatePages( PageCursor cursor ) throws IOException
+    {
+        PageCursorUtil.goTo( cursor, "State page A", IdSpace.STATE_PAGE_A );
+        PageCursorUtil.goTo( cursor, "State page B", IdSpace.STATE_PAGE_B );
+    }
+
+    /**
      * Reads the tree state pair, one from each of {@code pageIdA} and {@code pageIdB}, deciding their validity
      * and returning them as a {@link Pair}.
      * do-shouldRetry is managed inside this method because data is read from two pages.


### PR DESCRIPTION
where previously it wouldn't allocate pages for the initial meta/state creation
in strict order of rising page id. This would have the page cache on some devices
produce unexpected content on some of those pages.