### PR TITLE
GB+Tree rebalance and merge

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -795,7 +795,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
         SingleWriter( InternalTreeLogic<KEY,VALUE> treeLogic )
         {
-            this.structurePropagation = new StructurePropagation<>( layout.newKey(), layout.newKey() );
+            this.structurePropagation = new StructurePropagation<>( layout.newKey(), layout.newKey(), layout.newKey() );
             this.treeLogic = treeLogic;
         }
 
@@ -843,8 +843,9 @@ public class GBPTree<KEY,VALUE> implements Closeable
             checkOutOfBounds( cursor );
         }
 
-        private void setRoot( long rootId )
+        private void setRoot( long rootPointer )
         {
+            long rootId = GenSafePointerPair.pointer( rootPointer );
             GBPTree.this.setRoot( rootId, unstableGeneration );
             treeLogic.initialize( cursor );
         }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -795,7 +795,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
         SingleWriter( InternalTreeLogic<KEY,VALUE> treeLogic )
         {
-            this.structurePropagation = new StructurePropagation<>( layout.newKey() );
+            this.structurePropagation = new StructurePropagation<>( layout.newKey(), layout.newKey() );
             this.treeLogic = treeLogic;
         }
 
@@ -819,22 +819,24 @@ public class GBPTree<KEY,VALUE> implements Closeable
             treeLogic.insert( cursor, structurePropagation, key, value, valueMerger,
                     stableGeneration, unstableGeneration );
 
-            if ( structurePropagation.hasSplit )
+            if ( structurePropagation.hasRightKeyInsert )
             {
                 // New root
                 long newRootId = freeList.acquireNewId( stableGeneration, unstableGeneration );
                 PageCursorUtil.goTo( cursor, "new root", newRootId );
 
                 bTreeNode.initializeInternal( cursor, stableGeneration, unstableGeneration );
-                bTreeNode.insertKeyAt( cursor, structurePropagation.primKey, 0, 0 );
+                bTreeNode.insertKeyAt( cursor, structurePropagation.rightKey, 0, 0 );
                 bTreeNode.setKeyCount( cursor, 1 );
-                bTreeNode.setChildAt( cursor, structurePropagation.left, 0, stableGeneration, unstableGeneration );
-                bTreeNode.setChildAt( cursor, structurePropagation.right, 1, stableGeneration, unstableGeneration );
+                bTreeNode.setChildAt( cursor, structurePropagation.midChild, 0,
+                        stableGeneration, unstableGeneration );
+                bTreeNode.setChildAt( cursor, structurePropagation.rightChild, 1,
+                        stableGeneration, unstableGeneration );
                 setRoot( newRootId );
             }
-            else if ( structurePropagation.hasNewGen )
+            else if ( structurePropagation.hasMidChildUpdate )
             {
-                setRoot( structurePropagation.left );
+                setRoot( structurePropagation.midChild );
             }
             structurePropagation.clear();
 
