### PR TITLE
MuninnPageCursor no longer trigger out of bounds when copyTo with zero bytes

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -682,7 +682,7 @@ abstract class MuninnPageCursor extends PageCursor
              & targetOffset >= 0
              & sourceOffset < sourcePageSize
              & targetOffset < targetPageSize
-             & lengthInBytes > 0 )
+             & lengthInBytes >= 0 )
         {
             MuninnPageCursor cursor = (MuninnPageCursor) targetCursor;
             int remainingSource = sourcePageSize - sourceOffset;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -4042,6 +4042,11 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             assertFalse( cursorA.checkAndClearBoundsFlag() );
             assertFalse( cursorB.checkAndClearBoundsFlag() );
 
+            // zero length
+            assertThat( cursorA.copyTo( 0, cursorB, 1, 0 ), is( 0 ) );
+            assertFalse( cursorA.checkAndClearBoundsFlag() );
+            assertFalse( cursorB.checkAndClearBoundsFlag() );
+
             // negative length
             cursorA.copyTo( 1, cursorB, 1, -1 );
             assertTrue( cursorA.checkAndClearBoundsFlag() );


### PR DESCRIPTION
Previously trying to copy zero bytes would cause outOfBounds flag to be raised. Since no cursor is actually reading out of bounds this behaviour is not expected.

Use case:
In GBPTree, deleting an empty leaf node is done by merging it with a sibling. Merging in general means copy content over between pages, but in the case of an empty leaf we want to copy over exactly zero bytes.