### PR TITLE
Unflake TestBranchedData

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -537,18 +537,58 @@ public abstract class SwitchToSlave
         }
     }
 
+    /**
+     * Monitors events in {@link SwitchToSlave}
+     */
     public interface Monitor
     {
-        void switchToSlaveStarted();
+        /**
+         * Called before any other slave-switching code is executed.
+         */
+        default void switchToSlaveStarted()
+        {   // no-op by default
+        }
 
-        void switchToSlaveCompleted( boolean wasSuccessful );
+        /**
+         * Called after all slave-switching code has been executed, regardless of whether it was successful or not.
+         *
+         * @param wasSuccessful whether or not the slave switch was successful. Depending on the type of failure
+         * other failure handling outside this class kicks in and there may be a switch retry later.
+         */
+        default void switchToSlaveCompleted( boolean wasSuccessful )
+        {   // no-op by default
+        }
 
-        void storeCopyStarted();
+        /**
+         * A full store-copy is required, either if this is the first time this db starts up or if this
+         * store has branched and needs to fetch a new copy from master.
+         */
+        default void storeCopyStarted()
+        {   // no-op by default
+        }
 
-        void storeCopyCompleted( boolean wasSuccessful );
+        /**
+         * A full store-copy has completed.
+         *
+         * @param wasSuccessful whether or not this store-copy was successful.
+         */
+        default void storeCopyCompleted( boolean wasSuccessful )
+        {   // no-op by default
+        }
 
-        void catchupStarted();
+        /**
+         * After a successful handshake with master an optimized catch-up is performed.
+         * This call marks the start of that.
+         */
+        default void catchupStarted()
+        {   // no-op by default
+        }
 
-        void catchupCompleted();
+        /**
+         * This db is now caught up with the master.
+         */
+        default void catchupCompleted()
+        {   // no-op by default
+        }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionIT.java
@@ -37,7 +37,7 @@ import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.NetworkFlag;
 import org.neo4j.test.rule.LoggerRule;
-import org.neo4j.test.rule.RetryOnTransientFailure;
+import org.neo4j.test.rule.RetryACoupleOfTimesHandler;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -52,6 +52,8 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesSlavesAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.memberSeesOtherMemberAsFailed;
 import static org.neo4j.test.rule.DatabaseRule.tx;
+import static org.neo4j.test.rule.RetryACoupleOfTimesHandler.TRANSIENT_ERRORS;
+import static org.neo4j.test.rule.RetryACoupleOfTimesHandler.retryACoupleOfTimesOn;
 
 public class ClusterPartitionIT
 {
@@ -364,7 +366,7 @@ public class ClusterPartitionIT
     {
         assertEquals( PENDING, instance.getInstanceState() );
 
-        tx( instance, new RetryOnTransientFailure(),
+        tx( instance, retryACoupleOfTimesOn( TRANSIENT_ERRORS ),
                 db -> assertEquals( testPropValue, instance.getNodeById( testNodeId ).getProperty( testPropKey ) ) );
 
         try ( Transaction ignored = instance.beginTx() )
@@ -380,7 +382,7 @@ public class ClusterPartitionIT
 
     private void ensureInstanceIsWritable( HighlyAvailableGraphDatabase instance )
     {
-        tx( instance, new RetryOnTransientFailure(),
+        tx( instance, retryACoupleOfTimesOn( TRANSIENT_ERRORS ),
                 db -> db.createNode().setProperty( testPropKey, testPropValue ) );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -458,38 +458,10 @@ public class HighAvailabilityMemberStateMachineTest
         SwitchToSlave.Monitor monitor = new SwitchToSlave.Monitor()
         {
             @Override
-            public void switchToSlaveStarted()
-            {
-            }
-
-            @Override
             public void switchToSlaveCompleted( boolean wasSuccessful )
             {
                 switchedSuccessfully.set( wasSuccessful );
                 latch.countDown();
-            }
-
-            @Override
-            public void storeCopyStarted()
-            {
-            }
-
-            @Override
-            public void storeCopyCompleted( boolean wasSuccessful )
-            {
-
-            }
-
-            @Override
-            public void catchupStarted()
-            {
-
-            }
-
-            @Override
-            public void catchupCompleted()
-            {
-
             }
         };
 


### PR DESCRIPTION
Problem being that after a role switch there were 3 big transactions w/ indexing and everything
taking place which, on some JVMs, caused full GC pauses on up to 2s. This was a problem because
the heartbeat timeout in ClusterManager is 2s and so the cluster would go into an unstable state
and try to switch role right when the transaction would commit, causing the test to fail.

This commit changes this test so that it no longer performs these big transactions.
There were no apparent reason for those transactions being so big, potentially it could be
(as the comment in the test suggests) that it wanted the lucene index files to change underneath.
Although there were no checking of those files, rather it would most likely use the suggested
file changes to verify that a branch + store-copy was actually performed.

Now instead the test installs a monitor to assert that a store-copy is performed on the
correct instances after the repair has been done.