### PR TITLE
Removed dependency on kernel internal schema types

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/IndexSeekMode.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/IndexSeekMode.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.{QueryExpression, RangeQueryExpression}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 case class IndexSeekModeFactory(unique: Boolean, readOnly: Boolean) {
   def fromQueryExpression[T](qexpr: QueryExpression[T]) = qexpr match {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexContainsScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexContainsScanPipe.scala
@@ -24,12 +24,12 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{Index, LegacyExpression}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{LabelToken, PropertyKeyToken}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CTNode
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 abstract class AbstractNodeIndexStringScanPipe(ident: String,
                                                label: LabelToken,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexScanPipe.scala
@@ -23,10 +23,10 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.Index
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{LabelToken, PropertyKeyToken}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CTNode
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 case class NodeIndexScanPipe(ident: String,
                              label: LabelToken,
@@ -34,7 +34,7 @@ case class NodeIndexScanPipe(ident: String,
                             (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends Pipe with RonjaPipe {
 
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipe.scala
@@ -25,11 +25,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.{QueryExpression, RangeQ
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{Index, InequalityIndex, PrefixIndex}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{LabelToken, PropertyKeyToken}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CTNode
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 case class NodeIndexSeekPipe(ident: String,
                              label: LabelToken,
@@ -39,7 +39,7 @@ case class NodeIndexSeekPipe(ident: String,
                             (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends Pipe with RonjaPipe {
 
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   private val indexFactory = indexMode.indexFactory(descriptor)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -19,14 +19,14 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_0.commands.{SingleQueryExpression, QueryExpression}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.{QueryExpression, SingleQueryExpression}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.notification.IndexLookupUnfulfillableNotification
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/mergeUniqueIndexSeekLeafPlanner.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.QueryExpression
 import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan, NodeUniqueIndexSeek}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, HasLabels, LabelToken, PropertyKeyToken, UsingIndexHint}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
 
 /*
  * Plan the following type of plan

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
@@ -23,9 +23,9 @@ import java.net.URL
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 import scala.collection.Iterator
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/PlanContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/PlanContext.scala
@@ -21,9 +21,8 @@ package org.neo4j.cypher.internal.compiler.v3_0.spi
 
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.EntityProducer
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.{ExpanderStep, TraversalMatcher}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.graphdb.Node
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 /**
  * PlanContext is an internal access layer to the graph that is solely used during plan building

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
@@ -24,10 +24,9 @@ import java.net.URL
 import org.neo4j.cypher.internal.compiler.v3_0.InternalQueryStatistics
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 import scala.collection.Iterator
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/SchemaTypes.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/SchemaTypes.scala
@@ -17,6 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0
+package org.neo4j.cypher.internal.compiler.v3_0.spi
 
-case class IndexDescriptor(label: Int, property: Int)
+object SchemaTypes {
+  case class UniquenessConstraint( labelId:Int, propertyId:Int )
+  case class NodePropertyExistenceConstraint( labelId:Int, propertyId:Int)
+  case class RelationshipPropertyExistenceConstraint( relTypeId:Int, propertyId:Int)
+  case class IndexDescriptor( labelId:Int, propertyId:Int)
+}

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -25,11 +25,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.DefaultIDPSolverConfig
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_0.{Scope, SemanticTable}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class RuleExecutablePlanBuilderTest extends CypherFunSuite {
   val planContext: PlanContext = mock[PlanContext]
@@ -66,7 +66,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
 
     when(planContext.getOptLabelId("Person")).thenReturn(Some(1))
     when(planContext.getOptPropertyKeyId("name")).thenReturn(Some(1))
-    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(new IndexDescriptor(1, 1)))
+    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(IndexDescriptor(1, 1)))
     when(planContext.getUniquenessConstraint("Person", "name")).thenReturn(None)
 
     val pipe = buildExecutionPipe("LOAD CSV FROM 'file:///tmp/foo.csv' AS line MATCH (p:Person { name: line[0] }) RETURN p;")
@@ -79,7 +79,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
 
     when(planContext.getOptLabelId("Person")).thenReturn(Some(1))
     when(planContext.getOptPropertyKeyId("name")).thenReturn(Some(1))
-    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(new IndexDescriptor(1, 1)))
+    when(planContext.getIndexRule("Person", "name")).thenReturn(Some(IndexDescriptor(1, 1)))
     when(planContext.getUniquenessConstraint("Person", "name")).thenReturn(None)
 
     val pipe = buildExecutionPipe("LOAD CSV FROM 'file:///tmp/foo.csv' AS line MATCH (p:Person { name: \"Foo Bar Baz\" }) RETURN p;")

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/EntityProducerFactoryTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/EntityProducerFactoryTest.scala
@@ -24,10 +24,10 @@ import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_0.commands._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryStateHelper
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{PlanContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v3_0.IndexHintException
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class EntityProducerFactoryTest extends CypherFunSuite {
   var planContext: PlanContext = null
@@ -54,7 +54,7 @@ class EntityProducerFactoryTest extends CypherFunSuite {
     //GIVEN
     val label: String = "label"
     val prop: String = "prop"
-    val index: IndexDescriptor = new IndexDescriptor(123,456)
+    val index: IndexDescriptor = IndexDescriptor(123,456)
     val value = 42
     val queryContext: QueryContext = mock[QueryContext]
     when(planContext.getIndexRule(label, prop)).thenReturn(Some(index))
@@ -87,7 +87,7 @@ class EntityProducerFactoryTest extends CypherFunSuite {
     //GIVEN
     val labelName = "Label"
     val propertyKey = "prop"
-    val index: IndexDescriptor = new IndexDescriptor(123, 456)
+    val index: IndexDescriptor = IndexDescriptor(123, 456)
     when(planContext.getIndexRule(labelName, propertyKey)).thenReturn(Some(index))
     val producer = factory.nodeByIndexHint(readOnly = true)(planContext -> SchemaIndex("x", labelName, propertyKey, AnyIndex, Some(SingleQueryExpression(Literal(Seq(1,2,3))))))
     val queryContext: QueryContext = mock[QueryContext]

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/NodeFetchStrategyTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/NodeFetchStrategyTest.scala
@@ -22,17 +22,17 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.AnyInList
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{ListLiteral, Variable, Property}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{ListLiteral, Property, Variable}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{Equals, HasLabel}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{UnresolvedLabel, UnresolvedProperty}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v3_0.ast
 import org.neo4j.cypher.internal.frontend.v3_0.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class NodeFetchStrategyTest extends CypherFunSuite {
   val propertyName = "prop"
@@ -44,7 +44,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val equalityPredicate = Equals(Property(Variable("a"), UnresolvedProperty(propertyName)), Variable("b"))
     val labelPredicate = HasLabel(Variable("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
 
@@ -61,7 +61,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val equalityPredicate = Equals(Property(Variable("a"), UnresolvedProperty(propertyName)), Variable("b"))
     val labelPredicate = HasLabel(Variable("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
     when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)
@@ -79,7 +79,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
     val inPredicate = AnyInList(ListLiteral(Variable("b")), "_inner_", Equals(Property(Variable("a"), UnresolvedProperty(propertyName)), Variable("_inner_")))
     val labelPredicate = HasLabel(Variable("a"), UnresolvedLabel(labelName))
     val planCtx = mock[PlanContext]
-    val indexDescriptor = new IndexDescriptor(0, 0)
+    val indexDescriptor = IndexDescriptor(0, 0)
 
     when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
     when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)
@@ -103,7 +103,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
         val startsWithPredicate = toCommandPredicate(startsWith)
 
         val planCtx = mock[PlanContext]
-        val indexDescriptor = new IndexDescriptor(0, 0)
+        val indexDescriptor = IndexDescriptor(0, 0)
 
         when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
         when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)
@@ -133,7 +133,7 @@ class NodeFetchStrategyTest extends CypherFunSuite {
         val inequalityPredicate = toCommandPredicate(inequality)
 
         val planCtx = mock[PlanContext]
-        val indexDescriptor = new IndexDescriptor(0, 0)
+        val indexDescriptor = IndexDescriptor(0, 0)
 
         when(planCtx.getIndexRule(labelName, propertyName)).thenReturn(Some(indexDescriptor))
         when(planCtx.getUniquenessConstraint(labelName, propertyName)).thenReturn(None)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointBuilderTest.scala
@@ -29,9 +29,9 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.values.TokenType.Propert
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.PartiallySolvedQuery
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.NodeStartPipe
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_0.{ExclusiveBound, InclusiveBound, IndexHintException}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class StartPointBuilderTest extends BuilderTest {
 
@@ -51,7 +51,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -62,7 +62,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -73,7 +73,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -85,7 +85,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, AnyIndex, Some(RangeQueryExpression(range))))))
-    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -96,7 +96,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -108,7 +108,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -119,7 +119,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -130,7 +130,7 @@ class StartPointBuilderTest extends BuilderTest {
     val propertyName = "prop"
     val q = PartiallySolvedQuery().
       copy(start = Seq(Unsolved(SchemaIndex("n", labelName, propertyName, UniqueIndex, Some(RangeQueryExpression(range))))))
-    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getUniqueIndexRule(labelName, propertyName)).thenReturn(Some(IndexDescriptor(123,456)))
 
     assertAccepts(q)
   }
@@ -188,7 +188,7 @@ class StartPointBuilderTest extends BuilderTest {
       where = Seq(Unsolved(Equals(Property(Variable("n"), propertyKey), Literal("Stefan")))),
       start = Seq(Unsolved(SchemaIndex("n", labelName, propertyKey.name, AnyIndex, Some(SingleQueryExpression(Literal("a")))))))
 
-    when(context.getIndexRule(labelName, propertyKey.name)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule(labelName, propertyKey.name)).thenReturn(Some(IndexDescriptor(123,456)))
 
     //THEN
     val producedPlan = assertAccepts(q)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointChoosingBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointChoosingBuilderTest.scala
@@ -30,12 +30,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenT
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.PartiallySolvedQuery
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.FakePipe
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v3_0.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.{SemanticDirection, ast}
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class StartPointChoosingBuilderTest extends BuilderTest {
   def builder = new StartPointChoosingBuilder
@@ -89,7 +88,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
         Equals(Property(Variable(_var), PropertyKey("prop1")), Literal("banana")))
     )
 
-    when(context.getIndexRule("Person", "prop1")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop1")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -120,7 +119,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -139,8 +138,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -158,7 +157,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -177,8 +176,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -196,7 +195,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -215,7 +214,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -234,8 +233,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule("Person", "prop")).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule("Person", "prop")).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getUniquenessConstraint( "Person", "prop" )).thenReturn(Some(UniquenessConstraint(123,456)))
 
     // When
     val plan = assertAccepts(query)
@@ -254,8 +253,8 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
     when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
     // When
@@ -279,7 +278,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
           patterns = Seq(SingleNode(_var))
         )
 
-        when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123, 456)))
+        when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123, 456)))
         when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
         // When
@@ -308,7 +307,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
           patterns = Seq(SingleNode(_var))
         )
 
-        when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123, 456)))
+        when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123, 456)))
         when(context.getUniquenessConstraint( Matchers.any(), Matchers.any() )).thenReturn(None)
 
         // When
@@ -332,10 +331,10 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
     when(context.getUniquenessConstraint( label, property )).thenReturn(None)
-    when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(Some(new UniquenessConstraint(2468,3579)))
+    when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(Some(UniquenessConstraint(2468,3579)))
 
     // When
     val result = assertAccepts(query).query
@@ -354,9 +353,9 @@ class StartPointChoosingBuilderTest extends BuilderTest {
       SingleNode(_var)
     ))
 
-    when(context.getIndexRule(label, property)).thenReturn(Some(new IndexDescriptor(123,456)))
-    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(new IndexDescriptor(2468,3579)))
-    when(context.getUniquenessConstraint( label, property )).thenReturn(Some(new UniquenessConstraint(123,456)))
+    when(context.getIndexRule(label, property)).thenReturn(Some(IndexDescriptor(123,456)))
+    when(context.getIndexRule(label, otherProperty)).thenReturn(Some(IndexDescriptor(2468,3579)))
+    when(context.getUniquenessConstraint( label, property )).thenReturn(Some(UniquenessConstraint(123,456)))
     when(context.getUniquenessConstraint( label, otherProperty )).thenReturn(None)
 
     // When

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexScanPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexScanPipeTest.scala
@@ -21,11 +21,11 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{LabelToken, PropertyKeyToken, _}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_0.{LabelId, PropertyKeyId}
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class NodeIndexScanPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
@@ -33,7 +33,7 @@ class NodeIndexScanPipeTest extends CypherFunSuite with AstConstructionTestSuppo
 
   private val label = LabelToken(LabelName("LabelName")_, LabelId(11))
   private val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName")_, PropertyKeyId(10))
-  private val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
   private val node = mock[Node]
 
   test("should return nodes found by index scan when both labelId and property key id are solved at compile time") {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeIndexSeekPipeTest.scala
@@ -25,11 +25,11 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expression, ListLiteral, Literal, Variable}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.{ManyQueryExpression, QueryExpression, RangeQueryExpression, SingleQueryExpression}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InternalException, LabelId, PropertyKeyId}
 import org.neo4j.graphdb.Node
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
@@ -38,7 +38,7 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
 
   val label = LabelToken(LabelName("LabelName") _, LabelId(11))
   val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName") _, PropertyKeyId(10))
-  val descriptor = new IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
+  val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
   val node = mock[Node]
   val node2 = mock[Node]
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/StartPipePlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/StartPipePlanDescriptionTest.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.commands._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Literal
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class StartPipePlanDescriptionTest extends CypherFunSuite {
 
@@ -40,7 +40,7 @@ class StartPipePlanDescriptionTest extends CypherFunSuite {
     super.beforeEach()
     planContext = mock[PlanContext]
     factory = new EntityProducerFactory
-    when(planContext.getIndexRule(label, prop)).thenReturn(Some(new IndexDescriptor(123,456)))
+    when(planContext.getIndexRule(label, prop)).thenReturn(Some(IndexDescriptor(123,456)))
     when(planContext.getOptLabelId(label)).thenReturn(Some(1))
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{IDPQueryGrap
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter.{LogicalPlanRewriter, unnestApply}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, ProcedureSignature, QualifiedProcedureName}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
@@ -40,8 +41,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, Cyp
 import org.neo4j.cypher.internal.frontend.v3_0.{Foldable, PropertyKeyId, SemanticTable, _}
 import org.neo4j.graphdb.Node
 import org.neo4j.helpers.collection.Visitable
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 import org.neo4j.kernel.impl.util.dbstructure.DbStructureVisitor
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 
@@ -90,7 +89,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getUniqueIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] =
         if (config.uniqueIndexes((labelName, propertyKey)))
-          Some(new IndexDescriptor(
+          Some(IndexDescriptor(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))
@@ -99,7 +98,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getUniquenessConstraint(labelName: String, propertyKey: String): Option[UniquenessConstraint] = {
         if (config.uniqueIndexes((labelName, propertyKey)))
-          Some(new UniquenessConstraint(
+          Some(UniquenessConstraint(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))
@@ -109,7 +108,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
       def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor] =
         if (config.indexes((labelName, propertyKey)) || config.uniqueIndexes((labelName, propertyKey)))
-          Some(new IndexDescriptor(
+          Some(IndexDescriptor(
             semanticTable.resolvedLabelIds(labelName).id,
             semanticTable.resolvedPropertyKeyNames(propertyKey).id
           ))

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/ExtractBestPlanTest.scala
@@ -25,11 +25,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.RecordingNotificationLogger
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.notification.{IndexHintUnfulfillableNotification, JoinHintUnfulfillableNotification}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticDirection, IndexHintException, JoinHintException}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
+import org.neo4j.cypher.internal.frontend.v3_0.{IndexHintException, JoinHintException, SemanticDirection}
 
 class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -52,7 +52,7 @@ class ExtractBestPlanTest extends CypherFunSuite with LogicalPlanningTestSupport
   private def getPlanContext(hasIndex: Boolean): PlanContext = {
 
     val planContext = newMockedPlanContext
-    val indexDescriptor: Option[IndexDescriptor] = if (hasIndex) Option(new IndexDescriptor(0,0)) else None
+    val indexDescriptor: Option[IndexDescriptor] = if (hasIndex) Option(IndexDescriptor(0,0)) else None
 
     when(planContext.getIndexRule(anyString(),anyString())).thenReturn(indexDescriptor)
     when(planContext.getUniqueIndexRule(anyString(),anyString())).thenReturn(None)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContextAdaptation.scala
@@ -23,10 +23,9 @@ import java.net.URL
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 trait QueryContextAdaptation {
   self: QueryContext =>

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/UpdateCountingQueryContextTest.scala
@@ -24,10 +24,9 @@ import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v3_0.InternalQueryStatistics
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Node, Relationship}
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class UpdateCountingQueryContextTest extends CypherFunSuite {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_0.scala
@@ -23,11 +23,11 @@ import java.net.URL
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expander, KernelPredicate}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.spi._
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.cypher.internal.spi.v3_0.ExceptionTranslationSupport
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 import scala.collection.Iterator
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/ExceptionTranslatingPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/ExceptionTranslatingPlanContext.scala
@@ -21,10 +21,9 @@ package org.neo4j.cypher.internal.spi.v3_0
 
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.EntityProducer
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.{ExpanderStep, TraversalMatcher}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, ProcedureSignature, QualifiedProcedureName}
 import org.neo4j.graphdb.Node
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class ExceptionTranslatingPlanContext(inner: PlanContext) extends PlanContext with ExceptionTranslationSupport {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/IndexDescriptorCompatibility.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.spi.v3_0
 
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.kernel.api.index.{IndexDescriptor => KernelIndexDescriptor}
 
 trait IndexDescriptorCompatibility {
   implicit def toKernelIndexDescriptor(descriptor: IndexDescriptor): KernelIndexDescriptor =
-    new KernelIndexDescriptor(descriptor.label, descriptor.property)
+    new KernelIndexDescriptor(descriptor.labelId, descriptor.propertyId)
 
   implicit def toCypherIndexDescriptor(descriptor: KernelIndexDescriptor): IndexDescriptor =
     new IndexDescriptor(descriptor.getLabelId, descriptor.getPropertyKeyId)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundGraphStatistics.scala
@@ -20,11 +20,11 @@
 package org.neo4j.cypher.internal.spi.v3_0
 
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cardinality, Selectivity}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, StatisticsCompletingGraphStatistics}
 import org.neo4j.cypher.internal.frontend.v3_0.{LabelId, NameId, PropertyKeyId, RelTypeId}
-import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 import org.neo4j.kernel.api.ReadOperations
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
 
 object TransactionBoundGraphStatistics {
   def apply(ops: ReadOperations) = new StatisticsCompletingGraphStatistics(new BaseTransactionBoundGraphStatistics(ops))
@@ -35,7 +35,7 @@ object TransactionBoundGraphStatistics {
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = new IndexDescriptor(label, property)
+        val indexDescriptor = IndexDescriptor(label, property)
         val labeledNodes = operations.countsForNodeWithoutTxState(label).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
@@ -51,7 +51,7 @@ object TransactionBoundGraphStatistics {
 
     def indexPropertyExistsSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = new IndexDescriptor(label, property)
+        val indexDescriptor = IndexDescriptor(label, property)
         val labeledNodes = operations.countsForNodeWithoutTxState(label).toDouble
 
         // Probability of any node with the given label, to have a given property

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
@@ -21,18 +21,18 @@ package org.neo4j.cypher.internal.spi.v3_0
 
 import org.neo4j.cypher.MissingIndexException
 import org.neo4j.cypher.internal.LastCommittedTxIdProvider
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.EntityProducer
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.ExpanderStep
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v3_0.spi._
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CypherType
 import org.neo4j.cypher.internal.frontend.v3_0.{CypherExecutionException, symbols}
 import org.neo4j.cypher.internal.spi.TransactionalContextWrapper
 import org.neo4j.graphdb.Node
-import org.neo4j.kernel.api.constraints.UniquenessConstraint
+import org.neo4j.kernel.api.constraints.{UniquenessConstraint => KernelUniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
-import org.neo4j.kernel.api.index.{IndexDescriptor => KernelIndexDescriptor, InternalIndexState}
+import org.neo4j.kernel.api.index.{InternalIndexState, IndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, ProcedureSignature => KernelProcedureSignature}
 
@@ -81,7 +81,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper)
 
     import scala.collection.JavaConverters._
     tc.statement.readOperations().constraintsGetForLabelAndPropertyKey(labelId, propertyKeyId).asScala.collectFirst {
-      case unique: UniquenessConstraint => unique
+      case unique: KernelUniquenessConstraint => UniquenessConstraint(unique.label(), unique.propertyKey())
     }
   } catch {
     case _: KernelException => None

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -33,6 +33,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{KernelPredi
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.JavaConversionSupport
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v3_0.spi._
 import org.neo4j.cypher.internal.frontend.v3_0.{Bound, EntityNotFoundException, FailedIndexException, SemanticDirection, spi => frontend}
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
@@ -47,10 +48,10 @@ import org.neo4j.graphdb.security.URLAccessValidationError
 import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription, Uniqueness}
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api._
-import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
+import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint => KernelNPEConstraint, RelationshipPropertyExistenceConstraint => KernelRPEConstraint, UniquenessConstraint => KernelUniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
-import org.neo4j.kernel.api.index.InternalIndexState
+import org.neo4j.kernel.api.index.{InternalIndexState, IndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.locking.ResourceTypes
 
@@ -478,39 +479,42 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   }
 
   override def dropIndexRule(labelId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations().indexDrop(new IndexDescriptor(labelId, propertyKeyId))
+    transactionalContext.statement.schemaWriteOperations().indexDrop(new KernelIndexDescriptor(labelId, propertyKeyId))
 
   override def createUniqueConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = try {
-    IdempotentResult(transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(labelId, propertyKeyId))
+    transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(labelId, propertyKeyId)
+    IdempotentResult(UniquenessConstraint(labelId, propertyKeyId))
   } catch {
     case existing: AlreadyConstrainedException =>
-      IdempotentResult(existing.constraint().asInstanceOf[UniquenessConstraint], wasCreated = false)
+      IdempotentResult(UniquenessConstraint(labelId, propertyKeyId), wasCreated = false)
   }
 
   override def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(new KernelUniquenessConstraint(labelId, propertyKeyId))
 
   override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[NodePropertyExistenceConstraint] =
     try {
-      IdempotentResult(transactionalContext.statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(labelId, propertyKeyId))
+      transactionalContext.statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(labelId, propertyKeyId)
+      IdempotentResult(NodePropertyExistenceConstraint(labelId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
-        IdempotentResult(existing.constraint().asInstanceOf[NodePropertyExistenceConstraint], wasCreated = false)
+        IdempotentResult(NodePropertyExistenceConstraint(labelId, propertyKeyId), wasCreated = false)
     }
 
   override def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations().constraintDrop(new NodePropertyExistenceConstraint(labelId, propertyKeyId))
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(new KernelNPEConstraint(labelId, propertyKeyId))
 
   override def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[RelationshipPropertyExistenceConstraint] =
     try {
-      IdempotentResult(transactionalContext.statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(relTypeId, propertyKeyId))
+      transactionalContext.statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(relTypeId, propertyKeyId)
+      IdempotentResult(RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
-        IdempotentResult(existing.constraint().asInstanceOf[RelationshipPropertyExistenceConstraint], wasCreated = false)
+        IdempotentResult(RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId), wasCreated = false)
     }
 
   override def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
-    transactionalContext.statement.schemaWriteOperations().constraintDrop(new RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(new KernelRPEConstraint(relTypeId, propertyKeyId))
 
   override def getImportURL(url: URL): Either[String,URL] = transactionalContext.graph match {
     case db: GraphDatabaseQueryService =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UniqueIndexUsageAcceptanceTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.internal.compiler.v3_0.spi.SchemaTypes.IndexDescriptor
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
-import org.neo4j.cypher.internal.compiler.v3_0.IndexDescriptor
 
 class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
   test("should be able to use indexes") {


### PR DESCRIPTION
Introduced own case classes in SchemaTypes, and map back and forth in
the PlanContext and QueryContext