### PR TITLE
Log connection info to help identify configuration issues.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -159,7 +159,6 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         {
             tcpIpConfig.addMember( address.toString() );
         }
-        log.info( "Discovering cluster with initial members: " + initialMembers );
 
         Setting<ListenSocketAddress> discovery_listen_address = CausalClusteringSettings.discovery_listen_address;
         ListenSocketAddress hazelcastAddress = config.get( discovery_listen_address );
@@ -185,7 +184,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         MemberAttributeConfig memberAttributeConfig = HazelcastClusterTopology.buildMemberAttributes( myself, config );
 
         c.setMemberAttributeConfig( memberAttributeConfig );
-        userLog.info( "Waiting for other members to join cluster before continuing..." );
+        logConnectionInfo( initialMembers );
 
         DelayedLog delayedLog = new DelayedLog( "The server has not been able to connect in a timely fashion to the " +
                 "cluster. Please consult the logs for more details. Rebooting the server may solve the problem", log );
@@ -210,6 +209,25 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         }
 
         return hazelcastInstance;
+    }
+
+    private void logConnectionInfo( List<AdvertisedSocketAddress> initialMembers )
+    {
+        userLog.info(   "My connection info: " +
+                        "[\n\tDiscovery:   listen=%s, advertised=%s," +
+                        "\n\tTransaction: listen=%s, advertised=%s, " +
+                        "\n\tRaft:        listen=%s, advertised=%s, " +
+                        "\n\tClient Connector Addresses: %s" +
+                        "\n]",
+                config.get( CausalClusteringSettings.discovery_listen_address ),
+                config.get( CausalClusteringSettings.discovery_advertised_address ),
+                config.get( CausalClusteringSettings.transaction_listen_address ),
+                config.get( CausalClusteringSettings.transaction_advertised_address ),
+                config.get( CausalClusteringSettings.raft_listen_address ),
+                config.get( CausalClusteringSettings.raft_advertised_address ),
+                ClientConnectorAddresses.extractFromConfig( config ) );
+        userLog.info( "Discovering cluster with initial members: " + initialMembers );
+        userLog.info( "Attempting to connect to the other cluster members before continuing..." );
     }
 
     private Integer minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize()


### PR DESCRIPTION
This change adds more logging to neo4j.log. Below is an example excerpt from the neo4j.log:

```
2017-02-08 11:15:40.054+0000 INFO  Starting...
2017-02-08 11:15:50.808+0000 INFO  Bolt enabled on localhost:7687.
2017-02-08 11:15:50.821+0000 INFO  Initiating metrics...
2017-02-08 11:15:50.941+0000 INFO  My connection info: [
    Discovery:   listen=localhost:5000, advertised=localhost:5000, 
    Transaction: listen=localhost:6000, advertised=localhost:6000, 
    Raft:        listen=localhost:7000, advertised=localhost:7000, 
    Client Connector Addresses: bolt://localhost:7687,http://localhost:7474,https://localhost:7473 
]
2017-02-08 11:15:50.942+0000 INFO  Discovering cluster with initial members: [localhost:5000, localhost:5001, localhost:5002]
2017-02-08 11:15:50.942+0000 INFO  Attempting to connect to the other cluster members before continuing...
```

This is useful when deploying a causal cluster and checking if each member is configured correctly. 