### PR TITLE
Fixes issue with lonely check point in log file during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -152,6 +152,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.kernel.recovery.DefaultRecoverySPI;
 import org.neo4j.kernel.recovery.LatestCheckPointFinder;
+import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 import org.neo4j.kernel.recovery.Recovery;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
 import org.neo4j.kernel.spi.legacyindex.IndexProviders;
@@ -468,6 +469,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                     transactionIdStore,
                     logVersionRepository,
                     monitors.newMonitor( Recovery.Monitor.class ),
+                    monitors.newMonitor( PositionToRecoverFrom.Monitor.class ),
                     transactionLogModule.logFiles(), startupStatistics,
                     storageEngine, logEntryReader, transactionLogModule.logicalTransactionStore() );
 
@@ -738,6 +740,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             TransactionIdStore transactionIdStore,
             LogVersionRepository logVersionRepository,
             Recovery.Monitor recoveryMonitor,
+            PositionToRecoverFrom.Monitor positionMonitor,
             final PhysicalLogFiles logFiles,
             final StartupStatisticsProvider startupStatistics,
             StorageEngine storageEngine,
@@ -748,7 +751,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 new LatestCheckPointFinder( logFiles, fileSystemAbstraction, logEntryReader );
         Recovery.SPI spi = new DefaultRecoverySPI(
                 storageEngine, logFiles, fileSystemAbstraction, logVersionRepository,
-                checkPointFinder, transactionIdStore, logicalTransactionStore );
+                checkPointFinder, transactionIdStore, logicalTransactionStore, positionMonitor );
         Recovery recovery = new Recovery( spi, recoveryMonitor );
         monitors.addMonitorListener( new Recovery.Monitor()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -34,6 +34,8 @@ import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.recovery.LatestCheckPointFinder;
 import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 
+import static org.neo4j.kernel.recovery.PositionToRecoverFrom.NO_MONITOR;
+
 /**
  * An external tool that can determine if a given store will need recovery.
  */
@@ -66,6 +68,6 @@ public class RecoveryRequiredChecker
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
 
         LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        return new PositionToRecoverFrom( finder ).apply( logVersion ) != LogPosition.UNSPECIFIED;
+        return new PositionToRecoverFrom( finder, NO_MONITOR ).apply( logVersion ) != LogPosition.UNSPECIFIED;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
@@ -23,11 +23,16 @@ import java.io.File;
 
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.recovery.Recovery;
+import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 import org.neo4j.logging.Log;
 
 import static java.lang.String.format;
 
-public class LoggingLogFileMonitor implements PhysicalLogFile.Monitor, LogRotation.Monitor, Recovery.Monitor
+public class LoggingLogFileMonitor implements
+        PhysicalLogFile.Monitor,
+        LogRotation.Monitor,
+        Recovery.Monitor,
+        PositionToRecoverFrom.Monitor
 {
     private long firstTransactionRecovered = -1, lastTransactionRecovered;
     private final Log log;
@@ -84,5 +89,26 @@ public class LoggingLogFileMonitor implements PhysicalLogFile.Monitor, LogRotati
     {
         log.info( format( "Opened logical log [%s] version=%d, lastTxId=%d (%s)",
                 logFile, logVersion, lastTransactionId,  (clean ? "clean" : "recovered") ) );
+    }
+
+    @Override
+    public void noCommitsAfterLastCheckPoint( LogPosition logPosition )
+    {
+        log.info( format( "No commits found after last check point (which is at %s)",
+                logPosition != null ? logPosition.toString() : "<no log position given>" ) );
+    }
+
+    @Override
+    public void commitsAfterLastCheckPoint( LogPosition logPosition, long firstTxIdAfterLastCheckPoint )
+    {
+        log.info( format(
+                "Commits found after last check point (which is at %s). First txId after last checkpoint: %d ",
+                logPosition, firstTxIdAfterLastCheckPoint ) );
+    }
+
+    @Override
+    public void noCheckPointFound()
+    {
+        log.info( "No check point found in transaction log" );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -54,6 +54,8 @@ public class PhysicalLogFile implements LogFile, Lifecycle
         }
     }
 
+    public static final Monitor NO_MONITOR = new Monitor.Adapter();
+
     public static final String DEFAULT_NAME = "neostore.transaction.db";
     public static final String REGEX_DEFAULT_NAME = "neostore\\.transaction\\.db";
     public static final String DEFAULT_VERSION_SUFFIX = ".";

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
@@ -56,7 +56,8 @@ public class DefaultRecoverySPI implements Recovery.SPI
             StorageEngine storageEngine,
             PhysicalLogFiles logFiles, FileSystemAbstraction fs,
             LogVersionRepository logVersionRepository, LatestCheckPointFinder checkPointFinder,
-            TransactionIdStore transactionIdStore, LogicalTransactionStore logicalTransactionStore )
+            TransactionIdStore transactionIdStore, LogicalTransactionStore logicalTransactionStore,
+            PositionToRecoverFrom.Monitor monitor )
     {
         this.storageEngine = storageEngine;
         this.logFiles = logFiles;
@@ -64,7 +65,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
         this.logVersionRepository = logVersionRepository;
         this.transactionIdStore = transactionIdStore;
         this.logicalTransactionStore = logicalTransactionStore;
-        this.positionToRecoverFrom = new PositionToRecoverFrom( checkPointFinder );
+        this.positionToRecoverFrom = new PositionToRecoverFrom( checkPointFinder, monitor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -141,7 +141,7 @@ public class LatestCheckPointFinder
             {
                 // This check point entry targets a previous log file.
                 // Go there and see if there's a transaction. Reader is capped to that log version.
-                startEntryAfterCheckPoint = extractFirstTxIdAfterPosition( target, target.getLogVersion() ) !=
+                startEntryAfterCheckPoint = extractFirstTxIdAfterPosition( target, version ) !=
                         LatestCheckPoint.NO_TRANSACTION_ID;
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
@@ -31,6 +32,7 @@ import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChanne
 import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 
@@ -91,9 +93,28 @@ public class LatestCheckPointFinder
 
             if ( latestCheckPoint != null )
             {
+                // Is the latest start entry in this log file version later than what the latest check point targets?
+                LogPosition target = latestCheckPoint.getLogPosition();
                 boolean commitsAfterCheckPoint = latestStartEntry != null &&
-                        latestStartEntry.getStartPosition().compareTo( latestCheckPoint.getLogPosition() ) >= 0;
-                return new LatestCheckPoint( latestCheckPoint, commitsAfterCheckPoint , oldestVersionFound );
+                        latestStartEntry.getStartPosition().compareTo( target ) >= 0;
+                if ( !commitsAfterCheckPoint )
+                {
+                    if ( target.getLogVersion() < version )
+                    {
+                        // This check point entry targets a previous log file.
+                        // Go there and see if there's a transaction. Reader is capped to that log version.
+                        commitsAfterCheckPoint = extractFirstTxIdAfterPosition( target, target.getLogVersion() ) !=
+                                LatestCheckPoint.NO_TRANSACTION_ID;
+                    }
+                }
+
+                // Extract first transaction id after check point target position.
+                // Reader may continue into log files after the initial version.
+                long firstTxIdAfterCheckPoint = commitsAfterCheckPoint
+                        ? extractFirstTxIdAfterPosition( target, fromVersionBackwards )
+                        : LatestCheckPoint.NO_TRANSACTION_ID;
+                return new LatestCheckPoint( latestCheckPoint, commitsAfterCheckPoint,
+                        firstTxIdAfterCheckPoint, oldestVersionFound );
             }
 
             version--;
@@ -105,19 +126,77 @@ public class LatestCheckPointFinder
             }
         }
 
-        return new LatestCheckPoint( null, latestStartEntry != null, oldestVersionFound );
+        boolean commitsAfterCheckPoint = latestStartEntry != null;
+        long firstTxAfterPosition = commitsAfterCheckPoint
+                ? extractFirstTxIdAfterPosition( latestStartEntry.getStartPosition(),
+                        latestStartEntry.getStartPosition().getLogVersion() )
+                : LatestCheckPoint.NO_TRANSACTION_ID;
+
+        return new LatestCheckPoint( null, commitsAfterCheckPoint, firstTxAfterPosition, oldestVersionFound );
+    }
+
+    /**
+     * Extracts txId from first commit entry, when starting reading at the given {@code position}.
+     * If no commit entry found in the version, the reader will continue into next version(s) up till
+     * {@code maxLogVersion} until finding one.
+     *
+     * @param initialPosition {@link LogPosition} to start scan from.
+     * @param maxLogVersion max log version to scan.
+     * @return txId of closes commit entry to {@code initialPosition}, or {@link LatestCheckPoint#NO_TRANSACTION_ID}
+     * if not found.
+     * @throws IOException on I/O error.
+     */
+    private long extractFirstTxIdAfterPosition( LogPosition initialPosition, long maxLogVersion ) throws IOException
+    {
+        LogPosition currentPosition = initialPosition;
+        while ( currentPosition.getLogVersion() <= maxLogVersion )
+        {
+            LogVersionedStoreChannel storeChannel = PhysicalLogFile.tryOpenForVersion( logFiles, fileSystem,
+                    currentPosition.getLogVersion(), false );
+            if ( storeChannel != null )
+            {
+                try
+                {
+                    storeChannel.position( currentPosition.getByteOffset() );
+                    try ( ReadAheadLogChannel logChannel = new ReadAheadLogChannel( storeChannel, NO_MORE_CHANNELS );
+                          LogEntryCursor cursor = new LogEntryCursor( logEntryReader, logChannel ) )
+                    {
+                        while ( cursor.next() )
+                        {
+                            LogEntry entry = cursor.get();
+                            if ( entry instanceof LogEntryCommit )
+                            {
+                                return ((LogEntryCommit) entry).getTxId();
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    storeChannel.close();
+                }
+            }
+
+            currentPosition = LogPosition.start( currentPosition.getLogVersion() + 1 );
+        }
+        return LatestCheckPoint.NO_TRANSACTION_ID;
     }
 
     public static class LatestCheckPoint
     {
+        public static long NO_TRANSACTION_ID = -1;
+
         public final CheckPoint checkPoint;
         public final boolean commitsAfterCheckPoint;
+        public final long firstTxIdAfterLastCheckPoint;
         public final long oldestLogVersionFound;
 
-        public LatestCheckPoint( CheckPoint checkPoint, boolean commitsAfterCheckPoint, long oldestLogVersionFound )
+        public LatestCheckPoint( CheckPoint checkPoint, boolean commitsAfterCheckPoint,
+                long firstTxIdAfterLastCheckPoint, long oldestLogVersionFound )
         {
             this.checkPoint = checkPoint;
             this.commitsAfterCheckPoint = commitsAfterCheckPoint;
+            this.firstTxIdAfterLastCheckPoint = firstTxIdAfterLastCheckPoint;
             this.oldestLogVersionFound = oldestLogVersionFound;
         }
 
@@ -136,6 +215,7 @@ public class LatestCheckPointFinder
             LatestCheckPoint that = (LatestCheckPoint) o;
 
             return commitsAfterCheckPoint == that.commitsAfterCheckPoint &&
+                   firstTxIdAfterLastCheckPoint == that.firstTxIdAfterLastCheckPoint &&
                    oldestLogVersionFound == that.oldestLogVersionFound &&
                    (checkPoint == null ? that.checkPoint == null : checkPoint.equals( that.checkPoint ));
         }
@@ -145,7 +225,11 @@ public class LatestCheckPointFinder
         {
             int result = checkPoint != null ? checkPoint.hashCode() : 0;
             result = 31 * result + (commitsAfterCheckPoint ? 1 : 0);
-            result = 31 * result + (int) (oldestLogVersionFound ^ (oldestLogVersionFound >>> 32));
+            if ( commitsAfterCheckPoint )
+            {
+                result = 31 * result + Long.hashCode( firstTxIdAfterLastCheckPoint );
+            }
+            result = 31 * result + Long.hashCode( oldestLogVersionFound );
             return result;
         }
 
@@ -155,6 +239,7 @@ public class LatestCheckPointFinder
             return "LatestCheckPoint{" +
                    "checkPoint=" + checkPoint +
                    ", commitsAfterCheckPoint=" + commitsAfterCheckPoint +
+                   (commitsAfterCheckPoint ? ", firstTxIdAfterLastCheckPoint=" + firstTxIdAfterLastCheckPoint : "") +
                    ", oldestLogVersionFound=" + oldestLogVersionFound +
                    '}';
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -95,25 +95,25 @@ public class LatestCheckPointFinder
             {
                 // Is the latest start entry in this log file version later than what the latest check point targets?
                 LogPosition target = latestCheckPoint.getLogPosition();
-                boolean commitsAfterCheckPoint = latestStartEntry != null &&
+                boolean startEntryAfterCheckPoint = latestStartEntry != null &&
                         latestStartEntry.getStartPosition().compareTo( target ) >= 0;
-                if ( !commitsAfterCheckPoint )
+                if ( !startEntryAfterCheckPoint )
                 {
                     if ( target.getLogVersion() < version )
                     {
                         // This check point entry targets a previous log file.
                         // Go there and see if there's a transaction. Reader is capped to that log version.
-                        commitsAfterCheckPoint = extractFirstTxIdAfterPosition( target, target.getLogVersion() ) !=
+                        startEntryAfterCheckPoint = extractFirstTxIdAfterPosition( target, target.getLogVersion() ) !=
                                 LatestCheckPoint.NO_TRANSACTION_ID;
                     }
                 }
 
                 // Extract first transaction id after check point target position.
                 // Reader may continue into log files after the initial version.
-                long firstTxIdAfterCheckPoint = commitsAfterCheckPoint
+                long firstTxIdAfterCheckPoint = startEntryAfterCheckPoint
                         ? extractFirstTxIdAfterPosition( target, fromVersionBackwards )
                         : LatestCheckPoint.NO_TRANSACTION_ID;
-                return new LatestCheckPoint( latestCheckPoint, commitsAfterCheckPoint,
+                return new LatestCheckPoint( latestCheckPoint, startEntryAfterCheckPoint,
                         firstTxIdAfterCheckPoint, oldestVersionFound );
             }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -75,6 +75,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
+import static org.neo4j.kernel.recovery.PositionToRecoverFrom.NO_MONITOR;
 
 public class RecoveryTest
 {
@@ -149,7 +150,7 @@ public class RecoveryTest
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine,
-                    logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore )
+                    logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
             {
                 private int nr = 0;
 
@@ -239,7 +240,7 @@ public class RecoveryTest
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine,
-                  logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore )
+                  logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
             {
                 @Override
                 public Visitor<CommittedTransactionRepresentation,Exception> startRecovery()
@@ -390,7 +391,7 @@ public class RecoveryTest
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine,
-                    logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore )
+                    logFiles, fs, logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
             {
                 @Override
                 public Visitor<CommittedTransactionRepresentation,Exception> startRecovery()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
@@ -127,18 +127,9 @@ public class Runner implements Callable<Long>
                 GraphDatabaseSettings.logical_log_rotation_threshold.getDefaultValue() );
         DeadSimpleLogVersionRepository logVersionRepository = new DeadSimpleLogVersionRepository( 0 );
         return new PhysicalLogFile( fs, logFiles, rotateAtSize,
-                transactionIdStore::getLastCommittedTransactionId, logVersionRepository, NOOP_LOGFILE_MONITOR,
+                transactionIdStore::getLastCommittedTransactionId, logVersionRepository, PhysicalLogFile.NO_MONITOR,
                 logHeaderCache );
     }
-
-    private static final PhysicalLogFile.Monitor NOOP_LOGFILE_MONITOR = new PhysicalLogFile.Monitor()
-    {
-        @Override
-        public void opened( File logFile, long logVersion, long lastTransactionId, boolean clean )
-        {
-
-        }
-    };
 
     private static final LogRotation.Monitor NOOP_LOGROTATION_MONITOR = new LogRotation.Monitor()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
@@ -19,50 +19,51 @@
  */
 package org.neo4j.kernel.recovery;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
-import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
+import org.neo4j.kernel.impl.transaction.log.FlushablePositionAwareChannel;
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
-import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
-import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.encodeLogVersion;
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.NO_MONITOR;
+import static org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint.NO_TRANSACTION_ID;
 
 @RunWith( Parameterized.class )
 public class LatestCheckPointFinderTest
 {
-    private final PhysicalLogFiles logFiles = mock( PhysicalLogFiles.class );
-    private final FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
-    @SuppressWarnings( "unchecked" )
-    private final LogEntryReader<ReadableClosablePositionAwareChannel> reader = mock( LogEntryReader.class );
-    private final int olderLogVersion = 0;
-    private final int logVersion = 1;
-
+    @Rule
+    public final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private final File directory = new File( "/somewhere" );
+    private final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
+    private LatestCheckPointFinder finder;
+    private PhysicalLogFiles logFiles;
     private final int startLogVersion;
     private final int endLogVersion;
 
@@ -78,327 +79,415 @@ public class LatestCheckPointFinderTest
         return Arrays.asList( new Object[]{0, 1}, new Object[]{42, 43}  );
     }
 
+    @Before
+    public void setUp()
+    {
+        fsRule.get().mkdirs( directory );
+        logFiles = new PhysicalLogFiles( directory, fsRule.get() );
+        finder = new LatestCheckPointFinder( logFiles, fsRule.get(), reader );
+    }
+
     @Test
     public void noLogFilesFound() throws Throwable
     {
         // given no files
+        setupLogFiles();
         int logVersion = startLogVersion;
-        when( logFiles.getLogFileForVersion( logVersion ) ).thenReturn( mock( File.class ) );
-        when( fs.fileExists( any( File.class ) ) ).thenReturn( false );
-
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
+        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fsRule.get(), reader );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, false, -1 ), latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, -1, latestCheckPoint );
     }
 
     @Test
     public void oneLogFileNoCheckPoints() throws Throwable
     {
         // given
-        int logVersion = startLogVersion;
-        setupLogFiles( logVersion, logVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
+        int logVersion = endLogVersion;
+        setupLogFiles( logFile() );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, false, logVersion ), latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, logVersion, latestCheckPoint );
     }
 
     @Test
     public void oneLogFileNoCheckPointsOneStart() throws Throwable
     {
         // given
-        int logVersion = startLogVersion;
-        setupLogFiles( logVersion, logVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( olderLogVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, null );
+        int logVersion = endLogVersion;
+        long txId = 10;
+        setupLogFiles( logFile( start(), commit( txId ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( logVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, true, logVersion ), latestCheckPoint );
+        assertLatestCheckPoint( false, true, txId, logVersion, latestCheckPoint );
     }
 
     @Test
     public void twoLogFilesNoCheckPoints() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
+        setupLogFiles( logFile(), logFile() );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, false, startLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
     }
 
     @Test
     public void twoLogFilesNoCheckPointsOneStart() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, null );
+        long txId = 21;
+        setupLogFiles( logFile(), logFile( start(), commit( txId ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( null, true, startLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( false, true, txId, startLogVersion, latestCheckPoint );
+    }
+
+    @Test
+    public void twoLogFilesNoCheckPointsOneStartWithoutCommit() throws Throwable
+    {
+        // given
+        setupLogFiles( logFile(), logFile( start() ) );
+
+        // when
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+
+        // then
+        assertLatestCheckPoint( false, true, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointOnly() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( checkPoint, null );
+        setupLogFiles( logFile( checkPoint() ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointAndAStartBefore() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        setupLogFiles( logFile( start(), checkPoint() ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingACheckPointAndAStartAfter() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 16 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 33 ) );
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        long txId = 35;
+        StartEntry start = start();
+        setupLogFiles( logFile( start, commit( txId ), checkPoint( start ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
     }
 
     @Test
-    public void latestLogFileContainingACheckPointAndAStartAtSamePosition() throws Throwable
+    public void latestLogFileContainingACheckPointAndAStartWithoutCommitAfter() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 16 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 16 ) );
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn( start, checkPoint, null );
+        StartEntry start = start();
+        setupLogFiles( logFile( start, checkPoint( start ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingMultipleCheckPointsOneStartInBetween() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 33 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                mock( CheckPoint.class ), start, checkPoint, null );
+        setupLogFiles( logFile( checkPoint(), start(), checkPoint() ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogFileContainingMultipleCheckPointsOneStartAfterBoth() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 22 ) );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 33 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                mock( CheckPoint.class ), checkPoint, start, null );
+        long txId = 11;
+        setupLogFiles( logFile( checkPoint(), checkPoint(), start(), commit( txId ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingACheckPointAndNewerFileContainingAStart() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start1 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( endLogVersion, 22 ) );
-        LogEntryStart start2 = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 33 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                start1, null, // first file
-                start2,  checkPoint, null // second file
-        );
+        long txId = 11;
+        StartEntry start = start();
+        setupLogFiles( logFile( checkPoint() ), logFile( start, commit( txId ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, startLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, startLogVersion, latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingACheckPointAndNewerFileIsEmpty() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 16 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 33 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                null, // first file
-                start,  checkPoint, null // second file
-        );
+        StartEntry start = start();
+        setupLogFiles( logFile( start, checkPoint() ), logFile() );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, startLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingAStartAndNewerFileContainingACheckPointPointingToAPreviousPositionThanStart() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 16 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                checkPoint, // first file
-                start, null // second file
-        );
+        long txId = 123;
+        StartEntry start = start();
+        setupLogFiles( logFile( start, commit( txId ) ), logFile( checkPoint( start ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
+    }
+
+    @Test
+    public void olderLogFileContainingAStartAndNewerFileContainingACheckPointPointingToAPreviousPositionThanStartWithoutCommit() throws Throwable
+    {
+        // given
+        StartEntry start = start();
+        setupLogFiles( logFile( start ), logFile( checkPoint( start ) ) );
+
+        // when
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+
+        // then
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void olderLogFileContainingAStartAndNewerFileContainingACheckPointPointingToALaterPositionThanStart() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntryStart start = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 22 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 25 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                checkPoint, // first file
-                start, null // second file
-        );
+        PositionEntry position = position();
+        setupLogFiles( logFile( start(), commit( 3 ), position ), logFile( checkPoint( position ) ) );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, false, endLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
     }
 
     @Test
     public void latestLogEmptyStartEntryBeforeAndAfterCheckPointInTheLastButOneLog() throws Throwable
     {
         // given
-        setupLogFiles( startLogVersion, endLogVersion );
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
-        LogEntry firstStart = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 20 ) );
-        LogEntry secondStart = new LogEntryStart( 0, 0, 0, 0, new byte[0], new LogPosition( startLogVersion, 27 ) );
-        CheckPoint checkPoint = new CheckPoint( new LogPosition( startLogVersion, 25 ) );
-
-        when( reader.readLogEntry( any( ReadableLogChannel.class ) ) ).thenReturn(
-                null, // first file
-                firstStart, checkPoint, secondStart, null // second file
-        );
+        long txId = 432;
+        setupLogFiles( logFile( start(), checkPoint(), start(), commit( txId ) ), logFile() );
 
         // when
         LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
 
         // then
-        assertEquals( new LatestCheckPoint( checkPoint, true, startLogVersion ), latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, startLogVersion, latestCheckPoint );
     }
 
-    private void setupLogFiles( int startLogVersion, int endLogVersion ) throws IOException
-    {
-        when( fs.fileExists( any( File.class ) ) ).thenReturn( false );
-        for ( int i = startLogVersion; i <= endLogVersion; i++ )
-        {
-            File file = mock( File.class );
-            when( fs.fileExists( file ) ).thenReturn( true );
-            when( logFiles.getLogFileForVersion( i ) ).thenReturn( file );
-            StoreChannel channel = mock( StoreChannel.class );
-            when( fs.open( eq( file ), anyString() ) ).thenReturn( channel );
-            final int version = i;
-            when( channel.read( any( ByteBuffer.class ) ) ).thenAnswer( new Answer<Object>()
-            {
-                @Override
-                public Object answer( InvocationOnMock invocationOnMock ) throws Throwable
-                {
-                    ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
-                    buffer.putLong( encodeLogVersion( version ) );
-                    buffer.putLong( 33 );
-                    return LOG_HEADER_SIZE;
-                }
-            } );
-        }
+    // === Below is code for helping the tests above ===
 
-        // to make sure we have a mocked file for the file before startLogVersion to avoid NPE...
-        if ( startLogVersion > 0 )
+    @SafeVarargs
+    private final void setupLogFiles( LogCreator... logFiles ) throws IOException
+    {
+        Map<Entry,LogPosition> positions = new HashMap<>();
+        long version = endLogVersion - logFiles.length;
+        for ( LogCreator logFile : logFiles )
         {
-            File file = mock( File.class );
-            when( logFiles.getLogFileForVersion( startLogVersion - 1 ) ).thenReturn( file );
+            logFile.create( ++version, positions );
         }
+    }
+
+    private LogCreator logFile( Entry... entries )
+    {
+        return (logVersion, positions) ->
+        {
+            try
+            {
+                AtomicLong lastTxId = new AtomicLong();
+                Supplier<Long> lastTxIdSupplier = () -> lastTxId.get();
+                LogVersionRepository logVersionRepository = new DeadSimpleLogVersionRepository( logVersion );
+                LifeSupport life = new LifeSupport();
+                life.start();
+                PhysicalLogFile logFile = life.add( new PhysicalLogFile( fsRule.get(), logFiles, mebiBytes( 1 ),
+                        lastTxIdSupplier, logVersionRepository, NO_MONITOR, new LogHeaderCache( 10 ) ) );
+                try
+                {
+                    FlushablePositionAwareChannel writeChannel = logFile.getWriter();
+                    LogPositionMarker positionMarker = new LogPositionMarker();
+                    LogEntryWriter writer = new LogEntryWriter( writeChannel );
+                    for ( Entry entry : entries )
+                    {
+                        LogPosition currentPosition = writeChannel.getCurrentPosition( positionMarker ).newPosition();
+                        positions.put( entry, currentPosition );
+                        if ( entry instanceof StartEntry )
+                        {
+                            writer.writeStartEntry( 0, 0, 0, 0, new byte[0] );
+                        }
+                        else if ( entry instanceof CommitEntry )
+                        {
+                            CommitEntry commitEntry = (CommitEntry) entry;
+                            writer.writeCommitEntry( commitEntry.txId, 0 );
+                            lastTxId.set( commitEntry.txId );
+                        }
+                        else if ( entry instanceof CheckPointEntry )
+                        {
+                            CheckPointEntry checkPointEntry = (CheckPointEntry) entry;
+                            Entry target = checkPointEntry.withPositionOfEntry;
+                            LogPosition logPosition = target != null ? positions.get( target ) : currentPosition;
+                            assert logPosition != null : "No registered log position for " + target;
+                            writer.writeCheckPointEntry( logPosition );
+                        }
+                        else if ( entry instanceof PositionEntry )
+                        {
+                            // Don't write anything, this entry is just for registering a position so that
+                            // another CheckPointEntry can refer to it
+                        }
+                        else
+                        {
+                            throw new IllegalArgumentException( "Unknown entry " + entry );
+                        }
+
+                    }
+                }
+                finally
+                {
+                    life.shutdown();
+                }
+            }
+            catch ( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
+        };
+    }
+
+    interface LogCreator
+    {
+        void create( long version, Map<Entry,LogPosition> positions ) throws IOException;
+    }
+
+    // Marker interface, helping compilation/test creation
+    interface Entry
+    {
+    }
+
+    private static StartEntry start()
+    {
+        return new StartEntry();
+    }
+
+    private static CommitEntry commit( long txId )
+    {
+        return new CommitEntry( txId );
+    }
+
+    private static CheckPointEntry checkPoint()
+    {
+        return checkPoint( null/*means self-position*/ );
+    }
+
+    private static CheckPointEntry checkPoint( Entry forEntry )
+    {
+        return new CheckPointEntry( forEntry );
+    }
+
+    private static PositionEntry position()
+    {
+        return new PositionEntry();
+    }
+
+    private static class StartEntry implements Entry
+    {
+    }
+
+    private static class CommitEntry implements Entry
+    {
+        final long txId;
+
+        CommitEntry( long txId )
+        {
+            this.txId = txId;
+        }
+    }
+
+    private static class CheckPointEntry implements Entry
+    {
+        final Entry withPositionOfEntry;
+
+        CheckPointEntry( Entry withPositionOfEntry )
+        {
+            this.withPositionOfEntry = withPositionOfEntry;
+        }
+    }
+
+    private static class PositionEntry implements Entry
+    {
+    }
+
+    private void assertLatestCheckPoint( boolean hasCheckPointEntry, boolean commitsAfterLastCheckPoint,
+            long firstTxIdAfterLastCheckPoint, long logVersion, LatestCheckPoint latestCheckPoint )
+    {
+        assertEquals( hasCheckPointEntry, latestCheckPoint.checkPoint != null );
+        assertEquals( commitsAfterLastCheckPoint, latestCheckPoint.commitsAfterCheckPoint );
+        if ( commitsAfterLastCheckPoint )
+        {
+            assertEquals( firstTxIdAfterLastCheckPoint, latestCheckPoint.firstTxIdAfterLastCheckPoint );
+        }
+        assertEquals( logVersion, latestCheckPoint.oldestLogVersionFound );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
@@ -76,7 +76,7 @@ public class LatestCheckPointFinderTest
     @Parameterized.Parameters( name="{0},{1}")
     public static Collection<Object[]> params()
     {
-        return Arrays.asList( new Object[]{0, 1}, new Object[]{42, 43}  );
+        return Arrays.asList( new Object[]{1, 2}, new Object[]{42, 43}  );
     }
 
     @Before
@@ -183,6 +183,24 @@ public class LatestCheckPointFinderTest
 
         // then
         assertLatestCheckPoint( false, true, txId, startLogVersion, latestCheckPoint );
+    }
+
+    @Test
+    public void twoLogFilesCheckPointTargetsPrevious() throws Exception
+    {
+        // given
+        long txId = 6;
+        PositionEntry position = position();
+        setupLogFiles(
+                logFile( start(), commit( txId - 1 ), position ),
+                logFile( start(), commit( txId ) ),
+                logFile( checkPoint( position ) ) );
+
+        // when
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+
+        // then
+        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LatestCheckPointFinderTest.java
@@ -172,6 +172,20 @@ public class LatestCheckPointFinderTest
     }
 
     @Test
+    public void twoLogFilesNoCheckPointsTwoCommits() throws Throwable
+    {
+        // given
+        long txId = 21;
+        setupLogFiles( logFile(), logFile( start(), commit( txId ), start(), commit( txId + 1 ) ) );
+
+        // when
+        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+
+        // then
+        assertLatestCheckPoint( false, true, txId, startLogVersion, latestCheckPoint );
+    }
+
+    @Test
     public void latestLogFileContainingACheckPointOnly() throws Throwable
     {
         // given

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/PositionToRecoverFromTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/PositionToRecoverFromTest.java
@@ -25,27 +25,32 @@ import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
 import org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint;
+import org.neo4j.kernel.recovery.PositionToRecoverFrom.Monitor;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionRepository.INITIAL_LOG_VERSION;
+import static org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint.NO_TRANSACTION_ID;
 
 public class PositionToRecoverFromTest
 {
     private final long logVersion = 2L;
     private final LatestCheckPointFinder finder = mock( LatestCheckPointFinder.class );
+    private final Monitor monitor = mock( Monitor.class );
 
     @Test
     public void shouldReturnUnspecifiedIfThereIsNoNeedForRecovery() throws Throwable
     {
         // given
-        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, false, logVersion ) );
+        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, false, NO_TRANSACTION_ID, logVersion ) );
 
         // when
-        LogPosition logPosition = new PositionToRecoverFrom( finder ).apply( logVersion );
+        LogPosition logPosition = new PositionToRecoverFrom( finder, monitor ).apply( logVersion );
 
         // then
+        verify( monitor ).noCommitsAfterLastCheckPoint( null );
         assertEquals( LogPosition.UNSPECIFIED, logPosition );
     }
 
@@ -55,12 +60,13 @@ public class PositionToRecoverFromTest
         // given
         LogPosition checkPointLogPosition = new LogPosition( 1L, 4242 );
         when( finder.find( logVersion ) )
-                .thenReturn( new LatestCheckPoint( new CheckPoint( checkPointLogPosition ), true, logVersion ) );
+                .thenReturn( new LatestCheckPoint( new CheckPoint( checkPointLogPosition ), true, 10L, logVersion ) );
 
         // when
-        LogPosition logPosition = new PositionToRecoverFrom( finder ).apply( logVersion );
+        LogPosition logPosition = new PositionToRecoverFrom( finder, monitor ).apply( logVersion );
 
         // then
+        verify( monitor ).commitsAfterLastCheckPoint( checkPointLogPosition, 10L );
         assertEquals( checkPointLogPosition, logPosition );
     }
 
@@ -68,12 +74,13 @@ public class PositionToRecoverFromTest
     public void shouldRecoverFromStartOfLogZeroIfThereAreNoCheckPointAndOldestLogIsVersionZero() throws Throwable
     {
         // given
-        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, true, INITIAL_LOG_VERSION ) );
+        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, true, 10L, INITIAL_LOG_VERSION ) );
 
         // when
-        LogPosition logPosition = new PositionToRecoverFrom( finder ).apply( logVersion );
+        LogPosition logPosition = new PositionToRecoverFrom( finder, monitor ).apply( logVersion );
 
         // then
+        verify( monitor ).noCheckPointFound();
         assertEquals( LogPosition.start( INITIAL_LOG_VERSION ), logPosition );
     }
 
@@ -82,12 +89,12 @@ public class PositionToRecoverFromTest
     {
         // given
         long oldestLogVersionFound = 1L;
-        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, true, oldestLogVersionFound ) );
+        when( finder.find( logVersion ) ).thenReturn( new LatestCheckPoint( null, true, 10L, oldestLogVersionFound ) );
 
         // when
         try
         {
-            new PositionToRecoverFrom( finder ).apply( logVersion );
+            new PositionToRecoverFrom( finder, monitor ).apply( logVersion );
         }
         catch( UnderlyingStorageException ex )
         {


### PR DESCRIPTION
LatestCheckPointFinderTest didn't test what it claimed to test and so this issue
slipped through the cracks. This whole test class have been simplified and its
use of mocking heavily reduced. Issue was this:

Given an older log file with some transaction in and a newer log file with only
a check point in, targeting an entry in the older log file ->
LatestCheckPointFinder would report that there were no transactions after
the last check point, while in fact there were. This would result in all those
transactions to not be recovered on that startup.

This commit also adds more detailed logging on finding last checkpoint at startup,
this to better be able to reason about recovery issues by reading debug.log.