### PR TITLE
Removed cypher dependency on kernel schema classes

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/IndexSeekMode.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/IndexSeekMode.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQueryExpression}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 case class IndexSeekModeFactory(unique: Boolean, readOnly: Boolean) {
   def fromQueryExpression[T](qexpr: QueryExpression[T]) = qexpr match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
@@ -23,10 +23,10 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.Index
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelToken, PropertyKeyToken}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols.CTNode
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 case class NodeIndexScanPipe(ident: String,
                              label: LabelToken,
@@ -34,7 +34,7 @@ case class NodeIndexScanPipe(ident: String,
                             (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends Pipe with RonjaPipe {
 
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
@@ -25,11 +25,11 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQ
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Index, InequalityIndex, PrefixIndex}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.InternalException
 import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelToken, PropertyKeyToken}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols.CTNode
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 case class NodeIndexSeekPipe(ident: String,
                              label: LabelToken,
@@ -39,7 +39,7 @@ case class NodeIndexSeekPipe(ident: String,
                             (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends Pipe with RonjaPipe {
 
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   private val indexFactory = indexMode.indexFactory(descriptor)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -23,9 +23,9 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.QueryExpression
 import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexLookupUnfulfillableNotification
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 
 abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -21,11 +21,11 @@ package org.neo4j.cypher.internal.compiler.v2_3.spi
 
 import java.net.URL
 
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{KernelPredicate, Expander}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{Path, Relationship, PropertyContainer, Node}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
 
 class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
@@ -20,10 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.EntityProducer
-import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{TraversalMatcher, ExpanderStep}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{ExpanderStep, TraversalMatcher}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.graphdb.Node
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 /**
  * PlanContext is an internal access layer to the graph that is solely used during plan building

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -24,10 +24,9 @@ import java.net.URL
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{Path, PropertyContainer, Relationship, Node}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
 
 /*
  * Developer note: This is an attempt at an internal graph database API, which defines a clean cut between

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/RepeatableReadQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/RepeatableReadQueryContext.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{PropertyContainer, Relationship, Node}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 
 
 trait Locker {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/SchemaTypes.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/SchemaTypes.scala
@@ -17,6 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3
+package org.neo4j.cypher.internal.compiler.v2_3.spi
 
-case class IndexDescriptor(label: Int, property: Int)
+object SchemaTypes {
+  case class UniquenessConstraint( labelId:Int, propertyId:Int )
+  case class NodePropertyExistenceConstraint( labelId:Int, propertyId:Int)
+  case class RelationshipPropertyExistenceConstraint( relTypeId:Int, propertyId:Int)
+  case class IndexDescriptor( labelId:Int, propertyId:Int)
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -21,13 +21,13 @@ package org.neo4j.cypher.internal.compiler.v2_3.executionplan
 
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v2_3.{Monitors, PreparedQuery, devNullLogger}
 import org.neo4j.cypher.internal.frontend.v2_3.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v2_3.{Scope, SemanticTable}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class RuleExecutablePlanBuilderTest extends CypherFunSuite {
   val planContext: PlanContext = mock[PlanContext]
@@ -53,7 +53,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
 
     when(planContext.getOptLabelId("Person")).thenReturn(Some(1))
     when(planContext.getOptPropertyKeyId("name")).thenReturn(Some(1))
-    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(new IndexDescriptor(1, 1)))
+    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(IndexDescriptor(1, 1)))
     when(planContext.getUniquenessConstraint("Person", "name")).thenReturn(None)
 
     val pipe = buildExecutionPipe("LOAD CSV FROM 'file:///tmp/foo.csv' AS line MATCH (p:Person { name: line[0] }) RETURN p;")
@@ -66,7 +66,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
 
     when(planContext.getOptLabelId("Person")).thenReturn(Some(1))
     when(planContext.getOptPropertyKeyId("name")).thenReturn(Some(1))
-    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(new IndexDescriptor(1, 1)))
+    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(IndexDescriptor(1, 1)))
     when(planContext.getUniquenessConstraint("Person", "name")).thenReturn(None)
 
     val pipe = buildExecutionPipe("LOAD CSV FROM 'file:///tmp/foo.csv' AS line MATCH (p:Person { name: \"Foo Bar Baz\" }) RETURN p;")

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/EntityProducerFactoryTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/EntityProducerFactoryTest.scala
@@ -24,10 +24,10 @@ import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryStateHelper
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{PlanContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v2_3.IndexHintException
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class EntityProducerFactoryTest extends CypherFunSuite {
   var planContext: PlanContext = null
@@ -54,7 +54,7 @@ class EntityProducerFactoryTest extends CypherFunSuite {
     //GIVEN
     val label: String = "label"
     val prop: String = "prop"
-    val index: IndexDescriptor = new IndexDescriptor(123,456)
+    val index: IndexDescriptor = IndexDescriptor(123,456)
     val value = 42
     val queryContext: QueryContext = mock[QueryContext]
     when(planContext.getIndexRule(label, prop)).thenReturn(Some(index))
@@ -87,7 +87,7 @@ class EntityProducerFactoryTest extends CypherFunSuite {
     //GIVEN
     val labelName = "Label"
     val propertyKey = "prop"
-    val index: IndexDescriptor = new IndexDescriptor(123, 456)
+    val index: IndexDescriptor = IndexDescriptor(123, 456)
     when(planContext.getIndexRule(labelName, propertyKey)).thenReturn(Some(index))
     val producer = factory.nodeByIndexHint(readOnly = true)(planContext -> SchemaIndex("x", labelName, propertyKey, AnyIndex, Some(SingleQueryExpression(Literal(Seq(1,2,3))))))
     val queryContext: QueryContext = mock[QueryContext]

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/NodeFetchStrategyTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/NodeFetchStrategyTest.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.AnyInCollection
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Collection, Identifier, Property}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.{Equals, HasLabel}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{UnresolvedLabel, UnresolvedProperty}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.ast
@@ -32,7 +33,6 @@ import org.neo4j.cypher.internal.frontend.v2_3.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class NodeFetchStrategyTest extends CypherFunSuite {
   val propertyName = "prop"
@@ -44,7 +44,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val equalityPredicate = Equals(Property(Identifier("a"), UnresolvedProperty(propertyName)), Identifier("b"))
     val labelPredicate = HasLabel(Identifier("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
 
@@ -61,7 +61,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val equalityPredicate = Equals(Property(Identifier("a"), UnresolvedProperty(propertyName)), Identifier("b"))
     val labelPredicate = HasLabel(Identifier("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
     when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)
@@ -79,7 +79,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val inPredicate = AnyInCollection(Collection(Identifier("b")),"_inner_",Equals(Property(Identifier("a"), UnresolvedProperty(propertyName)), Identifier("_inner_")))
     val labelPredicate = HasLabel(Identifier("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
     when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/StartPointBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/StartPointBuilderTest.scala
@@ -28,10 +28,10 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Equals
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.TokenType.PropertyKey
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.PartiallySolvedQuery
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.NodeStartPipe
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v2_3.{ExclusiveBound, InclusiveBound, IndexHintException}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class StartPointBuilderTest extends BuilderTest {
 
@@ -51,7 +51,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -62,7 +62,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -73,7 +73,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -85,7 +85,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -96,7 +96,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -108,7 +108,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -119,7 +119,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -130,7 +130,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -188,7 +188,7 @@ class StartPointBuilderTest extends BuilderTest {
       where = Seq(Unsolved(Equals(Property(Identifier("n"), propertyKey), Literal("Stefan")))),
       start = Seq(Unsolved(SchemaIndex("n", labelName, propertyKey.name, AnyIndex, Some(SingleQueryExpression(Literal("a")))))))
 
-    when(context.getIndexRule(labelName, propertyKey.name)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyKey.name)).thenReturn(Some(IndexDescriptor(123,456)))
 
     //THEN
     val producedPlan = assertAccepts(q)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/StartPointChoosingBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/StartPointChoosingBuilderTest.scala
@@ -29,13 +29,12 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.values.TokenType._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.PartiallySolvedQuery
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.FakePipe
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
-import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, ast}
 import org.neo4j.cypher.internal.frontend.v2_3.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, ast}
 
 class StartPointChoosingBuilderTest extends BuilderTest {
   def builder = new StartPointChoosingBuilder
@@ -89,7 +88,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
         Equals(Property(Identifier(identifier), PropertyKey("prop1")), Literal("banana")))
     )
 
-    when(context.getIndexRule("Person", "prop1")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop1")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -120,7 +119,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -139,8 +138,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -158,7 +157,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -177,8 +176,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -196,7 +195,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -215,7 +214,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -234,8 +233,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -254,8 +253,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -279,7 +278,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
           patterns = Seq(SingleNode(identifier))
         )
 
-        when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123, 456)))
+        when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123, 456)))
         when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
         // When
@@ -308,7 +307,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
           patterns = Seq(SingleNode(identifier))
         )
 
-        when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123, 456)))
+        when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123, 456)))
         when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
         // When
@@ -332,10 +331,10 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
     when(context.getUniquenessConstraint( label, property )).thenReturn(None)
-    when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(Some(new UniquenessConstraint(2468,3579)))
+    when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(Some(UniquenessConstraint(2468,3579)))
 
     // When
     val result = assertAccepts(query).query
@@ -354,9 +353,9 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(identifier)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
-    when(context.getUniquenessConstraint( label, property )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
+    when(context.getUniquenessConstraint( label, property )).thenReturn(Some(UniquenessConstraint(123,456)))
     when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(None)
 
     // When

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipeTest.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.mockito.Mockito._
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelToken, PropertyKeyToken, _}
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v2_3.{LabelId, PropertyKeyId}
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class NodeIndexScanPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
@@ -33,7 +33,7 @@ class NodeIndexScanPipeTest extends CypherFunSuite with AstConstructionTestSuppo
 
   private val label = LabelToken(LabelName("LabelName")_, LabelId(11))
   private val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName")_, PropertyKeyId(10))
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
   private val node = mock[Node]
 
   test("should return nodes found by index scan when both labelId and property key id are solved at compile time") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipeTest.scala
@@ -24,12 +24,12 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Collection, Expression, Identifier, Literal}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{ManyQueryExpression, QueryExpression, RangeQueryExpression, SingleQueryExpression}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v2_3.{CypherTypeException, InternalException, LabelId, PropertyKeyId}
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
@@ -37,7 +37,7 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
 
   val label = LabelToken(LabelName("LabelName") _, LabelId(11))
   val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName") _, PropertyKeyId(10))
-  val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
   val node = mock[Node]
   val node2 = mock[Node]
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipePlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipePlanDescriptionTest.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Literal
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class StartPipePlanDescriptionTest extends CypherFunSuite {
 
@@ -40,7 +40,7 @@ class StartPipePlanDescriptionTest extends CypherFunSuite {
     super.beforeEach()
     planContext = mock[PlanContext]
     factory = new EntityProducerFactory
-    when(planContext.getIndexRule(label, prop)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(planContext.getIndexRule(label, prop)).thenReturn(Some(IndexDescriptor(123,456)))
     when(planContext.getOptLabelId(label)).thenReturn(Some(1))
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.greedy.{GreedyPla
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.rewriter.{LogicalPlanRewriter, unnestApply}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{GraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v2_3._
@@ -39,8 +40,6 @@ import org.neo4j.cypher.internal.frontend.v2_3.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.graphdb.Node
 import org.neo4j.helpers.collection.Visitable
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 import org.neo4j.kernel.impl.util.dbstructure.DbStructureVisitor
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 
@@ -93,7 +92,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getUniqueIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] =
         if (config.uniqueIndexes((labelName, propertyKey)))
-          Some(new IndexDescriptor(
+          Some(IndexDescriptor(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))
@@ -102,7 +101,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getUniquenessConstraint(labelName: String, propertyKey: String): Option[UniquenessConstraint] = {
         if (config.uniqueIndexes((labelName, propertyKey)))
-          Some(new UniquenessConstraint(
+          Some(UniquenessConstraint(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))
@@ -112,7 +111,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] =
         if (config.indexes((labelName, propertyKey)) || config.uniqueIndexes((labelName, propertyKey)))
-          Some(new IndexDescriptor(
+          Some(IndexDescriptor(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ExtractBestPlanTest.scala
@@ -24,12 +24,12 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v2_3.RecordingNotificationLogger
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.notification.{IndexHintUnfulfillableNotification, JoinHintUnfulfillableNotification}
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, IndexHintException, JoinHintException}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v2_3.{IndexHintException, JoinHintException, SemanticDirection}
 
 class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -52,7 +52,7 @@ class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport
   private def getPlanContext(hasIndex: Boolean): PlanContext = {
 
     val planContext = newMockedPlanContext
-    val indexDescriptor: Option[IndexDescriptor] = if (hasIndex) Option(new IndexDescriptor(0,0)) else None
+    val indexDescriptor: Option[IndexDescriptor] = if (hasIndex) Option(IndexDescriptor(0,0)) else None
 
     when(planContext.getIndexRule(anyString(),anyString())).thenReturn(indexDescriptor)
     when(planContext.getUniqueIndexRule(anyString(),anyString())).thenReturn(None)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
@@ -24,10 +24,9 @@ import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Node, Relationship}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class UpdateCountingQueryContextTest extends CypherFunSuite {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -22,13 +22,13 @@ package org.neo4j.cypher.internal.compatibility
 import java.net.URL
 
 import org.neo4j.cypher.internal.compiler.v2_3.spi
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException}
-import org.neo4j.graphdb.{ConstraintViolationException => KernelConstraintViolationException, Node, PropertyContainer, Relationship}
+import org.neo4j.graphdb.{Node, PropertyContainer, Relationship, ConstraintViolationException => KernelConstraintViolationException}
 import org.neo4j.kernel.api.TokenNameLookup
 import org.neo4j.kernel.api.exceptions.KernelException
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends DelegatingQueryContext(inner) {
   override def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.spi.v2_3
 
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.kernel.api.index.{IndexDescriptor => KernelIndexDescriptor}
 
 trait IndexDescriptorCompatibility {
   implicit def toKernelIndexDescriptor(descriptor: IndexDescriptor): KernelIndexDescriptor =
-    new KernelIndexDescriptor(descriptor.label, descriptor.property)
+    new KernelIndexDescriptor(descriptor.labelId, descriptor.propertyId)
 
   implicit def toCypherIndexDescriptor(descriptor: KernelIndexDescriptor): IndexDescriptor =
-    new IndexDescriptor(descriptor.getLabelId, descriptor.getPropertyKeyId)
+    IndexDescriptor(descriptor.getLabelId, descriptor.getPropertyKeyId)
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -22,15 +22,15 @@ package org.neo4j.cypher.internal.spi.v2_3
 import org.neo4j.cypher.MissingIndexException
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.EntityProducer
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.ExpanderStep
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
-import org.neo4j.graphdb.{Node, GraphDatabaseService}
+import org.neo4j.graphdb.{GraphDatabaseService, Node}
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
+import org.neo4j.kernel.api.constraints.{UniquenessConstraint => KernelUniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
-import org.neo4j.kernel.api.index.{IndexDescriptor => KernelIndexDescriptor, InternalIndexState}
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
+import org.neo4j.kernel.api.index.{InternalIndexState, IndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
 import scala.collection.JavaConverters._
@@ -80,7 +80,7 @@ class TransactionBoundPlanContext(initialStatement: Statement, val gdb: GraphDat
 
     import scala.collection.JavaConverters._
     statement.readOperations().constraintsGetForLabelAndPropertyKey(labelId, propertyKeyId).asScala.collectFirst {
-      case unique: UniquenessConstraint => unique
+      case unique: KernelUniquenessConstraint => UniquenessConstraint(unique.label(), unique.propertyKey())
     }
   } catch {
     case _: KernelException => None

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.spi.v2_3.TransactionBoundQueryContext.IndexSearchMonitor
-import org.neo4j.cypher.internal.compiler.v2_3.IndexDescriptor
 
 class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
   test("should be able to use indexes") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -22,14 +22,14 @@ package org.neo4j.cypher.internal.compiler.v2_3
 import java.net.URL
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{KernelPredicate, Expander, Literal}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expander, KernelPredicate, Literal}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{LabelAction, LabelSetOp}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{IdempotentResult, LockingQueryContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{PropertyContainer, Path, Node, Relationship}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, UniquenessConstraint}
+import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
 
 class LabelActionTest extends GraphDatabaseFunSuite {
   val queryContext = new SnitchingQueryContext


### PR DESCRIPTION
Introduced own case classes in SchemaTypes, and map back and forth in
the PlanContext and QueryContext. 