### PR TITLE
Makes CSV backslash-escaped quotes parsing optional

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/BufferedCharSeeker.java
@@ -61,6 +61,7 @@ public class BufferedCharSeeker implements CharSeeker
     private long absoluteBufferStartPosition;
     private String sourceDescription;
     private final boolean multilineFields;
+    private final boolean legacyStyleQuoting;
     private final Source source;
     private Chunk currentChunk;
 
@@ -70,6 +71,7 @@ public class BufferedCharSeeker implements CharSeeker
         this.quoteChar = config.quotationCharacter();
         this.lineStartPos = this.bufferPos;
         this.multilineFields = config.multilineFields();
+        this.legacyStyleQuoting = config.legacyStyleQuoting();
     }
 
     @Override
@@ -154,7 +156,7 @@ public class BufferedCharSeeker implements CharSeeker
                         lineNumber++;
                     }
                 }
-                else if ( ch == BACK_SLASH )
+                else if ( ch == BACK_SLASH && legacyStyleQuoting )
                 {   // Legacy concern, support java style quote encoding
                     int nextCh = peekChar( skippedChars );
                     if ( nextCh == quoteChar || nextCh == BACK_SLASH )

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -25,6 +25,13 @@ package org.neo4j.csv.reader;
 public interface Configuration
 {
     /**
+     * TODO: Default value is false here, but it is our intention to flip this to true at some point
+     * because of how it better complies with common expectancy of behavior. It may be least disruptive
+     * to do this when changing major version of the product.
+     */
+    boolean DEFAULT_LEGACY_STYLE_QUOTING = true;
+
+    /**
      * Character to regard as quotes. Quoted values can contain newline characters and even delimiters.
      */
     char quotationCharacter();
@@ -43,6 +50,20 @@ public interface Configuration
      * @return {@code true} for treating empty strings, i.e. {@code ""} as null, instead of an empty string.
      */
     boolean emptyQuotedStringsAsNull();
+
+    /**
+     * Adds a default implementation returning {@link #DEFAULT_LEGACY_STYLE_QUOTING}, this to not requiring
+     * any change to other classes using this interface.
+     *
+     * @return whether or not the parsing will interpret <code>\"</code> (see {@link #quotationCharacter()})
+     * as an inner quote. Reason why this is configurable is that this interpretation conflicts with
+     * "standard" RFC for CSV parsing, see https://tools.ietf.org/html/rfc4180. This also makes it impossible
+     * to enter some combinations of characters, e.g. <code>"""abc\"""</code>, when expecting <code>"abc\"</code>.
+     */
+    default boolean legacyStyleQuoting()
+    {
+        return DEFAULT_LEGACY_STYLE_QUOTING;
+    }
 
     static int KB = 1024, MB = KB * KB;
 
@@ -106,6 +127,12 @@ public interface Configuration
         public boolean emptyQuotedStringsAsNull()
         {
             return defaults.emptyQuotedStringsAsNull();
+        }
+
+        @Override
+        public boolean legacyStyleQuoting()
+        {
+            return defaults.legacyStyleQuoting();
         }
     }
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -25,7 +25,7 @@ package org.neo4j.csv.reader;
 public interface Configuration
 {
     /**
-     * TODO: Default value is false here, but it is our intention to flip this to true at some point
+     * TODO: Our intention is to flip this to false (which means to comply with RFC4180) at some point
      * because of how it better complies with common expectancy of behavior. It may be least disruptive
      * to do this when changing major version of the product.
      */

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -205,7 +205,10 @@ public class ImportTool
                         + GraphDatabaseSettings.array_block_size.name() ),
         PAGE_SIZE( "page-size", Format.bytes( org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT.pageSize() ),
                 "<page size in bytes",
-                "Page size in bytes, or e.g. 4M or 8k" );
+                "Page size in bytes, or e.g. 4M or 8k" ),
+        LEGACY_STYLE_QUOTING( "legacy-style-quoting", Configuration.DEFAULT_LEGACY_STYLE_QUOTING,
+                "<true/false>",
+                "Whether or not backslash-escaped quote e.g. \\\" is interpreted as inner quote." );
 
         private final String key;
         private final Object defaultValue;
@@ -712,6 +715,7 @@ public class ImportTool
                 CHARACTER_CONVERTER );
         final Boolean multiLineFields = args.getBoolean( Options.MULTILINE_FIELDS.key(), null );
         final Boolean emptyStringsAsNull = args.getBoolean( Options.IGNORE_EMPTY_STRINGS.key(), null );
+        final Boolean legacyStyleQuoting = args.getBoolean( Options.LEGACY_STYLE_QUOTING.key(), null );
         return new Configuration.Default()
         {
             @Override
@@ -758,6 +762,14 @@ public class ImportTool
             public int bufferSize()
             {
                 return defaultSettingsSuitableForTests ? 10_000 : super.bufferSize();
+            }
+
+            @Override
+            public boolean legacyStyleQuoting()
+            {
+                return legacyStyleQuoting != null
+                        ? legacyStyleQuoting.booleanValue()
+                        : defaultConfiguration.legacyStyleQuoting();
             }
         };
     }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -1584,6 +1584,31 @@ public class ImportToolTest
         }
     }
 
+    @Test
+    public void shouldDisableLegacyStyleQuotingIfToldTo() throws Exception
+    {
+        // GIVEN
+        String nodeId = "me";
+        String labelName = "Alive";
+        List<String> lines = new ArrayList<>();
+        lines.add( ":ID,name,:LABEL" );
+        lines.add( nodeId + "," + "\"abc\"\"def\\\"\"ghi\"" + "," + labelName );
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", data( lines.toArray( new String[lines.size()] ) ).getAbsolutePath(),
+                "--legacy-style-quoting", "false",
+                "--stacktrace" );
+
+        // THEN
+        GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertNotNull( db.findNode( Label.label( labelName ), "name", "abc\"def\\\"ghi" ) );
+        }
+    }
+
     private File writeArrayCsv( String[] headers, String[] values ) throws FileNotFoundException
     {
         File data = file( fileName( "whitespace.csv" ) );


### PR DESCRIPTION
This because it prevents normally expected parsing behaviour of some CSV data.
This commit doesn't introduce any surface configuration though and the default
keeps the behaviour unchanged, to be changed in next major version perhaps).

Fixes #8472