### PR TITLE
Appends to FailureStorage on multiple failures

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
@@ -115,6 +115,10 @@ public class FailureStorage
         File failureFile = failureFile();
         try ( StoreChannel channel = fs.open( failureFile, "rw" ) )
         {
+            byte[] existingData = new byte[(int) channel.size()];
+            channel.read( ByteBuffer.wrap( existingData ) );
+            channel.position( lengthOf( existingData ) );
+
             byte[] data = UTF8.encode( failure );
             channel.write( ByteBuffer.wrap( data, 0, Math.min( data.length, MAX_FAILURE_SIZE ) ) );
 
@@ -135,7 +139,6 @@ public class FailureStorage
         {
             byte[] data = new byte[(int) channel.size()];
             int readData = channel.read( ByteBuffer.wrap( data ) );
-            channel.close();
             return readData <= 0 ? "" : UTF8.decode( withoutZeros( data ) );
         }
     }
@@ -149,7 +152,7 @@ public class FailureStorage
 
     private static int lengthOf( byte[] data )
     {
-        for (int i = 0; i < data.length; i++ )
+        for ( int i = 0; i < data.length; i++ )
         {
             if ( 0 == data[i] )
             {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
@@ -28,9 +28,12 @@ import java.io.File;
 import org.neo4j.kernel.api.impl.index.storage.layout.IndexFolderLayout;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FailureStorageTest
@@ -98,5 +101,24 @@ public class FailureStorageTest
 
         // THEN
         assertFalse( fs.get().fileExists( failureFile ) );
+    }
+
+    @Test
+    public void shouldAppendFailureIfAlreadyExists() throws Exception
+    {
+        // GIVEN
+        FailureStorage storage = new FailureStorage( fs.get(), indexFolderLayout );
+        storage.reserveForIndex();
+        String failure1 = "Once upon a time there was a first failure";
+        String failure2 = "Then there was another";
+        storage.storeIndexFailure( failure1 );
+
+        // WHEN
+        storage.storeIndexFailure( failure2 );
+
+        // THEN
+        String allFailures = storage.loadIndexFailure();
+        assertThat( allFailures, containsString( failure1 ) );
+        assertThat( allFailures, containsString( failure2 ) );
     }
 }


### PR DESCRIPTION
Noticed that first exception in inex FailureStorage could be overwritten
by second exception logged on e.g. closing populator. Since both could be
interesting failures are now appended instead of written at the beginning.