### PR TITLE
 Extend GraphDatabaseService to allow procedures to start transactions in new threads

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.api.proc;
 
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.SecurityContext;
 
 /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1542,6 +1542,7 @@ public class OperationsFacade
             BasicContext ctx = new BasicContext();
             ctx.put( Context.KERNEL_TRANSACTION, tx );
             ctx.put( Context.THREAD, Thread.currentThread() );
+            ctx.put( Context.SECURITY_CONTEXT, procedureSecurityContext );
             procedureCall = procedures.callProcedure( ctx, name, input );
         }
         return new RawIterator<Object[],ProcedureException>()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -371,8 +371,6 @@ public class DataSourceModule
         Guard guard = platform.dependencies.resolveDependency( Guard.class );
         procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ), true );
 
-        // Register injected private API components: useful to have available in procedures to access the kernel etc.
-
         // Below components are not public API, but are made available for internal
         // procedures to call, and to provide temporary workarounds for the following
         // patterns:

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -235,6 +235,10 @@ public class DataSourceModule
 
         this.storeId = neoStoreDataSource::getStoreId;
         this.kernelAPI = neoStoreDataSource::getKernel;
+
+        ProcedureGDSFactory gdsFactory = new ProcedureGDSFactory( platformModule, this, deps,
+                editionModule.coreAPIAvailabilityGuard );
+        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply, true );
     }
 
     protected RelationshipProxy.RelationshipActions createRelationshipActions(
@@ -368,10 +372,6 @@ public class DataSourceModule
         procedures.registerComponent( TerminationGuard.class, new TerminationGuardProvider( guard ), true );
 
         // Register injected private API components: useful to have available in procedures to access the kernel etc.
-        ProcedureGDSFactory gdsFactory = new ProcedureGDSFactory( platform.config, platform.storeDir,
-                platform.dependencies, storeId, this.queryExecutor, editionModule.coreAPIAvailabilityGuard,
-                platform.urlAccessRule );
-        procedures.registerComponent( GraphDatabaseService.class, gdsFactory::apply, true );
 
         // Below components are not public API, but are made available for internal
         // procedures to call, and to provide temporary workarounds for the following

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -182,7 +182,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
     }
 
     @Override
-    public KernelTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+    public KernelTransaction beginTransaction( KernelTransaction.Type type, SecurityContext ignoredSecurityContext, long timeout )
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
@@ -19,79 +19,55 @@
  */
 package org.neo4j.kernel.impl.proc;
 
-import java.io.File;
 import java.net.URL;
-import java.util.function.Supplier;
 
 import org.neo4j.function.ThrowingFunction;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.graphdb.security.URLAccessValidationError;
-import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.legacyindex.AutoIndexing;
 import org.neo4j.kernel.api.proc.Context;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.guard.Guard;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
+import org.neo4j.kernel.impl.factory.DataSourceModule;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.kernel.impl.query.QueryExecutionEngine;
-import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.factory.PlatformModule;
 
 public class ProcedureGDSFactory implements ThrowingFunction<Context,GraphDatabaseService,ProcedureException>
 {
-    private Config config;
-    private final File storeDir;
+    private final PlatformModule platform;
+    private final DataSourceModule dataSource;
     private final DependencyResolver resolver;
-    private final Supplier<StoreId> storeId;
-    private final Supplier<QueryExecutionEngine> queryExecutor;
     private final CoreAPIAvailabilityGuard availability;
     private final ThrowingFunction<URL, URL, URLAccessValidationError> urlValidator;
-    private final Guard guard;
-    private final ThreadToStatementContextBridge txBridge;
 
-    public ProcedureGDSFactory( Config config,
-                                File storeDir,
-                                DependencyResolver resolver,
-                                Supplier<StoreId> storeId,
-                                Supplier<QueryExecutionEngine> queryExecutor,
-                                CoreAPIAvailabilityGuard availability,
-                                URLAccessRule urlAccessRule )
+    public ProcedureGDSFactory( PlatformModule platform, DataSourceModule dataSource, DependencyResolver resolver,
+            CoreAPIAvailabilityGuard coreAPIAvailabilityGuard )
     {
-        this.config = config;
-        this.storeDir = storeDir;
+        this.platform = platform;
+        this.dataSource = dataSource;
         this.resolver = resolver;
-        this.storeId = storeId;
-        this.queryExecutor = queryExecutor;
-        this.availability = availability;
-        this.urlValidator = url -> urlAccessRule.validate( config, url );
-        this.guard = resolver.resolveDependency( Guard.class );
-        this.txBridge = resolver.resolveDependency( ThreadToStatementContextBridge.class );
+        this.availability = coreAPIAvailabilityGuard;
+        this.urlValidator = url -> platform.urlAccessRule.validate( platform.config, url );
     }
 
     @Override
     public GraphDatabaseService apply( Context context ) throws ProcedureException
     {
-        KernelTransaction transaction = context.get( Context.KERNEL_TRANSACTION );
-        Thread owningThread = context.get( Context.THREAD );
+        SecurityContext securityContext = context.getOrElse( Context.SECURITY_CONTEXT, SecurityContext.AUTH_DISABLED );
         GraphDatabaseFacade facade = new GraphDatabaseFacade();
         facade.init(
             new ProcedureGDBFacadeSPI(
-                owningThread,
-                transaction,
-                queryExecutor,
-                storeDir,
+                platform,
+                dataSource,
                 resolver,
-                AutoIndexing.UNSUPPORTED,
-                storeId,
                 availability,
-                urlValidator
+                urlValidator,
+                securityContext
             ),
-            guard,
-            txBridge,
-            config
+            dataSource.guard,
+            dataSource.threadToTransactionBridge,
+            platform.config
         );
         return facade;
     }

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -37,12 +37,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -53,7 +51,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -68,7 +65,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -824,7 +820,7 @@ public class ProcedureIT
     {
         // given
         Runnable doIt = () -> {
-            Result result = db.execute( "CALL org.neo4j.procedure.unsupportedProcedure()" );
+            Result result = db.execute( "CALL org.neo4j.procedure.supportedProcedure()" );
             while ( result.hasNext() )
             {
                 result.next();
@@ -1539,7 +1535,7 @@ public class ProcedureIT
         }
 
         @Procedure( mode = WRITE )
-        public void unsupportedProcedure()
+        public void supportedProcedure()
         {
             jobs.submit( () -> {
                 try ( Transaction tx = db.beginTx() )


### PR DESCRIPTION
This was previously not allowed since it meant that procedure authors could bypass security. Now all new transactions will be limited with the same access level as the procedure.