### PR TITLE
Package installation now creates a neo4j group

### DIFF
--- a/new-packaging/src/common/neo4j.service
+++ b/new-packaging/src/common/neo4j.service
@@ -6,6 +6,7 @@ After=network.target
 ExecStart=/usr/share/neo4j/bin/neo4j console
 Restart=on-failure
 User=neo4j
+Group=neo4j
 Environment="NEO4J_CONF=/etc/neo4j" "NEO4J_HOME=/var/lib/neo4j"
 LimitNOFILE=60000
 TimeoutSec=120

--- a/new-packaging/src/debian/skeleton/debian/package.postinst
+++ b/new-packaging/src/debian/skeleton/debian/package.postinst
@@ -19,14 +19,15 @@ set -e
 
 case "$1" in
     configure)
-        [ -r /etc/default/neo4j ] && . /etc/default/neo4j
-        : ${NEO_USER:=neo4j}
-
         # Create neo4j user if it doesn't exist.
-        if ! id $NEO_USER > /dev/null 2>&1 ; then
-            adduser --system --home /var/lib/neo4j --no-create-home \
-                --ingroup nogroup --disabled-password --shell /bin/bash \
-                $NEO_USER
+        if ! id neo4j > /dev/null 2>&1 ; then
+            useradd --system --user-group --home /var/lib/neo4j --shell /bin/bash neo4j
+        else
+            # Make sure a neo4j group exists in case user is upgrading
+            # from older version where no such group was created
+            groupadd --system --force neo4j
+            # Make sure neo4j user's primary group is neo4j
+            usermod --gid neo4j neo4j > /dev/null 2>&1
         fi
 
         # directories needed for neo4j
@@ -124,5 +125,3 @@ esac
 #DEBHELPER#
 
 exit 0
-
-

--- a/new-packaging/src/rpm/neo4j.spec
+++ b/new-packaging/src/rpm/neo4j.spec
@@ -33,7 +33,13 @@ leverage not only data but also its relationships.
 
 # Create neo4j user if it doesn't exist.
 if ! id neo4j > /dev/null 2>&1 ; then
-  useradd --system --no-user-group --home %{neo4jhome} --shell /bin/bash neo4j
+  useradd --system --user-group --home %{neo4jhome} --shell /bin/bash neo4j
+else
+  # Make sure a neo4j group exists in case user is upgrading
+  # from older version where no such group was created
+  groupadd --system --force neo4j
+  # Make sure neo4j user's primary group is neo4j
+  usermod --gid neo4j neo4j > /dev/null 2>&1
 fi
 
 if [ $1 -gt 1 ]; then
@@ -133,17 +139,17 @@ install -m 0644 manpages/* %{buildroot}/%{_mandir}/man1
 %dir %{neo4jhome}/plugins
 %dir %{neo4jhome}/import
 %dir %{neo4jhome}/data/databases
-%attr(-,neo4j,root) %dir %{_localstatedir}/run/neo4j
+%attr(-,neo4j,neo4j) %dir %{_localstatedir}/run/neo4j
 
 %{_datadir}/neo4j
 %{_bindir}/*
-%attr(-,neo4j,root) %{neo4jhome}
-%attr(-,neo4j,root) %dir %{_localstatedir}/log/neo4j
+%attr(-,neo4j,neo4j) %{neo4jhome}
+%attr(-,neo4j,neo4j) %dir %{_localstatedir}/log/neo4j
 /lib/systemd/system/neo4j.service
 %{_sysconfdir}/init.d/neo4j
 
 %config(noreplace) %{_sysconfdir}/default/neo4j
-%attr(-,neo4j,root) %config(noreplace) %{_sysconfdir}/neo4j
+%attr(-,neo4j,neo4j) %config(noreplace) %{_sysconfdir}/neo4j
 
 %doc %{_mandir}/man1/*
 %doc %{_datadir}/doc/neo4j/README.txt

--- a/new-packaging/src/rpm/neo4j.spec
+++ b/new-packaging/src/rpm/neo4j.spec
@@ -33,9 +33,7 @@ leverage not only data but also its relationships.
 
 # Create neo4j user if it doesn't exist.
 if ! id neo4j > /dev/null 2>&1 ; then
-  adduser --system --home %{neo4jhome} --no-create-home \
-          --no-user-group --shell /bin/bash \
-          neo4j
+  useradd --system --no-user-group --home %{neo4jhome} --shell /bin/bash neo4j
 fi
 
 if [ $1 -gt 1 ]; then


### PR DESCRIPTION
* Use `useradd` instead of `adduser` in debian package as well for
  consistency's sake
* Set the systemd service to run in the neo4j group (as well as user)
* On upgrade, set the primary group of the neo4j user to neo4j. This
  is safe because the neo4j user has no group currently

Example for user on my current machine

```
$ groups neo4j
neo4j : nogroup
```

Leaving existing `chown` calls in place for now since we make no use
of the neo4j group at the moment and to make sure we don't break
anyone's setup.

Primary motivation was to change to `useradd` to be compatible with Suse. This prompted the group change because I figured it was nice to make the environment consistent on all platforms. It's also what all other services do.
