### PR TITLE
More consistent DynamicIndexStoreViewIT test time

### DIFF
--- a/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
+++ b/community/neo4j/src/test/java/schema/DynamicIndexStoreViewIT.java
@@ -24,12 +24,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -76,29 +77,36 @@ public class DynamicIndexStoreViewIT
                 counter++;
             }
 
-            List<Populator> populators = new ArrayList<>();
+            int populatorCount = 5;
+            ExecutorService executor = Executors.newFixedThreadPool( populatorCount );
             CountDownLatch startSignal = new CountDownLatch( 1 );
-            for ( int i = 0; i < 5; i++ )
+            AtomicBoolean endSignal = new AtomicBoolean();
+            for ( int i = 0; i < populatorCount; i++ )
             {
-                Populator populator = new Populator( database, counter, startSignal );
-                populators.add( populator );
-                populator.start();
+                executor.submit( new Populator( database, counter, startSignal, endSignal ) );
             }
 
-            try ( Transaction transaction = database.beginTx() )
+            try
             {
-                database.schema().indexFor( Label.label( "label10" ) ).on( "property" ).create();
-                transaction.success();
-            }
-            startSignal.countDown();
+                try ( Transaction transaction = database.beginTx() )
+                {
+                    database.schema().indexFor( Label.label( "label10" ) ).on( "property" ).create();
+                    transaction.success();
+                }
+                startSignal.countDown();
 
-            try ( Transaction transaction = database.beginTx() )
+                try ( Transaction transaction = database.beginTx() )
+                {
+                    database.schema().awaitIndexesOnline( populatorCount, TimeUnit.MINUTES );
+                    transaction.success();
+                }
+            }
+            finally
             {
-                database.schema().awaitIndexesOnline( 5, TimeUnit.MINUTES );
-                transaction.success();
+                endSignal.set( true );
+                executor.shutdown();
+                // Basically we don't care to await their completion because they've done their job
             }
-
-            populators.forEach( Populator::terminate );
         }
         finally
         {
@@ -111,25 +119,27 @@ public class DynamicIndexStoreViewIT
         }
     }
 
-    private class Populator extends Thread
+    private class Populator implements Runnable
     {
         private final GraphDatabaseService databaseService;
         private final long totalNodes;
-        private volatile boolean terminate;
         private final CountDownLatch startSignal;
+        private final AtomicBoolean endSignal;
 
-        Populator( GraphDatabaseService databaseService, long totalNodes, CountDownLatch startSignal )
+        Populator( GraphDatabaseService databaseService, long totalNodes, CountDownLatch startSignal,
+                AtomicBoolean endSignal )
         {
             this.databaseService = databaseService;
             this.totalNodes = totalNodes;
             this.startSignal = startSignal;
+            this.endSignal = endSignal;
         }
 
         @Override
         public void run()
         {
             awaitLatch( startSignal );
-            while ( !terminate )
+            while ( !endSignal.get() )
             {
                 try ( Transaction transaction = databaseService.beginTx() )
                 {
@@ -166,11 +176,6 @@ public class DynamicIndexStoreViewIT
                     }
                 }
             }
-        }
-
-        void terminate()
-        {
-            terminate = true;
         }
     }
 }


### PR DESCRIPTION
This test takes a couple of seconds to run normally, but now and then takes
up to minutes or hours!

Problem was that there was a race where five threads were created, threads which
busy-looped on making transactions revolving nodes and properties.
Such transactions acquire the schema read lock. The main test thread would,
after starting these other threads, go on to creating an index, a transaction
which needs to acquire the schema write lock. If those other threads had started
before the main thread would have came as far as acquiring the schema write lock
the test would get itself into a situation where the main thread could face
starvation and be waiting for an unknown amount of time since the other threads
would constantly acquire the schema read lock, overlapping with each other
and basically never let the main thread create the index.

This commit starts the other threads, but let them wait for a count down latch
and let them loose as soon as the index has been created, letting them race
with the population of that index. Number of concurrent updates fed into the
index populator has been verified to be the same as before this change.