### PR TITLE
Cleanup error logging in Bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -29,14 +29,13 @@ import org.neo4j.bolt.security.auth.AuthenticationException;
 import org.neo4j.bolt.security.auth.AuthenticationResult;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.function.ThrowingConsumer;
-import org.neo4j.graphdb.security.AuthorizationExpiredException;
 import org.neo4j.graphdb.security.AuthProviderTimeoutException;
+import org.neo4j.graphdb.security.AuthorizationExpiredException;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 
-import static java.lang.String.format;
 import static org.neo4j.kernel.api.security.AuthToken.PRINCIPAL;
 
 /**
@@ -659,11 +658,7 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
 
     private static void fail( BoltStateMachine machine, Neo4jError neo4jError )
     {
-        if ( neo4jError.status().code().classification() == Status.Classification.DatabaseError )
-        {
-            machine.spi.reportError( neo4jError );
-        }
-
+        machine.spi.reportError( neo4jError );
         machine.ctx.markFailed( neo4jError );
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/Neo4jErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/Neo4jErrorTest.java
@@ -21,7 +21,6 @@ package org.neo4j.bolt.v1.runtime;
 
 import org.junit.Test;
 
-import org.neo4j.cypher.LoadExternalResourceException;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -29,7 +28,6 @@ import org.neo4j.kernel.api.exceptions.Status;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Neo4jErrorTest
@@ -53,16 +51,6 @@ public class Neo4jErrorTest
 
         // Then
         assertEquals( error.status(), Status.Transaction.DeadlockDetected );
-    }
-
-    @Test
-    public void loadExternalResourceShouldNotReferToLog()
-    {
-        // Given
-        Neo4jError error = Neo4jError.from( new LoadExternalResourceException( "foo", null ) );
-
-        // Then
-        assertThat( error.status().code().classification().shouldLog(), is( false ) );
     }
 
     @Test

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -606,14 +606,14 @@ public interface Status
     enum Classification
     {
         /** The Client sent a bad request - changing the request might yield a successful outcome. */
-        ClientError( TransactionEffect.ROLLBACK, PublishingPolicy.REPORTS_TO_CLIENT,
+        ClientError( TransactionEffect.ROLLBACK,
                 "The Client sent a bad request - changing the request might yield a successful outcome."),
         /** There are notifications about the request sent by the client.*/
-        ClientNotification( TransactionEffect.NONE, PublishingPolicy.REPORTS_TO_CLIENT,
+        ClientNotification( TransactionEffect.NONE,
                 "There are notifications about the request sent by the client." ),
 
         /** The database cannot service the request right now, retrying later might yield a successful outcome. */
-        TransientError( TransactionEffect.ROLLBACK, PublishingPolicy.REPORTS_TO_CLIENT_AND_LOG,
+        TransientError( TransactionEffect.ROLLBACK,
                 "The database cannot service the request right now, retrying later might yield a successful outcome. "),
 
         // Implementation note: These are a sharp tool, database error signals
@@ -621,7 +621,7 @@ public interface Status
         // an error report back to us. Only use this if the code path you are
         // at would truly indicate the database is in a broken or bug-induced state.
         /** The database failed to service the request. */
-        DatabaseError( TransactionEffect.ROLLBACK, PublishingPolicy.REFERS_TO_LOG,
+        DatabaseError( TransactionEffect.ROLLBACK,
                 "The database failed to service the request. " );
 
         private enum TransactionEffect
@@ -629,43 +629,18 @@ public interface Status
             ROLLBACK, NONE,
         }
 
-        private enum PublishingPolicy
-        {
-            REPORTS_TO_CLIENT( false ), REPORTS_TO_CLIENT_AND_LOG( true ), REFERS_TO_LOG( true );
-
-            private final boolean shouldLog;
-
-            PublishingPolicy( boolean shouldLog )
-            {
-                this.shouldLog = shouldLog;
-            }
-
-            boolean shouldLog()
-            {
-                return shouldLog;
-            }
-
-        }
-
         private final boolean rollbackTransaction;
-        private final boolean shouldLog;
         private final String description;
 
-        Classification( TransactionEffect transactionEffect, PublishingPolicy publishingPolicy, String description )
+        Classification( TransactionEffect transactionEffect, String description )
         {
             this.description = description;
-            this.shouldLog = publishingPolicy.shouldLog();
             this.rollbackTransaction = transactionEffect == TransactionEffect.ROLLBACK;
         }
 
         public boolean rollbackTransaction()
         {
             return rollbackTransaction;
-        }
-
-        public boolean shouldLog()
-        {
-            return shouldLog;
         }
 
         public String description()


### PR DESCRIPTION
This PR removes publishing policy from error classification. It was useful when we tried to send some errors to the user and only log other errors. Currently we try to send all errors to the user and log only database errors. So there is no need to publishing policy because we just need to know if error is a database error to log it.

Also removed self reference to `debug.log` from error messages. It was previously possible for messages like "[o.n.b.v.r.ErrorReporter] Client triggered an unexpected error [UnknownError]: null. See debug.log for more details..." to appear in `debug.log`. This was caused by the fact that we duplicate all user log messaged to internal log. See `StoreLogService` and `DuplicatingLogProvider` for more details.