### PR TITLE
Push index descriptor boundary

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -222,7 +222,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
     private void checkSchema( SchemaRule rule, DynamicRecord record,
             RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
     {
-        new CheckSchema( engine, records ).process( rule.schema() );
+        rule.schema().processWith( new CheckSchema( engine, records ) );
         checkForDuplicates( rule, record, engine );
     }
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -222,7 +222,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
     private void checkSchema( SchemaRule rule, DynamicRecord record,
             RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
     {
-        new CheckSchema( engine, records ).process( rule.getSchemaDescriptor() );
+        new CheckSchema( engine, records ).process( rule.schema() );
         checkForDuplicates( rule, record, engine );
     }
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IndexCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IndexCheck.java
@@ -38,7 +38,7 @@ public class IndexCheck implements RecordCheck<IndexEntry, ConsistencyReport.Ind
     @Override
     public void check( IndexEntry record, CheckerEngine<IndexEntry, ConsistencyReport.IndexConsistencyReport> engine, RecordAccess records )
     {
-        int labelId = indexRule.getSchemaDescriptor().getLabelId();
+        int labelId = indexRule.schema().getLabelId();
         engine.comparativeCheck( records.node( record.getId() ),
                 new NodeInUseWithCorrectLabelsCheck<>( new long[]{labelId}, false ) );
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -56,7 +56,7 @@ public class MandatoryProperties
         {
             if ( rule.getConstraintDescriptor().type() == EXISTS )
             {
-                constraintRecorder.process( rule.schema() );
+                rule.schema().processWith( constraintRecorder );
             }
         }
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -20,7 +20,6 @@
 package org.neo4j.consistency.checking.full;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.function.Function;
 
 import org.neo4j.collection.primitive.Primitive;
@@ -30,7 +29,6 @@ import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.report.ConsistencyReporter;
-import org.neo4j.kernel.api.exceptions.schema.MalformedSchemaRuleException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaProcessor;
@@ -58,7 +56,7 @@ public class MandatoryProperties
         {
             if ( rule.getConstraintDescriptor().type() == EXISTS )
             {
-                constraintRecorder.process( rule.getSchemaDescriptor() );
+                constraintRecorder.process( rule.schema() );
             }
         }
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -81,7 +81,7 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
         List<PropertyBlock> properties = null;
         for ( IndexRule indexRule : indexes.rules() )
         {
-            long labelId = indexRule.getSchemaDescriptor().getLabelId();
+            long labelId = indexRule.schema().getLabelId();
             if ( !labels.contains( labelId ) )
             {
                 continue;
@@ -91,7 +91,7 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
             {
                 properties = propertyReader.propertyBlocks( propertyRecs );
             }
-            int propertyId = indexRule.getSchemaDescriptor().getPropertyIds()[0]; // assuming 1 property always
+            int propertyId = indexRule.schema().getPropertyIds()[0]; // assuming 1 property always
             PropertyBlock property = propertyWithKey( properties, propertyId );
 
             if ( property == null )

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/IndexDescriptorCompatibility.scala
@@ -20,12 +20,13 @@
 package org.neo4j.cypher.internal.spi.v2_3
 
 import org.neo4j.cypher.internal.compiler.v2_3.{IndexDescriptor => CypherIndexDescriptor}
-import org.neo4j.kernel.api.schema.{IndexDescriptor => KernelIndexDescriptor, IndexDescriptorFactory}
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 
 trait IndexDescriptorCompatibility {
   implicit def cypherToKernel(index: CypherIndexDescriptor) =
-    IndexDescriptorFactory.of(index.label, index.property)
+    NewIndexDescriptorFactory.forLabel(index.label, index.property)
 
   implicit def kernelToCypher(index: KernelIndexDescriptor) =
-    CypherIndexDescriptor(index.getLabelId, index.getPropertyKeyId)
+    CypherIndexDescriptor(index.schema().getLabelId, index.schema().getPropertyIds()(0))
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundGraphStatistics.scala
@@ -22,9 +22,9 @@ package org.neo4j.cypher.internal.spi.v2_3
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{Cardinality, Selectivity}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{GraphStatistics, StatisticsCompletingGraphStatistics}
 import org.neo4j.cypher.internal.frontend.v2_3.{LabelId, NameId, PropertyKeyId, RelTypeId}
-import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
 import org.neo4j.kernel.api.ReadOperations
-import org.neo4j.kernel.api.schema.{IndexDescriptorFactory, NodePropertyDescriptor}
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
 
 object TransactionBoundGraphStatistics {
   def apply(ops: ReadOperations) = new StatisticsCompletingGraphStatistics(new BaseTransactionBoundGraphStatistics(ops))
@@ -35,11 +35,11 @@ object TransactionBoundGraphStatistics {
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
-        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity( indexDescriptor )
+        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity(indexDescriptor)
         val frequencyOfNodesWithSameValue = 1.0 / indexEntrySelectivity
         val indexSelectivity = frequencyOfNodesWithSameValue / labeledNodes
 
@@ -51,11 +51,11 @@ object TransactionBoundGraphStatistics {
 
     def indexPropertyExistsSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a given property
-        val indexSize = operations.indexSize( indexDescriptor )
+        val indexSize = operations.indexSize(indexDescriptor)
         val indexSelectivity = indexSize / labeledNodes
 
         Selectivity.of(indexSelectivity)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -30,7 +30,8 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
 import org.neo4j.kernel.api.index.InternalIndexState
-import org.neo4j.kernel.api.schema.{NodePropertyDescriptor, IndexDescriptor => KernelIndexDescriptor}
+import org.neo4j.kernel.api.schema.{NodePropertyDescriptor}
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
 import scala.collection.JavaConverters._

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/IndexDescriptorCompatibility.scala
@@ -20,12 +20,13 @@
 package org.neo4j.cypher.internal.spi.v3_1
 
 import org.neo4j.cypher.internal.compiler.v3_1.{IndexDescriptor => CypherIndexDescriptor}
-import org.neo4j.kernel.api.schema.{IndexDescriptor => KernelIndexDescriptor, IndexDescriptorFactory}
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 
 trait IndexDescriptorCompatibility {
   implicit def cypherToKernel(index: CypherIndexDescriptor) =
-    IndexDescriptorFactory.of(index.label, index.property)
+    NewIndexDescriptorFactory.forLabel(index.label, index.property)
 
   implicit def kernelToCypher(index: KernelIndexDescriptor) =
-    CypherIndexDescriptor(index.getLabelId, index.getPropertyKeyId)
+    CypherIndexDescriptor(index.schema().getLabelId, index.schema().getPropertyIds()(0))
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
@@ -39,7 +39,7 @@ object TransactionBoundGraphStatistics {
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
-        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity( indexDescriptor )
+        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity(indexDescriptor)
         val frequencyOfNodesWithSameValue = 1.0 / indexEntrySelectivity
         val indexSelectivity = frequencyOfNodesWithSameValue / labeledNodes
 
@@ -55,7 +55,7 @@ object TransactionBoundGraphStatistics {
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a given property
-        val indexSize = operations.indexSize( indexDescriptor )
+        val indexSize = operations.indexSize(indexDescriptor)
         val indexSelectivity = indexSize / labeledNodes
 
         Selectivity.of(indexSelectivity)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundGraphStatistics.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.spi.{GraphStatistics, StatisticsC
 import org.neo4j.cypher.internal.frontend.v3_1.{LabelId, NameId, PropertyKeyId, RelTypeId}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
 
 object TransactionBoundGraphStatistics {
   def apply(ops: ReadOperations) = new StatisticsCompletingGraphStatistics(new BaseTransactionBoundGraphStatistics(ops))
@@ -35,7 +35,7 @@ object TransactionBoundGraphStatistics {
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
@@ -51,7 +51,7 @@ object TransactionBoundGraphStatistics {
 
     def indexPropertyExistsSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a given property

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.LastCommittedTxIdProvider
 import org.neo4j.cypher.internal.compiler.v3_1.pipes.EntityProducer
 import org.neo4j.cypher.internal.compiler.v3_1.pipes.matching.ExpanderStep
 import org.neo4j.cypher.internal.compiler.v3_1.spi._
-import org.neo4j.cypher.internal.compiler.v3_1.{InternalNotificationLogger, IndexDescriptor}
+import org.neo4j.cypher.internal.compiler.v3_1.{IndexDescriptor, InternalNotificationLogger}
 import org.neo4j.cypher.internal.frontend.v3_1.symbols.CypherType
 import org.neo4j.cypher.internal.frontend.v3_1.{CypherExecutionException, symbols}
 import org.neo4j.graphdb.Node
@@ -36,7 +36,8 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
 import org.neo4j.kernel.api.index.InternalIndexState
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, QualifiedName => KernelQualifiedName}
-import org.neo4j.kernel.api.schema.{NodePropertyDescriptor, IndexDescriptor => KernelIndexDescriptor}
+import org.neo4j.kernel.api.schema.NodePropertyDescriptor
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.impl.proc.Neo4jValue
 import org.neo4j.procedure.Mode
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -35,8 +35,8 @@ import org.neo4j.cypher.internal.compiler.v3_1.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v3_1.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v3_1.spi._
 import org.neo4j.cypher.internal.frontend.v3_1.{Bound, EntityNotFoundException, FailedIndexException, SemanticDirection}
-import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.BeansAPIRelationshipIterator
+import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.cypher.{InternalException, internal}
 import org.neo4j.graphalgo.impl.path.ShortestPath
@@ -53,7 +53,8 @@ import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.InternalIndexState
 import org.neo4j.kernel.api.proc.{QualifiedName => KernelQualifiedName}
-import org.neo4j.kernel.api.schema.{IndexDescriptorFactory, NodePropertyDescriptor, RelationshipPropertyDescriptor}
+import org.neo4j.kernel.api.schema.{NodePropertyDescriptor, RelationshipPropertyDescriptor}
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.locking.ResourceTypes
 
@@ -211,21 +212,18 @@ final class TransactionBoundQueryContext(txContext: TransactionalContextWrapper)
 
       case rangeLessThan: RangeLessThan[Number] =>
         rangeLessThan.limit(BY_NUMBER).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByNumber( index, null, false, limit.endPoint, limit.isInclusive )
+          readOps.nodesGetFromIndexRangeSeekByNumber(index, null, false, limit.endPoint, limit.isInclusive)
         }
 
       case rangeGreaterThan: RangeGreaterThan[Number] =>
         rangeGreaterThan.limit(BY_NUMBER).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByNumber( index, limit.endPoint, limit.isInclusive, null, false )
+          readOps.nodesGetFromIndexRangeSeekByNumber(index, limit.endPoint, limit.isInclusive, null, false)
         }
 
       case RangeBetween(rangeGreaterThan, rangeLessThan) =>
         rangeGreaterThan.limit(BY_NUMBER).flatMap { greaterThanLimit =>
           rangeLessThan.limit(BY_NUMBER).map { lessThanLimit =>
-            readOps.nodesGetFromIndexRangeSeekByNumber(
-              index,
-              greaterThanLimit.endPoint, greaterThanLimit.isInclusive,
-              lessThanLimit.endPoint, lessThanLimit.isInclusive )
+            readOps.nodesGetFromIndexRangeSeekByNumber(index, greaterThanLimit.endPoint, greaterThanLimit.isInclusive, lessThanLimit.endPoint, lessThanLimit.isInclusive)
           }
         }
     }).getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
@@ -238,21 +236,18 @@ final class TransactionBoundQueryContext(txContext: TransactionalContextWrapper)
 
       case rangeLessThan: RangeLessThan[String] =>
         rangeLessThan.limit(BY_STRING).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByString( index, null, false, limit.endPoint.asInstanceOf[String], limit.isInclusive )
+          readOps.nodesGetFromIndexRangeSeekByString(index, null, false, limit.endPoint.asInstanceOf[String], limit.isInclusive)
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
 
       case rangeGreaterThan: RangeGreaterThan[String] =>
         rangeGreaterThan.limit(BY_STRING).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByString( index, limit.endPoint.asInstanceOf[String], limit.isInclusive, null, false )
+          readOps.nodesGetFromIndexRangeSeekByString(index, limit.endPoint.asInstanceOf[String], limit.isInclusive, null, false)
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
 
       case RangeBetween(rangeGreaterThan, rangeLessThan) =>
         rangeGreaterThan.limit(BY_STRING).flatMap { greaterThanLimit =>
           rangeLessThan.limit(BY_STRING).map { lessThanLimit =>
-            readOps.nodesGetFromIndexRangeSeekByString(
-              index,
-              greaterThanLimit.endPoint.asInstanceOf[String], greaterThanLimit.isInclusive,
-              lessThanLimit.endPoint.asInstanceOf[String], lessThanLimit.isInclusive )
+            readOps.nodesGetFromIndexRangeSeekByString(index, greaterThanLimit.endPoint.asInstanceOf[String], greaterThanLimit.isInclusive, lessThanLimit.endPoint.asInstanceOf[String], lessThanLimit.isInclusive)
           }
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
     }
@@ -472,7 +467,7 @@ final class TransactionBoundQueryContext(txContext: TransactionalContextWrapper)
   }
 
   override def dropIndexRule(labelId: Int, propertyKeyId: Int) =
-    txContext.statement.schemaWriteOperations().indexDrop(IndexDescriptorFactory.of( labelId, propertyKeyId ))
+    txContext.statement.schemaWriteOperations().indexDrop(NewIndexDescriptorFactory.forLabel( labelId, propertyKeyId ))
 
   override def createUniqueConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = try {
     IdempotentResult(txContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(new NodePropertyDescriptor(labelId, propertyKeyId)))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/GeneratedMethodStructure.scala
@@ -38,7 +38,7 @@ import org.neo4j.cypher.internal.frontend.v3_1.{ParameterNotFoundException, Sema
 import org.neo4j.cypher.internal.spi.v3_1.codegen.Methods._
 import org.neo4j.cypher.internal.spi.v3_1.codegen.Templates.{createNewInstance, handleKernelExceptions, newRelationshipDataExtractor, tryCatch}
 import org.neo4j.graphdb.Direction
-import org.neo4j.kernel.api.schema.{IndexDescriptor, IndexDescriptorFactory, NodePropertyDescriptor}
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor, NewIndexDescriptorFactory}
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 
@@ -737,16 +737,10 @@ case class GeneratedMethodStructure(fields: Fields, generator: CodeBlock, aux: A
     generator.assign(typeRef[Int], propIdVar, invoke(readOperations, propertyKeyGetForName, constant(propName)))
 
   override def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String) = {
-    val getNodePropertyDescriptor =
-      method[IndexDescriptorFactory, NodePropertyDescriptor]("getNodePropertyDescriptor", typeRef[Int], typeRef[Int])
-    val getIndexDescriptor =
-      method[IndexDescriptorFactory, IndexDescriptor]("of", typeRef[NodePropertyDescriptor])
-    generator.assign(typeRef[IndexDescriptor], descriptorVar,
-      invoke(
-        getIndexDescriptor,
-        invoke(getNodePropertyDescriptor, generator.load(labelVar), generator.load(propKeyVar))
-      )
-    )
+    val getIndexDescriptor = method[NewIndexDescriptorFactory, NewIndexDescriptor]("forLabel", typeRef[Int], typeRef[Array[Int]])
+    val propertyIdsExpr = Expression.newArray(typeRef[Int], generator.load(propKeyVar))
+    generator.assign(typeRef[NewIndexDescriptor], descriptorVar,
+                      invoke(getIndexDescriptor, generator.load(labelVar), propertyIdsExpr))
   }
 
   override def indexSeek(iterVar: String, descriptorVar: String, value: Expression) = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/Methods.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/codegen/Methods.scala
@@ -30,7 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.spi.{InternalResultRow, InternalR
 import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.kernel.api.ReadOperations
-import org.neo4j.kernel.api.schema.IndexDescriptor
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.api.{RelationshipDataExtractor, RelationshipVisitor}
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy, RelationshipProxy}
@@ -80,8 +80,8 @@ object Methods {
   val nodeExists = method[ReadOperations, Boolean]("nodeExists", typeRef[Long])
   val nodesGetAll = method[ReadOperations, PrimitiveLongIterator]("nodesGetAll")
   val nodeGetProperty = method[ReadOperations, Object]("nodeGetProperty", typeRef[Long], typeRef[Int])
-  val nodesGetFromIndexLookup = method[ReadOperations, PrimitiveLongIterator]("nodesGetFromIndexSeek", typeRef[IndexDescriptor], typeRef[Object])
-  val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[IndexDescriptor], typeRef[Object])
+  val nodesGetFromIndexLookup = method[ReadOperations, PrimitiveLongIterator]("nodesGetFromIndexSeek", typeRef[NewIndexDescriptor], typeRef[Object])
+  val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[NewIndexDescriptor], typeRef[Object])
   val relationshipGetProperty = method[ReadOperations, Object]("relationshipGetProperty", typeRef[Long], typeRef[Int])
   val nodesGetForLabel = method[ReadOperations, PrimitiveLongIterator]("nodesGetForLabel", typeRef[Int])
   val nodeHasLabel = method[ReadOperations, Boolean]("nodeHasLabel", typeRef[Long], typeRef[Int])

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/IndexDescriptorCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/IndexDescriptorCompatibility.scala
@@ -20,12 +20,13 @@
 package org.neo4j.cypher.internal.spi.v3_2
 
 import org.neo4j.cypher.internal.compiler.v3_2.{IndexDescriptor => CypherIndexDescriptor}
-import org.neo4j.kernel.api.schema.{IndexDescriptor => KernelIndexDescriptor, NodeMultiPropertyDescriptor, NodePropertyDescriptor, IndexDescriptorFactory}
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 
 trait IndexDescriptorCompatibility {
   implicit def cypherToKernel(index: CypherIndexDescriptor) =
-    IndexDescriptorFactory.of(index.label, index.property)
+    NewIndexDescriptorFactory.forLabel(index.label, index.property)
 
   implicit def kernelToCypher(index: KernelIndexDescriptor) =
-    CypherIndexDescriptor(index.getLabelId, index.getPropertyKeyId)
+    CypherIndexDescriptor(index.schema().getLabelId, index.schema().getPropertyIds()(0))
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
@@ -39,7 +39,7 @@ object TransactionBoundGraphStatistics {
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
-        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity( indexDescriptor )
+        val indexEntrySelectivity = operations.indexUniqueValuesSelectivity(indexDescriptor)
         val frequencyOfNodesWithSameValue = 1.0 / indexEntrySelectivity
         val indexSelectivity = frequencyOfNodesWithSameValue / labeledNodes
 
@@ -55,7 +55,7 @@ object TransactionBoundGraphStatistics {
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a given property
-        val indexSize = operations.indexSize( indexDescriptor )
+        val indexSize = operations.indexSize(indexDescriptor)
         val indexSelectivity = indexSize / labeledNodes
 
         Selectivity.of(indexSelectivity)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, NameId, PropertyKeyId, 
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, Selectivity}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory
 
 object TransactionBoundGraphStatistics {
   def apply(ops: ReadOperations) = new StatisticsCompletingGraphStatistics(new BaseTransactionBoundGraphStatistics(ops))
@@ -35,7 +35,7 @@ object TransactionBoundGraphStatistics {
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a property with a given value
@@ -51,7 +51,7 @@ object TransactionBoundGraphStatistics {
 
     def indexPropertyExistsSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
       try {
-        val indexDescriptor = IndexDescriptorFactory.of( label, property )
+        val indexDescriptor = NewIndexDescriptorFactory.forLabel( label, property )
         val labeledNodes = operations.countsForNodeWithoutTxState( label ).toDouble
 
         // Probability of any node with the given label, to have a given property

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContext.scala
@@ -35,7 +35,7 @@ import org.neo4j.kernel.api.index.InternalIndexState
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, QualifiedName => KernelQualifiedName}
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor
-import org.neo4j.kernel.api.schema.{IndexDescriptor => KernelIndexDescriptor}
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor => KernelIndexDescriptor}
 import org.neo4j.kernel.impl.proc.Neo4jValue
 import org.neo4j.procedure.Mode
 
@@ -67,7 +67,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
 
     // here we do not need to use getOnlineIndex method because uniqueness constraint creation is synchronous
     val index = tc.statement.readOperations().uniqueIndexGetForLabelAndPropertyKey(new NodePropertyDescriptor(labelId, propertyKeyId))
-    Some(IndexDescriptor(index.getLabelId, index.getPropertyKeyId))
+    Some(IndexDescriptor(index.schema().getLabelId, index.schema().getPropertyIds()(0)))
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =
@@ -79,7 +79,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
 
   private def getOnlineIndex(descriptor: KernelIndexDescriptor): Option[IndexDescriptor] =
     tc.statement.readOperations().indexGetState(descriptor) match {
-      case InternalIndexState.ONLINE => Some(IndexDescriptor(descriptor.getLabelId, descriptor.getPropertyKeyId))
+      case InternalIndexState.ONLINE => Some(IndexDescriptor(descriptor.schema().getLabelId, descriptor.schema().getPropertyIds()(0)))
       case _ => None
     }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -22,10 +22,10 @@ package org.neo4j.cypher.internal.spi.v3_2
 import java.net.URL
 import java.util.function.Predicate
 
-import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor.toKernelEncode
 import org.neo4j.collection.RawIterator
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.collection.primitive.base.Empty.EMPTY_PRIMITIVE_LONG_COLLECTION
+import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor.toKernelEncode
 import org.neo4j.cypher.internal.compiler.v3_2.MinMaxOrdering.{BY_NUMBER, BY_STRING, BY_VALUE}
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.DirectionConverter.toGraphDb
@@ -54,7 +54,7 @@ import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, Alre
 import org.neo4j.kernel.api.index.InternalIndexState
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction.Aggregator
 import org.neo4j.kernel.api.proc.{QualifiedName => KernelQualifiedName}
-import org.neo4j.kernel.api.schema.{IndexDescriptorFactory, NodeMultiPropertyDescriptor, NodePropertyDescriptor, RelationshipPropertyDescriptor}
+import org.neo4j.kernel.api.schema.{NodeMultiPropertyDescriptor, NodePropertyDescriptor, RelationshipPropertyDescriptor}
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.locking.ResourceTypes
 
@@ -212,21 +212,18 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
       case rangeLessThan: RangeLessThan[Number] =>
         rangeLessThan.limit(BY_NUMBER).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByNumber( index, null, false, limit.endPoint, limit.isInclusive )
+          readOps.nodesGetFromIndexRangeSeekByNumber(index, null, false, limit.endPoint, limit.isInclusive)
         }
 
       case rangeGreaterThan: RangeGreaterThan[Number] =>
         rangeGreaterThan.limit(BY_NUMBER).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByNumber( index, limit.endPoint, limit.isInclusive, null, false )
+          readOps.nodesGetFromIndexRangeSeekByNumber(index, limit.endPoint, limit.isInclusive, null, false)
         }
 
       case RangeBetween(rangeGreaterThan, rangeLessThan) =>
         rangeGreaterThan.limit(BY_NUMBER).flatMap { greaterThanLimit =>
           rangeLessThan.limit(BY_NUMBER).map { lessThanLimit =>
-            readOps.nodesGetFromIndexRangeSeekByNumber(
-              index,
-              greaterThanLimit.endPoint, greaterThanLimit.isInclusive,
-              lessThanLimit.endPoint, lessThanLimit.isInclusive )
+            readOps.nodesGetFromIndexRangeSeekByNumber(index, greaterThanLimit.endPoint, greaterThanLimit.isInclusive, lessThanLimit.endPoint, lessThanLimit.isInclusive)
           }
         }
     }).getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
@@ -239,21 +236,18 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
       case rangeLessThan: RangeLessThan[String] =>
         rangeLessThan.limit(BY_STRING).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByString( index, null, false, limit.endPoint.asInstanceOf[String], limit.isInclusive )
+          readOps.nodesGetFromIndexRangeSeekByString(index, null, false, limit.endPoint.asInstanceOf[String], limit.isInclusive)
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
 
       case rangeGreaterThan: RangeGreaterThan[String] =>
         rangeGreaterThan.limit(BY_STRING).map { limit =>
-          readOps.nodesGetFromIndexRangeSeekByString( index, limit.endPoint.asInstanceOf[String], limit.isInclusive, null, false )
+          readOps.nodesGetFromIndexRangeSeekByString(index, limit.endPoint.asInstanceOf[String], limit.isInclusive, null, false)
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
 
       case RangeBetween(rangeGreaterThan, rangeLessThan) =>
         rangeGreaterThan.limit(BY_STRING).flatMap { greaterThanLimit =>
           rangeLessThan.limit(BY_STRING).map { lessThanLimit =>
-            readOps.nodesGetFromIndexRangeSeekByString(
-              index,
-              greaterThanLimit.endPoint.asInstanceOf[String], greaterThanLimit.isInclusive,
-              lessThanLimit.endPoint.asInstanceOf[String], lessThanLimit.isInclusive )
+            readOps.nodesGetFromIndexRangeSeekByString(index, greaterThanLimit.endPoint.asInstanceOf[String], greaterThanLimit.isInclusive, lessThanLimit.endPoint.asInstanceOf[String], lessThanLimit.isInclusive)
           }
         }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -122,7 +121,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexSeek( IndexDescriptor index, Object value )
+    PrimitiveLongIterator nodesGetFromIndexSeek( NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
     /**
@@ -130,7 +129,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( IndexDescriptor index, String prefix )
+    PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( NewIndexDescriptor index, String prefix )
             throws IndexNotFoundKernelException;
 
     /**
@@ -138,7 +137,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( IndexDescriptor index, Number lower, boolean includeLower, Number upper, boolean includeUpper )
+    PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( NewIndexDescriptor index, Number lower, boolean includeLower, Number upper, boolean includeUpper )
             throws IndexNotFoundKernelException;
 
     /**
@@ -146,7 +145,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( IndexDescriptor index, String lower, boolean includeLower, String upper, boolean includeUpper )
+    PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( NewIndexDescriptor index, String lower, boolean includeLower, String upper, boolean includeUpper )
             throws IndexNotFoundKernelException;
 
     /**
@@ -154,7 +153,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexScan( IndexDescriptor index )
+    PrimitiveLongIterator nodesGetFromIndexScan( NewIndexDescriptor index )
             throws IndexNotFoundKernelException;
 
     /**
@@ -162,7 +161,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexContainsScan( IndexDescriptor index, String term )
+    PrimitiveLongIterator nodesGetFromIndexContainsScan( NewIndexDescriptor index, String term )
             throws IndexNotFoundKernelException;
 
     /**
@@ -170,7 +169,7 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexEndsWithScan( IndexDescriptor index, String suffix )
+    PrimitiveLongIterator nodesGetFromIndexEndsWithScan( NewIndexDescriptor index, String suffix )
             throws IndexNotFoundKernelException;
 
     /**
@@ -201,10 +200,10 @@ public interface ReadOperations
      *
      * @throws org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException if no such index found.
      */
-    long nodeGetFromUniqueIndexSeek( IndexDescriptor index, Object value ) throws IndexNotFoundKernelException,
+    long nodeGetFromUniqueIndexSeek( NewIndexDescriptor index, Object value ) throws IndexNotFoundKernelException,
             IndexBrokenKernelException;
 
-    long nodesCountIndexed( IndexDescriptor index, long nodeId, Object value )
+    long nodesCountIndexed( NewIndexDescriptor index, long nodeId, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException;
 
     boolean nodeExists( long nodeId );
@@ -526,10 +525,10 @@ public interface ReadOperations
      */
     long countsForRelationshipWithoutTxState( int startLabelId, int typeId, int endLabelId );
 
-    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target )
+    DoubleLongRegister indexUpdatesAndSize( NewIndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException;
 
-    DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target )
+    DoubleLongRegister indexSample( NewIndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException;
 
     //===========================================

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.register.Register.DoubleLongRegister;
@@ -266,39 +267,44 @@ public interface ReadOperations
     //===========================================
 
     /** Returns the index rule for the given labelId and propertyKey. */
-    IndexDescriptor indexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
+    NewIndexDescriptor indexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
             throws SchemaRuleNotFoundException;
 
     /** Get all indexes for a label. */
-    Iterator<IndexDescriptor> indexesGetForLabel( int labelId );
+    Iterator<NewIndexDescriptor> indexesGetForLabel( int labelId );
 
     /** Returns all indexes. */
-    Iterator<IndexDescriptor> indexesGetAll();
+    Iterator<NewIndexDescriptor> indexesGetAll();
 
     /** Returns the constraint index for the given labelId and propertyKey. */
-    IndexDescriptor uniqueIndexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
+    NewIndexDescriptor uniqueIndexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
             throws SchemaRuleNotFoundException, DuplicateSchemaRuleException;
 
     /** Get all constraint indexes for a label. */
-    Iterator<IndexDescriptor> uniqueIndexesGetForLabel( int labelId );
+    Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( int labelId );
 
     /** Returns all constraint indexes. */
-    Iterator<IndexDescriptor> uniqueIndexesGetAll();
+    Iterator<NewIndexDescriptor> uniqueIndexesGetAll();
 
-    /** Retrieve the state of an index. */
-    InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    /** Retrieve the state of an index.
+     * @param descriptor*/
+    InternalIndexState indexGetState( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Retrieve the population progress of an index. */
-    PopulationProgress indexGetPopulationProgress( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    /** Retrieve the population progress of an index.
+     * @param descriptor*/
+    PopulationProgress indexGetPopulationProgress( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Get the index size. */
-    long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    /** Get the index size.
+     * @param descriptor*/
+    long indexSize( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Calculate the index unique values percentage (range: {@code 0.0} exclusive to {@code 1.0} inclusive). */
-    double indexUniqueValuesSelectivity( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    /** Calculate the index unique values percentage (range: {@code 0.0} exclusive to {@code 1.0} inclusive).
+     * @param descriptor*/
+    double indexUniqueValuesSelectivity( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Returns the failure description of a failed index. */
-    String indexGetFailure( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    /** Returns the failure description of a failed index.
+     * @param descriptor*/
+    String indexGetFailure( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Get all constraints applicable to label and propertyKey. There are only {@link NodePropertyConstraint}
@@ -334,7 +340,7 @@ public interface ReadOperations
     /**
      * Get the owning constraint for a constraint index. Returns null if the index does not have an owning constraint.
      */
-    Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
+    Long indexGetOwningUniquenessConstraintId( NewIndexDescriptor index ) throws SchemaRuleNotFoundException;
 
     <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -29,9 +29,9 @@ import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
 public interface SchemaWriteOperations
 {
@@ -39,11 +39,11 @@ public interface SchemaWriteOperations
      * Creates an index, indexing properties with the given {@code propertyKeyId} for nodes with the given
      * {@code labelId}.
      */
-    IndexDescriptor indexCreate( NodePropertyDescriptor nodeDescriptor )
+    NewIndexDescriptor indexCreate( NodePropertyDescriptor nodeDescriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException;
 
-    /** Drops a {@link IndexDescriptor} from the database */
-    void indexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
+    /** Drops a {@link NewIndexDescriptor} from the database */
+    void indexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     UniquenessConstraint uniquePropertyConstraintCreate( NodePropertyDescriptor descriptor )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
@@ -63,5 +63,5 @@ public interface SchemaWriteOperations
      * This should not be used, it is exposed to allow an external job to clean up constraint indexes.
      * That external job should become an internal job, at which point this operation should go away.
      */
-    void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
+    void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DropIndexFailureException.java
@@ -19,21 +19,23 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
 import static java.lang.String.format;
 
 public class DropIndexFailureException extends SchemaKernelException
 {
-    private final NodePropertyDescriptor descriptor;
+    private final LabelSchemaDescriptor descriptor;
     private static final String message = "Unable to drop index on %s: %s";
 
-    public DropIndexFailureException( NodePropertyDescriptor descriptor, SchemaKernelException cause )
+    public DropIndexFailureException( LabelSchemaDescriptor descriptor, SchemaKernelException cause )
     {
-        super( Status.Schema.IndexDropFailed, format( message, descriptor, cause.getMessage() ), cause );
+        super( Status.Schema.IndexDropFailed, format( message, descriptor.userDescription( SchemaUtil.idTokenNameLookup ),
+                        cause.getMessage() ), cause );
         this.descriptor = descriptor;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexBelongsToConstraintException.java
@@ -19,26 +19,26 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 
 import static java.lang.String.format;
 
 public class IndexBelongsToConstraintException extends SchemaKernelException
 {
-    private final NodePropertyDescriptor index;
+    private final LabelSchemaDescriptor descriptor;
     private static final String message = "Index belongs to constraint: %s";
 
-    public IndexBelongsToConstraintException( NodePropertyDescriptor index )
+    public IndexBelongsToConstraintException( LabelSchemaDescriptor descriptor )
     {
-        super( Status.Schema.ForbiddenOnConstraintIndex, format( "Index belongs to constraint: %s", index ) );
-        this.index = index;
+        super( Status.Schema.ForbiddenOnConstraintIndex, format( "Index belongs to constraint: %s", descriptor ) );
+        this.descriptor = descriptor;
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return format( message, index.userDescription( tokenNameLookup ) );
+        return format( message, descriptor.userDescription( tokenNameLookup ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NoSuchIndexException.java
@@ -19,20 +19,22 @@
  */
 package org.neo4j.kernel.api.exceptions.schema;
 
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
 import static java.lang.String.format;
 
 public class NoSuchIndexException extends SchemaKernelException
 {
-    private final NodePropertyDescriptor descriptor;
+    private final LabelSchemaDescriptor descriptor;
     private static final String message = "No such INDEX ON %s.";
 
-    public NoSuchIndexException( NodePropertyDescriptor descriptor )
+    public NoSuchIndexException( LabelSchemaDescriptor descriptor )
     {
-        super( Status.Schema.IndexNotFound, format( message, descriptor ) );
+        super( Status.Schema.IndexNotFound, format( message,
+                descriptor.userDescription( SchemaUtil.idTokenNameLookup ) ) );
         this.descriptor = descriptor;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
@@ -44,7 +44,7 @@ class SchemaRuleException extends SchemaKernelException
             SchemaDescriptor descriptor )
     {
         super( status, format( messageTemplate, kind.userString().toLowerCase(),
-                descriptor.userDescription( SchemaUtil.noopTokenNameLookup ) ) );
+                descriptor.userDescription( SchemaUtil.idTokenNameLookup ) ) );
         this.descriptor = descriptor;
         this.messageTemplate = messageTemplate;
         this.kind = kind;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema/IndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema/IndexDescriptor.java
@@ -29,6 +29,7 @@ import static java.lang.String.format;
  *
  * @see SchemaRule
  */
+@Deprecated
 public interface IndexDescriptor
 {
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaBoundary.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.schema_new;
 
+import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 
@@ -42,5 +43,10 @@ public class SchemaBoundary
     public static RelationTypeSchemaDescriptor map( RelationshipPropertyDescriptor descriptor )
     {
         return SchemaDescriptorFactory.forRelType( descriptor.getRelationshipTypeId(), descriptor.getPropertyKeyId() );
+    }
+
+    public static NodePropertyDescriptor map( LabelSchemaDescriptor descriptor )
+    {
+        return IndexDescriptorFactory.getNodePropertyDescriptor( descriptor.getLabelId(), descriptor.getPropertyIds() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaComputer.java
@@ -33,15 +33,6 @@ package org.neo4j.kernel.api.schema_new;
  */
 public interface SchemaComputer<R>
 {
-    /**
-     * Convenience method to make compute calls more readable.
-     * @param schema the SchemaDescriptor that is to be computed with.
-     */
-    default R compute( SchemaDescriptor schema )
-    {
-        return schema.computeWith( this );
-    }
-
     /*
     The following section contains the overloaded process signatures for all concrete SchemaDescriptor implementers.
     Add new overloaded methods here when adding more concrete SchemaDescriptors.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
@@ -66,11 +66,11 @@ public interface SchemaDescriptor
      */
     default boolean isSame( SchemaDescriptor.Supplier supplier )
     {
-        return this.equals( supplier.getSchemaDescriptor() );
+        return this.equals( supplier.schema() );
     }
 
     interface Supplier
     {
-        SchemaDescriptor getSchemaDescriptor();
+        SchemaDescriptor schema();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.schema_new;
 
+import java.util.function.Predicate;
+
 import org.neo4j.kernel.api.TokenNameLookup;
 
 /**
@@ -60,13 +62,14 @@ public interface SchemaDescriptor
     String userDescription( TokenNameLookup tokenNameLookup );
 
     /**
-     * Checks whether a schema descriptor Supplier supplies this schema descriptor.
-     * @param supplier supplier to get a schema descriptor from
-     * @return true if the supplied schema descriptor equals this schema descriptor
+     * Create a predicate that checks whether a schema descriptor Supplier supplies the given schema descriptor.
+     * @param descriptor The schema descriptor to check equality with.
+     * @return A predicate that returns {@code true} if it is given a schema descriptor supplier that supplies the
+     * same schema descriptor as the given schema descriptor.
      */
-    default boolean isSame( SchemaDescriptor.Supplier supplier )
+    static <T extends SchemaDescriptor.Supplier> Predicate<T> equalTo( SchemaDescriptor descriptor )
     {
-        return this.equals( supplier.schema() );
+        return supplier -> descriptor.equals( supplier.schema() );
     }
 
     interface Supplier

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptorPredicates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptorPredicates.java
@@ -27,19 +27,19 @@ public class SchemaDescriptorPredicates
 {
     public static boolean hasLabel( SchemaDescriptor.Supplier supplier, int labelId )
     {
-        Optional<Integer> labelOpt = getLabel.compute( supplier.schema() );
+        Optional<Integer> labelOpt = supplier.schema().computeWith( getLabel );
         return labelOpt.isPresent() && labelOpt.get() == labelId;
     }
 
     public static boolean hasRelType( SchemaDescriptor.Supplier supplier, int relTypeId )
     {
-        Optional<Integer> relTypeOpt = getRelType.compute( supplier.schema() );
+        Optional<Integer> relTypeOpt = supplier.schema().computeWith( getRelType );
         return relTypeOpt.isPresent() && relTypeOpt.get() == relTypeId;
     }
 
     public static boolean hasProperty( SchemaDescriptor.Supplier supplier, int propertyId )
     {
-        List<Integer> properties = getProperties.compute( supplier.schema() );
+        List<Integer> properties = supplier.schema().computeWith( getProperties );
         return properties.contains( propertyId );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptorPredicates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptorPredicates.java
@@ -27,19 +27,19 @@ public class SchemaDescriptorPredicates
 {
     public static boolean hasLabel( SchemaDescriptor.Supplier supplier, int labelId )
     {
-        Optional<Integer> labelOpt = getLabel.compute( supplier.getSchemaDescriptor() );
+        Optional<Integer> labelOpt = getLabel.compute( supplier.schema() );
         return labelOpt.isPresent() && labelOpt.get() == labelId;
     }
 
     public static boolean hasRelType( SchemaDescriptor.Supplier supplier, int relTypeId )
     {
-        Optional<Integer> relTypeOpt = getRelType.compute( supplier.getSchemaDescriptor() );
+        Optional<Integer> relTypeOpt = getRelType.compute( supplier.schema() );
         return relTypeOpt.isPresent() && relTypeOpt.get() == relTypeId;
     }
 
     public static boolean hasProperty( SchemaDescriptor.Supplier supplier, int propertyId )
     {
-        List<Integer> properties = getProperties.compute( supplier.getSchemaDescriptor() );
+        List<Integer> properties = getProperties.compute( supplier.schema() );
         return properties.contains( propertyId );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaProcessor.java
@@ -26,15 +26,6 @@ package org.neo4j.kernel.api.schema_new;
  */
 public interface SchemaProcessor
 {
-    /**
-     * Convenience method to make calls more readable.
-     * @param schema the SchemaDescriptor that is to be processed.
-     */
-    default void process( SchemaDescriptor schema )
-    {
-        schema.processWith( this );
-    }
-
     /*
     The following section contains the overloaded process signatures for all concrete SchemaDescriptor implementers.
     Add new overloaded methods here when adding more concrete SchemaDescriptors.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.api.schema_new;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 
+import static java.lang.String.format;
+
 public class SchemaUtil
 {
     private SchemaUtil()
@@ -37,32 +39,24 @@ public class SchemaUtil
         return String.join( ", ", properties );
     }
 
-    public static TokenNameLookup noopTokenNameLookup = new PrefixTokenName( "" );
-    public static class PrefixTokenName implements TokenNameLookup
-    {
-        private final String prefix;
-
-        public PrefixTokenName( String prefix )
-        {
-            this.prefix = prefix;
-        }
+    public static TokenNameLookup idTokenNameLookup = new TokenNameLookup() {
 
         @Override
         public String labelGetName( int labelId )
         {
-            return prefix + labelId;
+            return format( "label[%d]", labelId );
         }
 
         @Override
         public String relationshipTypeGetName( int relationshipTypeId )
         {
-            return prefix + relationshipTypeId;
+            return format( "relType[%d]", relationshipTypeId );
         }
 
         @Override
         public String propertyKeyGetName( int propertyKeyId )
         {
-            return prefix + propertyKeyId;
+            return format( "property[%d]", propertyKeyId );
         }
-    }
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
@@ -39,17 +39,18 @@ public class ConstraintBoundary
 {
     public static PropertyConstraint map( ConstraintDescriptor descriptor )
     {
-        return new BoundaryTransformer( descriptor ).compute( descriptor.schema() );
+        return descriptor.schema().computeWith( new BoundaryTransformer( descriptor ) );
     }
 
     public static NodePropertyConstraint mapNode( ConstraintDescriptor descriptor )
     {
-        return (NodePropertyConstraint)new BoundaryTransformer( descriptor ).compute( descriptor.schema() );
+        return (NodePropertyConstraint) descriptor.schema().computeWith( new BoundaryTransformer( descriptor ) );
     }
 
     public static RelationshipPropertyConstraint mapRelationship( ConstraintDescriptor descriptor )
     {
-        return (RelationshipPropertyConstraint)new BoundaryTransformer( descriptor ).compute( descriptor.schema() );
+        return (RelationshipPropertyConstraint) descriptor.schema()
+                                                          .computeWith( new BoundaryTransformer( descriptor ) );
     }
 
     static class BoundaryTransformer implements SchemaComputer<PropertyConstraint>

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
@@ -28,7 +28,7 @@ import static java.lang.String.format;
  * Internal representation of a graph constraint, including the schema unit it targets (eg. label-property combination)
  * and the how that schema unit is constrained (eg. "has to exist", or "must be unique").
  */
-public class ConstraintDescriptor
+public class ConstraintDescriptor implements SchemaDescriptor.Supplier
 {
     public enum Type { UNIQUE, EXISTS }
 
@@ -48,6 +48,7 @@ public class ConstraintDescriptor
 
     // METHODS
 
+    @Override
     public SchemaDescriptor schema()
     {
         return schema;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 
 /**
  * This class represents the boundary of where new index descriptors are converted to old index descriptors. Take me
@@ -38,6 +39,15 @@ public class IndexBoundary
             return null;
         }
         return IndexDescriptorFactory.of( descriptor.schema().getLabelId(), descriptor.schema().getPropertyIds()[0] );
+    }
+
+    public static IndexDescriptor map( LabelSchemaDescriptor descriptor )
+    {
+        if ( descriptor == null )
+        {
+            return null;
+        }
+        return IndexDescriptorFactory.of( descriptor.getLabelId(), descriptor.getPropertyIds() );
     }
 
     public static NewIndexDescriptor map( IndexDescriptor descriptor )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/IndexBoundary.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 
 /**
@@ -57,6 +58,24 @@ public class IndexBoundary
             return null;
         }
         return NewIndexDescriptorFactory.forLabel( descriptor.getLabelId(), descriptor.getPropertyKeyId() );
+    }
+
+    public static NewIndexDescriptor map( NodePropertyDescriptor descriptor )
+    {
+        if ( descriptor == null )
+        {
+            return null;
+        }
+        return NewIndexDescriptorFactory.forLabel( descriptor.getLabelId(), descriptor.getPropertyKeyId() );
+    }
+
+    public static NewIndexDescriptor mapUnique( IndexDescriptor descriptor )
+    {
+        if ( descriptor == null )
+        {
+            return null;
+        }
+        return NewIndexDescriptorFactory.uniqueForLabel( descriptor.getLabelId(), descriptor.getPropertyKeyId() );
     }
 
     public static Iterator<IndexDescriptor> map( Iterator<NewIndexDescriptor> iterator )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
@@ -19,8 +19,11 @@
  */
 package org.neo4j.kernel.api.schema_new.index;
 
+import java.util.function.Predicate;
+
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 
 import static java.lang.String.format;
 
@@ -31,9 +34,37 @@ import static java.lang.String.format;
  * This will be renamed to IndexDescriptor, once the old org.neo4j.kernel.api.schema.IndexDescriptor is completely
  * removed.
  */
-public class NewIndexDescriptor
+public class NewIndexDescriptor implements SchemaDescriptor.Supplier
 {
     public enum Type { GENERAL, UNIQUE }
+
+    public enum Filter implements Predicate<NewIndexDescriptor>
+    {
+        GENERAL
+                {
+                    @Override
+                    public boolean test( NewIndexDescriptor rule )
+                    {
+                        return rule.type == Type.GENERAL;
+                    }
+                },
+        UNIQUE
+                {
+                    @Override
+                    public boolean test( NewIndexDescriptor rule )
+                    {
+                        return rule.type == Type.UNIQUE;
+                    }
+                },
+        ANY
+                {
+                    @Override
+                    public boolean test( NewIndexDescriptor rule )
+                    {
+                        return true;
+                    }
+                }
+    }
 
     public interface Supplier
     {
@@ -60,6 +91,7 @@ public class NewIndexDescriptor
      * This method currently returns the specific LabelSchemaDescriptor, as we do not support indexes on relations.
      * When we do, consider down-typing this to a SchemaDescriptor.
      */
+    @Override
     public LabelSchemaDescriptor schema()
     {
         return schema;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -24,9 +24,10 @@ import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 
 /**
@@ -78,13 +79,9 @@ public interface TransactionState extends ReadableTransactionState
 
     // SCHEMA RELATED
 
-    void indexRuleDoAdd( IndexDescriptor descriptor );
+    void indexRuleDoAdd( NewIndexDescriptor descriptor );
 
-    void constraintIndexRuleDoAdd( IndexDescriptor descriptor );
-
-    void indexDoDrop( IndexDescriptor descriptor );
-
-    void constraintIndexDoDrop( IndexDescriptor descriptor );
+    void indexDoDrop( NewIndexDescriptor descriptor );
 
     void constraintDoAdd( UniquenessConstraint constraint, long indexId );
 
@@ -100,5 +97,5 @@ public interface TransactionState extends ReadableTransactionState
 
     boolean constraintIndexDoUnRemove( UniquenessConstraint constraint );
 
-    void indexDoUpdateProperty( IndexDescriptor descriptor, long nodeId, DefinedProperty before, DefinedProperty after );
+    void indexDoUpdateProperty( LabelSchemaDescriptor descriptor, long nodeId, DefinedProperty before, DefinedProperty after );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -101,15 +102,14 @@ public class BuiltInProcedures
             ReadOperations operations = statement.readOperations();
             TokenNameLookup tokens = new StatementTokenNameLookup( operations );
 
-            List<IndexDescriptor> indexes =
-                    asList( operations.indexesGetAll() );
+            List<NewIndexDescriptor> indexes = asList( operations.indexesGetAll() );
 
-            Set<IndexDescriptor> uniqueIndexes = asSet( operations.uniqueIndexesGetAll() );
+            Set<NewIndexDescriptor> uniqueIndexes = asSet( operations.uniqueIndexesGetAll() );
             indexes.addAll( uniqueIndexes );
             indexes.sort( Comparator.comparing( a -> a.userDescription( tokens ) ) );
 
             ArrayList<IndexResult> result = new ArrayList<>();
-            for ( IndexDescriptor index : indexes )
+            for ( NewIndexDescriptor index : indexes )
             {
                 try
                 {
@@ -123,7 +123,7 @@ public class BuiltInProcedures
                         type = IndexType.NODE_LABEL_PROPERTY.typeName();
                     }
 
-                    result.add( new IndexResult( "INDEX ON " + index.userDescription( tokens ),
+                    result.add( new IndexResult( "INDEX ON " + index.schema().userDescription( tokens ),
                             operations.indexGetState( index ).toString(), type ) );
                 }
                 catch ( IndexNotFoundKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/IndexProcedures.java
@@ -33,6 +33,8 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
 
@@ -106,7 +108,7 @@ public class IndexProcedures implements AutoCloseable
         return propertyKeyId;
     }
 
-    private IndexDescriptor getIndex( int labelId, int propertyKeyId, IndexSpecifier index ) throws
+    private NewIndexDescriptor getIndex( int labelId, int propertyKeyId, IndexSpecifier index ) throws
             ProcedureException
     {
         try
@@ -119,8 +121,8 @@ public class IndexProcedures implements AutoCloseable
         }
     }
 
-    private void waitUntilOnline( IndexDescriptor index, IndexSpecifier indexDescription, long timeout, TimeUnit
-            timeoutUnits )
+    private void waitUntilOnline( NewIndexDescriptor index, IndexSpecifier indexDescription,
+            long timeout, TimeUnit timeoutUnits )
             throws ProcedureException
     {
         try
@@ -134,7 +136,7 @@ public class IndexProcedures implements AutoCloseable
         }
     }
 
-    private boolean isOnline( IndexSpecifier indexDescription, IndexDescriptor index ) throws ProcedureException
+    private boolean isOnline( IndexSpecifier indexDescription, NewIndexDescriptor index ) throws ProcedureException
     {
         InternalIndexState state = getState( indexDescription, index );
         switch ( state )
@@ -151,7 +153,7 @@ public class IndexProcedures implements AutoCloseable
         }
     }
 
-    private InternalIndexState getState( IndexSpecifier indexDescription, IndexDescriptor index )
+    private InternalIndexState getState( IndexSpecifier indexDescription, NewIndexDescriptor index )
             throws ProcedureException
     {
         try
@@ -164,9 +166,9 @@ public class IndexProcedures implements AutoCloseable
         }
     }
 
-    private void triggerSampling( IndexDescriptor index ) throws IndexNotFoundKernelException
+    private void triggerSampling( NewIndexDescriptor index ) throws IndexNotFoundKernelException
     {
-        indexingService.triggerIndexSampling( index, IndexSamplingMode.TRIGGER_REBUILD_ALL );
+        indexingService.triggerIndexSampling( IndexBoundary.map( index ), IndexSamplingMode.TRIGGER_REBUILD_ALL );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.coreapi.schema.PropertyNameUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
@@ -78,14 +79,14 @@ public class SchemaProcedure
                     Label label = labelsInDatabase.next();
                     Map<String,Object> properties = new HashMap<>();
 
-                    Iterator<IndexDescriptor> indexDescriptorIterator =
+                    Iterator<NewIndexDescriptor> indexDescriptorIterator =
                             readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
                     ArrayList<String> indexes = new ArrayList<>();
                     while ( indexDescriptorIterator.hasNext() )
                     {
-                        IndexDescriptor index = indexDescriptorIterator.next();
-                        String[] propertyNames =
-                                PropertyNameUtils.getPropertyKeys( statementTokenNameLookup, index.descriptor() );
+                        NewIndexDescriptor index = indexDescriptorIterator.next();
+                        String[] propertyNames = PropertyNameUtils.getPropertyKeys(
+                                                    statementTokenNameLookup, index.schema().getPropertyIds() );
                         indexes.add( String.join( ",", propertyNames ) );
                     }
                     properties.put( "indexes", indexes );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -50,6 +50,8 @@ import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.operations.EntityOperations;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
@@ -144,7 +146,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         {
             // TODO: Support composite constraints
             IndexDescriptor index = constraint.indexDescriptor();
-            assertIndexOnline( state, index );
+            assertIndexOnline( state, IndexBoundary.map( index ) );
             state.locks().optimistic().acquireExclusive( state.lockTracer(), INDEX_ENTRY,
                     indexEntryResourceId( index.getLabelId(), index.getPropertyKeyId(), Strings.prettyPrint( value
                     ) ) );
@@ -163,7 +165,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         }
     }
 
-    private void assertIndexOnline( KernelStatement state, IndexDescriptor indexDescriptor )
+    private void assertIndexOnline( KernelStatement state, NewIndexDescriptor indexDescriptor )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         switch ( schemaReadOperations.indexGetState( state, indexDescriptor ) )
@@ -311,7 +313,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
-        assertIndexOnline( state, index );
+        assertIndexOnline( state, IndexBoundary.map( index ) );
 
         // TODO: Support composite index, either by allowing value to be an array, or by creating a new method
         int labelId = index.getLabelId();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -434,20 +434,20 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public IndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
         return schemaWriteOperations.indexCreate( state, descriptor );
     }
 
     @Override
-    public void indexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void indexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         schemaWriteOperations.indexDrop( state, descriptor );
     }
 
     @Override
-    public void uniqueIndexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         schemaWriteOperations.uniqueIndexDrop( state, descriptor );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -151,7 +151,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
                     indexEntryResourceId( index.getLabelId(), index.getPropertyKeyId(), Strings.prettyPrint( value
                     ) ) );
 
-            long existing = entityReadOperations.nodeGetFromUniqueIndexSeek( state, index, value );
+            long existing = entityReadOperations.nodeGetFromUniqueIndexSeek( state, IndexBoundary.map( index ), value );
             if ( existing != NO_SUCH_NODE && existing != modifiedNode )
             {
                 throw new UniquePropertyConstraintViolationKernelException( index.getLabelId(),
@@ -263,7 +263,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException
     {
         return entityReadOperations.nodesGetFromIndexSeek( state, index, value );
@@ -271,7 +271,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement statement,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             Number lower, boolean includeLower,
             Number upper, boolean includeUpper )
             throws IndexNotFoundKernelException
@@ -282,7 +282,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( KernelStatement statement,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             String lower, boolean includeLower,
             String upper, boolean includeUpper )
             throws IndexNotFoundKernelException
@@ -293,14 +293,14 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( KernelStatement state,
-            IndexDescriptor index, String prefix )
+            NewIndexDescriptor index, String prefix )
             throws IndexNotFoundKernelException
     {
         return entityReadOperations.nodesGetFromIndexRangeSeekByPrefix( state, index, prefix );
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, NewIndexDescriptor index )
             throws IndexNotFoundKernelException
     {
         return entityReadOperations.nodesGetFromIndexScan( state, index );
@@ -309,15 +309,15 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     @Override
     public long nodeGetFromUniqueIndexSeek(
             KernelStatement state,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
-        assertIndexOnline( state, IndexBoundary.map( index ) );
+        assertIndexOnline( state, index );
 
         // TODO: Support composite index, either by allowing value to be an array, or by creating a new method
-        int labelId = index.getLabelId();
-        int propertyKeyId = index.getPropertyKeyId();
+        int labelId = index.schema().getLabelId();
+        int propertyKeyId = index.schema().getPropertyIds()[0];
         String stringVal = "";
         if ( null != value )
         {
@@ -351,21 +351,21 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public long nodesCountIndexed( KernelStatement statement, IndexDescriptor index, long nodeId, Object value )
+    public long nodesCountIndexed( KernelStatement statement, NewIndexDescriptor index, long nodeId, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         return entityReadOperations.nodesCountIndexed( statement, index, nodeId, value );
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement state, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement state, NewIndexDescriptor index,
             String term ) throws IndexNotFoundKernelException
     {
         return entityReadOperations.nodesGetFromIndexContainsScan( state, index, term );
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement state, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement state, NewIndexDescriptor index,
             String suffix ) throws IndexNotFoundKernelException
     {
         return entityReadOperations.nodesGetFromIndexEndsWithScan( state, index, suffix );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -247,17 +247,13 @@ public class DataIntegrityValidatingStatementOperations implements
         NewIndexDescriptor existingIndex = schemaReadDelegate.indexGetForLabelAndPropertyKey( state, descriptor );
         if ( existingIndex != null )
         {
-            switch ( existingIndex.type() )
+            if ( existingIndex.type() == UNIQUE )
             {
-            case GENERAL:
-                throw new AlreadyIndexedException( descriptor, context );
-            case UNIQUE:
                 throw new AlreadyConstrainedException(
                         new UniquenessConstraint( descriptor ), context,
                         new StatementTokenNameLookup( state.readOperations() ) );
-            default:
-                break;
             }
+            throw new AlreadyIndexedException( descriptor, context );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -42,7 +42,6 @@ import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchIndexException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException.OperationContext;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaBoundary;
 import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -112,7 +111,7 @@ public class DataIntegrityValidatingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
         checkIndexExistence( state, OperationContext.INDEX_CREATION, descriptor );
@@ -120,24 +119,23 @@ public class DataIntegrityValidatingStatementOperations implements
     }
 
     @Override
-    public void indexDrop( KernelStatement state, IndexDescriptor index ) throws DropIndexFailureException
+    public void indexDrop( KernelStatement state, NewIndexDescriptor index ) throws DropIndexFailureException
     {
         try
         {
-            NewIndexDescriptor newIndex = IndexBoundary.map( index );
-            assertIsNotUniqueIndex( newIndex, schemaReadDelegate.uniqueIndexesGetForLabel(
-                    state, index.getLabelId() ) );
-            assertIndexExists( newIndex, schemaReadDelegate.indexesGetForLabel( state, index.getLabelId() ) );
+            assertIsNotUniqueIndex( index, schemaReadDelegate.uniqueIndexesGetForLabel(
+                    state, index.schema().getLabelId() ) );
+            assertIndexExists( index, schemaReadDelegate.indexesGetForLabel( state, index.schema().getLabelId() ) );
         }
         catch ( IndexBelongsToConstraintException | NoSuchIndexException e )
         {
-            throw new DropIndexFailureException( index.descriptor(), e );
+            throw new DropIndexFailureException( index.schema(), e );
         }
         schemaWriteDelegate.indexDrop( state, index );
     }
 
     @Override
-    public void uniqueIndexDrop( KernelStatement state, IndexDescriptor index ) throws DropIndexFailureException
+    public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor index ) throws DropIndexFailureException
     {
         schemaWriteDelegate.uniqueIndexDrop( state, index );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -29,9 +29,9 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.AutoIndexingKernelException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
@@ -169,7 +169,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement statement, IndexDescriptor index, Object value )
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement statement, NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException
     {
         guard.check( statement );
@@ -178,7 +178,7 @@ public class GuardingStatementOperations implements
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement statement,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             Number lower, boolean includeLower,
             Number upper, boolean includeUpper )
             throws IndexNotFoundKernelException
@@ -191,7 +191,7 @@ public class GuardingStatementOperations implements
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( KernelStatement statement,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             String lower, boolean includeLower,
             String upper, boolean includeUpper )
             throws IndexNotFoundKernelException
@@ -203,7 +203,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( KernelStatement statement, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( KernelStatement statement, NewIndexDescriptor index,
             String prefix ) throws IndexNotFoundKernelException
     {
         guard.check( statement );
@@ -211,7 +211,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement statement, IndexDescriptor index )
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement statement, NewIndexDescriptor index )
             throws IndexNotFoundKernelException
     {
         guard.check( statement );
@@ -219,7 +219,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement statement, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement statement, NewIndexDescriptor index,
             String term ) throws IndexNotFoundKernelException
     {
         guard.check( statement );
@@ -227,7 +227,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement statement, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement statement, NewIndexDescriptor index,
             String suffix ) throws IndexNotFoundKernelException
     {
         guard.check( statement );
@@ -235,7 +235,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public long nodeGetFromUniqueIndexSeek( KernelStatement statement, IndexDescriptor index, Object value )
+    public long nodeGetFromUniqueIndexSeek( KernelStatement statement, NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         guard.check( statement );
@@ -243,7 +243,7 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public long nodesCountIndexed( KernelStatement statement, IndexDescriptor index, long nodeId, Object value )
+    public long nodesCountIndexed( KernelStatement statement, NewIndexDescriptor index, long nodeId, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         guard.check( statement );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -43,7 +43,7 @@ import org.neo4j.kernel.api.exceptions.TransactionHookException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
@@ -349,7 +349,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         if ( hasTxStateWithChanges() )
         {
-            for ( IndexDescriptor createdConstraintIndex : txState().constraintIndexesCreatedInTx() )
+            for ( NewIndexDescriptor createdConstraintIndex : txState().constraintIndexesCreatedInTx() )
             {
                 try
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.LockOperations;
@@ -246,7 +247,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<IndexRule> filter )
+    public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<NewIndexDescriptor> filter )
             throws SchemaRuleNotFoundException
     {
         acquireSharedSchemaLock( state );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -128,7 +127,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
         acquireExclusiveSchemaLock( state );
@@ -137,7 +136,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void indexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void indexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();
@@ -145,7 +144,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void uniqueIndexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -57,12 +57,9 @@ import org.neo4j.kernel.impl.api.operations.LockOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
-import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
-import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
-import org.neo4j.storageengine.api.schema.SchemaRule;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -180,7 +177,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Iterator<IndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId )
+    public Iterator<NewIndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -188,7 +185,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, NodePropertyDescriptor descriptor )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -196,7 +193,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Iterator<IndexDescriptor> indexesGetAll( KernelStatement state )
+    public Iterator<NewIndexDescriptor> indexesGetAll( KernelStatement state )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -204,7 +201,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor )
+    public InternalIndexState indexGetState( KernelStatement state, NewIndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
         acquireSharedSchemaLock( state );
@@ -213,7 +210,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public PopulationProgress indexGetPopulationProgress( KernelStatement state, IndexDescriptor descriptor )
+    public PopulationProgress indexGetPopulationProgress( KernelStatement state, NewIndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
         acquireSharedSchemaLock( state );
@@ -222,7 +219,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public long indexSize( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public long indexSize( KernelStatement state, NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -231,7 +228,7 @@ public class LockingStatementOperations implements
 
     @Override
     public double indexUniqueValuesPercentage( KernelStatement state,
-            IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+            NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -239,7 +236,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( KernelStatement state, NewIndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -247,7 +244,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<NewIndexDescriptor> filter )
+    public long indexGetCommittedId( KernelStatement state, NewIndexDescriptor index, NewIndexDescriptor.Filter filter )
             throws SchemaRuleNotFoundException
     {
         acquireSharedSchemaLock( state );
@@ -256,7 +253,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId )
+    public Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -264,7 +261,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Iterator<IndexDescriptor> uniqueIndexesGetAll( KernelStatement state )
+    public Iterator<NewIndexDescriptor> uniqueIndexesGetAll( KernelStatement state )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
@@ -533,7 +530,7 @@ public class LockingStatementOperations implements
 
     // === TODO Below is unnecessary delegate methods
     @Override
-    public String indexGetFailure( Statement state, IndexDescriptor descriptor )
+    public String indexGetFailure( Statement state, NewIndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
         return schemaReadDelegate.indexGetFailure( state, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -227,7 +227,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexSeek( IndexDescriptor index, Object value )
+    public PrimitiveLongIterator nodesGetFromIndexSeek( NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -235,7 +235,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( NewIndexDescriptor index,
             Number lower,
             boolean includeLower,
             Number upper,
@@ -248,7 +248,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( NewIndexDescriptor index,
             String lower,
             boolean includeLower,
             String upper,
@@ -261,7 +261,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( IndexDescriptor index, String prefix )
+    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( NewIndexDescriptor index, String prefix )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -269,7 +269,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexScan( IndexDescriptor index )
+    public PrimitiveLongIterator nodesGetFromIndexScan( NewIndexDescriptor index )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -277,7 +277,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexContainsScan( IndexDescriptor index, String term )
+    public PrimitiveLongIterator nodesGetFromIndexContainsScan( NewIndexDescriptor index, String term )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -285,7 +285,7 @@ public class OperationsFacade
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( IndexDescriptor index, String suffix )
+    public PrimitiveLongIterator nodesGetFromIndexEndsWithScan( NewIndexDescriptor index, String suffix )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -293,7 +293,7 @@ public class OperationsFacade
     }
 
     @Override
-    public long nodeGetFromUniqueIndexSeek( IndexDescriptor index, Object value )
+    public long nodeGetFromUniqueIndexSeek( NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         statement.assertOpen();
@@ -588,7 +588,7 @@ public class OperationsFacade
     }
 
     @Override
-    public long nodesCountIndexed( IndexDescriptor index, long nodeId, Object value )
+    public long nodesCountIndexed( NewIndexDescriptor index, long nodeId, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
         statement.assertOpen();
@@ -1383,7 +1383,7 @@ public class OperationsFacade
     }
 
     @Override
-    public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target )
+    public DoubleLongRegister indexUpdatesAndSize( NewIndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -1391,7 +1391,7 @@ public class OperationsFacade
     }
 
     @Override
-    public DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target )
+    public DoubleLongRegister indexSample( NewIndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException
     {
         statement.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -82,7 +82,9 @@ import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.SchemaBoundary;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.operations.CountsOperations;
@@ -612,11 +614,11 @@ public class OperationsFacade
 
     // <SchemaRead>
     @Override
-    public IndexDescriptor indexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
             throws SchemaRuleNotFoundException
     {
         statement.assertOpen();
-        IndexDescriptor indexDescriptor = schemaRead().indexGetForLabelAndPropertyKey( statement, descriptor );
+        NewIndexDescriptor indexDescriptor = schemaRead().indexGetForLabelAndPropertyKey( statement, descriptor );
         if ( indexDescriptor == null )
         {
             throw new SchemaRuleNotFoundException( SchemaRule.Kind.INDEX_RULE,
@@ -626,30 +628,30 @@ public class OperationsFacade
     }
 
     @Override
-    public Iterator<IndexDescriptor> indexesGetForLabel( int labelId )
+    public Iterator<NewIndexDescriptor> indexesGetForLabel( int labelId )
     {
         statement.assertOpen();
         return schemaRead().indexesGetForLabel( statement, labelId );
     }
 
     @Override
-    public Iterator<IndexDescriptor> indexesGetAll()
+    public Iterator<NewIndexDescriptor> indexesGetAll()
     {
         statement.assertOpen();
         return schemaRead().indexesGetAll( statement );
     }
 
     @Override
-    public IndexDescriptor uniqueIndexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor uniqueIndexGetForLabelAndPropertyKey( NodePropertyDescriptor descriptor )
             throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
 
     {
-        IndexDescriptor result = null;
-        Iterator<IndexDescriptor> indexes = uniqueIndexesGetForLabel( descriptor.getLabelId() );
+        NewIndexDescriptor result = null;
+        Iterator<NewIndexDescriptor> indexes = uniqueIndexesGetForLabel( descriptor.getLabelId() );
         while ( indexes.hasNext() )
         {
-            IndexDescriptor index = indexes.next();
-            if ( index.equals( descriptor ) )
+            NewIndexDescriptor index = indexes.next();
+            if ( index.schema().equals( SchemaBoundary.map( descriptor ) ) )
             {
                 if ( null == result )
                 {
@@ -657,8 +659,7 @@ public class OperationsFacade
                 }
                 else
                 {
-                    throw new DuplicateSchemaRuleException( SchemaRule.Kind.CONSTRAINT_INDEX_RULE,
-                            SchemaDescriptorFactory.forLabel( descriptor.getLabelId(), descriptor.getPropertyKeyId() ) );
+                    throw new DuplicateSchemaRuleException( SchemaRule.Kind.CONSTRAINT_INDEX_RULE, index.schema() );
                 }
             }
         }
@@ -673,56 +674,56 @@ public class OperationsFacade
     }
 
     @Override
-    public Iterator<IndexDescriptor> uniqueIndexesGetForLabel( int labelId )
+    public Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( int labelId )
     {
         statement.assertOpen();
         return schemaRead().uniqueIndexesGetForLabel( statement, labelId );
     }
 
     @Override
-    public Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( NewIndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         statement.assertOpen();
         return schemaRead().indexGetOwningUniquenessConstraintId( statement, index );
     }
 
     @Override
-    public Iterator<IndexDescriptor> uniqueIndexesGetAll()
+    public Iterator<NewIndexDescriptor> uniqueIndexesGetAll()
     {
         statement.assertOpen();
         return schemaRead().uniqueIndexesGetAll( statement );
     }
 
     @Override
-    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();
         return schemaRead().indexGetState( statement, descriptor );
     }
 
     @Override
-    public PopulationProgress indexGetPopulationProgress( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public PopulationProgress indexGetPopulationProgress( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();
         return schemaRead().indexGetPopulationProgress( statement, descriptor );
     }
 
     @Override
-    public long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public long indexSize( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();
         return schemaRead().indexSize( statement, descriptor );
     }
 
     @Override
-    public double indexUniqueValuesSelectivity( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public double indexUniqueValuesSelectivity( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();
         return schemaRead().indexUniqueValuesPercentage( statement, descriptor );
     }
 
     @Override
-    public String indexGetFailure( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public String indexGetFailure( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();
         return schemaRead().indexGetFailure( statement, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1039,7 +1039,7 @@ public class OperationsFacade
 
     // <SchemaWrite>
     @Override
-    public IndexDescriptor indexCreate( NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexCreate( NodePropertyDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
         statement.assertOpen();
@@ -1047,7 +1047,7 @@ public class OperationsFacade
     }
 
     @Override
-    public void indexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void indexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         statement.assertOpen();
         schemaWrite().indexDrop( statement, descriptor );
@@ -1093,7 +1093,7 @@ public class OperationsFacade
     }
 
     @Override
-    public void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         statement.assertOpen();
         schemaWrite().uniqueIndexDrop( statement, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
@@ -62,11 +61,11 @@ import org.neo4j.kernel.api.legacyindex.AutoIndexing;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaBoundary;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
@@ -541,7 +540,7 @@ public class StateHandlingStatementOperations implements
         if ( state.hasTxStateWithChanges() )
         {
             rules = filter(
-                    descriptor::isSame,
+                    SchemaDescriptor.equalTo( descriptor ),
                     state.txState().indexDiffSetsByLabel( descriptor.getLabelId(), GENERAL ).apply( rules ) );
         }
         return singleOrNull( rules );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -566,7 +566,7 @@ public class StateHandlingStatementOperations implements
             }
         }
 
-        return storeLayer.indexGetState( descriptor );
+        return storeLayer.indexGetState( SchemaBoundary.map( descriptor.descriptor() ) );
     }
 
     @Override
@@ -588,7 +588,7 @@ public class StateHandlingStatementOperations implements
             }
         }
 
-        return storeLayer.indexGetPopulationProgress( descriptor );
+        return storeLayer.indexGetPopulationProgress( SchemaBoundary.map( descriptor.descriptor() ) );
     }
 
     private boolean checkIndexState( IndexDescriptor indexRule, ReadableDiffSets<IndexDescriptor> diffSet )
@@ -1140,28 +1140,28 @@ public class StateHandlingStatementOperations implements
     public long indexSize( KernelStatement statement, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        return storeLayer.indexSize( descriptor );
+        return storeLayer.indexSize( SchemaBoundary.map( descriptor.descriptor() ) );
     }
 
     @Override
     public double indexUniqueValuesPercentage( KernelStatement statement, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        return storeLayer.indexUniqueValuesPercentage( descriptor );
+        return storeLayer.indexUniqueValuesPercentage( SchemaBoundary.map( descriptor.descriptor() ) );
     }
 
     @Override
     public DoubleLongRegister indexUpdatesAndSize( KernelStatement statement, IndexDescriptor index,
             DoubleLongRegister target ) throws IndexNotFoundKernelException
     {
-        return storeLayer.indexUpdatesAndSize( index, target );
+        return storeLayer.indexUpdatesAndSize( SchemaBoundary.map( index.descriptor() ), target );
     }
 
     @Override
     public DoubleLongRegister indexSample( KernelStatement statement, IndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException
     {
-        return storeLayer.indexSample( index, target );
+        return storeLayer.indexSample( SchemaBoundary.map( index.descriptor() ), target );
     }
 
     //
@@ -1186,7 +1186,7 @@ public class StateHandlingStatementOperations implements
     public String indexGetFailure( Statement state, IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        return storeLayer.indexGetFailure( descriptor );
+        return storeLayer.indexGetFailure( SchemaBoundary.map( descriptor.descriptor() ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1173,7 +1173,7 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<IndexRule> filter )
+    public long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<NewIndexDescriptor> filter )
             throws SchemaRuleNotFoundException
     {
         return storeLayer.indexGetCommittedId( IndexBoundary.map( index ), filter );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -377,22 +377,22 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public IndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
+    public NewIndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
     {
         state.txState().indexRuleDoAdd( IndexBoundary.map( descriptor ) );
-        return IndexDescriptorFactory.of( descriptor );
+        return IndexBoundary.map( descriptor );
     }
 
     @Override
-    public void indexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void indexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
-        state.txState().indexDoDrop( IndexBoundary.map( descriptor ) );
+        state.txState().indexDoDrop( descriptor );
     }
 
     @Override
-    public void uniqueIndexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException
+    public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
-        state.txState().indexDoDrop( IndexBoundary.mapUnique( descriptor ) );
+        state.txState().indexDoDrop( descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdaterMap.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.index.IndexUpdater;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.store.MultipleUnderlyingStorageExceptions;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 
@@ -93,7 +95,7 @@ class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
     @Override
     public void close() throws UnderlyingStorageException
     {
-        Set<Pair<IndexDescriptor, UnderlyingStorageException>> exceptions = null;
+        Set<Pair<NewIndexDescriptor, UnderlyingStorageException>> exceptions = null;
 
         for ( Map.Entry<IndexDescriptor, IndexUpdater> updaterEntry : updaterMap.entrySet() )
         {
@@ -108,7 +110,8 @@ class IndexUpdaterMap implements AutoCloseable, Iterable<IndexUpdater>
                 {
                     exceptions = new HashSet<>();
                 }
-                exceptions.add( Pair.of( updaterEntry.getKey(), new UnderlyingStorageException( e ) ) );
+                exceptions.add( Pair.of( IndexBoundary.map( updaterEntry.getKey() ),
+                        new UnderlyingStorageException( e ) ) );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
@@ -57,7 +57,7 @@ public class RemoveOrphanConstraintIndexesOnStartup
                 if ( statement.readOperations().indexGetOwningUniquenessConstraintId( index ) == null )
                 {
                     log.info( "Removing orphan constraint index: " + index );
-                    statement.schemaWriteOperations().uniqueIndexDrop( IndexBoundary.map( index ) );
+                    statement.schemaWriteOperations().uniqueIndexDrop( index );
                 }
             }
             transaction.success();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/CountsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/CountsOperations.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel.impl.api.operations;
 
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.register.Register.DoubleLongRegister;
 
@@ -38,9 +38,9 @@ public interface CountsOperations
     /** @see org.neo4j.kernel.api.CountsRead#countsForRelationshipWithoutTxState(int, int, int) */
     long countsForRelationshipWithoutTxState( KernelStatement statement, int startLabelId, int typeId, int endLabelId );
 
-    DoubleLongRegister indexUpdatesAndSize( KernelStatement statement, IndexDescriptor index,
+    DoubleLongRegister indexUpdatesAndSize( KernelStatement statement, NewIndexDescriptor index,
             DoubleLongRegister target ) throws IndexNotFoundKernelException;
 
-    DoubleLongRegister indexSample( KernelStatement statement, IndexDescriptor index, DoubleLongRegister target )
+    DoubleLongRegister indexSample( KernelStatement statement, NewIndexDescriptor index, DoubleLongRegister target )
             throws IndexNotFoundKernelException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -25,7 +25,7 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.storageengine.api.NodeItem;
@@ -44,7 +44,7 @@ public interface EntityReadOperations
      *
      * @throws IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
+    PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
     /**
@@ -53,7 +53,7 @@ public interface EntityReadOperations
      * @throws IndexNotFoundKernelException if no such index found.
      */
     PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement state,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             Number lower,
             boolean includeLower,
             Number upper,
@@ -66,7 +66,7 @@ public interface EntityReadOperations
      * @throws IndexNotFoundKernelException if no such index found.
      */
     PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( KernelStatement state,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             String lower,
             boolean includeLower,
             String upper,
@@ -79,7 +79,7 @@ public interface EntityReadOperations
      * @throws IndexNotFoundKernelException if no such index found.
      */
     PrimitiveLongIterator nodesGetFromIndexRangeSeekByPrefix( KernelStatement state,
-            IndexDescriptor index,
+            NewIndexDescriptor index,
             String prefix )
             throws IndexNotFoundKernelException;
 
@@ -88,7 +88,7 @@ public interface EntityReadOperations
      *
      * @throws IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
+    PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, NewIndexDescriptor index )
             throws IndexNotFoundKernelException;
 
     /**
@@ -96,7 +96,7 @@ public interface EntityReadOperations
      *
      * @throws IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement state, IndexDescriptor index, String term )
+    PrimitiveLongIterator nodesGetFromIndexContainsScan( KernelStatement state, NewIndexDescriptor index, String term )
             throws IndexNotFoundKernelException;
 
     /**
@@ -104,7 +104,7 @@ public interface EntityReadOperations
      *
      * @throws IndexNotFoundKernelException if no such index found.
      */
-    PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement state, IndexDescriptor index, String suffix )
+    PrimitiveLongIterator nodesGetFromIndexEndsWithScan( KernelStatement state, NewIndexDescriptor index, String suffix )
             throws IndexNotFoundKernelException;
 
     /**
@@ -113,10 +113,10 @@ public interface EntityReadOperations
      * @throws IndexNotFoundKernelException if no such index found.
      * @throws IndexBrokenKernelException   if we found an index that was corrupt or otherwise in a failed state.
      */
-    long nodeGetFromUniqueIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
+    long nodeGetFromUniqueIndexSeek( KernelStatement state, NewIndexDescriptor index, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException;
 
-    long nodesCountIndexed( KernelStatement statement, IndexDescriptor index, long nodeId, Object value )
+    long nodesCountIndexed( KernelStatement statement, NewIndexDescriptor index, long nodeId, Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException;
 
     boolean graphHasProperty( KernelStatement state, int propertyKeyId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
@@ -30,66 +30,63 @@ import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
-import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
-import org.neo4j.storageengine.api.schema.SchemaRule;
 
 public interface SchemaReadOperations
 {
     /**
      * Returns the descriptor for the given labelId and propertyKey.
      */
-    IndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, NodePropertyDescriptor descriptor );
+    NewIndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, NodePropertyDescriptor descriptor );
 
     /**
      * Get all indexes for a label.
      */
-    Iterator<IndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId );
+    Iterator<NewIndexDescriptor> indexesGetForLabel( KernelStatement state, int labelId );
 
     /**
      * Returns all indexes.
      */
-    Iterator<IndexDescriptor> indexesGetAll( KernelStatement state );
+    Iterator<NewIndexDescriptor> indexesGetAll( KernelStatement state );
 
     /**
      * Get all constraint indexes for a label.
      */
-    Iterator<IndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId );
+    Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId );
 
     /**
      * Returns all constraint indexes.
      */
-    Iterator<IndexDescriptor> uniqueIndexesGetAll( KernelStatement state );
+    Iterator<NewIndexDescriptor> uniqueIndexesGetAll( KernelStatement state );
 
     /**
      * Retrieve the state of an index.
      */
-    InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    InternalIndexState indexGetState( KernelStatement state, NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Retrieve the population progress of an index.
      */
-    PopulationProgress indexGetPopulationProgress( KernelStatement state, IndexDescriptor descriptor ) throws
+    PopulationProgress indexGetPopulationProgress( KernelStatement state, NewIndexDescriptor descriptor ) throws
             IndexNotFoundKernelException;
 
     /**
      * Get the index size.
      **/
-    long indexSize( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    long indexSize( KernelStatement state, NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Calculate the index unique values percentage.
      **/
-    double indexUniqueValuesPercentage( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    double indexUniqueValuesPercentage( KernelStatement state, NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Returns the failure description of a failed index.
      */
-    String indexGetFailure( Statement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+    String indexGetFailure( Statement state, NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Get all constraints applicable to label and propertyKeys. There are only {@link NodePropertyConstraint}
@@ -126,12 +123,12 @@ public interface SchemaReadOperations
     /**
      * Get the owning constraint for a constraint index. Returns null if the index does not have an owning constraint.
      */
-    Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index ) throws SchemaRuleNotFoundException;
+    Long indexGetOwningUniquenessConstraintId( KernelStatement state, NewIndexDescriptor index ) throws SchemaRuleNotFoundException;
 
     /**
      * Get the index id (the id or the schema rule record) for a committed index
      * - throws exception for indexes that aren't committed.
      */
-    long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<NewIndexDescriptor> filter )
+    long indexGetCommittedId( KernelStatement state, NewIndexDescriptor index, NewIndexDescriptor.Filter filter )
             throws SchemaRuleNotFoundException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -131,6 +132,6 @@ public interface SchemaReadOperations
      * Get the index id (the id or the schema rule record) for a committed index
      * - throws exception for indexes that aren't committed.
      */
-    long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<IndexRule> filter )
+    long indexGetCommittedId( KernelStatement state, IndexDescriptor index, Predicate<NewIndexDescriptor> filter )
             throws SchemaRuleNotFoundException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 
 public interface SchemaWriteOperations
@@ -40,17 +41,17 @@ public interface SchemaWriteOperations
      * Creates an index, indexing properties with the given {@code propertyKeyId} for nodes with the given
      * {@code labelId}.
      */
-    IndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
+    NewIndexDescriptor indexCreate( KernelStatement state, NodePropertyDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException;
 
-    /** Drops a {@link IndexDescriptor} from the database */
-    void indexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException;
+    /** Drops a {@link NewIndexDescriptor} from the database */
+    void indexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     /**
      * This should not be used, it is exposed to allow an external job to clean up constraint indexes.
      * That external job should become an internal job, at which point this operation should go away.
      */
-    void uniqueIndexDrop( KernelStatement state, IndexDescriptor descriptor ) throws DropIndexFailureException;
+    void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     UniquenessConstraint uniquePropertyConstraintCreate( KernelStatement state, NodePropertyDescriptor descriptor )
             throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 
 import static java.util.Collections.singleton;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
-import static org.neo4j.kernel.impl.store.SchemaStorage.IndexRuleKind.CONSTRAINT;
 
 public class ConstraintIndexCreator
 {
@@ -69,7 +68,7 @@ public class ConstraintIndexCreator
         boolean success = false;
         try
         {
-            long indexId = schema.indexGetCommittedId( state, IndexBoundary.map( index ), CONSTRAINT );
+            long indexId = schema.indexGetCommittedId( state, IndexBoundary.map( index ), NewIndexDescriptor.Filter.UNIQUE );
 
             awaitConstrainIndexPopulation( constraint, indexId );
             success = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -68,7 +68,7 @@ public class ConstraintIndexCreator
         boolean success = false;
         try
         {
-            long indexId = schema.indexGetCommittedId( state, IndexBoundary.map( index ), NewIndexDescriptor.Filter.UNIQUE );
+            long indexId = schema.indexGetCommittedId( state, index, NewIndexDescriptor.Filter.UNIQUE );
 
             awaitConstrainIndexPopulation( constraint, indexId );
             success = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -101,7 +101,7 @@ public class SchemaCache
     {
         for ( IndexRule rule : indexRuleById.values() )
         {
-            if ( rule.getSchemaDescriptor().equals( descriptor ) )
+            if ( rule.schema().equals( descriptor ) )
             {
                 return true;
             }
@@ -165,7 +165,7 @@ public class SchemaCache
         {
             IndexRule indexRule = (IndexRule) rule;
             indexRuleById.put( indexRule.getId(), indexRule );
-            indexDescriptors.put( indexRule.getSchemaDescriptor(), indexRule.getIndexDescriptor() );
+            indexDescriptors.put( indexRule.schema(), indexRule.getIndexDescriptor() );
         }
     }
 
@@ -205,7 +205,7 @@ public class SchemaCache
         else if ( indexRuleById.containsKey( id ) )
         {
             IndexRule rule = indexRuleById.remove( id );
-            indexDescriptors.remove( rule.getSchemaDescriptor() );
+            indexDescriptors.remove( rule.schema() );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -20,14 +20,12 @@
 package org.neo4j.kernel.impl.api.store;
 
 import java.util.Iterator;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
-import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.ReadOperations;
@@ -43,7 +41,6 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.IndexBoundary;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -225,7 +225,7 @@ public class StorageLayer implements StoreReadLayer
     }
 
     @Override
-    public long indexGetCommittedId( NewIndexDescriptor index, Predicate<IndexRule> filter )
+    public long indexGetCommittedId( NewIndexDescriptor index, Predicate<NewIndexDescriptor> filter )
             throws SchemaRuleNotFoundException
     {
         IndexRule rule = indexRule( index, filter );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -95,9 +95,6 @@ import static org.neo4j.register.Registers.newDoubleLongRegister;
  */
 public class StorageLayer implements StoreReadLayer
 {
-    private static final Function<? super IndexRule,IndexDescriptor> TO_INDEX_RULE =
-            rule -> IndexBoundary.map( rule.getIndexDescriptor() );
-
     // These token holders should perhaps move to the cache layer.. not really any reason to have them here?
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
     private final LabelTokenHolder labelTokenHolder;
@@ -240,35 +237,35 @@ public class StorageLayer implements StoreReadLayer
     }
 
     @Override
-    public InternalIndexState indexGetState( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexService.getIndexProxy( descriptor ).getState();
+        return indexService.getIndexProxy( IndexBoundary.map( descriptor ) ).getState();
     }
 
     @Override
-    public PopulationProgress indexGetPopulationProgress( IndexDescriptor descriptor )
+    public PopulationProgress indexGetPopulationProgress( LabelSchemaDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        return indexService.getIndexProxy( descriptor ).getIndexPopulationProgress();
+        return indexService.getIndexProxy( IndexBoundary.map( descriptor ) ).getIndexPopulationProgress();
     }
 
     @Override
-    public long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public long indexSize( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        Register.DoubleLongRegister result = indexService.indexUpdatesAndSize( descriptor );
+        Register.DoubleLongRegister result = indexService.indexUpdatesAndSize( IndexBoundary.map( descriptor ) );
         return result.readSecond();
     }
 
     @Override
-    public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public double indexUniqueValuesPercentage( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexService.indexUniqueValuesPercentage( descriptor );
+        return indexService.indexUniqueValuesPercentage( IndexBoundary.map( descriptor ) );
     }
 
     @Override
-    public String indexGetFailure( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public String indexGetFailure( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexService.getIndexProxy( descriptor ).getPopulationFailure().asString();
+        return indexService.getIndexProxy( IndexBoundary.map( descriptor ) ).getPopulationFailure().asString();
     }
 
     @Override
@@ -485,22 +482,22 @@ public class StorageLayer implements StoreReadLayer
     }
 
     @Override
-    public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor, DoubleLongRegister target )
+    public DoubleLongRegister indexUpdatesAndSize( LabelSchemaDescriptor descriptor, DoubleLongRegister target )
             throws IndexNotFoundKernelException
     {
         return counts.indexUpdatesAndSize( tryGetIndexId( descriptor ), target );
     }
 
     @Override
-    public DoubleLongRegister indexSample( IndexDescriptor descriptor, DoubleLongRegister target )
+    public DoubleLongRegister indexSample( LabelSchemaDescriptor descriptor, DoubleLongRegister target )
             throws IndexNotFoundKernelException
     {
         return counts.indexSample( tryGetIndexId( descriptor ), target );
     }
 
-    private long tryGetIndexId( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    private long tryGetIndexId( LabelSchemaDescriptor descriptor) throws IndexNotFoundKernelException
     {
-        return indexService.getIndexId( descriptor );
+        return indexService.getIndexId( IndexBoundary.map( descriptor ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -216,7 +216,7 @@ public class StorageLayer implements StoreReadLayer
     @Override
     public Long indexGetOwningUniquenessConstraintId( NewIndexDescriptor index ) throws SchemaRuleNotFoundException
     {
-        IndexRule rule = indexRule( index, Predicates.alwaysTrue() );
+        IndexRule rule = indexRule( index, NewIndexDescriptor.Filter.ANY );
         if ( rule != null )
         {
             return rule.getOwningConstraint();
@@ -225,7 +225,7 @@ public class StorageLayer implements StoreReadLayer
     }
 
     @Override
-    public long indexGetCommittedId( NewIndexDescriptor index, Predicate<NewIndexDescriptor> filter )
+    public long indexGetCommittedId( NewIndexDescriptor index, NewIndexDescriptor.Filter filter )
             throws SchemaRuleNotFoundException
     {
         IndexRule rule = indexRule( index, filter );
@@ -519,11 +519,11 @@ public class StorageLayer implements StoreReadLayer
         }
     }
 
-    private IndexRule indexRule( NewIndexDescriptor index, Predicate<IndexRule> filter )
+    private IndexRule indexRule( NewIndexDescriptor index, NewIndexDescriptor.Filter filter )
     {
         for ( IndexRule rule : schemaCache.indexRules() )
         {
-            if ( filter.test( rule ) && rule.getSchemaDescriptor().equals( index.schema() ) )
+            if ( filter.test( rule.getIndexDescriptor() ) && rule.schema().equals( index.schema() ) )
             {
                 return rule;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
@@ -23,7 +23,8 @@ import java.util.function.Supplier;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
@@ -176,15 +177,15 @@ public class StoreStatement implements StorageStatement
     }
 
     @Override
-    public IndexReader getIndexReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public IndexReader getIndexReader( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexReaderFactory().newReader( descriptor );
+        return indexReaderFactory().newReader( IndexBoundary.map( descriptor ) );
     }
 
     @Override
-    public IndexReader getFreshIndexReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public IndexReader getFreshIndexReader( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexReaderFactory().newUnCachedReader( descriptor );
+        return indexReaderFactory().newUnCachedReader( IndexBoundary.map( descriptor ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -450,7 +450,7 @@ public class SchemaImpl implements Schema
                 try
                 {
                     statement.schemaWriteOperations().indexDrop(
-                            IndexBoundary.map( getIndexDescriptor( statement.readOperations(), indexDefinition ) ) );
+                            getIndexDescriptor( statement.readOperations(), indexDefinition ) );
                 }
                 catch ( NotFoundException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -592,7 +592,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
             return emptyIterator();
         }
 
-        IndexDescriptor descriptor = findAnyIndexByLabelAndProperty( readOps, propertyId, labelId );
+        NewIndexDescriptor descriptor = findAnyIndexByLabelAndProperty( readOps, propertyId, labelId );
 
         try
         {
@@ -610,7 +610,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         return getNodesByLabelAndPropertyWithoutIndex( propertyId, value, statement, labelId );
     }
 
-    private IndexDescriptor findAnyIndexByLabelAndProperty( ReadOperations readOps, int propertyId, int labelId )
+    private NewIndexDescriptor findAnyIndexByLabelAndProperty( ReadOperations readOps, int propertyId, int labelId )
     {
         try
         {
@@ -620,7 +620,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
             if ( readOps.indexGetState( descriptor ) == InternalIndexState.ONLINE )
             {
                 // Ha! We found an index - let's use it to find matching nodes
-                return IndexBoundary.map( descriptor );
+                return descriptor;
             }
         }
         catch ( SchemaRuleNotFoundException | IndexNotFoundKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -71,6 +71,8 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.legacyindex.AutoIndexing;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.guard.Guard;
@@ -612,13 +614,13 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
     {
         try
         {
-            IndexDescriptor descriptor =
+            NewIndexDescriptor descriptor =
                     readOps.indexGetForLabelAndPropertyKey( new NodePropertyDescriptor( labelId, propertyId ) );
 
             if ( readOps.indexGetState( descriptor ) == InternalIndexState.ONLINE )
             {
                 // Ha! We found an index - let's use it to find matching nodes
-                return descriptor;
+                return IndexBoundary.map( descriptor );
             }
         }
         catch ( SchemaRuleNotFoundException | IndexNotFoundKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -192,10 +192,10 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
     @Override
     public void visitRemovedIndex( NewIndexDescriptor index )
     {
-        SchemaStorage.IndexRuleKind kind = index.type() == UNIQUE ?
-                SchemaStorage.IndexRuleKind.CONSTRAINT
-                : SchemaStorage.IndexRuleKind.INDEX;
-        IndexRule rule = schemaStorage.indexGetForSchema( index.schema(), kind );
+        NewIndexDescriptor.Filter filter = index.type() == UNIQUE ?
+                                          NewIndexDescriptor.Filter.UNIQUE
+                                        : NewIndexDescriptor.Filter.GENERAL;
+        IndexRule rule = schemaStorage.indexGetForSchema( index.schema(), filter );
         recordState.dropSchemaRule( rule );
     }
 
@@ -207,8 +207,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         int propertyKeyId = element.descriptor().getPropertyKeyId();
 
         IndexRule indexRule = schemaStorage.indexGetForSchema(
-                SchemaDescriptorFactory.forLabel( element.label(), propertyKeyId ),
-                SchemaStorage.IndexRuleKind.CONSTRAINT );
+                SchemaDescriptorFactory.forLabel( element.label(), propertyKeyId ), NewIndexDescriptor.Filter.UNIQUE );
         recordState.createSchemaRule(
                 constraintSemantics.writeUniquePropertyConstraint(
                         constraintId, element.descriptor(), indexRule.getId() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -28,12 +28,12 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
-import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.store.SchemaStorage;
@@ -41,6 +41,8 @@ import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.transaction.state.TransactionRecordState;
 import org.neo4j.storageengine.api.StorageProperty;
 import org.neo4j.storageengine.api.txstate.TxStateVisitor;
+
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.UNIQUE;
 
 public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
 {
@@ -179,37 +181,21 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
     }
 
     @Override
-    public void visitAddedIndex( IndexDescriptor element, boolean isConstraintIndex )
+    public void visitAddedIndex( NewIndexDescriptor index )
     {
         SchemaIndexProvider.Descriptor providerDescriptor =
                 schemaIndexProviderMap.getDefaultProvider().getProviderDescriptor();
-        IndexRule rule;
-        if ( isConstraintIndex )
-        {
-            // was IndexRule.constraintIndexRule, but calling this with null gives the non-constraint version?
-            rule = IndexRule.indexRule(
-                        schemaStorage.newRuleId(),
-                        NewIndexDescriptorFactory.uniqueForLabel( element.getLabelId(), element.getPropertyKeyId() ),
-                        providerDescriptor );
-        }
-        else
-        {
-            rule = IndexRule.indexRule(
-                        schemaStorage.newRuleId(),
-                        NewIndexDescriptorFactory.forLabel( element.getLabelId(), element.getPropertyKeyId() ),
-                        providerDescriptor );
-        }
+        IndexRule rule = IndexRule.indexRule( schemaStorage.newRuleId(), index, providerDescriptor );
         recordState.createSchemaRule( rule );
     }
 
     @Override
-    public void visitRemovedIndex( IndexDescriptor desc, boolean isConstraintIndex )
+    public void visitRemovedIndex( NewIndexDescriptor index )
     {
-        SchemaStorage.IndexRuleKind kind = isConstraintIndex ?
+        SchemaStorage.IndexRuleKind kind = index.type() == UNIQUE ?
                 SchemaStorage.IndexRuleKind.CONSTRAINT
                 : SchemaStorage.IndexRuleKind.INDEX;
-        IndexRule rule = schemaStorage.indexGetForSchema(
-                SchemaDescriptorFactory.forLabel( desc.getLabelId(), desc.getPropertyKeyId() ), kind );
+        IndexRule rule = schemaStorage.indexGetForSchema( index.schema(), kind );
         recordState.dropSchemaRule( rule );
     }
 
@@ -252,7 +238,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
             throw new IllegalStateException( "Multiple constraints found for specified label and property." );
         }
         // Remove the index for the constraint as well
-        visitRemovedIndex( element.indexDescriptor(), true );
+        visitRemovedIndex( IndexBoundary.mapUnique( element.indexDescriptor() ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MultipleUnderlyingStorageExceptions.java
@@ -23,31 +23,31 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.neo4j.helpers.collection.Pair;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
 import static java.lang.String.format;
 
 public class MultipleUnderlyingStorageExceptions extends UnderlyingStorageException
 {
-    public final Set<Pair<IndexDescriptor, UnderlyingStorageException>> exceptions;
+    public final Set<Pair<NewIndexDescriptor, UnderlyingStorageException>> exceptions;
 
-    public MultipleUnderlyingStorageExceptions( Set<Pair<IndexDescriptor, UnderlyingStorageException>> exceptions )
+    public MultipleUnderlyingStorageExceptions( Set<Pair<NewIndexDescriptor, UnderlyingStorageException>> exceptions )
     {
         super( buildMessage( exceptions ) );
         this.exceptions = Collections.unmodifiableSet( exceptions );
 
-        for ( Pair<IndexDescriptor, UnderlyingStorageException> exception : exceptions )
+        for ( Pair<NewIndexDescriptor, UnderlyingStorageException> exception : exceptions )
         {
             this.addSuppressed( exception.other() );
         }
     }
 
-    private static String buildMessage( Set<Pair<IndexDescriptor, UnderlyingStorageException>> exceptions )
+    private static String buildMessage( Set<Pair<NewIndexDescriptor, UnderlyingStorageException>> exceptions )
     {
         StringBuilder builder = new StringBuilder( );
         builder.append("Errors when closing (flushing) index updaters:");
 
-        for ( Pair<IndexDescriptor, UnderlyingStorageException> pair : exceptions )
+        for ( Pair<NewIndexDescriptor, UnderlyingStorageException> pair : exceptions )
         {
             builder.append( format( " (%s) %s", pair.first().toString(), pair.other().getMessage() ) );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorPredicates;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
@@ -39,34 +40,6 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 
 public class SchemaStorage implements SchemaRuleAccess
 {
-    public enum IndexRuleKind implements Predicate<IndexRule>
-    {
-        INDEX
-        {
-            @Override
-            public boolean test( IndexRule rule )
-            {
-                return !rule.canSupportUniqueConstraint();
-            }
-        },
-        CONSTRAINT
-        {
-            @Override
-            public boolean test( IndexRule rule )
-            {
-                return rule.canSupportUniqueConstraint();
-            }
-        },
-        ALL
-        {
-            @Override
-            public boolean test( IndexRule rule )
-            {
-                return true;
-            }
-        }
-    }
-
     private final RecordStore<DynamicRecord> schemaStore;
 
     public SchemaStorage( RecordStore<DynamicRecord> schemaStore )
@@ -82,7 +55,7 @@ public class SchemaStorage implements SchemaRuleAccess
      */
     public IndexRule indexGetForSchema( SchemaDescriptor schemaDescriptor )
     {
-        return indexGetForSchema( schemaDescriptor, IndexRuleKind.ALL );
+        return indexGetForSchema( schemaDescriptor, NewIndexDescriptor.Filter.ANY );
     }
 
     /**
@@ -91,7 +64,7 @@ public class SchemaStorage implements SchemaRuleAccess
      * @return  the matching IndexRule, or null if no matching IndexRule was found
      * @throws  IllegalStateException if more than one matching rule.
      */
-    public IndexRule indexGetForSchema( final SchemaDescriptor descriptor, Predicate<IndexRule> filter )
+    public IndexRule indexGetForSchema( final SchemaDescriptor descriptor, NewIndexDescriptor.Filter filter )
     {
         Iterator<IndexRule> rules = loadAllSchemaRules( descriptor::isSame, IndexRule.class, false );
 
@@ -100,7 +73,7 @@ public class SchemaStorage implements SchemaRuleAccess
         while ( rules.hasNext() )
         {
             IndexRule candidate = rules.next();
-            if ( filter.test( candidate ) )
+            if ( filter.test( candidate.getIndexDescriptor() ) )
             {
                 if ( foundRule != null )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
@@ -66,7 +66,7 @@ public class SchemaStorage implements SchemaRuleAccess
      */
     public IndexRule indexGetForSchema( final SchemaDescriptor descriptor, NewIndexDescriptor.Filter filter )
     {
-        Iterator<IndexRule> rules = loadAllSchemaRules( descriptor::isSame, IndexRule.class, false );
+        Iterator<IndexRule> rules = loadAllSchemaRules( SchemaDescriptor.equalTo( descriptor ), IndexRule.class, false );
 
         IndexRule foundRule = null;
 
@@ -116,7 +116,7 @@ public class SchemaStorage implements SchemaRuleAccess
 
     public Iterator<ConstraintRule> constraintsGetForSchema( SchemaDescriptor schemaDescriptor )
     {
-        return loadAllSchemaRules( schemaDescriptor::isSame, ConstraintRule.class, false );
+        return loadAllSchemaRules( SchemaDescriptor.equalTo( schemaDescriptor ), ConstraintRule.class, false );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/countStore/CountsSnapshotDeserializer.java
@@ -23,10 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.neo4j.kernel.api.schema.NodeMultiPropertyDescriptor;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKeyType;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosableChannel;
@@ -50,7 +46,6 @@ public class CountsSnapshotDeserializer
         for ( int i = 0; i < size; i++ )
         {
             CountsKeyType type = value( channel.get() );
-            IndexDescriptor descriptor;
             switch ( type )
             {
             case ENTITY_NODE:

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsUpdater.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.store.counts;
 
 import java.io.IOException;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
@@ -95,7 +94,7 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
      *  u - number of updates
      *  s - size of index
      * </pre>
-     * For key format, see {@link KeyFormat#visitIndexStatistics(IndexDescriptor, long, long)}
+     * For key format, see {@link KeyFormat#visitIndexStatistics(long, long, long)}
      */
     @Override
     public void replaceIndexUpdateAndSize( long indexId, long updates, long size )
@@ -118,7 +117,7 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
      *  u - number of unique values
      *  s - size of index
      * </pre>
-     * For key format, see {@link KeyFormat#visitIndexSample(IndexDescriptor, long, long)}
+     * For key format, see {@link KeyFormat#visitIndexSample(long, long, long)}
      */
     @Override
     public void replaceIndexSample( long indexId, long unique, long size )
@@ -134,7 +133,7 @@ final class CountsUpdater implements CountsAccessor.Updater, CountsAccessor.Inde
     }
 
     /**
-     * For key format, see {@link KeyFormat#visitIndexStatistics(IndexDescriptor, long, long)}
+     * For key format, see {@link KeyFormat#visitIndexStatistics(long, long, long)}
      * For value format, see {@link CountsUpdater#replaceIndexUpdateAndSize(long, long, long)}
      */
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
@@ -66,7 +66,7 @@ public class ConstraintRule implements SchemaRule, ConstraintDescriptor.Supplier
     }
 
     @Override
-    public SchemaDescriptor getSchemaDescriptor()
+    public SchemaDescriptor schema()
     {
         return descriptor.schema();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
@@ -25,7 +25,7 @@ import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
-import static org.neo4j.kernel.api.schema_new.SchemaUtil.noopTokenNameLookup;
+import static org.neo4j.kernel.api.schema_new.SchemaUtil.idTokenNameLookup;
 
 public class ConstraintRule implements SchemaRule, ConstraintDescriptor.Supplier
 {
@@ -61,7 +61,7 @@ public class ConstraintRule implements SchemaRule, ConstraintDescriptor.Supplier
     @Override
     public String toString()
     {
-        return "ConstraintRule[id=" + id + ", descriptor=" + descriptor.userDescription( noopTokenNameLookup ) + ", " +
+        return "ConstraintRule[id=" + id + ", descriptor=" + descriptor.userDescription( idTokenNameLookup ) + ", " +
                 "ownedIndex=" + ownedIndexRule + "]";
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
@@ -27,7 +27,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
-import static org.neo4j.kernel.api.schema_new.SchemaUtil.noopTokenNameLookup;
+import static org.neo4j.kernel.api.schema_new.SchemaUtil.idTokenNameLookup;
 
 /**
  * A {@link Label} can have zero or more index rules which will have data specified in the rules indexed.
@@ -134,7 +134,7 @@ public class IndexRule implements SchemaRule, NewIndexDescriptor.Supplier
             ownerString = ", owner=" + owningConstraint;
         }
 
-        return "IndexRule[id=" + id + ", descriptor=" + descriptor.userDescription( noopTokenNameLookup ) +
+        return "IndexRule[id=" + id + ", descriptor=" + descriptor.userDescription( idTokenNameLookup ) +
                ", provider=" + providerDescriptor + ownerString + "]";
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
@@ -139,7 +139,7 @@ public class IndexRule implements SchemaRule, NewIndexDescriptor.Supplier
     }
 
     @Override
-    public LabelSchemaDescriptor getSchemaDescriptor()
+    public LabelSchemaDescriptor schema()
     {
         return descriptor.schema();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
@@ -180,7 +180,7 @@ public class SchemaRuleSerialization
             length += 8; // owning constraint id
         }
 
-        length += schemaSizeComputer.compute( indexDescriptor.schema() );
+        length += indexDescriptor.schema().computeWith( schemaSizeComputer );
         return length;
     }
 
@@ -201,7 +201,7 @@ public class SchemaRuleSerialization
             length += 8; // owned index id
         }
 
-        length += schemaSizeComputer.compute( constraintDescriptor.schema() );
+        length += constraintDescriptor.schema().computeWith( schemaSizeComputer );
         return length;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/IndexLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/IndexLookup.java
@@ -64,7 +64,7 @@ class IndexLookup implements AutoCloseable
             if ( schemaRule instanceof IndexRule )
             {
                 IndexRule rule = (IndexRule) schemaRule;
-                int propertyId = rule.getSchemaDescriptor().getPropertyIds()[0]; // assuming 1 property always
+                int propertyId = rule.schema().getPropertyIds()[0]; // assuming 1 property always
                 List<IndexRule> ruleList = indexRuleIndex.get( propertyId );
                 if ( ruleList == null )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.util.dbstructure;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
 public interface DbStructureVisitor
 {
@@ -30,8 +30,9 @@ public interface DbStructureVisitor
     void visitPropertyKey( int propertyKeyId, String propertyKeyName );
     void visitRelationshipType( int relTypeId, String relTypeName );
 
-    void visitIndex( IndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
-    void visitUniqueIndex( IndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
+    void visitIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
+    void visitUniqueIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long
+            size );
     void visitUniqueConstraint( UniquenessConstraint constraint, String userDescription );
     void visitNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint, String userDescription );
     void visitRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -31,8 +31,8 @@ public interface DbStructureVisitor
     void visitRelationshipType( int relTypeId, String relTypeName );
 
     void visitIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
-    void visitUniqueIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long
-            size );
+    void visitUniqueIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage,
+                           long size );
     void visitUniqueConstraint( UniquenessConstraint constraint, String userDescription );
     void visitNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint, String userDescription );
     void visitRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -38,10 +38,12 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import static java.lang.String.format;
+import static org.neo4j.helpers.collection.Iterators.loop;
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
 
@@ -139,11 +141,9 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
 
     private void showIndices( DbStructureVisitor visitor, ReadOperations read, TokenNameLookup nameLookup ) throws IndexNotFoundKernelException
     {
-        Iterator<IndexDescriptor> indexDescriptors = read.indexesGetAll();
-        while ( indexDescriptors.hasNext() )
+        for ( NewIndexDescriptor descriptor : loop( read.indexesGetAll() ) )
         {
-            IndexDescriptor descriptor = indexDescriptors.next();
-            String userDescription = descriptor.userDescription( nameLookup );
+            String userDescription = descriptor.schema().userDescription( nameLookup );
             double uniqueValuesPercentage = read.indexUniqueValuesSelectivity( descriptor );
             long size = read.indexSize( descriptor );
             visitor.visitIndex( descriptor, userDescription , uniqueValuesPercentage, size );
@@ -153,11 +153,9 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
     private void showUniqueIndices( DbStructureVisitor visitor, ReadOperations read, TokenNameLookup nameLookup ) throws IndexNotFoundKernelException
 
     {
-        Iterator<IndexDescriptor> indexDescriptors = read.uniqueIndexesGetAll();
-        while ( indexDescriptors.hasNext() )
+        for ( NewIndexDescriptor descriptor : loop( read.uniqueIndexesGetAll() ) )
         {
-            IndexDescriptor descriptor = indexDescriptors.next();
-            String userDescription = descriptor.userDescription( nameLookup );
+            String userDescription = descriptor.schema().userDescription( nameLookup );
             double uniqueValuesPercentage = read.indexUniqueValuesSelectivity( descriptor );
             long size = read.indexSize( descriptor );
             visitor.visitUniqueIndex( descriptor, userDescription, uniqueValuesPercentage, size );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -21,9 +21,8 @@ package org.neo4j.storageengine.api;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.RecordCursors;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
 
@@ -107,11 +106,11 @@ public interface StorageStatement extends AutoCloseable
      * Reader returned from this method should not be closed. All such readers will be closed during {@link #close()}
      * of the current statement.
      *
-     * @param index {@link IndexDescriptor} to get reader for.
+     * @param index {@link NewIndexDescriptor} to get reader for.
      * @return {@link IndexReader} capable of searching entity ids given property values.
      * @throws IndexNotFoundKernelException if no such index exists.
      */
-    IndexReader getIndexReader( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    IndexReader getIndexReader( NewIndexDescriptor index ) throws IndexNotFoundKernelException;
 
     /**
      * Returns an {@link IndexReader} for searching entity ids given property values. A new reader is allocated
@@ -121,11 +120,11 @@ public interface StorageStatement extends AutoCloseable
      * <b>NOTE:</b>
      * It is caller's responsibility to close the returned reader.
      *
-     * @param index {@link IndexDescriptor} to get reader for.
+     * @param index {@link NewIndexDescriptor} to get reader for.
      * @return {@link IndexReader} capable of searching entity ids given property values.
      * @throws IndexNotFoundKernelException if no such index exists.
      */
-    IndexReader getFreshIndexReader( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    IndexReader getFreshIndexReader( NewIndexDescriptor index ) throws IndexNotFoundKernelException;
 
     /**
      * Access to low level record cursors

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -155,28 +155,28 @@ public interface StoreReadLayer
     /**
      * Returns state of a stored index.
      *
-     * @param index {@link IndexDescriptor} to get state for.
+     * @param descriptor {@link LabelSchemaDescriptor} to get state for.
      * @return {@link InternalIndexState} for index.
      * @throws IndexNotFoundKernelException if index not found.
      */
-    InternalIndexState indexGetState( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    InternalIndexState indexGetState( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
-     * @param index {@link IndexDescriptor} to get population progress for.
+     * @param descriptor {@link LabelSchemaDescriptor} to get population progress for.
      * @return progress of index population, which is the initial state of an index when it's created.
      * @throws IndexNotFoundKernelException if index not found.
      */
-    PopulationProgress indexGetPopulationProgress( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    PopulationProgress indexGetPopulationProgress( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Returns any failure that happened during population or operation of an index. Such failures
      * are persisted and can be accessed even after restart.
      *
-     * @param index {@link IndexDescriptor} to get failure for.
+     * @param descriptor {@link LabelSchemaDescriptor} to get failure for.
      * @return failure of an index, or {@code null} if index is working as it should.
      * @throws IndexNotFoundKernelException if index not found.
      */
-    String indexGetFailure( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    String indexGetFailure( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * @param labelName name of label.
@@ -338,22 +338,22 @@ public interface StoreReadLayer
     /**
      * Returns size of index, i.e. number of entities in that index.
      *
-     * @param index {@link IndexDescriptor} to return size for.
+     * @param descriptor {@link LabelSchemaDescriptor} to return size for.
      * @return number of entities in the given index.
      * @throws IndexNotFoundKernelException if no such index exists.
      */
-    long indexSize( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    long indexSize( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**
      * Returns percentage of values in the given {@code index} are unique. A value of {@code 1.0} means that
      * all values in the index are unique, e.g. that there are no duplicate values. A value of, say {@code 0.9}
      * means that 10% of the values are duplicates.
      *
-     * @param index {@link IndexDescriptor} to get uniqueness percentage for.
+     * @param descriptor {@link LabelSchemaDescriptor} to get uniqueness percentage for.
      * @return percentage of values being unique in this index, max {@code 1.0} for all unique.
      * @throws IndexNotFoundKernelException if no such index exists.
      */
-    double indexUniqueValuesPercentage( IndexDescriptor index ) throws IndexNotFoundKernelException;
+    double indexUniqueValuesPercentage( LabelSchemaDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     long nodesGetCount();
 
@@ -365,10 +365,10 @@ public interface StoreReadLayer
 
     int relationshipTypeCount();
 
-    DoubleLongRegister indexUpdatesAndSize( IndexDescriptor index, DoubleLongRegister target )
+    DoubleLongRegister indexUpdatesAndSize( LabelSchemaDescriptor descriptor, DoubleLongRegister target )
             throws IndexNotFoundKernelException;
 
-    DoubleLongRegister indexSample( IndexDescriptor index, DoubleLongRegister target )
+    DoubleLongRegister indexSample( LabelSchemaDescriptor descriptor, DoubleLongRegister target )
             throws IndexNotFoundKernelException;
 
     boolean nodeExists( long id );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -93,7 +93,7 @@ public interface StoreReadLayer
      * @return schema rule id for matching index.
      * @throws SchemaRuleNotFoundException if no such index exists in storage.
      */
-    long indexGetCommittedId( NewIndexDescriptor index, Predicate<IndexRule> filter )
+    long indexGetCommittedId( NewIndexDescriptor index, Predicate<NewIndexDescriptor> filter )
             throws SchemaRuleNotFoundException;
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -20,7 +20,6 @@
 package org.neo4j.storageengine.api;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -35,14 +34,12 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.InternalIndexState;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.DegreeVisitor;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
-import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 
@@ -93,7 +90,7 @@ public interface StoreReadLayer
      * @return schema rule id for matching index.
      * @throws SchemaRuleNotFoundException if no such index exists in storage.
      */
-    long indexGetCommittedId( NewIndexDescriptor index, Predicate<NewIndexDescriptor> filter )
+    long indexGetCommittedId( NewIndexDescriptor index, NewIndexDescriptor.Filter filter )
             throws SchemaRuleNotFoundException;
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
@@ -98,7 +98,7 @@ public interface SchemaRule extends SchemaDescriptor.Supplier, RecordSerializabl
             case UNIQUE:
                 return UNIQUENESS_CONSTRAINT;
             case EXISTS:
-                return existenceKindMapper.compute( descriptor.schema() );
+                return descriptor.schema().computeWith( existenceKindMapper );
             default:
                 throw new IllegalStateException( "Cannot end up here, says johant" );
             }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -31,9 +31,9 @@ import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.storageengine.api.Direction;
@@ -112,15 +112,11 @@ public interface ReadableTransactionState
 
     // SCHEMA RELATED
 
-    ReadableDiffSets<IndexDescriptor> indexDiffSetsByLabel( int labelId );
+    ReadableDiffSets<NewIndexDescriptor> indexDiffSetsByLabel( int labelId, NewIndexDescriptor.Filter indexType );
 
-    ReadableDiffSets<IndexDescriptor> constraintIndexDiffSetsByLabel( int labelId );
+    ReadableDiffSets<NewIndexDescriptor> indexChanges( NewIndexDescriptor.Filter indexType );
 
-    ReadableDiffSets<IndexDescriptor> indexChanges();
-
-    ReadableDiffSets<IndexDescriptor> constraintIndexChanges();
-
-    Iterable<IndexDescriptor> constraintIndexesCreatedInTx();
+    Iterable<NewIndexDescriptor> constraintIndexesCreatedInTx();
 
     ReadableDiffSets<PropertyConstraint> constraintsChanges();
 
@@ -135,17 +131,17 @@ public interface ReadableTransactionState
 
     Long indexCreatedForConstraint( UniquenessConstraint constraint );
 
-    ReadableDiffSets<Long> indexUpdatesForScanOrSeek( IndexDescriptor index, Object value );
+    ReadableDiffSets<Long> indexUpdatesForScanOrSeek( NewIndexDescriptor index, Object value );
 
-    ReadableDiffSets<Long> indexUpdatesForRangeSeekByNumber( IndexDescriptor index,
+    ReadableDiffSets<Long> indexUpdatesForRangeSeekByNumber( NewIndexDescriptor index,
                                                              Number lower, boolean includeLower,
                                                              Number upper, boolean includeUpper );
 
-    ReadableDiffSets<Long> indexUpdatesForRangeSeekByString( IndexDescriptor index,
+    ReadableDiffSets<Long> indexUpdatesForRangeSeekByString( NewIndexDescriptor index,
                                                              String lower, boolean includeLower,
                                                              String upper, boolean includeUpper );
 
-    ReadableDiffSets<Long> indexUpdatesForRangeSeekByPrefix( IndexDescriptor index, String prefix );
+    ReadableDiffSets<Long> indexUpdatesForRangeSeekByPrefix( NewIndexDescriptor index, String prefix );
 
     NodeState getNodeState( long id );
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/TxStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/TxStateVisitor.java
@@ -27,7 +27,7 @@ import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.StorageProperty;
 
 /**
@@ -56,9 +56,9 @@ public interface TxStateVisitor extends AutoCloseable
     void visitNodeLabelChanges( long id, Set<Integer> added, Set<Integer> removed )
             throws ConstraintValidationKernelException;
 
-    void visitAddedIndex( IndexDescriptor element, boolean isConstraintIndex );
+    void visitAddedIndex( NewIndexDescriptor element );
 
-    void visitRemovedIndex( IndexDescriptor element, boolean isConstraintIndex );
+    void visitRemovedIndex( NewIndexDescriptor element );
 
     void visitAddedUniquePropertyConstraint( UniquenessConstraint element );
 
@@ -133,12 +133,12 @@ public interface TxStateVisitor extends AutoCloseable
         }
 
         @Override
-        public void visitAddedIndex( IndexDescriptor element, boolean isConstraintIndex )
+        public void visitAddedIndex( NewIndexDescriptor index )
         {
         }
 
         @Override
-        public void visitRemovedIndex( IndexDescriptor element, boolean isConstraintIndex )
+        public void visitRemovedIndex( NewIndexDescriptor index )
         {
         }
 
@@ -264,15 +264,15 @@ public interface TxStateVisitor extends AutoCloseable
         }
 
         @Override
-        public void visitAddedIndex( IndexDescriptor element, boolean isConstraintIndex )
+        public void visitAddedIndex( NewIndexDescriptor index )
         {
-            actual.visitAddedIndex( element, isConstraintIndex );
+            actual.visitAddedIndex( index );
         }
 
         @Override
-        public void visitRemovedIndex( IndexDescriptor element, boolean isConstraintIndex )
+        public void visitRemovedIndex( NewIndexDescriptor index )
         {
-            actual.visitRemovedIndex( element, isConstraintIndex );
+            actual.visitRemovedIndex( index );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -451,8 +451,8 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         for ( int i = 0; i < labelIds.length; i++ )
         {
             IndexRule rule = rules[i];
-            int labelId = rule.getSchemaDescriptor().getLabelId();
-            int propertyKeyId = rule.getSchemaDescriptor().getPropertyIds()[0];
+            int labelId = rule.schema().getLabelId();
+            int propertyKeyId = rule.schema().getPropertyIds()[0];
 
             labelIds[i] = labelId;
             // TODO: Support composite indexes

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -488,7 +488,7 @@ public class IndexingAcceptanceTest
         {
             Statement statement = getStatement( (GraphDatabaseAPI) db );
             ReadOperations ops = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( ops, index );
+            NewIndexDescriptor descriptor = indexDescriptor( ops, index );
             found.addAll( ops.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Karl" ) );
         }
 
@@ -513,7 +513,7 @@ public class IndexingAcceptanceTest
             createNode( db, map( "name", "Karla" ), LABEL1 );
             Statement statement = getStatement( (GraphDatabaseAPI) db );
             ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+            NewIndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Carl" ) );
         }
         // THEN
@@ -543,7 +543,7 @@ public class IndexingAcceptanceTest
             }
             Statement statement = getStatement( (GraphDatabaseAPI) db );
             ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+            NewIndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Karl" ) );
         }
         // THEN
@@ -582,7 +582,7 @@ public class IndexingAcceptanceTest
             }
             Statement statement = getStatement( (GraphDatabaseAPI) db );
             ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+            NewIndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, prefix ) );
         }
         // THEN
@@ -603,11 +603,11 @@ public class IndexingAcceptanceTest
         return expected;
     }
 
-    private IndexDescriptor indexDescriptor(ReadOperations readOperations, IndexDefinition index)
+    private NewIndexDescriptor indexDescriptor(ReadOperations readOperations, IndexDefinition index)
             throws SchemaRuleNotFoundException
     {
         NodePropertyDescriptor descriptor = IndexDescriptorFactory.getTokens( readOperations, index );
-        return IndexBoundary.map( readOperations.indexGetForLabelAndPropertyKey( descriptor ) );
+        return readOperations.indexGetForLabelAndPropertyKey( descriptor );
     }
 
     private Statement getStatement( GraphDatabaseAPI db )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -38,6 +38,8 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.mockito.matcher.Neo4jMatchers;
@@ -605,7 +607,7 @@ public class IndexingAcceptanceTest
             throws SchemaRuleNotFoundException
     {
         NodePropertyDescriptor descriptor = IndexDescriptorFactory.getTokens( readOperations, index );
-        return readOperations.indexGetForLabelAndPropertyKey( descriptor );
+        return IndexBoundary.map( readOperations.indexGetForLabelAndPropertyKey( descriptor ) );
     }
 
     private Statement getStatement( GraphDatabaseAPI db )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema_new/SchemaProcessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema_new/SchemaProcessorTest.java
@@ -51,12 +51,12 @@ public class SchemaProcessorTest
             }
         };
 
-        processor.process( disguisedLabel() );
-        processor.process( disguisedLabel() );
-        processor.process( disguisedRelType() );
-        processor.process( disguisedLabel() );
-        processor.process( disguisedRelType() );
-        processor.process( disguisedRelType() );
+        disguisedLabel().processWith( processor );
+        disguisedLabel().processWith( processor );
+        disguisedRelType().processWith( processor );
+        disguisedLabel().processWith( processor );
+        disguisedRelType().processWith( processor );
+        disguisedRelType().processWith( processor );
 
         assertThat( callHistory, Matchers.contains(
                 "LabelSchemaDescriptor", "LabelSchemaDescriptor",

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
@@ -37,6 +37,8 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -63,7 +65,7 @@ public class AwaitIndexProcedureTest
     private final IndexProcedures procedure = new IndexProcedures( new StubKernelTransaction( operations ), null );
     private final NodePropertyDescriptor descriptor = new NodePropertyDescriptor( 123, 456 );
     private final NodePropertyDescriptor anyDescriptor = new NodePropertyDescriptor( 0, 0 );
-    private final IndexDescriptor anyIndex = IndexDescriptorFactory.of( anyDescriptor );
+    private final NewIndexDescriptor anyIndex = IndexBoundary.map( anyDescriptor );
 
     @Test
     public void shouldThrowAnExceptionIfTheLabelDoesntExist() throws ProcedureException
@@ -104,7 +106,7 @@ public class AwaitIndexProcedureTest
         when( operations.labelGetForName( anyString() ) ).thenReturn( descriptor.getLabelId() );
         when( operations.propertyKeyGetForName( anyString() ) ).thenReturn( descriptor.getPropertyKeyId() );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( anyIndex );
-        when( operations.indexGetState( any( IndexDescriptor.class ) ) ).thenReturn( ONLINE );
+        when( operations.indexGetState( any( NewIndexDescriptor.class ) ) ).thenReturn( ONLINE );
 
         procedure.awaitIndex( ":Person(name)", timeout, timeoutUnits );
 
@@ -119,7 +121,7 @@ public class AwaitIndexProcedureTest
         when( operations.labelGetForName( anyString() ) ).thenReturn( 0 );
         when( operations.propertyKeyGetForName( anyString() ) ).thenReturn( 0 );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( anyIndex );
-        when( operations.indexGetState( any( IndexDescriptor.class ) ) ).thenReturn( FAILED );
+        when( operations.indexGetState( any( NewIndexDescriptor.class ) ) ).thenReturn( FAILED );
 
         try
         {
@@ -162,7 +164,7 @@ public class AwaitIndexProcedureTest
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( anyIndex );
 
         AtomicReference<InternalIndexState> state = new AtomicReference<>( POPULATING );
-        when( operations.indexGetState( any( IndexDescriptor.class ) ) ).then( new Answer<InternalIndexState>()
+        when( operations.indexGetState( any( NewIndexDescriptor.class ) ) ).then( new Answer<InternalIndexState>()
         {
             @Override
             public InternalIndexState answer( InvocationOnMock invocationOnMock ) throws Throwable
@@ -199,7 +201,7 @@ public class AwaitIndexProcedureTest
         when( operations.labelGetForName( anyString() ) ).thenReturn( 0 );
         when( operations.propertyKeyGetForName( anyString() ) ).thenReturn( 0 );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( anyIndex );
-        when( operations.indexGetState( any( IndexDescriptor.class ) ) ).thenReturn( POPULATING );
+        when( operations.indexGetState( any( NewIndexDescriptor.class ) ) ).thenReturn( POPULATING );
 
         AtomicReference<ProcedureException> exception = new AtomicReference<>();
         new Thread( () ->

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/ResampleIndexProcedureTest.java
@@ -30,6 +30,9 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
 
@@ -87,7 +90,7 @@ public class ResampleIndexProcedureTest
     public void shouldLookUpTheIndexByLabelIdAndPropertyKeyId()
             throws ProcedureException, SchemaRuleNotFoundException, IndexNotFoundKernelException
     {
-        IndexDescriptor index = IndexDescriptorFactory.of( 0, 0 );
+        NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 0, 0 );
         when( operations.labelGetForName( anyString() ) ).thenReturn( 123 );
         when( operations.propertyKeyGetForName( anyString() ) ).thenReturn( 456 );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( index );
@@ -122,11 +125,12 @@ public class ResampleIndexProcedureTest
     public void shouldTriggerResampling()
             throws SchemaRuleNotFoundException, ProcedureException, IndexNotFoundKernelException
     {
-        IndexDescriptor index = IndexDescriptorFactory.of( 123, 456 );
+        NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 123, 456 );
         when( operations.indexGetForLabelAndPropertyKey( anyObject() ) ).thenReturn( index );
 
         procedure.resampleIndex( ":Person(name)" );
 
-        verify( indexingService ).triggerIndexSampling( index, IndexSamplingMode.TRIGGER_REBUILD_ALL );
+        verify( indexingService ).triggerIndexSampling( IndexBoundary.map( index ),
+                IndexSamplingMode.TRIGGER_REBUILD_ALL );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
@@ -131,7 +131,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         // WHEN
         try
         {
-            ctx.indexDrop( state, IndexBoundary.map( index ) );
+            ctx.indexDrop( state, index );
             fail( "Should have thrown exception." );
         }
         catch ( DropIndexFailureException e )
@@ -157,7 +157,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         // WHEN
         try
         {
-            ctx.indexDrop( state, IndexBoundary.map( index ) );
+            ctx.indexDrop( state, index );
             fail( "Should have thrown exception." );
         }
         catch ( DropIndexFailureException e )
@@ -183,7 +183,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         // WHEN
         try
         {
-            ctx.indexDrop( state, IndexBoundary.map( index ) );
+            ctx.indexDrop( state, index );
             fail( "Should have thrown exception." );
         }
         catch ( DropIndexFailureException e )
@@ -209,7 +209,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         // WHEN
         try
         {
-            ctx.indexDrop( state, IndexBoundary.map( index ) );
+            ctx.indexDrop( state, index );
             fail( "Should have thrown exception." );
         }
         catch ( DropIndexFailureException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
@@ -27,7 +27,6 @@ import org.mockito.stubbing.Answer;
 
 import java.util.Iterator;
 
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
@@ -36,9 +35,6 @@ import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBelongsToConstraintException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchIndexException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
-import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.operations.KeyWriteOperations;
@@ -48,8 +44,6 @@ import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -65,6 +59,7 @@ public class DataIntegrityValidatingStatementOperationsTest
 
     NodePropertyDescriptor descriptor = new NodePropertyDescriptor( 0, 7 );
     NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 0, 7 );
+    NewIndexDescriptor uniqueIndex = NewIndexDescriptorFactory.uniqueForLabel( 0, 7 );
 
     @Test
     public void shouldDisallowReAddingIndex() throws Exception
@@ -74,7 +69,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.indexesGetForLabel( state, index.schema().getLabelId() ) ).thenAnswer( withIterator( index ) );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( index );
 
         // WHEN
         try
@@ -99,8 +94,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.indexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator() );
-        when( innerRead.uniqueIndexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator( index ) );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -125,8 +119,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.uniqueIndexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator(  ) );
-        when( innerRead.indexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator( ) );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( null );
 
         // WHEN
         try
@@ -151,8 +144,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.uniqueIndexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator( index ) );
-        when( innerRead.indexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator() );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -177,8 +169,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.uniqueIndexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator( index ) );
-        when( innerRead.indexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator(  ) );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -203,8 +194,7 @@ public class DataIntegrityValidatingStatementOperationsTest
         SchemaWriteOperations innerWrite = mock( SchemaWriteOperations.class );
         DataIntegrityValidatingStatementOperations ctx =
                 new DataIntegrityValidatingStatementOperations( null, innerRead, innerWrite );
-        when( innerRead.uniqueIndexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator( index ) );
-        when( innerRead.indexesGetForLabel( state, descriptor.getLabelId() ) ).thenAnswer( withIterator() );
+        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -162,9 +162,9 @@ public class KernelSchemaStateFlushingTest
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = transaction.acquireStatement() )
         {
-            IndexDescriptor descriptor = statement.schemaWriteOperations().indexCreate( descriptor1 );
+            NewIndexDescriptor descriptor = statement.schemaWriteOperations().indexCreate( descriptor1 );
             transaction.success();
-            return IndexBoundary.map( descriptor );
+            return descriptor;
         }
     }
 
@@ -173,7 +173,7 @@ public class KernelSchemaStateFlushingTest
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = transaction.acquireStatement() )
         {
-            statement.schemaWriteOperations().indexDrop( IndexBoundary.map( descriptor ) );
+            statement.schemaWriteOperations().indexDrop( descriptor );
             transaction.success();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
@@ -74,9 +76,7 @@ public class KernelSchemaStateFlushingTest
         // given
         commitToSchemaState( "test", "before" );
 
-        IndexDescriptor descriptor = createIndex();
-
-        awaitIndexOnline( descriptor, "test" );
+        awaitIndexOnline( createIndex(), "test" );
 
         // when
         String after = commitToSchemaState( "test", "after" );
@@ -88,7 +88,7 @@ public class KernelSchemaStateFlushingTest
     @Test
     public void shouldInvalidateSchemaStateOnDropIndex() throws Exception
     {
-        IndexDescriptor descriptor = createIndex();
+        NewIndexDescriptor descriptor = createIndex();
 
         awaitIndexOnline( descriptor, "test" );
 
@@ -157,28 +157,28 @@ public class KernelSchemaStateFlushingTest
         }
     }
 
-    private IndexDescriptor createIndex() throws KernelException
+    private NewIndexDescriptor createIndex() throws KernelException
     {
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = transaction.acquireStatement() )
         {
             IndexDescriptor descriptor = statement.schemaWriteOperations().indexCreate( descriptor1 );
             transaction.success();
-            return descriptor;
+            return IndexBoundary.map( descriptor );
         }
     }
 
-    private void dropIndex( IndexDescriptor descriptor ) throws KernelException
+    private void dropIndex( NewIndexDescriptor descriptor ) throws KernelException
     {
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = transaction.acquireStatement() )
         {
-            statement.schemaWriteOperations().indexDrop( descriptor );
+            statement.schemaWriteOperations().indexDrop( IndexBoundary.map( descriptor ) );
             transaction.success();
         }
     }
 
-    private void awaitIndexOnline( IndexDescriptor descriptor, String keyForProbing )
+    private void awaitIndexOnline( NewIndexDescriptor descriptor, String keyForProbing )
             throws IndexNotFoundKernelException, TransactionFailureException
     {
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
@@ -237,11 +238,11 @@ public class LockingStatementOperationsTest
     public void shouldAcquireSchemaReadLockBeforeGettingIndexRules() throws Exception
     {
         // given
-        Iterator<IndexDescriptor> rules = Collections.emptyIterator();
+        Iterator<NewIndexDescriptor> rules = Collections.emptyIterator();
         when( schemaReadOps.indexesGetAll( state ) ).thenReturn( rules );
 
         // when
-        Iterator<IndexDescriptor> result = lockingOps.indexesGetAll( state );
+        Iterator<NewIndexDescriptor> result = lockingOps.indexesGetAll( state );
 
         // then
         assertSame( rules, result );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
@@ -208,14 +209,14 @@ public class LockingStatementOperationsTest
     {
         // given
         NodePropertyDescriptor descriptor = new NodePropertyDescriptor( 123, 456 );
-        IndexDescriptor rule = mock( IndexDescriptor.class );
-        when( schemaWriteOps.indexCreate( state, descriptor ) ).thenReturn( rule );
+        NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 123, 456 );
+        when( schemaWriteOps.indexCreate( state, descriptor ) ).thenReturn( index );
 
         // when
-        IndexDescriptor result = lockingOps.indexCreate( state, descriptor );
+        NewIndexDescriptor result = lockingOps.indexCreate( state, descriptor );
 
         // then
-        assertSame( rule, result );
+        assertSame( index, result );
         order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
         order.verify( schemaWriteOps ).indexCreate( state, descriptor );
     }
@@ -224,14 +225,14 @@ public class LockingStatementOperationsTest
     public void shouldAcquireSchemaWriteLockBeforeRemovingIndexRule() throws Exception
     {
         // given
-        IndexDescriptor rule = IndexDescriptorFactory.of( 0, 0 );
+        NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 0, 0 );
 
         // when
-        lockingOps.indexDrop( state, rule );
+        lockingOps.indexDrop( state, index );
 
         // then
         order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.SCHEMA, schemaResource() );
-        order.verify( schemaWriteOps ).indexDrop( state, rule );
+        order.verify( schemaWriteOps ).indexDrop( state, index );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
@@ -36,6 +36,9 @@ import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.test.mockito.matcher.KernelExceptionUserMessageMatcher;
 
@@ -85,7 +88,7 @@ public class OperationsFacadeTest
             throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
     {
         SchemaReadOperations readOperations = setupSchemaReadOperations();
-        IndexDescriptor index = IndexDescriptorFactory.of( descriptor );
+        NewIndexDescriptor index = IndexBoundary.map( descriptor );
         Mockito.when( readOperations
                 .uniqueIndexesGetForLabel( Mockito.any( KernelStatement.class ), Mockito.eq( descriptor.getLabelId() ) ) )
                 .thenReturn( Iterators.iterator( index, index ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -61,9 +61,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.UNIQUE;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedParts;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedState;
-import static org.neo4j.kernel.impl.store.SchemaStorage.IndexRuleKind.CONSTRAINT;
 
 public class ConstraintIndexCreatorTest
 {
@@ -82,7 +82,7 @@ public class ConstraintIndexCreatorTest
         IndexingService indexingService = mock( IndexingService.class );
         StubKernel kernel = new StubKernel();
 
-        when( constraintCreationContext.schemaReadOperations().indexGetCommittedId( state, index, CONSTRAINT ) )
+        when( constraintCreationContext.schemaReadOperations().indexGetCommittedId( state, index, UNIQUE ) )
                 .thenReturn( 2468L );
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getIndexProxy( 2468L ) ).thenReturn( indexProxy );
@@ -97,7 +97,7 @@ public class ConstraintIndexCreatorTest
         assertEquals( 1, kernel.statements.size() );
         verify( kernel.statements.get( 0 ).txState() ).indexRuleDoAdd( eq( IndexBoundary.mapUnique( index ) ) );
         verifyNoMoreInteractions( indexCreationContext.schemaWriteOperations() );
-        verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, index, CONSTRAINT );
+        verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, index, UNIQUE );
         verifyNoMoreInteractions( constraintCreationContext.schemaReadOperations() );
         verify( indexProxy ).awaitStoreScanCompleted();
     }
@@ -114,7 +114,7 @@ public class ConstraintIndexCreatorTest
         IndexingService indexingService = mock( IndexingService.class );
         StubKernel kernel = new StubKernel();
 
-        when( constraintCreationContext.schemaReadOperations().indexGetCommittedId( state, index, CONSTRAINT ) )
+        when( constraintCreationContext.schemaReadOperations().indexGetCommittedId( state, index, UNIQUE ) )
                 .thenReturn( 2468L );
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getIndexProxy( 2468L ) ).thenReturn( indexProxy );
@@ -142,7 +142,7 @@ public class ConstraintIndexCreatorTest
         NewIndexDescriptor newIndex = NewIndexDescriptorFactory.uniqueForLabel( 123, 456 );
         verify( tx1 ).indexRuleDoAdd( newIndex );
         verifyNoMoreInteractions( tx1 );
-        verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, index, CONSTRAINT );
+        verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, index, UNIQUE );
         verifyNoMoreInteractions( constraintCreationContext.schemaReadOperations() );
         TransactionState tx2 = kernel.statements.get( 1 ).txState();
         verify( tx2 ).indexDoDrop( newIndex );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -68,6 +68,7 @@ import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedStat
 public class ConstraintIndexCreatorTest
 {
     private final NodePropertyDescriptor descriptor = new NodePropertyDescriptor( 123, 456 );
+    private final NewIndexDescriptor index = NewIndexDescriptorFactory.uniqueForLabel( 123, 456 );
 
     @Test
     public void shouldCreateIndexInAnotherTransaction() throws Exception
@@ -76,7 +77,6 @@ public class ConstraintIndexCreatorTest
         StatementOperationParts constraintCreationContext = mockedParts();
         StatementOperationParts indexCreationContext = mockedParts();
 
-        IndexDescriptor index = IndexDescriptorFactory.of( descriptor );
         KernelStatement state = mockedState();
 
         IndexingService indexingService = mock( IndexingService.class );
@@ -95,7 +95,7 @@ public class ConstraintIndexCreatorTest
         // then
         assertEquals( 2468L, indexId );
         assertEquals( 1, kernel.statements.size() );
-        verify( kernel.statements.get( 0 ).txState() ).indexRuleDoAdd( eq( IndexBoundary.mapUnique( index ) ) );
+        verify( kernel.statements.get( 0 ).txState() ).indexRuleDoAdd( eq( index ) );
         verifyNoMoreInteractions( indexCreationContext.schemaWriteOperations() );
         verify( constraintCreationContext.schemaReadOperations() ).indexGetCommittedId( state, index, UNIQUE );
         verifyNoMoreInteractions( constraintCreationContext.schemaReadOperations() );
@@ -108,8 +108,6 @@ public class ConstraintIndexCreatorTest
         // given
         StatementOperationParts constraintCreationContext = mockedParts();
         KernelStatement state = mockedState();
-
-        IndexDescriptor index = IndexDescriptorFactory.of( descriptor );
 
         IndexingService indexingService = mock( IndexingService.class );
         StubKernel kernel = new StubKernel();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -76,7 +76,7 @@ public class IndexIT extends KernelIntegrationTest
         SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
 
         // WHEN
-        NewIndexDescriptor expectedRule = IndexBoundary.map( schemaWriteOperations.indexCreate( descriptor ) );
+        NewIndexDescriptor expectedRule = schemaWriteOperations.indexCreate( descriptor );
         commit();
 
         // THEN
@@ -91,16 +91,14 @@ public class IndexIT extends KernelIntegrationTest
     {
         // GIVEN
         SchemaWriteOperations schemaWriteOperations = schemaWriteOperationsInNewTransaction();
-        NewIndexDescriptor existingRule = IndexBoundary.map( schemaWriteOperations.indexCreate( descriptor ) );
+        NewIndexDescriptor existingRule = schemaWriteOperations.indexCreate( descriptor );
         commit();
 
         // WHEN
-        NewIndexDescriptor addedRule;
-        Set<NewIndexDescriptor> indexRulesInTx;
         Statement statement = statementInNewTransaction( AnonymousContext.AUTH_DISABLED );
-        addedRule = IndexBoundary.map( statement.schemaWriteOperations().indexCreate(
-                new NodePropertyDescriptor( labelId, 10 ) ) );
-        indexRulesInTx = asSet( statement.readOperations().indexesGetForLabel( labelId ) );
+        NewIndexDescriptor addedRule = statement.schemaWriteOperations()
+                                            .indexCreate( new NodePropertyDescriptor( labelId, 10 ) );
+        Set<NewIndexDescriptor> indexRulesInTx = asSet( statement.readOperations().indexesGetForLabel( labelId ) );
         commit();
 
         // THEN
@@ -144,7 +142,7 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldDisallowDroppingIndexThatDoesNotExist() throws Exception
     {
         // given
-        IndexDescriptor index;
+        NewIndexDescriptor index;
         {
             SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
             index = statement.indexCreate( descriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -54,6 +54,8 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
@@ -133,7 +135,7 @@ public class IndexStatisticsTest
         createSomePersons();
 
         // when
-        IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        NewIndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
 
         // then
         assertEquals( 0.75d, indexSelectivity( index ), DOUBLE_ERROR_TOLERANCE );
@@ -145,7 +147,7 @@ public class IndexStatisticsTest
     public void shouldNotSeeDataCreatedAfterPopulation() throws KernelException
     {
         // given
-        IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        NewIndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
 
         // when
         createSomePersons();
@@ -162,7 +164,7 @@ public class IndexStatisticsTest
     {
         // given
         createSomePersons();
-        IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        NewIndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
 
         // when
         createSomePersons();
@@ -178,7 +180,7 @@ public class IndexStatisticsTest
     {
         // given
         createSomePersons();
-        IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        NewIndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
         long indexId = indexId( index );
 
         // when
@@ -208,7 +210,7 @@ public class IndexStatisticsTest
         int created = repeatCreateNamedPeopleFor( NAMES.length * CREATION_MULTIPLIER ).length;
 
         // when
-        IndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
+        NewIndexDescriptor index = awaitOnline( createIndex( "Person", "name" ) );
 
         // then
         double expectedSelectivity = UNIQUE_NAMES / (created);
@@ -224,7 +226,7 @@ public class IndexStatisticsTest
         int initialNodes = repeatCreateNamedPeopleFor( NAMES.length * CREATION_MULTIPLIER ).length;
 
         // when populating while creating
-        IndexDescriptor index = createIndex( "Person", "name" );
+        NewIndexDescriptor index = createIndex( "Person", "name" );
         final UpdatesTracker updatesTracker = executeCreations( index, CREATION_MULTIPLIER );
         awaitOnline( index );
 
@@ -244,7 +246,7 @@ public class IndexStatisticsTest
         int initialNodes = nodes.length;
 
         // when populating while creating
-        IndexDescriptor index = createIndex( "Person", "name" );
+        NewIndexDescriptor index = createIndex( "Person", "name" );
         UpdatesTracker updatesTracker = executeCreationsAndDeletions( nodes, index, CREATION_MULTIPLIER );
         awaitOnline( index );
 
@@ -266,7 +268,7 @@ public class IndexStatisticsTest
         int initialNodes = nodes.length;
 
         // when populating while creating
-        IndexDescriptor index = createIndex( "Person", "name" );
+        NewIndexDescriptor index = createIndex( "Person", "name" );
         UpdatesTracker updatesTracker = executeCreationsAndUpdates( nodes, index, CREATION_MULTIPLIER );
         awaitOnline( index );
 
@@ -288,7 +290,7 @@ public class IndexStatisticsTest
         ExecutorService executorService = Executors.newFixedThreadPool( threads );
 
         // when populating while creating
-        final IndexDescriptor index = createIndex( "Person", "name" );
+        final NewIndexDescriptor index = createIndex( "Person", "name" );
 
         final Collection<Callable<UpdatesTracker>> jobs = new ArrayList<>( threads );
         for ( int i = 0; i < threads; i++ )
@@ -423,31 +425,31 @@ public class IndexStatisticsTest
         return nodes;
     }
 
-    private void dropIndex( IndexDescriptor index ) throws KernelException
+    private void dropIndex( NewIndexDescriptor index ) throws KernelException
     {
         try ( Transaction tx = db.beginTx() )
         {
             Statement statement = bridge.get();
-            statement.schemaWriteOperations().indexDrop( index );
+            statement.schemaWriteOperations().indexDrop( IndexBoundary.map( index ) );
             tx.success();
         }
     }
 
-    private long indexSize( IndexDescriptor descriptor ) throws KernelException
+    private long indexSize( NewIndexDescriptor descriptor ) throws KernelException
     {
         return ((GraphDatabaseAPI) db).getDependencyResolver()
                                       .resolveDependency( IndexingService.class )
-                                      .indexUpdatesAndSize( descriptor ).readSecond();
+                                      .indexUpdatesAndSize( IndexBoundary.map( descriptor ) ).readSecond();
     }
 
-    private long indexUpdates( IndexDescriptor descriptor ) throws KernelException
+    private long indexUpdates( NewIndexDescriptor descriptor ) throws KernelException
     {
         return ((GraphDatabaseAPI) db).getDependencyResolver()
                                       .resolveDependency( IndexingService.class )
-                                      .indexUpdatesAndSize( descriptor ).readFirst();
+                                      .indexUpdatesAndSize( IndexBoundary.map( descriptor ) ).readFirst();
     }
 
-    private double indexSelectivity( IndexDescriptor descriptor ) throws KernelException
+    private double indexSelectivity( NewIndexDescriptor descriptor ) throws KernelException
     {
         try ( Transaction tx = db.beginTx() )
         {
@@ -488,7 +490,7 @@ public class IndexStatisticsTest
         return nodeId;
     }
 
-    private IndexDescriptor createIndex( String labelName, String propertyKeyName ) throws KernelException
+    private NewIndexDescriptor createIndex( String labelName, String propertyKeyName ) throws KernelException
     {
         try ( Transaction tx = db.beginTx() )
         {
@@ -498,16 +500,14 @@ public class IndexStatisticsTest
             NodePropertyDescriptor descriptor = new NodePropertyDescriptor( labelId, propertyKeyId );
             IndexDescriptor index = statement.schemaWriteOperations().indexCreate( descriptor );
             tx.success();
-            return index;
+            return IndexBoundary.map( index );
         }
     }
 
-    private long indexId( IndexDescriptor index )
+    private long indexId( NewIndexDescriptor index )
     {
         SchemaStorage storage = new SchemaStorage( neoStores().getSchemaStore() );
-        LabelSchemaDescriptor descriptor =
-                SchemaDescriptorFactory.forLabel( index.getLabelId(), index.getPropertyKeyId() );
-        return storage.indexGetForSchema( descriptor ).getId();
+        return storage.indexGetForSchema( index.schema() ).getId();
     }
 
     private NeoStores neoStores()
@@ -516,7 +516,7 @@ public class IndexStatisticsTest
                 .testAccessNeoStores();
     }
 
-    private IndexDescriptor awaitOnline( IndexDescriptor index ) throws KernelException
+    private NewIndexDescriptor awaitOnline( NewIndexDescriptor index ) throws KernelException
     {
         long start = System.currentTimeMillis();
         long end = start + 20_000;
@@ -551,34 +551,34 @@ public class IndexStatisticsTest
         throw new IllegalStateException( "Index did not become ONLINE within reasonable time" );
     }
 
-    private UpdatesTracker executeCreations( IndexDescriptor index, int numberOfCreations ) throws KernelException
+    private UpdatesTracker executeCreations( NewIndexDescriptor index, int numberOfCreations ) throws KernelException
     {
         return internalExecuteCreationsDeletionsAndUpdates( null, index, numberOfCreations, false, false );
     }
 
     private UpdatesTracker executeCreationsAndDeletions( long[] nodes,
-                                                         IndexDescriptor index,
+                                                         NewIndexDescriptor index,
                                                          int numberOfCreations ) throws KernelException
     {
         return internalExecuteCreationsDeletionsAndUpdates( nodes, index, numberOfCreations, true, false );
     }
 
     private UpdatesTracker executeCreationsAndUpdates( long[] nodes,
-                                                       IndexDescriptor index,
+                                                       NewIndexDescriptor index,
                                                        int numberOfCreations ) throws KernelException
     {
         return internalExecuteCreationsDeletionsAndUpdates( nodes, index, numberOfCreations, false, true );
     }
 
     private UpdatesTracker executeCreationsDeletionsAndUpdates( long[] nodes,
-                                                                IndexDescriptor index,
+                                                                NewIndexDescriptor index,
                                                                 int numberOfCreations ) throws KernelException
     {
         return internalExecuteCreationsDeletionsAndUpdates( nodes, index, numberOfCreations, true, true );
     }
 
     private UpdatesTracker internalExecuteCreationsDeletionsAndUpdates( long[] nodes,
-                                                                        IndexDescriptor index,
+                                                                        NewIndexDescriptor index,
                                                                         int numberOfCreations,
                                                                         boolean allowDeletions,
                                                                         boolean allowUpdates ) throws KernelException
@@ -593,7 +593,9 @@ public class IndexStatisticsTest
             updatesTracker.increaseCreated( created );
 
             // check index online
-            if ( !updatesTracker.isPopulationCompleted() && indexOnlineMonitor.isIndexOnline( index ) )
+            IndexDescriptor oldIndex = IndexBoundary.map( index );
+            if ( !updatesTracker.isPopulationCompleted() &&
+                    indexOnlineMonitor.isIndexOnline( oldIndex ) )
             {
                 updatesTracker.notifyPopulationCompleted();
             }
@@ -613,7 +615,8 @@ public class IndexStatisticsTest
                 }
 
                 // check again index online
-                if ( !updatesTracker.isPopulationCompleted() && indexOnlineMonitor.isIndexOnline( index ) )
+                if ( !updatesTracker.isPopulationCompleted() &&
+                        indexOnlineMonitor.isIndexOnline( oldIndex ) )
                 {
                     updatesTracker.notifyPopulationCompleted();
                 }
@@ -633,7 +636,7 @@ public class IndexStatisticsTest
                 }
 
                 // check again index online
-                if ( !updatesTracker.isPopulationCompleted() && indexOnlineMonitor.isIndexOnline( index ) )
+                if ( !updatesTracker.isPopulationCompleted() && indexOnlineMonitor.isIndexOnline( oldIndex ) )
                 {
                     updatesTracker.notifyPopulationCompleted();
                 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -430,7 +430,7 @@ public class IndexStatisticsTest
         try ( Transaction tx = db.beginTx() )
         {
             Statement statement = bridge.get();
-            statement.schemaWriteOperations().indexDrop( IndexBoundary.map( index ) );
+            statement.schemaWriteOperations().indexDrop( index );
             tx.success();
         }
     }
@@ -498,9 +498,9 @@ public class IndexStatisticsTest
             int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( labelName );
             int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( propertyKeyName );
             NodePropertyDescriptor descriptor = new NodePropertyDescriptor( labelId, propertyKeyId );
-            IndexDescriptor index = statement.schemaWriteOperations().indexCreate( descriptor );
+            NewIndexDescriptor index = statement.schemaWriteOperations().indexCreate( descriptor );
             tx.success();
-            return IndexBoundary.map( index );
+            return index;
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/SchemaIndexTestHelper.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.spi.KernelContext;
@@ -110,13 +111,13 @@ public class SchemaIndexTestHelper
         }
     }
 
-    public static void awaitIndexOnline( ReadOperations readOperations, IndexDescriptor indexRule )
+    public static void awaitIndexOnline( ReadOperations readOperations, NewIndexDescriptor index )
             throws IndexNotFoundKernelException
     {
         long start = System.currentTimeMillis();
         while(true)
         {
-            if ( readOperations.indexGetState( indexRule ) == InternalIndexState.ONLINE )
+            if ( readOperations.indexGetState( index ) == InternalIndexState.ONLINE )
            {
                break;
            }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.Kernel;
@@ -490,7 +491,7 @@ public class KernelIT extends KernelIntegrationTest
     public void schemaStateShouldBeEvictedOnIndexDropped() throws Exception
     {
         // GIVEN
-        IndexDescriptor idx = createIndex( statementInNewTransaction( SecurityContext.AUTH_DISABLED ) );
+        NewIndexDescriptor idx = createIndex( statementInNewTransaction( SecurityContext.AUTH_DISABLED ) );
         commit();
 
         try ( Transaction tx = db.beginTx() )
@@ -627,7 +628,7 @@ public class KernelIT extends KernelIntegrationTest
         return txIdStore.getLastCommittedTransactionId();
     }
 
-    private IndexDescriptor createIndex( Statement statement )
+    private NewIndexDescriptor createIndex( Statement statement )
             throws SchemaKernelException, InvalidTransactionTypeKernelException
     {
         return statement.schemaWriteOperations().indexCreate( new NodePropertyDescriptor(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -84,7 +84,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
         // when looking for it
         ReadOperations readOperations = readOperationsInNewTransaction();
-        long foundId = readOperations.nodeGetFromUniqueIndexSeek( IndexBoundary.map( index ), value );
+        long foundId = readOperations.nodeGetFromUniqueIndexSeek( index, value );
         commit();
 
         // then
@@ -101,7 +101,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
         // when looking for it
         ReadOperations readOperations = readOperationsInNewTransaction();
-        long foundId = readOperations.nodeGetFromUniqueIndexSeek( IndexBoundary.map( index ), value );
+        long foundId = readOperations.nodeGetFromUniqueIndexSeek( index, value );
         commit();
 
         // then
@@ -145,7 +145,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
             {
                 try ( Statement statement1 = statementContextSupplier.get() )
                 {
-                    statement1.readOperations().nodeGetFromUniqueIndexSeek( IndexBoundary.map( index ), value );
+                    statement1.readOperations().nodeGetFromUniqueIndexSeek( index, value );
                 }
                 tx.success();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.integrationtest;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
@@ -29,8 +30,9 @@ import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.security.AnonymousContext;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -324,16 +326,17 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         }
 
         Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        int person = statement.readOperations().labelGetForName( "Person" );
-        int id = statement.readOperations().propertyKeyGetForName( "id" );
-        IndexDescriptor idx = statement.readOperations()
+        ReadOperations readOps = statement.readOperations();
+        int person = readOps.labelGetForName( "Person" );
+        int id = readOps.propertyKeyGetForName( "id" );
+        NewIndexDescriptor idx = readOps
                 .uniqueIndexGetForLabelAndPropertyKey( new NodePropertyDescriptor( person, id ) );
 
         // when
         createLabeledNode( statement, "Item", "id", 2 );
 
         // then I should find the original node
-        assertThat( statement.readOperations().nodeGetFromUniqueIndexSeek( idx, 1 ), equalTo( ourNode ) );
+        assertThat( readOps.nodeGetFromUniqueIndexSeek( IndexBoundary.map( idx ), 1 ), equalTo( ourNode ) );
     }
 
     @Test
@@ -350,16 +353,17 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         }
 
         Statement statement = statementInNewTransaction( AnonymousContext.writeToken() );
-        int person = statement.readOperations().labelGetForName( "Person" );
-        int id = statement.readOperations().propertyKeyGetForName( "id" );
-        IndexDescriptor idx = statement.readOperations()
+        ReadOperations readOps = statement.readOperations();
+        int person = readOps.labelGetForName( "Person" );
+        int id = readOps.propertyKeyGetForName( "id" );
+        NewIndexDescriptor idx = readOps
                 .uniqueIndexGetForLabelAndPropertyKey( new NodePropertyDescriptor( person, id ) );
 
         // when
         createLabeledNode( statement, "Person", "id", 2 );
 
         // then I should find the original node
-        assertThat( statement.readOperations().nodeGetFromUniqueIndexSeek( idx, 1 ), equalTo( ourNode ));
+        assertThat( readOps.nodeGetFromUniqueIndexSeek( IndexBoundary.map( idx ), 1 ), equalTo( ourNode ));
     }
 
     private long constrainedNode( String labelName, String propertyKey, Object propertyValue )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -336,7 +336,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         createLabeledNode( statement, "Item", "id", 2 );
 
         // then I should find the original node
-        assertThat( readOps.nodeGetFromUniqueIndexSeek( IndexBoundary.map( idx ), 1 ), equalTo( ourNode ) );
+        assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, 1 ), equalTo( ourNode ) );
     }
 
     @Test
@@ -363,7 +363,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         createLabeledNode( statement, "Person", "id", 2 );
 
         // then I should find the original node
-        assertThat( readOps.nodeGetFromUniqueIndexSeek( IndexBoundary.map( idx ), 1 ), equalTo( ourNode ));
+        assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, 1 ), equalTo( ourNode ));
     }
 
     private long constrainedNode( String labelName, String propertyKey, Object propertyValue )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -26,6 +26,9 @@ import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.ConstraintEnforcingEntityOperations;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
@@ -62,7 +65,8 @@ public class ConstraintEnforcingEntityOperationsTest
         SchemaReadOperations schemaReadOps = mock( SchemaReadOperations.class );
         SchemaWriteOperations schemaWriteOps = mock( SchemaWriteOperations.class );
         this.state = mock( KernelStatement.class );
-        when( schemaReadOps.indexGetState( state, indexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
+        when( schemaReadOps.indexGetState( state, IndexBoundary.map( indexDescriptor ) ) )
+                .thenReturn( InternalIndexState.ONLINE );
         this.locks = mock( Locks.Client.class );
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
         when( state.lockTracer() ).thenReturn( LockTracer.NONE );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -22,9 +22,6 @@ package org.neo4j.kernel.impl.api.operations;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -51,8 +48,7 @@ public class ConstraintEnforcingEntityOperationsTest
     private final int labelId = 1;
     private final int propertyKeyId = 2;
     private final String value = "value";
-    private final IndexDescriptor indexDescriptor =
-            IndexDescriptorFactory.of( labelId, propertyKeyId );
+    private final NewIndexDescriptor index = NewIndexDescriptorFactory.uniqueForLabel( labelId, propertyKeyId );
     private EntityReadOperations readOps;
     private KernelStatement state;
     private Locks.Client locks;
@@ -65,8 +61,7 @@ public class ConstraintEnforcingEntityOperationsTest
         SchemaReadOperations schemaReadOps = mock( SchemaReadOperations.class );
         SchemaWriteOperations schemaWriteOps = mock( SchemaWriteOperations.class );
         this.state = mock( KernelStatement.class );
-        when( schemaReadOps.indexGetState( state, IndexBoundary.map( indexDescriptor ) ) )
-                .thenReturn( InternalIndexState.ONLINE );
+        when( schemaReadOps.indexGetState( state, index ) ).thenReturn( InternalIndexState.ONLINE );
         this.locks = mock( Locks.Client.class );
         when( state.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
         when( state.lockTracer() ).thenReturn( LockTracer.NONE );
@@ -79,10 +74,10 @@ public class ConstraintEnforcingEntityOperationsTest
     {
         // given
         long expectedNodeId = 15;
-        when( readOps.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value ) ).thenReturn( expectedNodeId );
+        when( readOps.nodeGetFromUniqueIndexSeek( state, index, value ) ).thenReturn( expectedNodeId );
 
         // when
-        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, index, value );
 
         // then
         assertEquals( expectedNodeId, nodeId );
@@ -96,10 +91,10 @@ public class ConstraintEnforcingEntityOperationsTest
     public void shouldHoldIndexWriteLockIfNodeDoesNotExist() throws Exception
     {
         // given
-        when( readOps.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value ) ).thenReturn( NO_SUCH_NODE );
+        when( readOps.nodeGetFromUniqueIndexSeek( state, index, value ) ).thenReturn( NO_SUCH_NODE );
 
         // when
-        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, index, value );
 
         // then
         assertEquals( NO_SUCH_NODE, nodeId );
@@ -118,12 +113,12 @@ public class ConstraintEnforcingEntityOperationsTest
     {
         // given
         long expectedNodeId = 15;
-        when( readOps.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value ) )
+        when( readOps.nodeGetFromUniqueIndexSeek( state, index, value ) )
                 .thenReturn( NO_SUCH_NODE )
                 .thenReturn( expectedNodeId );
 
         // when
-        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long nodeId = ops.nodeGetFromUniqueIndexSeek( state, index, value );
 
         // then
         assertEquals( expectedNodeId, nodeId );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -74,7 +74,8 @@ public class IndexQueryTransactionStateTest
     String value = "My Value";
     NodePropertyDescriptor descriptor = new NodePropertyDescriptor( labelId, propertyKeyId );
     IndexDescriptor indexDescriptor = IndexDescriptorFactory.of( descriptor );
-    List<NewIndexDescriptor> indexes = Collections.singletonList( IndexBoundary.map( indexDescriptor ) );
+    private final NewIndexDescriptor newIndexDescriptor = IndexBoundary.map( indexDescriptor );
+    List<NewIndexDescriptor> indexes = Collections.singletonList( newIndexDescriptor );
 
     private StoreReadLayer store;
     private StoreStatement statement;
@@ -98,14 +99,13 @@ public class IndexQueryTransactionStateTest
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
         when( store.constraintsGetForLabel( labelId ) ).thenReturn( Collections.<NodePropertyConstraint>emptyIterator() );
-        when( store.indexGetForLabelAndPropertyKey( SchemaBoundary.map( descriptor ) ) ).thenReturn(
-                IndexBoundary.map( indexDescriptor ) );
+        when( store.indexGetForLabelAndPropertyKey( SchemaBoundary.map( descriptor ) ) ).thenReturn( newIndexDescriptor );
 
         statement = mock( StoreStatement.class );
         when( state.getStoreStatement() ).thenReturn( statement );
         indexReader = mock( IndexReader.class );
-        when( statement.getIndexReader( indexDescriptor ) ).thenReturn( indexReader );
-        when( statement.getFreshIndexReader( indexDescriptor ) ).thenReturn( indexReader );
+        when( statement.getIndexReader( newIndexDescriptor ) ).thenReturn( indexReader );
+        when( statement.getFreshIndexReader( newIndexDescriptor ) ).thenReturn( indexReader );
 
         StateHandlingStatementOperations stateHandlingOperations = new StateHandlingStatementOperations(
                 store,
@@ -128,7 +128,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeDelete( state, nodeId );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( 1L, 3L ) ) );
@@ -146,7 +146,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeDelete( state, nodeId );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertNoSuchNode( result );
@@ -162,7 +162,7 @@ public class IndexQueryTransactionStateTest
                 Property.intProperty( propertyKeyId, 10 ) );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( 2L, 3L ) ) );
@@ -177,7 +177,7 @@ public class IndexQueryTransactionStateTest
                 Property.intProperty( propertyKeyId, 10 ) );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertNoSuchNode( result );
@@ -200,7 +200,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeAddLabel( state, nodeId, labelId );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( nodeId, 2L, 3L ) ) );
@@ -223,7 +223,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeAddLabel( state, nodeId, labelId );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( result, equalTo( nodeId ) );
@@ -244,7 +244,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeAddLabel( state, nodeId, labelId );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( nodeId, 2L, 3L ) ) );
@@ -266,7 +266,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeAddLabel( state, nodeId, labelId );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( result, equalTo( nodeId ) );
@@ -287,7 +287,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeRemoveLabel( state, nodeId, labelId );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( 2L, 3L ) ) );
@@ -308,7 +308,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeRemoveLabel( state, nodeId, labelId );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertNoSuchNode( result );
@@ -332,7 +332,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeAddLabel( state, nodeId, labelId );
 
         // When
-        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, indexDescriptor, value );
+        PrimitiveLongIterator result = txContext.nodesGetFromIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertThat( PrimitiveLongCollections.toSet( result ), equalTo( asSet( 2L, 3L ) ) );
@@ -353,7 +353,7 @@ public class IndexQueryTransactionStateTest
         txContext.nodeRemoveProperty( state, nodeId, propertyKeyId );
 
         // When
-        long result = txContext.nodeGetFromUniqueIndexSeek( state, indexDescriptor, value );
+        long result = txContext.nodeGetFromUniqueIndexSeek( state, newIndexDescriptor, value );
 
         // Then
         assertNoSuchNode( result );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -90,7 +90,8 @@ public class IndexQueryTransactionStateTest
 
         int labelId1 = 10, labelId2 = 12;
         store = mock( StoreReadLayer.class );
-        when( store.indexGetState( indexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
+        when( store.indexGetState( SchemaBoundary.map( indexDescriptor.descriptor() ) )
+            ).thenReturn( InternalIndexState.ONLINE );
         when( store.indexesGetForLabel( labelId1 ) ).then( answerAsIteratorFrom( Collections
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetForLabel( labelId2 ) ).then( answerAsIteratorFrom( Collections

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -65,7 +65,7 @@ public class SchemaTransactionStateTest
     private static NewIndexDescriptor indexCreate( StateHandlingStatementOperations txContext, KernelStatement state,
             int labelId, int propertyKey )
     {
-        return IndexBoundary.map( txContext.indexCreate( state, new NodePropertyDescriptor( labelId, propertyKey ) ) );
+        return txContext.indexCreate( state, new NodePropertyDescriptor( labelId, propertyKey ) );
     }
 
     private static NewIndexDescriptor indexGetForLabelAndPropertyKey(
@@ -210,10 +210,10 @@ public class SchemaTransactionStateTest
     {
         // GIVEN
         // -- a rule that exists in the store
-        NewIndexDescriptor rule = NewIndexDescriptorFactory.forLabel( labelId1, key1 );
-        when( store.indexesGetForLabel( labelId1 ) ).thenReturn( option( rule ).iterator() );
+        NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( labelId1, key1 );
+        when( store.indexesGetForLabel( labelId1 ) ).thenReturn( option( index ).iterator() );
         // -- that same rule dropped in the transaction
-        txContext.indexDrop( state, IndexBoundary.map( rule ) );
+        txContext.indexDrop( state, index );
 
         // WHEN
         assertNull( indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -62,14 +62,14 @@ import static org.neo4j.helpers.collection.Iterators.emptySetOf;
 
 public class SchemaTransactionStateTest
 {
-    private static IndexDescriptor indexCreate( StateHandlingStatementOperations txContext, KernelStatement state,
+    private static NewIndexDescriptor indexCreate( StateHandlingStatementOperations txContext, KernelStatement state,
             int labelId, int propertyKey )
     {
-        return txContext.indexCreate( state, new NodePropertyDescriptor( labelId, propertyKey ) );
+        return IndexBoundary.map( txContext.indexCreate( state, new NodePropertyDescriptor( labelId, propertyKey ) ) );
     }
 
-    private static IndexDescriptor indexGetForLabelAndPropertyKey( StateHandlingStatementOperations txContext, KernelStatement state,
-            int labelId, int propertyKey )
+    private static NewIndexDescriptor indexGetForLabelAndPropertyKey(
+            StateHandlingStatementOperations txContext, KernelStatement state, int labelId, int propertyKey )
     {
         return txContext.indexGetForLabelAndPropertyKey( state, new NodePropertyDescriptor( labelId, propertyKey ) );
     }
@@ -86,13 +86,13 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule = indexCreate( txContext, state, labelId1, key1 );
+        NewIndexDescriptor index = indexCreate( txContext, state, labelId1, key1 );
 
         // THEN
-        assertEquals( asSet( rule ), Iterators.asSet( txContext.indexesGetForLabel( state, labelId1 ) ) );
+        assertEquals( asSet( index ), Iterators.asSet( txContext.indexesGetForLabel( state, labelId1 ) ) );
         verify( store ).indexesGetForLabel( labelId1 );
 
-        assertEquals( asSet( rule ), Iterators.asSet( txContext.indexesGetAll( state ) ) );
+        assertEquals( asSet( index ), Iterators.asSet( txContext.indexesGetAll( state ) ) );
         verify( store ).indexesGetAll();
 
         verifyNoMoreInteractions( store );
@@ -105,8 +105,8 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule1 = indexCreate( txContext, state, labelId1, key1 );
-        IndexDescriptor rule2 = indexCreate( txContext, state, labelId2, key2 );
+        NewIndexDescriptor rule1 = indexCreate( txContext, state, labelId1, key1 );
+        NewIndexDescriptor rule2 = indexCreate( txContext, state, labelId2, key2 );
 
         // THEN
         assertEquals( asSet( rule1 ), Iterators.asSet( txContext.indexesGetForLabel( state, labelId1 ) ) );
@@ -128,8 +128,8 @@ public class SchemaTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        IndexDescriptor rule1 = indexCreate( txContext, state, labelId1, key1 );
-        IndexDescriptor rule2 = indexCreate( txContext, state, labelId1, key2 );
+        NewIndexDescriptor rule1 = indexCreate( txContext, state, labelId1, key1 );
+        NewIndexDescriptor rule2 = indexCreate( txContext, state, labelId1, key2 );
 
         // THEN
         assertEquals( asSet( rule1, rule2 ), Iterators.asSet( txContext.indexesGetForLabel( state, labelId1 ) ) );
@@ -140,7 +140,7 @@ public class SchemaTransactionStateTest
     {
         // GIVEN
         commitLabels( labelId1 );
-        IndexDescriptor rule = indexCreate( txContext, state, labelId1, key1 );
+        NewIndexDescriptor rule = indexCreate( txContext, state, labelId1, key1 );
 
         // THEN
         assertEquals( InternalIndexState.POPULATING, txContext.indexGetState( state, rule ) );
@@ -154,12 +154,12 @@ public class SchemaTransactionStateTest
         indexCreate( txContext, state, labelId1, key1 );
 
         // WHEN
-        IndexDescriptor rule = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 );
-        Iterator<IndexDescriptor> labelRules = txContext.indexesGetForLabel( state, labelId1 );
+        NewIndexDescriptor index = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 );
+        Iterator<NewIndexDescriptor> labelRules = txContext.indexesGetForLabel( state, labelId1 );
 
         // THEN
-        IndexDescriptor expectedRule = IndexDescriptorFactory.of( labelId1, key1 );
-        assertEquals(expectedRule, rule);
+        NewIndexDescriptor expectedRule = NewIndexDescriptorFactory.forLabel( labelId1, key1 );
+        assertEquals( expectedRule, index );
         assertEquals( asSet( expectedRule ), asSet( labelRules ) );
     }
 
@@ -173,14 +173,14 @@ public class SchemaTransactionStateTest
         // -- the store already have an index on a different label with the same property
         NewIndexDescriptor existingRule2 = NewIndexDescriptorFactory.forLabel( labelId2, key2 );
         when( indexGetForLabelAndPropertyKey( store, labelId2, key2 ) ).thenReturn( existingRule2 );
-        // -- a non-existent rule has been added in the transaction
+        // -- a non-existent index has been added in the transaction
         indexCreate( txContext, state, labelId1, key2 );
 
         // WHEN
-        IndexDescriptor rule = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key2 );
+        NewIndexDescriptor index = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key2 );
 
         // THEN
-        assertEquals( IndexDescriptorFactory.of( labelId1, key2 ), rule );
+        assertEquals( NewIndexDescriptorFactory.forLabel( labelId1, key2 ), index );
     }
 
     @Test
@@ -197,12 +197,12 @@ public class SchemaTransactionStateTest
         indexCreate( txContext, state, labelId1, key2 );
 
         // WHEN
-        IndexDescriptor lookupRule1 = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 );
-        IndexDescriptor lookupRule2 = indexGetForLabelAndPropertyKey( txContext, state, labelId2, key2 );
+        NewIndexDescriptor lookupRule1 = indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 );
+        NewIndexDescriptor lookupRule2 = indexGetForLabelAndPropertyKey( txContext, state, labelId2, key2 );
 
         // THEN
-        assertEquals( existingIndex1, IndexBoundary.map( lookupRule1 ) );
-        assertEquals( existingIndex2, IndexBoundary.map( lookupRule2 ) );
+        assertEquals( existingIndex1, lookupRule1 );
+        assertEquals( existingIndex2, lookupRule2 );
     }
 
     @Test
@@ -217,10 +217,10 @@ public class SchemaTransactionStateTest
 
         // WHEN
         assertNull( indexGetForLabelAndPropertyKey( txContext, state, labelId1, key1 ) );
-        Iterator<IndexDescriptor> rulesByLabel = txContext.indexesGetForLabel( state, labelId1 );
+        Iterator<NewIndexDescriptor> rulesByLabel = txContext.indexesGetForLabel( state, labelId1 );
 
         // THEN
-        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( rulesByLabel ) );
+        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( rulesByLabel ) );
     }
 
     // exists

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -99,7 +99,7 @@ public class StateHandlingStatementOperationsTest
         NodePropertyDescriptor descriptor = new NodePropertyDescriptor( 0, 0 );
         ctx.indexCreate( state, descriptor );
         ctx.nodeAddLabel( state, 0, 0 );
-        ctx.indexDrop( state, IndexDescriptorFactory.of( descriptor ) );
+        ctx.indexDrop( state, IndexBoundary.map( descriptor ) );
         ctx.nodeRemoveLabel( state, 0, 0 );
 
         // one for add and one for remove

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -37,6 +37,8 @@ import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaBoundary;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
@@ -75,10 +77,9 @@ public class StateHandlingStatementOperationsTest
 
     StoreReadLayer inner = mock( StoreReadLayer.class );
 
-    private int[] properties={66};
-    private int[] properties2={99};
     private NodePropertyDescriptor descriptor1 = new NodePropertyDescriptor( 10, 66 );
     private NodePropertyDescriptor descriptor2 = new NodePropertyDescriptor( 11, 99 );
+    private NewIndexDescriptor index = NewIndexDescriptorFactory.forLabel( 1, 2 );
 
     @Test
     public void shouldNeverDelegateWrites() throws Exception
@@ -207,7 +208,6 @@ public class StateHandlingStatementOperationsTest
         KernelStatement statement = mock( KernelStatement.class );
         when( statement.hasTxStateWithChanges() ).thenReturn( true );
         when( statement.txState() ).thenReturn( txState );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 2 );
         when( txState.indexUpdatesForScanOrSeek( index, null ) ).thenReturn(
                 new DiffSets<>( Collections.singleton( 42L ), Collections.singleton( 44L ) )
         );
@@ -224,7 +224,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexScan( statement, index );
+        PrimitiveLongIterator results = context.nodesGetFromIndexScan( statement, IndexBoundary.map( index ) );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -238,7 +238,6 @@ public class StateHandlingStatementOperationsTest
         KernelStatement statement = mock( KernelStatement.class );
         when( statement.hasTxStateWithChanges() ).thenReturn( true );
         when( statement.txState() ).thenReturn( txState );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 2 );
         when( txState.indexUpdatesForScanOrSeek( index, "value" ) ).thenReturn(
                 new DiffSets<>( Collections.singleton( 42L ), Collections.singleton( 44L ) )
         );
@@ -254,7 +253,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexSeek( statement, index, "value" );
+        PrimitiveLongIterator results = context.nodesGetFromIndexSeek( statement, IndexBoundary.map( index ), "value" );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -268,7 +267,6 @@ public class StateHandlingStatementOperationsTest
         KernelStatement statement = mock( KernelStatement.class );
         when( statement.hasTxStateWithChanges() ).thenReturn( true );
         when( statement.txState() ).thenReturn( txState );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 2 );
         when( txState.indexUpdatesForRangeSeekByPrefix( index, "prefix" ) ).thenReturn(
                 new DiffSets<>( Collections.singleton( 42L ), Collections.singleton( 44L ) )
         );
@@ -284,7 +282,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByPrefix( statement, index, "prefix" );
+        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByPrefix( statement, IndexBoundary.map( index ), "prefix" );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -306,7 +304,6 @@ public class StateHandlingStatementOperationsTest
         when( statement.txState() ).thenReturn( txState );
         StorageStatement storageStatement = mock( StorageStatement.class );
         when( statement.getStoreStatement() ).thenReturn( storageStatement );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, propertyKey );
         when( txState.indexUpdatesForRangeSeekByNumber( index, lower, true, upper, false ) ).thenReturn(
                 new DiffSets<>( Collections.singleton( 42L ), Collections.singleton( 44L ) )
         );
@@ -333,8 +330,8 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByNumber( statement, index, lower, true,
-                upper, false );
+        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByNumber(
+                statement, IndexBoundary.map( index ), lower, true, upper, false );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -348,7 +345,6 @@ public class StateHandlingStatementOperationsTest
         KernelStatement statement = mock( KernelStatement.class );
         when( statement.hasTxStateWithChanges() ).thenReturn( true );
         when( statement.txState() ).thenReturn( txState );
-        IndexDescriptor index = IndexDescriptorFactory.of( 1, 2 );
         when( txState.indexUpdatesForRangeSeekByString( index, "Anne", true, "Bill", false ) ).thenReturn(
                 new DiffSets<>( Collections.singleton( 42L ), Collections.singleton( 44L ) )
         );
@@ -365,7 +361,8 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByString( statement, index, "Anne", true, "Bill", false );
+        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByString(
+                statement, IndexBoundary.map( index ), "Anne", true, "Bill", false );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -224,7 +224,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexScan( statement, IndexBoundary.map( index ) );
+        PrimitiveLongIterator results = context.nodesGetFromIndexScan( statement, index );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -253,7 +253,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexSeek( statement, IndexBoundary.map( index ), "value" );
+        PrimitiveLongIterator results = context.nodesGetFromIndexSeek( statement, index, "value" );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -282,7 +282,7 @@ public class StateHandlingStatementOperationsTest
         StateHandlingStatementOperations context = newTxStateOps( storeReadLayer );
 
         // When
-        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByPrefix( statement, IndexBoundary.map( index ), "prefix" );
+        PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByPrefix( statement, index, "prefix" );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -331,7 +331,7 @@ public class StateHandlingStatementOperationsTest
 
         // When
         PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByNumber(
-                statement, IndexBoundary.map( index ), lower, true, upper, false );
+                statement, index, lower, true, upper, false );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -362,7 +362,7 @@ public class StateHandlingStatementOperationsTest
 
         // When
         PrimitiveLongIterator results = context.nodesGetFromIndexRangeSeekByString(
-                statement, IndexBoundary.map( index ), "Anne", true, "Bill", false );
+                statement, index, "Anne", true, "Bill", false );
 
         // Then
         assertEquals( asSet( 42L, 43L ), PrimitiveLongCollections.toSet( results ) );
@@ -381,7 +381,7 @@ public class StateHandlingStatementOperationsTest
 
         StateHandlingStatementOperations operations = newTxStateOps( mock( StoreReadLayer.class ) );
 
-        operations.nodeGetFromUniqueIndexSeek( kernelStatement, IndexDescriptorFactory.of( 1, 1 ), "foo" );
+        operations.nodeGetFromUniqueIndexSeek( kernelStatement, NewIndexDescriptorFactory.uniqueForLabel( 1, 1 ), "foo" );
 
         verify( indexReader ).close();
     }
@@ -404,7 +404,7 @@ public class StateHandlingStatementOperationsTest
             throws IndexNotFoundKernelException
     {
         IndexReader indexReader = mock( IndexReader.class );
-        when( storeStatement.getIndexReader( any( IndexDescriptor.class ) ) ).thenReturn( indexReader );
+        when( storeStatement.getIndexReader( any( NewIndexDescriptor.class ) ) ).thenReturn( indexReader );
         return indexReader;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
@@ -53,7 +53,6 @@ import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
-import org.neo4j.kernel.impl.store.SchemaStorage.IndexRuleKind;
 import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.test.GraphDatabaseServiceCleaner;
@@ -138,7 +137,7 @@ public class SchemaStorageTest
                 index( LABEL1, PROP2 ) );
 
         // When
-        IndexRule rule = storage.indexGetForSchema( schemaDescriptor( LABEL1, PROP1 ), IndexRuleKind.CONSTRAINT );
+        IndexRule rule = storage.indexGetForSchema( schemaDescriptor( LABEL1, PROP1 ), NewIndexDescriptor.Filter.UNIQUE );
 
         // Then
         assertNotNull( rule );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
@@ -95,7 +95,7 @@ public class SchemaStoreTest
 
         // THEN
         assertEquals( indexRule.getId(), readIndexRule.getId() );
-        assertEquals( indexRule.getSchemaDescriptor(), readIndexRule.getSchemaDescriptor() );
+        assertEquals( indexRule.schema(), readIndexRule.schema() );
         assertEquals( indexRule.getIndexDescriptor(), readIndexRule.getIndexDescriptor() );
         assertEquals( indexRule.getProviderDescriptor(), readIndexRule.getProviderDescriptor() );
     }
@@ -114,7 +114,7 @@ public class SchemaStoreTest
 
         // THEN
         assertEquals( indexRule.getId(), readIndexRule.getId() );
-        assertEquals( indexRule.getSchemaDescriptor(), readIndexRule.getSchemaDescriptor() );
+        assertEquals( indexRule.schema(), readIndexRule.schema() );
         assertEquals( indexRule.getIndexDescriptor(), readIndexRule.getIndexDescriptor() );
         assertEquals( indexRule.getProviderDescriptor(), readIndexRule.getProviderDescriptor() );
     }
@@ -132,7 +132,7 @@ public class SchemaStoreTest
 
         // THEN
         assertEquals( indexRule.getId(), readIndexRule.getId() );
-        assertEquals( indexRule.getSchemaDescriptor(), readIndexRule.getSchemaDescriptor() );
+        assertEquals( indexRule.schema(), readIndexRule.schema() );
         assertEquals( indexRule.getIndexDescriptor(), readIndexRule.getIndexDescriptor() );
         assertEquals( indexRule.getProviderDescriptor(), readIndexRule.getProviderDescriptor() );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreSnapshotDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/countStore/InMemoryCountsStoreSnapshotDeserializerTest.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory;
 import org.neo4j.kernel.impl.store.counts.keys.IndexSampleKey;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
@@ -42,7 +42,7 @@ public class ConstraintRuleTest extends SchemaRuleTestBase
 
         // THEN
         assertThat( constraintRule.getId(), equalTo( RULE_ID ) );
-        assertThat( constraintRule.getSchemaDescriptor(), equalTo( descriptor.schema() ) );
+        assertThat( constraintRule.schema(), equalTo( descriptor.schema() ) );
         assertThat( constraintRule.getConstraintDescriptor(), equalTo( descriptor ) );
         assertException( constraintRule::getOwnedIndex, IllegalStateException.class, "" );
     }
@@ -68,7 +68,7 @@ public class ConstraintRuleTest extends SchemaRuleTestBase
 
         // THEN
         assertThat( constraintRule.getId(), equalTo( RULE_ID ) );
-        assertThat( constraintRule.getSchemaDescriptor(), equalTo( descriptor.schema() ) );
+        assertThat( constraintRule.schema(), equalTo( descriptor.schema() ) );
         assertThat( constraintRule.getConstraintDescriptor(), equalTo( descriptor ) );
         assertException( constraintRule::getOwnedIndex, IllegalStateException.class, "" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/IndexRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/IndexRuleTest.java
@@ -43,7 +43,7 @@ public class IndexRuleTest extends SchemaRuleTestBase
         // THEN
         assertThat( indexRule.getId(), equalTo( RULE_ID ) );
         assertFalse( indexRule.canSupportUniqueConstraint() );
-        assertThat( indexRule.getSchemaDescriptor(), equalTo( descriptor.schema() ) );
+        assertThat( indexRule.schema(), equalTo( descriptor.schema() ) );
         assertThat( indexRule.getIndexDescriptor(), equalTo( descriptor ) );
         assertThat( indexRule.getProviderDescriptor(), equalTo( PROVIDER_DESCRIPTOR ) );
         assertException( indexRule::getOwningConstraint, IllegalStateException.class, "" );
@@ -60,7 +60,7 @@ public class IndexRuleTest extends SchemaRuleTestBase
         // THEN
         assertThat( indexRule.getId(), equalTo( RULE_ID ) );
         assertTrue( indexRule.canSupportUniqueConstraint() );
-        assertThat( indexRule.getSchemaDescriptor(), equalTo( descriptor.schema() ) );
+        assertThat( indexRule.schema(), equalTo( descriptor.schema() ) );
         assertThat( indexRule.getIndexDescriptor(), equalTo( descriptor ) );
         assertThat( indexRule.getProviderDescriptor(), equalTo( PROVIDER_DESCRIPTOR ) );
         assertThat( indexRule.getOwningConstraint(), equalTo( null ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
@@ -282,7 +282,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( indexRule.getId() ) );
         assertThat( deserialized.getIndexDescriptor(), equalTo( indexRule.getIndexDescriptor() ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( indexRule.getSchemaDescriptor() ) );
+        assertThat( deserialized.schema(), equalTo( indexRule.schema() ) );
         assertThat( deserialized.getProviderDescriptor(), equalTo( indexRule.getProviderDescriptor() ) );
     }
 
@@ -310,7 +310,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( constraintRule.getId() ) );
         assertThat( deserialized.getConstraintDescriptor(), equalTo( constraintRule.getConstraintDescriptor() ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( constraintRule.getSchemaDescriptor() ) );
+        assertThat( deserialized.schema(), equalTo( constraintRule.schema() ) );
     }
 
     private ConstraintRule assertConstraintRule( SchemaRule schemaRule )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerializationTest.java
@@ -183,7 +183,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( ruleId ) );
         assertThat( deserialized.getIndexDescriptor(), equalTo( index ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( index.schema() ) );
+        assertThat( deserialized.schema(), equalTo( index.schema() ) );
         assertThat( deserialized.getProviderDescriptor(), equalTo( indexProvider ) );
         assertException( deserialized::getOwningConstraint, IllegalStateException.class, "" );
     }
@@ -203,7 +203,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( ruleId ) );
         assertThat( deserialized.getIndexDescriptor(), equalTo( index ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( index.schema() ) );
+        assertThat( deserialized.schema(), equalTo( index.schema() ) );
         assertThat( deserialized.getProviderDescriptor(), equalTo( indexProvider ) );
         assertThat( deserialized.getOwningConstraint(), equalTo( constraintId ) );
     }
@@ -224,7 +224,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( ruleId ) );
         assertThat( deserialized.getConstraintDescriptor(), equalTo( constraint ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( constraint.schema() ) );
+        assertThat( deserialized.schema(), equalTo( constraint.schema() ) );
         assertThat( deserialized.getOwnedIndex(), equalTo( ownedIndexId ) );
     }
 
@@ -243,7 +243,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( ruleId ) );
         assertThat( deserialized.getConstraintDescriptor(), equalTo( constraint ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( constraint.schema() ) );
+        assertThat( deserialized.schema(), equalTo( constraint.schema() ) );
         assertException( deserialized::getOwnedIndex, IllegalStateException.class, "" );
     }
 
@@ -262,7 +262,7 @@ public class SchemaRuleSerializationTest extends SchemaRuleTestBase
         // THEN
         assertThat( deserialized.getId(), equalTo( ruleId ) );
         assertThat( deserialized.getConstraintDescriptor(), equalTo( constraint ) );
-        assertThat( deserialized.getSchemaDescriptor(), equalTo( constraint.schema() ) );
+        assertThat( deserialized.schema(), equalTo( constraint.schema() ) );
         assertException( deserialized::getOwnedIndex, IllegalStateException.class, "" );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
@@ -23,6 +23,7 @@ import org.neo4j.helpers.collection.Visitable;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
 //
 // GENERATED FILE. DO NOT EDIT.
@@ -78,11 +79,11 @@ implements Visitable<DbStructureVisitor>
         visitor.visitRelationshipType( 2, "ACTS_IN" );
         visitor.visitRelationshipType( 3, "RATED" );
         visitor.visitRelationshipType( 4, "ROOT" );
-        visitor.visitIndex( IndexDescriptorFactory.of( 0, 9 ), ":Movie(title)", 1.0d, 12462L );
-        visitor.visitIndex( IndexDescriptorFactory.of( 1, 5 ), ":Person(name)", 1.0d, 49845L );
-        visitor.visitIndex( IndexDescriptorFactory.of( 3, 5 ), ":Actor(name)", 1.0d, 44689L );
-        visitor.visitIndex( IndexDescriptorFactory.of( 4, 5 ), ":Director(name)", 1.0d, 6010L );
-        visitor.visitUniqueIndex( IndexDescriptorFactory.of( 2, 3 ), ":User(login)", 1.0d, 45L );
+        visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 0, 9 ), ":Movie(title)", 1.0d, 12462L );
+        visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 1, 5 ), ":Person(name)", 1.0d, 49845L );
+        visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 3, 5 ), ":Actor(name)", 1.0d, 44689L );
+        visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 4, 5 ), ":Director(name)", 1.0d, 6010L );
+        visitor.visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 2, 3 ), ":User(login)", 1.0d, 45L );
         visitor.visitUniqueConstraint( new UniquenessConstraint( new NodePropertyDescriptor( 2, 3 ) ), "CONSTRAINT ON ( user:User ) ASSERT user.login IS UNIQUE" );
         visitor.visitAllNodesCount( 63042L );
         visitor.visitNodeCount( 0, "Movie", 12862L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
@@ -25,6 +25,7 @@ import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -43,9 +44,9 @@ public class DbStructureCollectorTest
         collector.visitPropertyKey( 2, "income" );
         collector.visitRelationshipType( 1, "LIVES_IN" );
         collector.visitRelationshipType( 2, "FRIEND" );
-        collector.visitUniqueIndex( IndexDescriptorFactory.of( 1, 1 ), ":Person(name)", 1.0d, 1L );
+        collector.visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 1, 1 ), ":Person(name)", 1.0d, 1L );
         collector.visitUniqueConstraint( new UniquenessConstraint( new NodePropertyDescriptor( 2, 1 ) ), ":Person(name)" );
-        collector.visitIndex( IndexDescriptorFactory.of( 2, 2 ), ":City(income)", 0.2d, 1L );
+        collector.visitIndex( NewIndexDescriptorFactory.forLabel( 2, 2 ), ":City(income)", 0.2d, 1L );
         collector.visitAllNodesCount( 50 );
         collector.visitNodeCount( 1, "Person", 20 );
         collector.visitNodeCount( 2, "City", 30 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
@@ -48,6 +48,7 @@ import org.neo4j.helpers.collection.Visitable;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -131,8 +132,8 @@ public class DbStructureInvocationTracingAcceptanceTest
         visitor.apply( null ).visitPropertyKey( 1, "age" );
         visitor.apply( null ).visitRelationshipType( 0, "ACCEPTS" );
         visitor.apply( null ).visitRelationshipType( 1, "REJECTS" );
-        visitor.apply( null ).visitIndex( IndexDescriptorFactory.of( 0, 1 ), ":Person(age)", 0.5d, 1L );
-        visitor.apply( null ).visitUniqueIndex( IndexDescriptorFactory.of( 0, 0 ), ":Person(name)", 0.5d, 1L );
+        visitor.apply( null ).visitIndex( NewIndexDescriptorFactory.forLabel( 0, 1 ), ":Person(age)", 0.5d, 1L );
+        visitor.apply( null ).visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 0, 0 ), ":Person(name)", 0.5d, 1L );
         visitor.apply( null ).visitUniqueConstraint( new UniquenessConstraint( new NodePropertyDescriptor( 1, 0) ), ":Party(name)" );
         visitor.apply( null ).visitAllNodesCount( 55 );
         visitor.apply( null ).visitNodeCount( 0, "Person", 50 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
@@ -228,7 +228,7 @@ public class GraphDbStructureGuideTest
 
     private NewIndexDescriptor createSchemaIndex( int labelId, int pkId ) throws Exception
     {
-        return IndexBoundary.map( schemaWrite().indexCreate( new NodePropertyDescriptor( labelId, pkId ) ) );
+        return schemaWrite().indexCreate( new NodePropertyDescriptor( labelId, pkId ) );
     }
 
     private UniquenessConstraint createUniqueConstraint( int labelId, int pkId ) throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
@@ -40,10 +40,14 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.schema.IndexDescriptor;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.IndexBoundary;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.graphdb.DynamicLabel.label;
@@ -123,7 +127,7 @@ public class GraphDbStructureGuideTest
 
         commitAndReOpen();
 
-        IndexDescriptor descriptor = createSchemaIndex( labelId, pkId );
+        NewIndexDescriptor descriptor = createSchemaIndex( labelId, pkId );
 
         // WHEN
         accept( visitor );
@@ -142,7 +146,7 @@ public class GraphDbStructureGuideTest
         commitAndReOpen();
 
         UniquenessConstraint constraint = createUniqueConstraint( labelId, pkId );
-        IndexDescriptor descriptor = IndexDescriptorFactory.of( labelId, pkId );
+        NewIndexDescriptor descriptor = NewIndexDescriptorFactory.uniqueForLabel( labelId, pkId );
 
         // WHEN
         accept( visitor );
@@ -222,9 +226,9 @@ public class GraphDbStructureGuideTest
         dataWrite().relationshipCreate( relTypeId, startId, endId );
     }
 
-    private IndexDescriptor createSchemaIndex( int labelId, int pkId ) throws Exception
+    private NewIndexDescriptor createSchemaIndex( int labelId, int pkId ) throws Exception
     {
-        return schemaWrite().indexCreate( new NodePropertyDescriptor( labelId, pkId ) );
+        return IndexBoundary.map( schemaWrite().indexCreate( new NodePropertyDescriptor( labelId, pkId ) ) );
     }
 
     private UniquenessConstraint createUniqueConstraint( int labelId, int pkId ) throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/QMULDbStructure.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.util.dbstructure;
 
 import org.neo4j.helpers.collection.Visitable;
 import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
 //
 // GENERATED FILE. DO NOT EDIT.
@@ -60,7 +61,7 @@ implements Visitable<DbStructureVisitor>
         visitor.visitPropertyKey( 16, "location_lat" );
         visitor.visitRelationshipType( 0, "friends" );
         visitor.visitRelationshipType( 1, "FRIEND" );
-        visitor.visitIndex( IndexDescriptorFactory.of( 1, 2 ), ":Person(uid)", 1.0d, 135164L );
+        visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 1, 2 ), ":Person(uid)", 1.0d, 135164L );
         visitor.visitAllNodesCount( 135242L );
         visitor.visitNodeCount( 1, "Person", 135213L );
         visitor.visitRelCount( -1, -1, -1, "MATCH ()-[]->() RETURN count(*)", 4537616L );

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -28,8 +28,8 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationKernelException;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.DatabaseRule;
@@ -75,7 +75,7 @@ public class ConstraintIndexConcurrencyTest
             Statement statement = statementSupplier.get();
             int labelId = statement.readOperations().labelGetForName( label.name() );
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
-            IndexDescriptor index = IndexDescriptorFactory.of( labelId, propertyKeyId );
+            NewIndexDescriptor index = NewIndexDescriptorFactory.uniqueForLabel( labelId, propertyKeyId );
             statement.readOperations().nodesGetFromIndexSeek( index,
                     "The value is irrelevant, we just want to perform some sort of lookup against this index" );
 

--- a/community/neo4j/src/test/java/schema/IndexPopulationFlipRaceIT.java
+++ b/community/neo4j/src/test/java/schema/IndexPopulationFlipRaceIT.java
@@ -29,8 +29,8 @@ import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
-import org.neo4j.kernel.api.schema.IndexDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
@@ -144,8 +144,8 @@ public class IndexPopulationFlipRaceIT
             int keyAId = statement.readOperations().propertyKeyGetForName( keyA( i ) );
             int labelBId = statement.readOperations().labelGetForName( labelB( i ).name() );
             int keyBId = statement.readOperations().propertyKeyGetForName( keyB( i ) );
-            IndexDescriptor indexA = IndexDescriptorFactory.of( labelAId, keyAId );
-            IndexDescriptor indexB = IndexDescriptorFactory.of( labelBId, keyBId );
+            NewIndexDescriptor indexA = NewIndexDescriptorFactory.forLabel( labelAId, keyAId );
+            NewIndexDescriptor indexB = NewIndexDescriptorFactory.forLabel( labelBId, keyBId );
 
             for ( int j = 0; j < NODES_PER_INDEX; j++ )
             {

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -42,7 +42,7 @@ import org.neo4j.cypher.internal.spi.v3_2.codegen.Methods._
 import org.neo4j.cypher.internal.spi.v3_2.codegen.Templates.{createNewInstance, handleKernelExceptions, newRelationshipDataExtractor, tryCatch}
 import org.neo4j.graphdb.Direction
 import org.neo4j.kernel.api.ReadOperations
-import org.neo4j.kernel.api.schema.{IndexDescriptor, IndexDescriptorFactory, NodePropertyDescriptor}
+import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptor, NewIndexDescriptorFactory}
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import GeneratedMethodStructure.CompletableFinalizer
@@ -1282,16 +1282,10 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     generator.assign(typeRef[Int], propIdVar, invoke(readOperations, propertyKeyGetForName, constant(propName)))
 
   override def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String) = {
-    val getNodePropertyDescriptor =
-      method[IndexDescriptorFactory, NodePropertyDescriptor]("getNodePropertyDescriptor", typeRef[Int], typeRef[Int])
-    val getIndexDescriptor =
-      method[IndexDescriptorFactory, IndexDescriptor]("of", typeRef[NodePropertyDescriptor])
-    generator.assign(typeRef[IndexDescriptor], descriptorVar,
-                      invoke(
-                        getIndexDescriptor,
-                        invoke(getNodePropertyDescriptor, generator.load(labelVar), generator.load(propKeyVar))
-                      )
-    )
+    val getIndexDescriptor = method[NewIndexDescriptorFactory, NewIndexDescriptor]("forLabel", typeRef[Int], typeRef[Array[Int]])
+    val propertyIdsExpr = Expression.newArray(typeRef[Int], generator.load(propKeyVar))
+    generator.assign(typeRef[NewIndexDescriptor], descriptorVar,
+                      invoke(getIndexDescriptor, generator.load(labelVar), propertyIdsExpr ))
   }
 
   override def indexSeek(iterVar: String, descriptorVar: String, value: Expression) = {

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/Methods.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{InternalResultRow, InternalR
 import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.kernel.api.ReadOperations
-import org.neo4j.kernel.api.schema.IndexDescriptor
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.api.{RelationshipDataExtractor, RelationshipVisitor}
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy, RelationshipProxy}
@@ -83,8 +83,8 @@ object Methods {
   val nodeExists = method[ReadOperations, Boolean]("nodeExists", typeRef[Long])
   val nodesGetAll = method[ReadOperations, PrimitiveLongIterator]("nodesGetAll")
   val nodeGetProperty = method[ReadOperations, Object]("nodeGetProperty", typeRef[Long], typeRef[Int])
-  val nodesGetFromIndexLookup = method[ReadOperations, PrimitiveLongIterator]("nodesGetFromIndexSeek", typeRef[IndexDescriptor], typeRef[Object])
-  val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[IndexDescriptor], typeRef[Object])
+  val nodesGetFromIndexLookup = method[ReadOperations, PrimitiveLongIterator]("nodesGetFromIndexSeek", typeRef[NewIndexDescriptor], typeRef[Object])
+  val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[NewIndexDescriptor], typeRef[Object])
   val countsForNode = method[ReadOperations, Long]("countsForNode", typeRef[Int])
   val countsForRel = method[ReadOperations, Long]("countsForRelationship", typeRef[Int], typeRef[Int], typeRef[Int])
   val relationshipGetProperty = method[ReadOperations, Object]("relationshipGetProperty", typeRef[Long], typeRef[Int])

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -49,6 +49,8 @@ import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.SchemaStorage;
@@ -68,6 +70,7 @@ public class UniquenessConstraintCreationIT
         extends AbstractConstraintCreationIT<UniquenessConstraint,NodePropertyDescriptor>
 {
     private static final String DUPLICATED_VALUE = "apa";
+    private NewIndexDescriptor uniqueIndex;
 
     @Override
     int initializeLabelOrRelType( TokenWriteOperations tokenWriteOperations, String name ) throws KernelException
@@ -121,6 +124,7 @@ public class UniquenessConstraintCreationIT
     @Override
     NodePropertyDescriptor makeDescriptor( int typeId, int propertyKeyId )
     {
+        uniqueIndex = NewIndexDescriptorFactory.uniqueForLabel( typeId, propertyKeyId );
         return new NodePropertyDescriptor( typeId, propertyKeyId );
     }
 
@@ -179,7 +183,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( asSet( IndexDescriptorFactory.of( descriptor ) ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( asSet( uniqueIndex ), asSet( readOperations.uniqueIndexesGetAll() ) );
     }
 
     @Test
@@ -188,7 +192,7 @@ public class UniquenessConstraintCreationIT
         // given
         Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( IndexDescriptorFactory.of( descriptor ) ),
+        assertEquals( asSet( uniqueIndex ),
                 asSet( statement.readOperations().uniqueIndexesGetAll() ) );
 
         // when
@@ -196,7 +200,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
         commit();
     }
 
@@ -268,7 +272,7 @@ public class UniquenessConstraintCreationIT
         Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
         UniquenessConstraint constraint =
                 statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( IndexDescriptorFactory.of( descriptor ) ),
+        assertEquals( asSet( uniqueIndex ),
                 asSet( statement.readOperations().uniqueIndexesGetAll() ) );
         commit();
 
@@ -279,7 +283,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySetOf( IndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
         commit();
     }
 


### PR DESCRIPTION
This PR pushes the boundary between the old and new Index Descriptors (so the the new ones are used more). The double models remain, but this is a step in the right direction.

This PR has no functional changes. Replaces #8775