### PR TITLE
PropertyRecord.getType() now returns PropertyType instead of int

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/RecordCheckTestBase.java
@@ -240,16 +240,8 @@ public abstract class RecordCheckTestBase<RECORD extends AbstractBaseRecord,
 
     static PropertyBlock propertyBlock( PropertyKeyTokenRecord key, DynamicRecord value )
     {
-        PropertyType type;
-        if ( value.getType() == PropertyType.STRING.intValue() )
-        {
-            type = PropertyType.STRING;
-        }
-        else if ( value.getType() == PropertyType.ARRAY.intValue() )
-        {
-            type = PropertyType.ARRAY;
-        }
-        else
+        PropertyType type = value.getType();
+        if ( value.getType() != PropertyType.STRING && value.getType() != PropertyType.ARRAY )
         {
             fail( "Dynamic record must be either STRING or ARRAY" );
             return null;

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
@@ -333,15 +333,15 @@ public class RecordAccessStub implements RecordAccess
         else if ( newRecord instanceof DynamicRecord )
         {
             DynamicRecord dyn = (DynamicRecord) newRecord;
-            if ( dyn.getType() == PropertyType.STRING.intValue() )
+            if ( dyn.getType() == PropertyType.STRING )
             {
                 add( strings, (DynamicRecord) oldRecord, dyn );
             }
-            else if ( dyn.getType() == PropertyType.ARRAY.intValue() )
+            else if ( dyn.getType() == PropertyType.ARRAY )
             {
                 add( arrays, (DynamicRecord) oldRecord, dyn );
             }
-            else if ( dyn.getType() == SCHEMA_RECORD_TYPE )
+            else if ( dyn.getTypeAsInt() == SCHEMA_RECORD_TYPE )
             {
                 add( schemata, (DynamicRecord) oldRecord, dyn );
             }
@@ -386,15 +386,15 @@ public class RecordAccessStub implements RecordAccess
         else if ( record instanceof DynamicRecord )
         {
             DynamicRecord dyn = (DynamicRecord) record;
-            if ( dyn.getType() == PropertyType.STRING.intValue() )
+            if ( dyn.getType() == PropertyType.STRING )
             {
                 addString( dyn );
             }
-            else if ( dyn.getType() == PropertyType.ARRAY.intValue() )
+            else if ( dyn.getType() == PropertyType.ARRAY )
             {
                 addArray( dyn );
             }
-            else if ( dyn.getType() == SCHEMA_RECORD_TYPE )
+            else if ( dyn.getTypeAsInt() == SCHEMA_RECORD_TYPE )
             {
                 addSchema( dyn );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -139,11 +139,12 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
     {
         for ( DynamicRecord valueRecord : records )
         {
-            if ( valueRecord.getType() == PropertyType.STRING.intValue() )
+            PropertyType recordType = valueRecord.getType();
+            if ( recordType == PropertyType.STRING )
             {
                 stringStore.updateRecord( valueRecord );
             }
-            else if ( valueRecord.getType() == PropertyType.ARRAY.intValue() )
+            else if ( recordType == PropertyType.ARRAY )
             {
                 arrayStore.updateRecord( valueRecord );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/DynamicRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/DynamicRecord.java
@@ -93,7 +93,19 @@ public class DynamicRecord extends AbstractBaseRecord
         return startRecord;
     }
 
-    public int getType()
+    /**
+     * @return The {@link PropertyType} of this record or null if unset or non valid
+     */
+    public PropertyType getType()
+    {
+        return PropertyType.getPropertyTypeOrNull( (long) (this.type << 24) );
+    }
+
+    /**
+     * @return The {@link #type} field of this record, as set by previous invocations to {@link #setType(int)} or
+     * {@link #initialize(boolean, boolean, long, int, int)}
+     */
+    public int getTypeAsInt()
     {
         return type;
     }
@@ -148,7 +160,7 @@ public class DynamicRecord extends AbstractBaseRecord
                 .append( getId() )
                 .append( ",used=" ).append(inUse() ).append( "," )
                 .append("(" ).append( length ).append( "),type=" );
-        PropertyType type = PropertyType.getPropertyTypeOrNull( (long) (this.type << 24) );
+        PropertyType type = getType();
         if ( type == null ) buf.append( this.type ); else buf.append( type.name() );
         buf.append( ",data=" );
         if ( type == PropertyType.STRING && data.length <= MAX_CHARS_IN_TO_STRING )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
@@ -156,7 +156,7 @@ public abstract class Command implements StorageCommand
                 inUse |= Record.FIRST_IN_CHAIN.byteValue();
             }
             channel.putLong( record.getId() )
-                   .putInt( record.getType() )
+                   .putInt( record.getTypeAsInt() )
                    .put( inUse )
                    .putInt( record.getLength() )
                    .putLong( record.getNextBlock() );
@@ -168,7 +168,7 @@ public abstract class Command implements StorageCommand
         {
             byte inUse = Record.NOT_IN_USE.byteValue();
             channel.putLong( record.getId() )
-                   .putInt( record.getType() )
+                   .putInt( record.getTypeAsInt() )
                    .put( inUse );
         }
     }


### PR DESCRIPTION
Reading the property type and converting to a PropertyType value
 requires bit shifting and masking that is not achieved by simply
 using the type int value as read from disk. This can lead to
 improper identification of the record type during recovery, among
 other scenarios.
This patch changes the PropertyRecord.getType() method to return
 PropertyType, properly parsed. It adds a getTypeAsInt() method
 to allow for access to the raw int value for serialization
 purposes.