@@ -852,9 +854,9 @@ public class GBPTree<KEY,VALUE> implements Closeable
         {
             VALUE result = treeLogic.remove( cursor, structurePropagation, key, layout.newValue(),
                     stableGeneration, unstableGeneration );
-            if ( structurePropagation.hasNewGen )
+            if ( structurePropagation.hasMidChildUpdate )
             {
-                setRoot( structurePropagation.left );
+                setRoot( structurePropagation.midChild );
             }
             structurePropagation.clear();
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -1077,30 +1077,30 @@ class InternalTreeLogic<KEY,VALUE>
     private void updateRightmostChildInLeftSibling( PageCursor cursor, long childPointer, long stableGeneration,
             long unstableGeneration ) throws IOException
     {
-        long currentPageId = cursor.getCurrentPageId();
         long leftSibling = bTreeNode.leftSibling( cursor, stableGeneration, unstableGeneration );
         // Left sibling is not allowed to be NO_NODE here because that means there is a child node with no parent
         PointerChecking.checkPointer( leftSibling, false );
 
-        bTreeNode.goTo( cursor, "left sibling", leftSibling );
-        int keyCount = bTreeNode.keyCount( cursor );
-        bTreeNode.setChildAt( cursor, childPointer, keyCount, stableGeneration, unstableGeneration );
-
-        bTreeNode.goTo( cursor, "back to current from left sibling", currentPageId );
+        try ( PageCursor leftSiblingCursor = cursor.openLinkedCursor( leftSibling ) )
+        {
+            bTreeNode.goTo( leftSiblingCursor, "left sibling", leftSibling );
+            int keyCount = bTreeNode.keyCount( leftSiblingCursor );
+            bTreeNode.setChildAt( leftSiblingCursor, childPointer, keyCount, stableGeneration, unstableGeneration );
+        }
     }
 
     private void updateLeftmostChildInRightSibling( PageCursor cursor, long childPointer, long stableGeneration,
             long unstableGeneration ) throws IOException
     {
-        long currentPageId = cursor.getCurrentPageId();
         long rightSibling = bTreeNode.rightSibling( cursor, stableGeneration, unstableGeneration );
         // Left sibling is not allowed to be NO_NODE here because that means there is a child node with no parent
         PointerChecking.checkPointer( rightSibling, false );
 
-        bTreeNode.goTo( cursor, "right sibling", rightSibling );
-        bTreeNode.setChildAt( cursor, childPointer, 0, stableGeneration, unstableGeneration );
-
-        bTreeNode.goTo( cursor, "back to current from right sibling", currentPageId );
+        try ( PageCursor rightSiblingCursor = cursor.openLinkedCursor( rightSibling ) )
+        {
+            bTreeNode.goTo( rightSiblingCursor, "right sibling", rightSibling );
+            bTreeNode.setChildAt( rightSiblingCursor, childPointer, 0, stableGeneration, unstableGeneration );
+        }
     }
 
     /**
@@ -1315,13 +1315,6 @@ class InternalTreeLogic<KEY,VALUE>
         int newKeyCount = keyCount - 1;
         bTreeNode.setKeyCount( cursor, newKeyCount );
         return newKeyCount;
-    }
-
-    void applySecondPhaseUpdate( PageCursor cursor, StructurePropagation<KEY> structurePropagation,
-            long stableGeneration, long unstableGeneration )
-    {
-        // todo
-        throw new UnsupportedOperationException( "Implement me" );
     }
 
     /**

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -1025,7 +1025,6 @@ class InternalTreeLogic<KEY,VALUE>
 
             bTreeNode.goTo( cursor, "child", rightmostSubtree );
 
-
             boolean foundKeyBelow = bubbleRightmostKeyRecursive( cursor, structurePropagation, currentPageId,
                     stableGeneration, unstableGeneration );
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -560,7 +560,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                     continue; // in the read loop above so that we can continue reading from next sibling
                 }
             }
-            else if ( insideEndRange() )
+            else if ( 0 <= pos && pos < keyCount && insideEndRange() )
             {
                 if ( isResultKey() )
                 {

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
@@ -59,20 +59,26 @@ package org.neo4j.index.internal.gbptree;
  */
 class StructurePropagation<KEY>
 {
+    // First level of updates, used when bubbling up the tree
     boolean hasLeftChildUpdate;
+    boolean hasRightChildUpdate;
     boolean hasMidChildUpdate;
     boolean hasRightKeyInsert;
     boolean hasLeftKeyReplace;
+    boolean hasRightKeyReplace;
     final KEY leftKey;
     final KEY rightKey;
+    final KEY bubbleKey;
     long leftChild;
     long midChild;
     long rightChild;
+    KeyReplaceStrategy keyReplaceStrategy;
 
-    StructurePropagation( KEY leftKey, KEY rightKey )
+    StructurePropagation( KEY leftKey, KEY rightKey, KEY bubbleKey )
     {
         this.leftKey = leftKey;
         this.rightKey = rightKey;
+        this.bubbleKey = bubbleKey;
     }
 
     /**
@@ -81,9 +87,11 @@ class StructurePropagation<KEY>
     void clear()
     {
         hasLeftChildUpdate = false;
+        hasRightChildUpdate = false;
         hasMidChildUpdate = false;
         hasRightKeyInsert = false;
         hasLeftKeyReplace = false;
+        hasRightKeyReplace = false;
     }
 
     interface StructureUpdate
@@ -100,4 +108,14 @@ class StructurePropagation<KEY>
         sp.hasMidChildUpdate = true;
         sp.midChild = childId;
     };
+
+    static final StructureUpdate UPDATE_RIGHT_CHILD = ( sp, childId ) -> {
+        sp.hasRightChildUpdate = true;
+        sp.rightChild = childId;
+    };
+
+    enum KeyReplaceStrategy
+    {
+        REPLACE, BUBBLE
+    }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
@@ -22,20 +22,57 @@ package org.neo4j.index.internal.gbptree;
 /**
  * Means of communicating information about splits, caused by insertion, from lower levels of the tree up to parent
  * and potentially all the way up to the root.
+ * <ul>
+ *  <li> {@link #midChild} - new version of the child that was traversed to/through while traversing down the tree.
+ *  <li> {@link #leftChild} - new version of left sibling to {@link #midChild}.
+ *  <li> {@link #rightChild} - new right sibling to {@link #midChild} (not new version, completely new right sibling).
+ *  <li> {@link #leftKey} - if position of {@link #midChild} pointer in node is {@code n} then {@link #leftKey} should
+ *  replace key at position {@code n-1}. If {@code n==0} then {@link #leftKey} does not fit here and must be passed
+ *  along one level further up the tree.
+ *  <li> {@link #rightKey} - new key to be inserted at position {@code n} (if position of {@link #midChild} is
+ *  {@code n}) together with {@link #rightChild}.
+ * </ul>
+ * If position of {@link #midChild} {@code n > 0}.
+ * <pre>
+ * Current level-> [...,leftKey,rightKey,...]
+ *                    ╱        │         ╲
+ *              leftChild  midChild  rightChild
+ *                  ╱          │           ╲
+ *                 v           v            v
+ * Child nodes-> [...] <───> [...] <────> [...]
+ * </pre>
+ * If position of {@link #midChild} {@code n == 0}.
+ * <pre>
  *
+ * Parent node->          [...,leftKey,...]
+ *                   ┌────────┘       └────────┐
+ *                   v                         v
+ * Current level-> [...] <───────────> [rightKey,...]
+ *                     │               │        ╲
+ *                 leftChild       midChild    rightChild
+ *                     │               │          ╲
+ *                     v               v           v
+ * Child nodes->     [...] <───────> [...] <───> [...]
+ *
+ * </pre>
  * @param <KEY> type of key.
  */
 class StructurePropagation<KEY>
 {
-    boolean hasNewGen;
-    boolean hasSplit;
-    final KEY primKey;
-    long left;
-    long right;
+    boolean hasLeftChildUpdate;
+    boolean hasMidChildUpdate;
+    boolean hasRightKeyInsert;
+    boolean hasLeftKeyReplace;
+    final KEY leftKey;
+    final KEY rightKey;
+    long leftChild;
+    long midChild;
+    long rightChild;
 
-    StructurePropagation( KEY primKey )
+    StructurePropagation( KEY leftKey, KEY rightKey )
     {
-        this.primKey = primKey;
+        this.leftKey = leftKey;
+        this.rightKey = rightKey;
     }
 
     /**
@@ -43,7 +80,9 @@ class StructurePropagation<KEY>
      */
     void clear()
     {
-        hasNewGen = false;
-        hasSplit = false;
+        hasLeftChildUpdate = false;
+        hasMidChildUpdate = false;
+        hasRightKeyInsert = false;
+        hasLeftKeyReplace = false;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/StructurePropagation.java
@@ -85,4 +85,19 @@ class StructurePropagation<KEY>
         hasRightKeyInsert = false;
         hasLeftKeyReplace = false;
     }
+
+    interface StructureUpdate
+    {
+        void update( StructurePropagation structurePropagation, long childId );
+    }
+
+    static final StructureUpdate UPDATE_LEFT_CHILD = ( sp, childId ) -> {
+        sp.hasLeftChildUpdate = true;
+        sp.leftChild = childId;
+    };
+
+    static final StructureUpdate UPDATE_MID_CHILD = ( sp, childId ) -> {
+        sp.hasMidChildUpdate = true;
+        sp.midChild = childId;
+    };
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -247,10 +247,10 @@ class TreeNode<KEY,VALUE>
         removeSlotAt( cursor, pos, keyCount, keyOffset( 0 ), keySize );
     }
 
-    private void removeSlotAt( PageCursor cursor, int pos, int keyCount, int baseOffset, int itemSize )
+    private void removeSlotAt( PageCursor cursor, int pos, int itemCount, int baseOffset, int itemSize )
     {
         for ( int posToMoveLeft = pos + 1, offset = baseOffset + posToMoveLeft * itemSize;
-                posToMoveLeft < keyCount; posToMoveLeft++, offset += itemSize )
+                posToMoveLeft < itemCount; posToMoveLeft++, offset += itemSize )
         {
             cursor.copyTo( offset, cursor, offset - itemSize, itemSize );
         }
@@ -297,6 +297,11 @@ class TreeNode<KEY,VALUE>
     {
         insertChildSlotsAt( cursor, pos, 1, keyCount );
         setChildAt( cursor, child, pos, stableGeneration, unstableGeneration );
+    }
+
+    void removeChildAt( PageCursor cursor, int pos, int keyCount )
+    {
+        removeSlotAt( cursor, pos, keyCount + 1, childOffset( 0 ), childSize() );
     }
 
     void setChildAt( PageCursor cursor, long child, int pos, long stableGeneration, long unstableGeneration )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -256,6 +256,12 @@ class TreeNode<KEY,VALUE>
         }
     }
 
