### PR TITLE
Fix wrong return value from visit keys iterator

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
@@ -80,7 +80,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
         labelIds.visitKeys( labelId ->
         {
             counts.incrementNodeCount( labelId, -1 );
-            return true;
+            return false;
         } );
 
         node.degrees().forAll(

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
@@ -94,6 +94,36 @@ public class LabelCountsTest
     }
 
     @Test
+    public void shouldAccountForDeletedNodesWithMultipleLabels() throws Exception
+    {
+        // given
+        GraphDatabaseService graphDb = db.getGraphDatabaseAPI();
+        Node node;
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            node = graphDb.createNode( label( "Foo" ), label( "Bar" ) );
+            graphDb.createNode( label( "Foo" ) );
+            graphDb.createNode( label( "Bar" ) );
+
+            tx.success();
+        }
+        try ( Transaction tx = graphDb.beginTx() )
+        {
+            node.delete();
+
+            tx.success();
+        }
+
+        // when
+        long fooCount = numberOfNodesWith( label( "Foo" ) );
+        long barCount = numberOfNodesWith( label( "Bar" ) );
+
+        // then
+        assertEquals( 1, fooCount );
+        assertEquals( 1, barCount );
+    }
+
+    @Test
     public void shouldAccountForAddedLabels() throws Exception
     {
         // given


### PR DESCRIPTION
We should return false to visit all labels in the set rather than
breaking after the first one.