### PR TITLE
Mention systemd service in debian changelog

### DIFF
--- a/new-packaging/src/debian/skeleton/debian/changelog
+++ b/new-packaging/src/debian/skeleton/debian/changelog
@@ -4,3 +4,11 @@ ${PACKAGE_NAME} (${VERSION}) ${DISTRIBUTION}; urgency=low
 
  -- Neo Technology <debian@neotechnology.com>  ${DATE}
 
+${PACKAGE_NAME} (3.2.0) ${DISTRIBUTION}; urgency=medium
+
+  * Neo4j now ships a native systemd service. Options in
+    /etc/default/neo4j have migrated to
+    /etc/systemd/system/neo4j.service.d/override.conf.
+    In addition, the main neo4j log is now written to journald instead.
+
+ -- Neo Technology <debian@neotechnology.com>  Mon, 13 Feb 2017 11:35:10 +0100


### PR DESCRIPTION
Sets date and version to static values so that they don't change.