+    void setKeyAt( PageCursor cursor, KEY key, int pos )
+    {
+        cursor.setOffset( keyOffset( pos ) );
+        layout.writeKey( cursor, key );
+    }
+
     VALUE valueAt( PageCursor cursor, VALUE value, int pos )
     {
         cursor.setOffset( valueOffset( pos ) );

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -52,7 +52,7 @@ class TreePrinter<KEY,VALUE>
      *
      * @param cursor {@link PageCursor} placed at root of tree or sub-tree.
      * @param out target to print tree at.
-     * @param printPosition
+     * @param printPosition whether or not to include positional (slot number) information.
      * @throws IOException on page cache access error.
      */
     void printTree( PageCursor cursor, PrintStream out, boolean printValues, boolean printPosition ) throws IOException

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
@@ -88,7 +88,8 @@ public class ConsistencyCheckerTest
         cursor.next( idProvider.acquireNewId( stableGeneration, unstableGeneration ) );
         node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
         logic.initialize( cursor );
-        StructurePropagation<MutableLong> structure = new StructurePropagation<>( layout.newKey(), layout.newKey() );
+        StructurePropagation<MutableLong> structure = new StructurePropagation<>( layout.newKey(), layout.newKey(),
+                layout.newKey() );
         MutableLong key = layout.newKey();
         for ( int g = 0, k = 0; g < 3; g++ )
         {

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
@@ -88,7 +88,7 @@ public class ConsistencyCheckerTest
         cursor.next( idProvider.acquireNewId( stableGeneration, unstableGeneration ) );
         node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
         logic.initialize( cursor );
-        StructurePropagation<MutableLong> structure = new StructurePropagation<>( layout.newKey() );
+        StructurePropagation<MutableLong> structure = new StructurePropagation<>( layout.newKey(), layout.newKey() );
         MutableLong key = layout.newKey();
         for ( int g = 0, k = 0; g < 3; g++ )
         {
@@ -97,17 +97,19 @@ public class ConsistencyCheckerTest
                 key.setValue( k );
                 logic.insert( cursor, structure, key, key, ValueMergers.overwrite(),
                         stableGeneration, unstableGeneration );
-                if ( structure.hasSplit )
+                if ( structure.hasRightKeyInsert )
                 {
-                    goTo( cursor, "new root", idProvider.acquireNewId( stableGeneration, unstableGeneration ) );
+                    goTo( cursor, "new root",
+                            idProvider.acquireNewId( stableGeneration, unstableGeneration ) );
                     node.initializeInternal( cursor, stableGeneration, unstableGeneration );
-                    node.insertKeyAt( cursor, structure.primKey, 0, 0 );
+                    node.insertKeyAt( cursor, structure.rightKey, 0, 0 );
                     node.setKeyCount( cursor, 1 );
-                    node.setChildAt( cursor, structure.left, 0, stableGeneration, unstableGeneration );
-                    node.setChildAt( cursor, structure.right, 1, stableGeneration, unstableGeneration );
+                    node.setChildAt( cursor, structure.midChild, 0, stableGeneration, unstableGeneration );
+                    node.setChildAt( cursor, structure.rightChild, 1,
+                            stableGeneration, unstableGeneration );
                     logic.initialize( cursor );
                 }
-                if ( structure.hasNewGen )
+                if ( structure.hasMidChildUpdate )
                 {
                     logic.initialize( cursor );
                 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
@@ -21,7 +21,6 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -138,8 +137,6 @@ public class GBPTreeConcurrencyIT
         shouldReadCorrectlyWithConcurrentUpdates( testCoordinator );
     }
 
-    @Ignore( "Test will leave tree nodes empty because merge is still missing in implementation. " +
-            "When seeking backwards this will cause infinite loops in SeekCursor." )
     @Test
     public void shouldReadBackwardCorrectlyWithConcurrentRemove() throws Throwable
     {
@@ -331,7 +328,7 @@ public class GBPTreeConcurrencyIT
                 }
                 else if ( toRemove.isEmpty() )
                 {
-                    operation = new WriteOperation( toAdd.poll() );
+                    operation = new PutOperation( toAdd.poll() );
                 }
                 else
                 {
@@ -342,7 +339,7 @@ public class GBPTreeConcurrencyIT
                     }
                     else
                     {
-                        operation = new WriteOperation( toAdd.poll() );
+                        operation = new PutOperation( toAdd.poll() );
                     }
                 }
                 updateOperations.add( operation );
@@ -394,9 +391,9 @@ public class GBPTreeConcurrencyIT
         abstract boolean isInsert();
     }
 
-    private class WriteOperation extends UpdateOperation
+    private class PutOperation extends UpdateOperation
     {
-        WriteOperation( long key )
+        PutOperation( long key )
         {
             super( key );
         }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
@@ -71,7 +71,7 @@ public class InternalTreeLogicTest
     private final MutableLong readKey = new MutableLong();
     private final MutableLong readValue = new MutableLong();
     private final StructurePropagation<MutableLong> structurePropagation = new StructurePropagation<>(
-            layout.newKey(), layout.newKey() );
+            layout.newKey(), layout.newKey(), layout.newKey() );
 
     private static long stableGen = GenSafePointer.MIN_GENERATION;
     private static long unstableGen = stableGen + 1;
@@ -913,15 +913,23 @@ public class InternalTreeLogicTest
         initialize();
         long targetLastId = id.lastId() + 3; // 2 splits and 1 new allocated root
         long i = 0;
-        for ( ; id.lastId() < targetLastId; i++ )
+        for ( ; id.lastId() < targetLastId; i += 2 )
         {
             insert( i, i );
         }
         goTo( readCursor, rootId );
         assertEquals( 2, keyCount() );
+
         long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
         long middleChild = childAt( readCursor, 1, stableGen, unstableGen );
         long rightChild = childAt( readCursor, 2, stableGen, unstableGen );
+
+        // add some more keys to middleChild to not have remove trigger a merge
+        goTo( readCursor, middleChild );
+        Long firstKeyInMiddleChild = keyAt( 0 );
+        insert( firstKeyInMiddleChild + 1, firstKeyInMiddleChild + 1 );
+        goTo( readCursor, rootId );
+
         assertSiblings( leftChild, middleChild, rightChild );
 
         // WHEN

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -65,7 +65,7 @@ public class SeekCursorTest
     private final TreeNode<MutableLong,MutableLong> node = new TreeNode<>( PAGE_SIZE, layout );
     private final InternalTreeLogic<MutableLong,MutableLong> treeLogic = new InternalTreeLogic<>( id, node, layout );
     private final StructurePropagation<MutableLong> structurePropagation =
-            new StructurePropagation<>( layout.newKey() );
+            new StructurePropagation<>( layout.newKey(), layout.newKey() );
     private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
     private final int maxKeyCount = node.leafMaxKeyCount();
 
@@ -1754,15 +1754,15 @@ public class SeekCursorTest
 
     private void newRootFromSplit( StructurePropagation<MutableLong> split ) throws IOException
     {
-        assertTrue( split.hasSplit );
+        assertTrue( split.hasRightKeyInsert );
         long rootId = id.acquireNewId( stableGen, unstableGen );
         cursor.next( rootId );
         node.initializeInternal( cursor, stableGen, unstableGen );
-        node.insertKeyAt( cursor, split.primKey, 0, 0 );
+        node.insertKeyAt( cursor, split.rightKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
-        node.setChildAt( cursor, split.left, 0, stableGen, unstableGen );
-        node.setChildAt( cursor, split.right, 1, stableGen, unstableGen );
-        split.hasSplit = false;
+        node.setChildAt( cursor, split.midChild, 0, stableGen, unstableGen );
+        node.setChildAt( cursor, split.rightChild, 1, stableGen, unstableGen );
+        split.hasRightKeyInsert = false;
         numberOfRootSplits++;
         updateRoot();
     }
@@ -1802,13 +1802,13 @@ public class SeekCursorTest
 
     private void handleAfterChange() throws IOException
     {
-        if ( structurePropagation.hasSplit )
+        if ( structurePropagation.hasRightKeyInsert )
         {
             newRootFromSplit( structurePropagation );
         }
-        if ( structurePropagation.hasNewGen )
+        if ( structurePropagation.hasMidChildUpdate )
         {
-            structurePropagation.hasNewGen = false;
+            structurePropagation.hasMidChildUpdate = false;
             updateRoot();
         }
     }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -66,7 +66,7 @@ public class SeekCursorTest
     private final TreeNode<MutableLong,MutableLong> node = new TreeNode<>( PAGE_SIZE, layout );
     private final InternalTreeLogic<MutableLong,MutableLong> treeLogic = new InternalTreeLogic<>( id, node, layout );
     private final StructurePropagation<MutableLong> structurePropagation =
-            new StructurePropagation<>( layout.newKey(), layout.newKey() );
+            new StructurePropagation<>( layout.newKey(), layout.newKey(), layout.newKey() );
     private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
     private final int maxKeyCount = node.leafMaxKeyCount();
 


### PR DESCRIPTION
**What?**
Implementation of rebalance and merge.

**Why?**
When removing keys from GB+Tree we want to avoid having leaves with key count less than half of max key count. This is done by rebalancing keys among sibling nodes if they between themselves have enough to at least get `maxKeyCount/2` keys each. Otherwise we will merge them together, effectively deleting the node that we merge from.

**Problems?**
Seek in GB+Tree rely on no keys ever being moved from right to left in the tree. Therefore we are not allowed to rebalance or merge from right to left. This creates a somewhat asymmetric implementation.