### PR TITLE
introduce filters and tags for server policy load balancing

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.causalclustering.discovery.CatchupServerAddress;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.CatchUpRequest;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -48,7 +48,7 @@ import static org.neo4j.causalclustering.catchup.TimeoutLoop.waitForCompletion;
 public class CatchUpClient extends LifecycleAdapter
 {
     private final LogProvider logProvider;
-    private final ReadReplicaTopologyService discoveryService;
+    private final TopologyService topologyService;
     private final Log log;
     private final Clock clock;
     private final Monitors monitors;
@@ -57,11 +57,11 @@ public class CatchUpClient extends LifecycleAdapter
 
     private NioEventLoopGroup eventLoopGroup;
 
-    public CatchUpClient( ReadReplicaTopologyService discoveryService, LogProvider logProvider, Clock clock,
+    public CatchUpClient( TopologyService topologyService, LogProvider logProvider, Clock clock,
             long inactivityTimeoutMillis, Monitors monitors )
     {
         this.logProvider = logProvider;
-        this.discoveryService = discoveryService;
+        this.topologyService = topologyService;
         this.log = logProvider.getLog( getClass() );
         this.clock = clock;
         this.inactivityTimeoutMillis = inactivityTimeoutMillis;
@@ -73,7 +73,7 @@ public class CatchUpClient extends LifecycleAdapter
     {
         CompletableFuture<T> future = new CompletableFuture<>();
         Optional<AdvertisedSocketAddress> catchUpAddress =
-                discoveryService.allServers().find( upstream ).map( CatchupServerAddress::getCatchupServer );
+                topologyService.allServers().find( upstream ).map( CatchupServerAddress::getCatchupServer );
 
         CatchUpChannel channel = pool.acquire( catchUpAddress.orElseThrow(
                 () -> new CatchUpClientException( "Cannot find the target member socket address" ) ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -313,4 +313,17 @@ public class CausalClusteringSettings implements LoadableConfig
             "upstream database server from which to pull transactional updates." )
     public static final Setting<List<String>> upstream_selection_strategy =
             setting( "causal_clustering.upstream_selection_strategy", list( ",", STRING ), "default" );
+
+    @Description( "The load balancing plugin to use. This must be the same for all core servers participating in the cluster." )
+    public static Setting<String> load_balancing_plugin =
+            setting( "causal_clustering.load_balancing.plugin", STRING, "server_policies" );
+
+    @Description( "The configuration must be valid for the configured plugin." )
+    public static Setting<String> load_balancing_config =
+            setting( "causal_clustering.load_balancing.config", STRING, "" );
+
+    @Description( "Tags for the server used when configuring load balancing and replication policies." +
+                  " Multiple tags can be configured by separating with a comma." )
+    public static Setting<List<String>> server_tags =
+            setting( "causal_clustering.server_tags", list( ",", STRING ), "" );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -43,7 +43,7 @@ import org.neo4j.causalclustering.core.replication.SendToMyself;
 import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
-import org.neo4j.causalclustering.discovery.RaftDiscoveryServiceConnector;
+import org.neo4j.causalclustering.discovery.RaftCoreTopologyConnector;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.CoreReplicatedContentMarshal;
 import org.neo4j.causalclustering.messaging.Outbound;
@@ -75,7 +75,7 @@ public class ConsensusModule
     private final InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>();
 
     public ConsensusModule( MemberId myself, final PlatformModule platformModule, Outbound<MemberId,RaftMessages.RaftMessage> outbound,
-            File clusterStateDirectory, CoreTopologyService discoveryService )
+            File clusterStateDirectory, CoreTopologyService coreTopologyService )
     {
         final Config config = platformModule.config;
         final LogService logging = platformModule.logging;
@@ -139,7 +139,7 @@ public class ConsensusModule
                         heartbeatInterval, raftTimeoutService, outbound, logProvider, raftMembershipManager,
                         logShipping, inFlightMap, platformModule.monitors );
 
-        life.add( new RaftDiscoveryServiceConnector( discoveryService, raftMachine ) );
+        life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 
         life.add( logShipping );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreServerInfo.java
@@ -19,20 +19,32 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Set;
+
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
-public class CoreAddresses implements CatchupServerAddress, ClientConnector
+import static java.util.Collections.emptySet;
+
+public class CoreServerInfo implements CatchupServerAddress, ClientConnector, TaggedServer
 {
     private final AdvertisedSocketAddress raftServer;
     private final AdvertisedSocketAddress catchupServer;
     private final ClientConnectorAddresses clientConnectorAddresses;
+    private Set<String> tags;
 
-    public CoreAddresses( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
-                          ClientConnectorAddresses clientConnectorAddresses )
+    public CoreServerInfo( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
+            ClientConnectorAddresses clientConnectors )
+    {
+        this( raftServer, catchupServer, clientConnectors, emptySet() );
+    }
+
+    public CoreServerInfo( AdvertisedSocketAddress raftServer, AdvertisedSocketAddress catchupServer,
+            ClientConnectorAddresses clientConnectorAddresses, Set<String> tags )
     {
         this.raftServer = raftServer;
         this.catchupServer = catchupServer;
         this.clientConnectorAddresses = clientConnectorAddresses;
+        this.tags = tags;
     }
 
     public AdvertisedSocketAddress getRaftServer()
@@ -46,18 +58,26 @@ public class CoreAddresses implements CatchupServerAddress, ClientConnector
         return catchupServer;
     }
 
+    @Override
     public ClientConnectorAddresses connectors()
     {
         return clientConnectorAddresses;
     }
 
     @Override
+    public Set<String> tags()
+    {
+        return tags;
+    }
+
+    @Override
     public String toString()
     {
-        return "CoreAddresses{" +
-                "raftServer=" + raftServer +
-                ", catchupServer=" + catchupServer +
-                ", clientConnectorAddresses=" + clientConnectorAddresses +
-                '}';
+        return "CoreServerInfo{" +
+               "raftServer=" + raftServer +
+               ", catchupServer=" + catchupServer +
+               ", clientConnectorAddresses=" + clientConnectorAddresses +
+               ", tags=" + tags +
+               '}';
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
@@ -38,9 +38,9 @@ public class CoreTopology
 
     private final ClusterId clusterId;
     private final boolean canBeBootstrapped;
-    private final Map<MemberId,CoreAddresses> coreMembers;
+    private final Map<MemberId,CoreServerInfo> coreMembers;
 
-    public CoreTopology( ClusterId clusterId, boolean canBeBootstrapped, Map<MemberId,CoreAddresses> coreMembers )
+    public CoreTopology( ClusterId clusterId, boolean canBeBootstrapped, Map<MemberId,CoreServerInfo> coreMembers )
     {
         this.clusterId = clusterId;
         this.canBeBootstrapped = canBeBootstrapped;
@@ -57,7 +57,7 @@ public class CoreTopology
         return clusterId;
     }
 
-    public Collection<CoreAddresses> addresses()
+    public Collection<CoreServerInfo> allMemberInfo()
     {
         return coreMembers.values();
     }
@@ -67,7 +67,7 @@ public class CoreTopology
         return canBeBootstrapped;
     }
 
-    public Optional<CoreAddresses> find( MemberId memberId )
+    public Optional<CoreServerInfo> find( MemberId memberId )
     {
         return Optional.ofNullable( coreMembers.get( memberId ) );
     }
@@ -139,18 +139,18 @@ public class CoreTopology
     private class Difference
     {
         private MemberId memberId;
-        private CoreAddresses coreAddresses;
+        private CoreServerInfo coreServerInfo;
 
-        Difference( MemberId memberId, CoreAddresses coreAddresses )
+        Difference( MemberId memberId, CoreServerInfo coreServerInfo )
         {
             this.memberId = memberId;
-            this.coreAddresses = coreAddresses;
+            this.coreServerInfo = coreServerInfo;
         }
 
         @Override
         public String toString()
         {
-            return String.format( "{memberId=%s, coreAddresses=%s}", memberId, coreAddresses );
+            return String.format( "{memberId=%s, coreServerInfo=%s}", memberId, coreServerInfo );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -21,7 +21,11 @@ package org.neo4j.causalclustering.discovery;
 
 import org.neo4j.causalclustering.identity.ClusterId;
 
-public interface CoreTopologyService extends ReadReplicaTopologyService
+/**
+ * Extends upon the topology service with a few extra services, connected to
+ * the underlying discovery service.
+ */
+public interface CoreTopologyService extends TopologyService
 {
     void addCoreTopologyListener( Listener listener );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/DiscoveryServiceFactory.java
@@ -30,7 +30,7 @@ public interface DiscoveryServiceFactory
     CoreTopologyService coreTopologyService( Config config, MemberId myself, JobScheduler jobScheduler,
             LogProvider logProvider, LogProvider userLogProvider );
 
-    ReadReplicaTopologyService readReplicaTopologyService( Config config, LogProvider logProvider,
+    TopologyService topologyService( Config config, LogProvider logProvider,
             DelayedRenewableTimeoutService timeoutService, long readReplicaTimeToLiveTimeout,
             long readReplicaRefreshRate, MemberId myself );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -43,7 +43,7 @@ import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.SERV
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.getCoreTopology;
 import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.getReadReplicaTopology;
 
-class HazelcastClient extends LifecycleAdapter implements ReadReplicaTopologyService
+class HazelcastClient extends LifecycleAdapter implements TopologyService
 {
     static final RenewableTimeoutService.TimeoutName REFRESH_READ_REPLICA = () -> "Refresh Read Replica";
     private final Log log;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -30,6 +30,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.core.MultiMap;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,7 @@ import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SE
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.WAIT_SECONDS_BEFORE_JOIN;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.neo4j.causalclustering.discovery.HazelcastClusterTopology.SERVER_TAGS_MULTIMAP_NAME;
 import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
 
 class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopologyService
@@ -208,6 +210,11 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
             log.error( errorMessage, e );
             throw new RuntimeException( e );
         }
+
+        List<String> tags = config.get( CausalClusteringSettings.server_tags );
+
+        MultiMap<String,String> tagsMap = hazelcastInstance.getMultiMap( SERVER_TAGS_MULTIMAP_NAME );
+        tags.forEach( tag -> tagsMap.put( myself.getUuid().toString(), tag ) );
 
         return hazelcastInstance;
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
@@ -37,7 +37,7 @@ public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory
     }
 
     @Override
-    public ReadReplicaTopologyService readReplicaTopologyService( Config config, LogProvider logProvider,
+    public TopologyService topologyService( Config config, LogProvider logProvider,
             DelayedRenewableTimeoutService timeoutService, long readReplicaTimeToLiveTimeout,
             long readReplicaRefreshRate, MemberId myself )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -26,21 +26,24 @@ import org.neo4j.causalclustering.core.consensus.RaftMachine.BootstrapException;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-public class RaftDiscoveryServiceConnector extends LifecycleAdapter implements CoreTopologyService.Listener
+/**
+ * Makes the Raft aware of changes to the core topology.
+ */
+public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreTopologyService.Listener
 {
-    private final CoreTopologyService discoveryService;
+    private final CoreTopologyService coreTopologyService;
     private final RaftMachine raftMachine;
 
-    public RaftDiscoveryServiceConnector( CoreTopologyService discoveryService, RaftMachine raftMachine )
+    public RaftCoreTopologyConnector( CoreTopologyService coreTopologyService, RaftMachine raftMachine )
     {
-        this.discoveryService = discoveryService;
+        this.coreTopologyService = coreTopologyService;
         this.raftMachine = raftMachine;
     }
 
     @Override
     public void start() throws BootstrapException
     {
-        discoveryService.addCoreTopologyListener( this );
+        coreTopologyService.addCoreTopologyListener( this );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaInfo.java
@@ -19,33 +19,55 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Set;
+
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
-public class ReadReplicaAddresses implements CatchupServerAddress, ClientConnector
+import static java.util.Collections.emptySet;
+
+public class ReadReplicaInfo implements CatchupServerAddress, ClientConnector, TaggedServer
 {
     private final AdvertisedSocketAddress catchupServerAddress;
     private final ClientConnectorAddresses clientConnectorAddresses;
+    private final Set<String> tags;
 
-    public ReadReplicaAddresses( ClientConnectorAddresses clientConnectorAddresses, AdvertisedSocketAddress catchupServerAddress )
+    public ReadReplicaInfo( ClientConnectorAddresses clientConnectorAddresses, AdvertisedSocketAddress catchupServerAddress )
+    {
+        this( clientConnectorAddresses, catchupServerAddress, emptySet() );
+    }
+
+    public ReadReplicaInfo( ClientConnectorAddresses clientConnectorAddresses, AdvertisedSocketAddress catchupServerAddress, Set<String> tags )
     {
         this.clientConnectorAddresses = clientConnectorAddresses;
         this.catchupServerAddress = catchupServerAddress;
+        this.tags = tags;
     }
 
+    @Override
     public ClientConnectorAddresses connectors()
     {
         return clientConnectorAddresses;
     }
 
     @Override
-    public String toString()
-    {
-        return String.format( "ReadReplicaAddresses{clientConnectorAddresses=%s}", clientConnectorAddresses );
-    }
-
-    @Override
     public AdvertisedSocketAddress getCatchupServer()
     {
         return catchupServerAddress;
+    }
+
+    @Override
+    public Set<String> tags()
+    {
+        return tags;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ReadReplicaInfo{" +
+               "catchupServerAddress=" + catchupServerAddress +
+               ", clientConnectorAddresses=" + clientConnectorAddresses +
+               ", tags=" + tags +
+               '}';
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
@@ -22,10 +22,8 @@ package org.neo4j.causalclustering.discovery;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.helpers.collection.Pair;
 
 import static java.util.Collections.emptyMap;
 
@@ -34,19 +32,19 @@ public class ReadReplicaTopology
 {
     static final ReadReplicaTopology EMPTY = new ReadReplicaTopology( emptyMap() );
 
-    private final Map<MemberId,ReadReplicaAddresses> readReplicaMembers;
+    private final Map<MemberId,ReadReplicaInfo> readReplicaMembers;
 
-    public ReadReplicaTopology( Map<MemberId,ReadReplicaAddresses> readReplicaMembers )
+    public ReadReplicaTopology( Map<MemberId,ReadReplicaInfo> readReplicaMembers )
     {
         this.readReplicaMembers = readReplicaMembers;
     }
 
-    public Collection<ReadReplicaAddresses> addresses()
+    public Collection<ReadReplicaInfo> allMemberInfo()
     {
         return readReplicaMembers.values();
     }
 
-    Optional<ReadReplicaAddresses> findAddressFor( MemberId memberId )
+    Optional<ReadReplicaInfo> find( MemberId memberId )
     {
         return Optional.ofNullable( readReplicaMembers.get( memberId ) );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TaggedServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TaggedServer.java
@@ -19,26 +19,9 @@
  */
 package org.neo4j.causalclustering.discovery;
 
-import java.util.Optional;
+import java.util.Set;
 
-import org.neo4j.causalclustering.identity.MemberId;
-
-public class ClusterTopology
+interface TaggedServer
 {
-    private final CoreTopology coreTopology;
-    private final ReadReplicaTopology readReplicaTopology;
-
-    public ClusterTopology( CoreTopology coreTopology, ReadReplicaTopology readReplicaTopology )
-    {
-        this.coreTopology = coreTopology;
-        this.readReplicaTopology = readReplicaTopology;
-    }
-
-    public Optional<CatchupServerAddress> find( MemberId upstream )
-    {
-        Optional<CatchupServerAddress> coreCatchupAddress = coreTopology.find( upstream ).map( a -> (CatchupServerAddress) a );
-        Optional<CatchupServerAddress> readCatchupAddress = readReplicaTopology.find( upstream ).map( a -> (CatchupServerAddress) a );
-
-        return coreCatchupAddress.map( Optional::of ).orElse( readCatchupAddress );
-    }
+    Set<String> tags();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyService.java
@@ -21,7 +21,10 @@ package org.neo4j.causalclustering.discovery;
 
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
-public interface ReadReplicaTopologyService extends Lifecycle
+/**
+ * Provides a read-only service for the eventually consistent topology information.
+ */
+public interface TopologyService extends Lifecycle
 {
     CoreTopology coreServers();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -21,7 +21,6 @@ package org.neo4j.causalclustering.discovery.procedures;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -32,8 +31,8 @@ import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
@@ -44,6 +43,7 @@ import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
+import static java.util.Comparator.comparing;
 import static org.neo4j.helpers.collection.Iterators.asRawIterator;
 import static org.neo4j.helpers.collection.Iterators.map;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
@@ -52,11 +52,11 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
 {
     private static final String[] PROCEDURE_NAMESPACE = {"dbms", "cluster"};
     public static final String PROCEDURE_NAME = "overview";
-    private final CoreTopologyService discoveryService;
+    private final TopologyService topologyService;
     private final LeaderLocator leaderLocator;
     private final Log log;
 
-    public ClusterOverviewProcedure( CoreTopologyService discoveryService,
+    public ClusterOverviewProcedure( TopologyService topologyService,
             LeaderLocator leaderLocator, LogProvider logProvider )
     {
         super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
@@ -64,7 +64,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
                 .out( "role", Neo4jTypes.NTString )
                 .description( "Overview of all currently accessible cluster members and their roles." )
                 .build() );
-        this.discoveryService = discoveryService;
+        this.topologyService = topologyService;
         this.leaderLocator = leaderLocator;
         this.log = logProvider.getLog( getClass() );
     }
@@ -73,7 +73,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
     public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
         List<ReadWriteEndPoint> endpoints = new ArrayList<>();
-        CoreTopology coreTopology = discoveryService.coreServers();
+        CoreTopology coreTopology = topologyService.coreServers();
         Set<MemberId> coreMembers = coreTopology.members();
         MemberId leader = null;
         try
@@ -99,12 +99,12 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
                 log.debug( "No Address found for " + memberId );
             }
         }
-        for ( ReadReplicaInfo readReplicaInfo : discoveryService.readReplicas().allMemberInfo() )
+        for ( ReadReplicaInfo readReplicaInfo : topologyService.readReplicas().allMemberInfo() )
         {
             endpoints.add( new ReadWriteEndPoint( readReplicaInfo.connectors(), Role.READ_REPLICA ) );
         }
 
-        Collections.sort( endpoints, ( o1, o2 ) -> o1.addresses().toString().compareTo( o2.addresses().toString() ) );
+        endpoints.sort( comparing( o -> o.addresses().toString() ) );
 
         return map( ( l ) -> new Object[]{l.identifier().toString(), l.addresses().uriList().stream().map( URI::toString ).toArray(), l.role().name()},
                 asRawIterator( endpoints.iterator() ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -30,10 +30,10 @@ import java.util.UUID;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
-import org.neo4j.causalclustering.discovery.ReadReplicaAddresses;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
@@ -88,7 +88,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
         for ( MemberId memberId : coreMembers )
         {
             Optional<ClientConnectorAddresses> clientConnectorAddresses =
-                    coreTopology.find( memberId ).map( CoreAddresses::connectors );
+                    coreTopology.find( memberId ).map( CoreServerInfo::connectors );
             if ( clientConnectorAddresses.isPresent() )
             {
                 Role role = memberId.equals( leader ) ? Role.LEADER : Role.FOLLOWER;
@@ -99,9 +99,9 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
                 log.debug( "No Address found for " + memberId );
             }
         }
-        for ( ReadReplicaAddresses readReplicaAddresses : discoveryService.readReplicas().addresses() )
+        for ( ReadReplicaInfo readReplicaInfo : discoveryService.readReplicas().allMemberInfo() )
         {
-            endpoints.add( new ReadWriteEndPoint( readReplicaAddresses.connectors(), Role.READ_REPLICA ) );
+            endpoints.add( new ReadWriteEndPoint( readReplicaInfo.connectors(), Role.READ_REPLICA ) );
         }
 
         Collections.sort( endpoints, ( o1, o2 ) -> o1.addresses().toString().compareTo( o2.addresses().toString() ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/Filter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/Filter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import java.util.Set;
+
+/**
+ * A filter for sets.
+ *
+ * A convention used for filters is to return an empty set if the result is to
+ * be interpreted as invalid. This is used for example in rule-lists where the first
+ * rule to return a valid non-empty result will be used.
+ */
+@FunctionalInterface
+public interface Filter<T>
+{
+    Set<T> apply( Set<T> data );
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/FilterChain.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/FilterChain.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Filters the set through each filter of the chain in order.
+ */
+public class FilterChain<T> implements Filter<T>
+{
+    private List<Filter<T>> chain;
+
+    public FilterChain( List<Filter<T>> chain )
+    {
+        this.chain = chain;
+    }
+
+    @Override
+    public Set<T> apply( Set<T> data )
+    {
+        for ( Filter<T> filter : chain )
+        {
+            data = filter.apply( data );
+        }
+        return data;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/FirstValidRule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/FirstValidRule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Each chain of filters is considered a rule and they are evaluated in order. The result
+ * of the first rule to return a valid result (non-empty set) will be the final result.
+ */
+public class FirstValidRule<T> implements Filter<T>
+{
+    private List<FilterChain<T>> chains;
+
+    public FirstValidRule( List<FilterChain<T>> chains )
+    {
+        this.chains = chains;
+    }
+
+    @Override
+    public Set<T> apply( Set<T> input )
+    {
+        Set<T> output = input;
+        for ( Filter<T> chain : chains )
+        {
+            output = chain.apply( input );
+            if ( !output.isEmpty() )
+            {
+                break;
+            }
+        }
+        return output;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/MinimumCountFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/filters/MinimumCountFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+
+public class MinimumCountFilter<T> implements Filter<T>
+{
+    private final int minCount;
+
+    public MinimumCountFilter( int minCount )
+    {
+        this.minCount = minCount;
+    }
+
+    @Override
+    public Set<T> apply( Set<T> data )
+    {
+        return data.size() >= minCount ? data : emptySet();
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1.java
@@ -29,7 +29,7 @@ import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
-import org.neo4j.causalclustering.discovery.CoreTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.load_balancing.Endpoint;
 import org.neo4j.causalclustering.load_balancing.LoadBalancingResult;
@@ -67,15 +67,15 @@ public class GetServersProcedureV1 implements CallableProcedure
                     .description( DESCRIPTION )
                     .build();
 
-    private final CoreTopologyService discoveryService;
+    private final TopologyService topologyService;
     private final LeaderLocator leaderLocator;
     private final Config config;
     private final Log log;
 
-    public GetServersProcedureV1( CoreTopologyService discoveryService, LeaderLocator leaderLocator,
+    public GetServersProcedureV1( TopologyService topologyService, LeaderLocator leaderLocator,
             Config config, LogProvider logProvider )
     {
-        this.discoveryService = discoveryService;
+        this.topologyService = topologyService;
         this.leaderLocator = leaderLocator;
         this.config = config;
         this.log = logProvider.getLog( getClass() );
@@ -111,12 +111,12 @@ public class GetServersProcedureV1 implements CallableProcedure
             return Optional.empty();
         }
 
-        return discoveryService.coreServers().find( leader ).map( extractBoltAddress() );
+        return topologyService.coreServers().find( leader ).map( extractBoltAddress() );
     }
 
     private List<Endpoint> routeEndpoints()
     {
-        Stream<AdvertisedSocketAddress> routers = discoveryService.coreServers()
+        Stream<AdvertisedSocketAddress> routers = topologyService.coreServers()
                 .allMemberInfo().stream().map( extractBoltAddress() );
         List<Endpoint> routeEndpoints = routers.map( Endpoint::route ).collect( toList() );
         Collections.shuffle( routeEndpoints );
@@ -130,7 +130,7 @@ public class GetServersProcedureV1 implements CallableProcedure
 
     private List<Endpoint> readEndpoints()
     {
-        List<AdvertisedSocketAddress> readReplicas = discoveryService.readReplicas().allMemberInfo().stream()
+        List<AdvertisedSocketAddress> readReplicas = topologyService.readReplicas().allMemberInfo().stream()
                 .map( extractBoltAddress() ).collect( toList() );
         boolean addFollowers = readReplicas.isEmpty() || config.get( cluster_allow_reads_on_followers );
         Stream<AdvertisedSocketAddress> readCore = addFollowers ? coreReadEndPoints() : Stream.empty();
@@ -143,8 +143,8 @@ public class GetServersProcedureV1 implements CallableProcedure
     private Stream<AdvertisedSocketAddress> coreReadEndPoints()
     {
         Optional<AdvertisedSocketAddress> leader = leaderBoltAddress();
-        Collection<CoreServerInfo> coreServerInfo = discoveryService.coreServers().allMemberInfo();
-        Stream<AdvertisedSocketAddress> boltAddresses = discoveryService.coreServers()
+        Collection<CoreServerInfo> coreServerInfo = topologyService.coreServers().allMemberInfo();
+        Stream<AdvertisedSocketAddress> boltAddresses = topologyService.coreServers()
                 .allMemberInfo().stream().map( extractBoltAddress() );
 
         // if the leader is present and it is not alone filter it out from the read end points

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/AnyTagFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/AnyTagFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.neo4j.causalclustering.load_balancing.filters.Filter;
+
+public class AnyTagFilter implements Filter<ServerInfo>
+{
+    private final Predicate<ServerInfo> matchesAnyTag;
+
+    AnyTagFilter( Set<String> tags )
+    {
+        this.matchesAnyTag = serverInfo ->
+        {
+            for ( String tag : serverInfo.tags() )
+            {
+                if ( tags.contains( tag ) )
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    @Override
+    public Set<ServerInfo> apply( Set<ServerInfo> data )
+    {
+        return data.stream().filter( matchesAnyTag ).collect( Collectors.toSet() );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/Policies.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/Policies.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.causalclustering.load_balancing.filters.Filter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+class Policies
+{
+    static final String POLICY_KEY = "load_balancing.policy"; // TODO: move somewhere (driver support package?)
+    private static final Filter<ServerInfo> DEFAULT_POLICY = input -> input;
+
+    private final Map<String,Filter<ServerInfo>> policies = new HashMap<>();
+    private final Log log;
+
+    Policies( LogProvider logProvider )
+    {
+        this.log = logProvider.getLog( getClass() );
+        policies.put( null, DEFAULT_POLICY );
+    }
+
+    void addPolicy( String policyName, Filter<ServerInfo> filter )
+    {
+        Filter<ServerInfo> oldPolicy = policies.putIfAbsent( policyName, filter );
+        if ( oldPolicy != null )
+        {
+            log.error( "Policy name conflict for: " + policyName );
+        }
+    }
+
+    Filter<ServerInfo> selectFor( Map<String,String> context )
+    {
+        return policies.get( context.get( POLICY_KEY ) );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/PolicyLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/PolicyLoader.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import org.neo4j.kernel.configuration.Config;
+
+public class PolicyLoader
+{
+    PolicyLoader( Config config, Policies policies )
+    {
+        // TODO: Load policies from config into policies.
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/ServerInfo.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/ServerInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+/**
+ * Hold the server information that is interesting for load balancing purposes.
+ */
+class ServerInfo
+{
+    private final AdvertisedSocketAddress boltAddress;
+    private Set<String> tags;
+
+    ServerInfo( AdvertisedSocketAddress boltAddress, Set<String> tags )
+    {
+        this.boltAddress = boltAddress;
+        this.tags = tags;
+    }
+
+    AdvertisedSocketAddress boltAddress()
+    {
+        return boltAddress;
+    }
+
+    Set<String> tags()
+    {
+        return tags;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+        ServerInfo that = (ServerInfo) o;
+        return Objects.equals( boltAddress, that.boltAddress ) &&
+               Objects.equals( tags, that.tags );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( boltAddress, tags );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ServerInfo{" +
+               "boltAddress=" + boltAddress +
+               ", tags=" + tags +
+               '}';
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/ServerPolicyStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/ServerPolicyStrategy.java
@@ -29,8 +29,8 @@ import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.load_balancing.Endpoint;
 import org.neo4j.causalclustering.load_balancing.LoadBalancingResult;
@@ -45,13 +45,13 @@ import static org.neo4j.causalclustering.load_balancing.Util.extractBoltAddress;
 // TODO: This is work in progress. Currently mostly copies V1 behaviour.
 public class ServerPolicyStrategy implements LoadBalancingStrategy
 {
-    private final CoreTopologyService topologyService;
+    private final TopologyService topologyService;
     private final LeaderLocator leaderLocator;
     private final Long timeToLive;
     private final boolean allowReadsOnFollowers;
     private final Policies policies;
 
-    public ServerPolicyStrategy( CoreTopologyService topologyService,
+    public ServerPolicyStrategy( TopologyService topologyService,
             LeaderLocator leaderLocator, Policies policies, Config config )
     {
         this.topologyService = topologyService;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
@@ -36,16 +36,16 @@ import org.neo4j.time.Clocks;
 
 public class RaftOutbound implements Outbound<MemberId, RaftMessage>
 {
-    private final CoreTopologyService discoveryService;
+    private final CoreTopologyService coreTopologyService;
     private final Outbound<AdvertisedSocketAddress,Message> outbound;
     private final Supplier<Optional<ClusterId>> clusterIdentity;
     private final UnknownAddressMonitor unknownAddressMonitor;
     private final Log log;
 
-    public RaftOutbound( CoreTopologyService discoveryService, Outbound<AdvertisedSocketAddress,Message> outbound,
+    public RaftOutbound( CoreTopologyService coreTopologyService, Outbound<AdvertisedSocketAddress,Message> outbound,
                          Supplier<Optional<ClusterId>> clusterIdentity, LogProvider logProvider, long logThresholdMillis )
     {
-        this.discoveryService = discoveryService;
+        this.coreTopologyService = coreTopologyService;
         this.outbound = outbound;
         this.clusterIdentity = clusterIdentity;
         this.log = logProvider.getLog( getClass() );
@@ -62,7 +62,7 @@ public class RaftOutbound implements Outbound<MemberId, RaftMessage>
             return;
         }
 
-        Optional<CoreServerInfo> coreServerInfo = discoveryService.coreServers().find( to );
+        Optional<CoreServerInfo> coreServerInfo = coreTopologyService.coreServers().find( to );
         if ( coreServerInfo.isPresent() )
         {
             outbound.send( coreServerInfo.get().getRaftServer(), new ClusterIdAwareMessage( clusterId.get(), message ) );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/RaftOutbound.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.core.consensus.RaftMessages.ClusterIdAwareMessage;
 import org.neo4j.causalclustering.core.consensus.RaftMessages.RaftMessage;
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -62,10 +62,10 @@ public class RaftOutbound implements Outbound<MemberId, RaftMessage>
             return;
         }
 
-        Optional<CoreAddresses> coreAddresses = discoveryService.coreServers().find( to );
-        if ( coreAddresses.isPresent() )
+        Optional<CoreServerInfo> coreServerInfo = discoveryService.coreServers().find( to );
+        if ( coreServerInfo.isPresent() )
         {
-            outbound.send( coreAddresses.get().getRaftServer(), new ClusterIdAwareMessage( clusterId.get(), message ) );
+            outbound.send( coreServerInfo.get().getRaftServer(), new ClusterIdAwareMessage( clusterId.get(), message ) );
         }
         else
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServer.java
@@ -40,7 +40,7 @@ public class ConnectToRandomCoreServer extends UpstreamDatabaseSelectionStrategy
     @Override
     public Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException
     {
-        final CoreTopology coreTopology = readReplicaTopologyService.coreServers();
+        final CoreTopology coreTopology = topologyService.coreServers();
 
         if ( coreTopology.members().size() == 0 )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplica.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplica.java
@@ -39,11 +39,11 @@ public class TypicallyConnectToRandomReadReplica extends UpstreamDatabaseSelecti
     {
         if ( counter.shouldReturnCoreMemberId() )
         {
-            return readReplicaTopologyService.coreServers().anyCoreMemberId();
+            return topologyService.coreServers().anyCoreMemberId();
         }
         else
         {
-            return readReplicaTopologyService.readReplicas().anyReadReplicaMemberId();
+            return topologyService.readReplicas().anyReadReplicaMemberId();
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
@@ -21,13 +21,13 @@ package org.neo4j.causalclustering.readreplica;
 
 import java.util.Optional;
 
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
 
 public abstract class UpstreamDatabaseSelectionStrategy extends Service
 {
-    ReadReplicaTopologyService readReplicaTopologyService;
+    TopologyService topologyService;
 
     public UpstreamDatabaseSelectionStrategy( String key, String... altKeys )
     {
@@ -35,9 +35,9 @@ public abstract class UpstreamDatabaseSelectionStrategy extends Service
     }
 
     // Service loaded can't inject this via the constructor
-    void setDiscoveryService( ReadReplicaTopologyService readReplicaTopologyService )
+    void setTopologyService( TopologyService topologyService )
     {
-        this.readReplicaTopologyService = readReplicaTopologyService;
+        this.topologyService = topologyService;
     }
 
     public abstract Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoader.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.configuration.Config;
 
@@ -33,12 +33,12 @@ import org.neo4j.kernel.configuration.Config;
  */
 public class UpstreamDatabaseStrategiesLoader implements Iterable<UpstreamDatabaseSelectionStrategy>
 {
-    private final ReadReplicaTopologyService readReplicaTopologyService;
+    private final TopologyService topologyService;
     private final Config config;
 
-    UpstreamDatabaseStrategiesLoader( ReadReplicaTopologyService readReplicaTopologyService, Config config )
+    UpstreamDatabaseStrategiesLoader( TopologyService topologyService, Config config )
     {
-        this.readReplicaTopologyService = readReplicaTopologyService;
+        this.topologyService = topologyService;
         this.config = config;
     }
 
@@ -56,7 +56,7 @@ public class UpstreamDatabaseStrategiesLoader implements Iterable<UpstreamDataba
             {
                 if ( candidate.getKeys().iterator().next().equals( key ) )
                 {
-                    candidate.setDiscoveryService( readReplicaTopologyService );
+                    candidate.setTopologyService( topologyService );
                     candidates.add( candidate );
                 }
             }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreTopologyTest.java
@@ -41,9 +41,9 @@ public class CoreTopologyTest
         UUID one = UUID.randomUUID();
         UUID two = UUID.randomUUID();
 
-        Map<MemberId, CoreAddresses> coreMembers = new HashMap<>();
-        coreMembers.put( new MemberId( one ), mock(CoreAddresses.class) );
-        coreMembers.put( new MemberId( two ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
+        coreMembers.put( new MemberId( one ), mock(CoreServerInfo.class) );
+        coreMembers.put( new MemberId( two ), mock(CoreServerInfo.class) );
 
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, coreMembers );
 
@@ -62,14 +62,14 @@ public class CoreTopologyTest
         UUID one = UUID.randomUUID();
         UUID two = UUID.randomUUID();
 
-        Map<MemberId, CoreAddresses> initialMembers = new HashMap<>();
-        initialMembers.put( new MemberId( one ), mock(CoreAddresses.class) );
-        initialMembers.put( new MemberId( two ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> initialMembers = new HashMap<>();
+        initialMembers.put( new MemberId( one ), mock(CoreServerInfo.class) );
+        initialMembers.put( new MemberId( two ), mock(CoreServerInfo.class) );
 
-        Map<MemberId, CoreAddresses> newMembers = new HashMap<>();
-        newMembers.put( new MemberId( one ), mock(CoreAddresses.class) );
-        newMembers.put( new MemberId( two ), mock(CoreAddresses.class) );
-        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> newMembers = new HashMap<>();
+        newMembers.put( new MemberId( one ), mock(CoreServerInfo.class) );
+        newMembers.put( new MemberId( two ), mock(CoreServerInfo.class) );
+        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreServerInfo.class) );
 
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 
@@ -88,12 +88,12 @@ public class CoreTopologyTest
         UUID one = UUID.randomUUID();
         UUID two = UUID.randomUUID();
 
-        Map<MemberId, CoreAddresses> initialMembers = new HashMap<>();
-        initialMembers.put( new MemberId( one ), mock(CoreAddresses.class) );
-        initialMembers.put( new MemberId( two ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> initialMembers = new HashMap<>();
+        initialMembers.put( new MemberId( one ), mock(CoreServerInfo.class) );
+        initialMembers.put( new MemberId( two ), mock(CoreServerInfo.class) );
 
-        Map<MemberId, CoreAddresses> newMembers = new HashMap<>();
-        newMembers.put( new MemberId( two ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> newMembers = new HashMap<>();
+        newMembers.put( new MemberId( two ), mock(CoreServerInfo.class) );
 
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 
@@ -110,13 +110,13 @@ public class CoreTopologyTest
     {
         // given
 
-        Map<MemberId, CoreAddresses> initialMembers = new HashMap<>();
-        initialMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreAddresses.class) );
-        initialMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> initialMembers = new HashMap<>();
+        initialMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreServerInfo.class) );
+        initialMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreServerInfo.class) );
 
-        Map<MemberId, CoreAddresses> newMembers = new HashMap<>();
-        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreAddresses.class) );
-        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreAddresses.class) );
+        Map<MemberId,CoreServerInfo> newMembers = new HashMap<>();
+        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreServerInfo.class) );
+        newMembers.put( new MemberId( UUID.randomUUID() ), mock(CoreServerInfo.class) );
 
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
@@ -37,6 +37,7 @@ import com.hazelcast.core.ItemListener;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MultiExecutionCallback;
+import com.hazelcast.core.MultiMap;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.listener.MapListener;
@@ -46,6 +47,7 @@ import com.hazelcast.mapreduce.aggregation.Aggregation;
 import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.query.Predicate;
 import org.junit.Test;
 
@@ -128,6 +130,7 @@ public class HazelcastClientTest
 
         when( hazelcastInstance.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
         when( hazelcastInstance.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
+        when( hazelcastInstance.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
 
         com.hazelcast.core.Cluster cluster = mock( Cluster.class );
         when( hazelcastInstance.getCluster() ).thenReturn( cluster );
@@ -156,6 +159,7 @@ public class HazelcastClientTest
 
         when( hazelcastInstance.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
         when( hazelcastInstance.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
+        when( hazelcastInstance.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
         when( hazelcastInstance.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
 
         com.hazelcast.core.Cluster cluster = mock( Cluster.class );
@@ -250,8 +254,10 @@ public class HazelcastClientTest
 
         when( hazelcastInstance1.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
         when( hazelcastInstance1.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
+        when( hazelcastInstance1.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
         when( hazelcastInstance2.getAtomicReference( anyString() ) ).thenReturn( mock( IAtomicReference.class ) );
         when( hazelcastInstance2.getSet( anyString() ) ).thenReturn( new HazelcastSet() );
+        when( hazelcastInstance2.getMultiMap( anyString() ) ).thenReturn( new HazelcastMultiMap() );
 
         when( hazelcastInstance1.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
         when( hazelcastInstance2.getExecutorService( anyString() ) ).thenReturn( new StubExecutorService() );
@@ -968,6 +974,214 @@ public class HazelcastClientTest
         public void destroy()
         {
 
+        }
+    }
+
+    private class HazelcastMultiMap implements MultiMap<Object,Object>
+    {
+        private Map<Object,Object> delegate = new HashMap<>();
+
+        @Override
+        public String getPartitionKey()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getName()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getServiceName()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void destroy()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean put( Object key, Object value )
+        {
+            if ( delegate.get( key ) != null )
+            {
+                throw new UnsupportedOperationException( "This is not a true multimap" );
+            }
+            delegate.put( key, value );
+            return true;
+        }
+
+        @Override
+        public Collection<Object> get( Object key )
+        {
+            return asSet( delegate.get( key ) );
+        }
+
+        @Override
+        public boolean remove( Object key, Object value )
+        {
+            return delegate.remove( key, value );
+        }
+
+        @Override
+        public Collection<Object> remove( Object key )
+        {
+            return asSet( delegate.remove( key ) );
+        }
+
+        @Override
+        public Set<Object> localKeySet()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Object> keySet()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<Object> values()
+        {
+            return delegate.values();
+        }
+
+        @Override
+        public Set<Map.Entry<Object,Object>> entrySet()
+        {
+            return delegate.entrySet();
+        }
+
+        @Override
+        public boolean containsKey( Object key )
+        {
+            return delegate.containsKey( key );
+        }
+
+        @Override
+        public boolean containsValue( Object value )
+        {
+            return delegate.containsValue( value );
+        }
+
+        @Override
+        public boolean containsEntry( Object key, Object value )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int size()
+        {
+            return delegate.size();
+        }
+
+        @Override
+        public void clear()
+        {
+            delegate.clear();
+        }
+
+        @Override
+        public int valueCount( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String addLocalEntryListener( EntryListener<Object,Object> listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String addEntryListener( EntryListener<Object,Object> listener, boolean includeValue )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeEntryListener( String registrationId )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String addEntryListener( EntryListener<Object,Object> listener, Object key, boolean includeValue )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void lock( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void lock( Object key, long leaseTime, TimeUnit timeUnit )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isLocked( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tryLock( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tryLock( Object key, long time, TimeUnit timeunit ) throws InterruptedException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tryLock( Object key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseTimeunit ) throws InterruptedException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void unlock( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void forceUnlock( Object key )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LocalMultiMapStats getLocalMultiMapStats()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <SuppliedValue, Result> Result aggregate( Supplier<Object,Object,SuppliedValue> supplier, Aggregation<Object,SuppliedValue,Result> aggregation )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <SuppliedValue, Result> Result aggregate( Supplier<Object,Object,SuppliedValue> supplier, Aggregation<Object,SuppliedValue,Result> aggregation, JobTracker jobTracker )
+        {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -35,7 +35,7 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
 {
     private final SharedDiscoveryService sharedDiscoveryService;
     private final MemberId member;
-    private final CoreAddresses coreAddresses;
+    private final CoreServerInfo coreServerInfo;
     private final Set<Listener> listeners = new LinkedHashSet<>();
     private final Log log;
 
@@ -46,7 +46,7 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     {
         this.sharedDiscoveryService = sharedDiscoveryService;
         this.member = member;
-        this.coreAddresses = extractAddresses( config );
+        this.coreServerInfo = extractCoreServerInfo( config );
         this.log = logProvider.getLog( getClass() );
     }
 
@@ -72,7 +72,7 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     @Override
     public void start() throws InterruptedException
     {
-        sharedDiscoveryService.registerCoreMember( member, coreAddresses, this );
+        sharedDiscoveryService.registerCoreMember( member, coreServerInfo, this );
         log.info( "Registered core server %s", member );
         sharedDiscoveryService.waitForClusterFormation();
         log.info( "Cluster formed" );
@@ -119,12 +119,12 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
         this.readReplicaTopology = readReplicaTopology;
     }
 
-    private static CoreAddresses extractAddresses( Config config )
+    private static CoreServerInfo extractCoreServerInfo( Config config )
     {
         AdvertisedSocketAddress raftAddress = config.get( CausalClusteringSettings.raft_advertised_address );
         AdvertisedSocketAddress transactionSource = config.get( CausalClusteringSettings.transaction_advertised_address );
         ClientConnectorAddresses clientConnectorAddresses = ClientConnectorAddresses.extractFromConfig( config );
 
-        return new CoreAddresses( raftAddress, transactionSource, clientConnectorAddresses );
+        return new CoreServerInfo( raftAddress, transactionSource, clientConnectorAddresses );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
@@ -32,7 +32,7 @@ import static org.neo4j.helpers.SocketAddressFormat.socketAddress;
 class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements ReadReplicaTopologyService
 {
     private final SharedDiscoveryService sharedDiscoveryService;
-    private final ReadReplicaAddresses addresses;
+    private final ReadReplicaInfo addresses;
     private final MemberId memberId;
     private final Log log;
 
@@ -40,7 +40,7 @@ class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements ReadR
             LogProvider logProvider )
     {
         this.sharedDiscoveryService = sharedDiscoveryService;
-        this.addresses = new ReadReplicaAddresses( ClientConnectorAddresses.extractFromConfig( config ),
+        this.addresses = new ReadReplicaInfo( ClientConnectorAddresses.extractFromConfig( config ),
                 socketAddress( config.get( CausalClusteringSettings.transaction_advertised_address ).toString(), AdvertisedSocketAddress::new ) );
         this.memberId = memberId;
         this.log = logProvider.getLog( getClass() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
@@ -29,7 +29,7 @@ import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.SocketAddressFormat.socketAddress;
 
-class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements ReadReplicaTopologyService
+class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements TopologyService
 {
     private final SharedDiscoveryService sharedDiscoveryService;
     private final ReadReplicaInfo addresses;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -59,7 +59,7 @@ public class SharedDiscoveryService implements DiscoveryServiceFactory
     }
 
     @Override
-    public ReadReplicaTopologyService readReplicaTopologyService( Config config, LogProvider logProvider,
+    public TopologyService topologyService( Config config, LogProvider logProvider,
             DelayedRenewableTimeoutService timeoutService, long readReplicaTimeToLiveTimeout,
             long readReplicaRefreshRate, MemberId myself )
     {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
@@ -116,7 +116,7 @@ public class SharedDiscoveryServiceIT
             {
                 RaftMachine raftMock = mock( RaftMachine.class );
                 topologyService.start();
-                topologyService.addCoreTopologyListener( new RaftDiscoveryServiceConnector( topologyService, raftMock ) );
+                topologyService.addCoreTopologyListener( new RaftCoreTopologyConnector( topologyService, raftMock ) );
 
                 assertEventually( "should discover complete target set", () ->
                 {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/TestTopology.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.causalclustering.discovery;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
 import static java.util.Collections.singletonList;
@@ -30,30 +26,25 @@ import static org.neo4j.causalclustering.discovery.ClientConnectorAddresses.Sche
 
 public class TestTopology
 {
-    public static Set<ReadReplicaAddresses> addressesForReadReplicas( int... ids )
-    {
-        return Arrays.stream( ids ).mapToObj( TestTopology::addressesForReadReplica ).collect( Collectors.toSet() );
-    }
-
     private static ClientConnectorAddresses wrapAsClientConnectorAddresses( AdvertisedSocketAddress advertisedSocketAddress )
     {
         return new ClientConnectorAddresses( singletonList( new ClientConnectorAddresses.ConnectorUri( bolt, advertisedSocketAddress ) ) );
     }
 
-    public static CoreAddresses adressesForCore( int id )
+    public static CoreServerInfo adressesForCore( int id )
     {
         AdvertisedSocketAddress raftServerAddress = new AdvertisedSocketAddress( "localhost", (3000 + id) );
         AdvertisedSocketAddress catchupServerAddress = new AdvertisedSocketAddress( "localhost", (4000 + id) );
         AdvertisedSocketAddress boltServerAddress = new AdvertisedSocketAddress( "localhost", (5000 + id) );
-        return new CoreAddresses( raftServerAddress, catchupServerAddress, wrapAsClientConnectorAddresses( boltServerAddress ) );
+        return new CoreServerInfo( raftServerAddress, catchupServerAddress, wrapAsClientConnectorAddresses( boltServerAddress ) );
     }
 
-    public static ReadReplicaAddresses addressesForReadReplica( int id )
+    public static ReadReplicaInfo addressesForReadReplica( int id )
     {
         AdvertisedSocketAddress advertisedSocketAddress = new AdvertisedSocketAddress( "localhost", (6000 + id) );
         ClientConnectorAddresses clientConnectorAddresses = new ClientConnectorAddresses(
                 singletonList( new ClientConnectorAddresses.ConnectorUri( bolt, advertisedSocketAddress ) ) );
 
-        return new ReadReplicaAddresses( clientConnectorAddresses, advertisedSocketAddress );
+        return new ReadReplicaInfo( clientConnectorAddresses, advertisedSocketAddress );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -28,10 +28,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
-import org.neo4j.causalclustering.discovery.ReadReplicaAddresses;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.logging.NullLogProvider;
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.causalclustering.discovery.TestTopology.adressesForCore;
-import static org.neo4j.causalclustering.load_balancing.procedure.GetServersProcedureV1Test.addresses;
+import static org.neo4j.causalclustering.load_balancing.procedure.GetServersProcedureV1Test.readReplicaInfoMap;
 import static org.neo4j.helpers.collection.Iterators.asList;
 
 public class ClusterOverviewProcedureTest
@@ -51,7 +51,7 @@ public class ClusterOverviewProcedureTest
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         MemberId theLeader = new MemberId( UUID.randomUUID() );
         MemberId follower1 = new MemberId( UUID.randomUUID() );
         MemberId follower2 = new MemberId( UUID.randomUUID() );
@@ -60,7 +60,7 @@ public class ClusterOverviewProcedureTest
         coreMembers.put( follower1, adressesForCore( 1 ) );
         coreMembers.put( follower2, adressesForCore( 2 ) );
 
-        Map<MemberId,ReadReplicaAddresses> readReplicas = addresses( 4, 5 );
+        Map<MemberId,ReadReplicaInfo> readReplicas = readReplicaInfoMap( 4, 5 );
 
         when( topologyService.coreServers() ).thenReturn( new CoreTopology( null, false, coreMembers ) );
         when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( readReplicas ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/FilterChainTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/FilterChainTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class FilterChainTest
+{
+    @Test
+    public void shouldFilterThroughAll() throws Exception
+    {
+        // given
+        Filter<Integer> removeValuesOfFive = data -> data.stream().filter( value -> value != 5 ).collect( Collectors.toSet() );
+        Filter<Integer> mustHaveThreeValues = data -> data.size() == 3 ? data : emptySet();
+        Filter<Integer> keepValuesBelowTen = data -> data.stream().filter( value -> value < 10 ).collect( Collectors.toSet() );
+
+        FilterChain<Integer> filterChain = new FilterChain<>( asList( removeValuesOfFive, mustHaveThreeValues, keepValuesBelowTen ) );
+        Set<Integer> data = asSet( 5, 5, 5, 3, 5, 10, 9 ); // carefully crafted to check order as well
+
+        // when
+        data = filterChain.apply( data );
+
+        // then
+        assertEquals( asSet( 3, 9 ), data );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/FirstValidRuleTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/FirstValidRuleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class FirstValidRuleTest
+{
+    @Test
+    public void shouldUseResultOfFirstNonEmpty() throws Exception
+    {
+        // given
+        Filter<Integer> removeValuesOfFive = data -> data.stream().filter( value -> value != 5 ).collect( Collectors.toSet() );
+        Filter<Integer> countMoreThanFour = data -> data.size() > 4 ? data : Collections.emptySet();
+        Filter<Integer> countMoreThanThree = data -> data.size() > 3 ? data : Collections.emptySet();
+
+        FilterChain<Integer> ruleA = new FilterChain<>( asList( removeValuesOfFive, countMoreThanFour ) ); // should not succeed
+        FilterChain<Integer> ruleB = new FilterChain<>( asList( removeValuesOfFive, countMoreThanThree ) ); // should succeed
+        FilterChain<Integer> ruleC = new FilterChain<>( singletonList( countMoreThanFour ) ); // never reached
+
+        FirstValidRule<Integer> firstValidRule = new FirstValidRule<>( asList( ruleA, ruleB, ruleC ) );
+
+        Set<Integer> data = asSet( 5, 1, 5, 2, 5, 3, 5, 4 );
+
+        // when
+        data = firstValidRule.apply( data );
+
+        // then
+        assertEquals( asSet( 1, 2, 3, 4 ), data );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/MinimumCountFilterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/filters/MinimumCountFilterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.filters;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class MinimumCountFilterTest
+{
+    @Test
+    public void shouldFilterBelowCount() throws Exception
+    {
+        // given
+        MinimumCountFilter<Integer> minFilter = new MinimumCountFilter<>( 3 );
+
+        Set<Integer> input = asSet( 1, 2 );
+
+        // when
+        Set<Integer> output = minFilter.apply( input );
+
+        // then
+        assertEquals( emptySet(), output );
+    }
+
+    @Test
+    public void shouldPassAtCount() throws Exception
+    {
+        // given
+        MinimumCountFilter<Integer> minFilter = new MinimumCountFilter<>( 3 );
+
+        Set<Integer> input = asSet( 1, 2, 3 );
+
+        // when
+        Set<Integer> output = minFilter.apply( input );
+
+        // then
+        assertEquals( input, output );
+    }
+
+    @Test
+    public void shouldPassAboveCount() throws Exception
+    {
+        // given
+        MinimumCountFilter<Integer> minFilter = new MinimumCountFilter<>( 3 );
+
+        Set<Integer> input = asSet( 1, 2, 3, 4 );
+
+        // when
+        Set<Integer> output = minFilter.apply( input );
+
+        // then
+        assertEquals( input, output );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1RoutingTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
@@ -41,7 +41,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.configuration.Config;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertFalse;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.mockito.Mockito.mock;
@@ -75,7 +74,7 @@ public class GetServersProcedureV1RoutingTest
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( member( 0 ) );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
         coreMembers.put( member( 1 ), adressesForCore( 1 ) );
         coreMembers.put( member( 2 ), adressesForCore( 2 ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
@@ -39,10 +39,10 @@ import java.util.stream.Stream;
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
-import org.neo4j.causalclustering.discovery.ReadReplicaAddresses;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -149,7 +149,7 @@ public class GetServersProcedureV1Test
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
@@ -179,7 +179,7 @@ public class GetServersProcedureV1Test
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( member( 0 ) );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
         coreMembers.put( member( 1 ), adressesForCore( 1 ) );
         coreMembers.put( member( 2 ), adressesForCore( 2 ) );
@@ -215,7 +215,7 @@ public class GetServersProcedureV1Test
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( member( 0 ) );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
 
         final CoreTopology clusterTopology = new CoreTopology( clusterId, false, coreMembers );
@@ -243,12 +243,12 @@ public class GetServersProcedureV1Test
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, adressesForCore( 0 ) );
 
         when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
-        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( addresses( 1 ) ) );
+        when( topologyService.readReplicas() ).thenReturn( new ReadReplicaTopology( readReplicaInfoMap( 1 ) ) );
 
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
@@ -278,7 +278,7 @@ public class GetServersProcedureV1Test
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         MemberId theLeader = member( 0 );
         coreMembers.put( theLeader, adressesForCore( 0 ) );
 
@@ -309,7 +309,7 @@ public class GetServersProcedureV1Test
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
 
         when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
@@ -338,7 +338,7 @@ public class GetServersProcedureV1Test
         // given
         final CoreTopologyService topologyService = mock( CoreTopologyService.class );
 
-        Map<MemberId,CoreAddresses> coreMembers = new HashMap<>();
+        Map<MemberId,CoreServerInfo> coreMembers = new HashMap<>();
         coreMembers.put( member( 0 ), adressesForCore( 0 ) );
 
         when( topologyService.coreServers() ).thenReturn( new CoreTopology( clusterId, false, coreMembers ) );
@@ -370,16 +370,16 @@ public class GetServersProcedureV1Test
         return ClusterView.parse( (List<Map<String,Object>>) rows[1] );
     }
 
-    public static Map<MemberId,ReadReplicaAddresses> addresses( int... ids )
+    public static Map<MemberId,ReadReplicaInfo> readReplicaInfoMap( int... ids )
     {
-        return Arrays.stream( ids ).mapToObj( GetServersProcedureV1Test::readReplicaAddresses ).collect( Collectors
+        return Arrays.stream( ids ).mapToObj( GetServersProcedureV1Test::readReplicaInfo ).collect( Collectors
                 .toMap( (p) -> new MemberId( UUID.randomUUID() ), Function.identity() ) );
     }
 
-    private static ReadReplicaAddresses readReplicaAddresses( int id )
+    private static ReadReplicaInfo readReplicaInfo( int id )
     {
         AdvertisedSocketAddress advertisedSocketAddress = new AdvertisedSocketAddress( "localhost", (6000 + id) );
-        return new ReadReplicaAddresses(
+        return new ReadReplicaInfo(
                 new ClientConnectorAddresses( singletonList( new ClientConnectorAddresses.ConnectorUri( bolt, advertisedSocketAddress ) ) ),
                 new AdvertisedSocketAddress( "localhost", 4000 + id ));
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/AnyTagFilterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/AnyTagFilterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class AnyTagFilterTest
+{
+    @Test
+    public void shouldReturnServersMatchingAnyTag() throws Exception
+    {
+        // given
+        AnyTagFilter tagFilter = new AnyTagFilter( asSet( "china-west", "europe" ) );
+
+        ServerInfo serverA = new ServerInfo( new AdvertisedSocketAddress( "bolt", 1 ), asSet( "china-west" ) );
+        ServerInfo serverB = new ServerInfo( new AdvertisedSocketAddress( "bolt", 2 ), asSet( "europe" ) );
+        ServerInfo serverC = new ServerInfo( new AdvertisedSocketAddress( "bolt", 3 ), asSet( "china", "china-west" ) );
+        ServerInfo serverD = new ServerInfo( new AdvertisedSocketAddress( "bolt", 4 ), asSet( "china-west", "china" ) );
+        ServerInfo serverE = new ServerInfo( new AdvertisedSocketAddress( "bolt", 5 ), asSet( "china-east", "asia" ) );
+        ServerInfo serverF = new ServerInfo( new AdvertisedSocketAddress( "bolt", 6 ), asSet( "europe-west" ) );
+        ServerInfo serverG = new ServerInfo( new AdvertisedSocketAddress( "bolt", 7 ), asSet( "china-west", "europe" ) );
+        ServerInfo serverH = new ServerInfo( new AdvertisedSocketAddress( "bolt", 8 ), asSet( "africa" ) );
+
+        Set<ServerInfo> data = asSet( serverA, serverB, serverC, serverD, serverE, serverF, serverG, serverH );
+
+        // when
+        Set<ServerInfo> output = tagFilter.apply( data );
+
+        // then
+        Set<Integer> ports = new HashSet<>();
+        for ( ServerInfo info : output )
+        {
+            ports.add( info.boltAddress().getPort() );
+        }
+
+        assertEquals( asSet( 1, 2, 3, 4, 7 ), ports );
+    }
+
+    ServerInfo serverInfo( String... tags )
+    {
+        return new ServerInfo( new AdvertisedSocketAddress( "bolt", 1 ), asSet( tags ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/PoliciesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/strategy/server_policy/PoliciesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.strategy.server_policy;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import org.neo4j.causalclustering.load_balancing.filters.Filter;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+import org.neo4j.logging.NullLogProvider;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class PoliciesTest
+{
+    @Test
+    public void shouldSupplyDefaultUnfilteredPolicy() throws Exception
+    {
+        // given
+        Policies policies = new Policies( NullLogProvider.getInstance() );
+
+        // when
+        Filter<ServerInfo> filter = policies.selectFor( emptyMap() );
+        Set<ServerInfo> input = asSet(
+                new ServerInfo( new AdvertisedSocketAddress( "bolt", 1 ), asSet( "tagA" ) ),
+                new ServerInfo( new AdvertisedSocketAddress( "bolt", 2 ), asSet( "tagB" ) )
+        );
+
+        Set<ServerInfo> output = filter.apply( input );
+
+        // then
+        assertEquals( input, output );
+    }
+
+    @Test
+    public void shouldAllowLookupOfAddedPolicy() throws Exception
+    {
+        // given
+        Policies policies = new Policies( NullLogProvider.getInstance() );
+
+        String myPolicyName = "china";
+        Filter<ServerInfo> myPolicy = data -> data;
+
+        // when
+        policies.addPolicy( myPolicyName, myPolicy );
+        Filter<ServerInfo> selectedPolicy = policies.selectFor( stringMap( Policies.POLICY_KEY, myPolicyName ) );
+
+        // then
+        assertEquals( myPolicy, selectedPolicy );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ConnectToRandomCoreServerTest.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -52,12 +52,12 @@ public class ConnectToRandomCoreServerTest
         MemberId memberId2 = new MemberId( UUID.randomUUID() );
         MemberId memberId3 = new MemberId( UUID.randomUUID() );
 
-        ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
-        when( readReplicaTopologyService.coreServers() )
+        TopologyService topologyService = mock( TopologyService.class );
+        when( topologyService.coreServers() )
                 .thenReturn( fakeCoreTopology( memberId1, memberId2, memberId3 ) );
 
         ConnectToRandomCoreServer connectionStrategy = new ConnectToRandomCoreServer();
-        connectionStrategy.setDiscoveryService( readReplicaTopologyService );
+        connectionStrategy.setTopologyService( topologyService );
 
         // when
         Optional<MemberId> memberId = connectionStrategy.upstreamDatabase();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/ReadReplicaStartupProcessTest.java
@@ -33,7 +33,7 @@ import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
 import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.helper.ConstantTimeRetryStrategy;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
@@ -62,7 +62,7 @@ public class ReadReplicaStartupProcessTest
     private FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
     private final PageCache pageCache = mock( PageCache.class );
     private LocalDatabase localDatabase = mock( LocalDatabase.class );
-    private ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
+    private TopologyService topologyService = mock( TopologyService.class );
     private CoreTopology clusterTopology = mock( CoreTopology.class );
     private Lifecycle txPulling = mock( Lifecycle.class );
 
@@ -77,7 +77,7 @@ public class ReadReplicaStartupProcessTest
         when( pageCache.streamFilesRecursive( any(File.class) ) ).thenAnswer( ( f ) -> Stream.empty() );
         when( localDatabase.storeDir() ).thenReturn( storeDir );
         when( localDatabase.storeId() ).thenReturn( localStoreId );
-        when( readReplicaTopologyService.coreServers() ).thenReturn( clusterTopology );
+        when( topologyService.coreServers() ).thenReturn( clusterTopology );
         when( clusterTopology.members() ).thenReturn( asSet( memberId ) );
     }
 
@@ -104,7 +104,7 @@ public class ReadReplicaStartupProcessTest
     private UpstreamDatabaseStrategySelector chooseFirstMember()
     {
         AlwaysChooseFirstMember firstMember = new AlwaysChooseFirstMember();
-        firstMember.setDiscoveryService( readReplicaTopologyService );
+        firstMember.setTopologyService( topologyService );
 
         return new UpstreamDatabaseStrategySelector( firstMember );
     }
@@ -189,7 +189,7 @@ public class ReadReplicaStartupProcessTest
         @Override
         public Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException
         {
-            CoreTopology coreTopology = readReplicaTopologyService.coreServers();
+            CoreTopology coreTopology = topologyService.coreServers();
             return Optional.ofNullable( coreTopology.members().iterator().next() );
         }
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaTest.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 import org.neo4j.causalclustering.discovery.ClientConnectorAddresses;
 import org.neo4j.causalclustering.discovery.ClusterTopology;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.ReadReplicaAddresses;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -131,13 +131,13 @@ public class TypicallyConnectToRandomReadReplicaTest
     {
         assert readReplicaIds.length > 0;
 
-        Map<MemberId,ReadReplicaAddresses> readReplicas = new HashMap<>();
+        Map<MemberId,ReadReplicaInfo> readReplicas = new HashMap<>();
 
         int offset = 0;
 
         for ( MemberId memberId : readReplicaIds )
         {
-            readReplicas.put( memberId, new ReadReplicaAddresses( new ClientConnectorAddresses( singletonList(
+            readReplicas.put( memberId, new ReadReplicaInfo( new ClientConnectorAddresses( singletonList(
                     new ClientConnectorAddresses.ConnectorUri( ClientConnectorAddresses.Scheme.bolt,
                             new AdvertisedSocketAddress( "localhost", 11000 + offset ) ) ) ),
                     new AdvertisedSocketAddress( "localhost", 10000 + offset ) ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/TypicallyConnectToRandomReadReplicaTest.java
@@ -32,7 +32,7 @@ import org.neo4j.causalclustering.discovery.ClusterTopology;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopology;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 
@@ -48,11 +48,11 @@ public class TypicallyConnectToRandomReadReplicaTest
     {
         // given
         MemberId theCoreMemberId = new MemberId( UUID.randomUUID() );
-        ReadReplicaTopologyService readReplicaTopologyService =
+        TopologyService topologyService =
                 fakeTopologyService( fakeCoreTopology( theCoreMemberId ), fakeReadReplicaTopology( memberIDs( 100 ) ) );
 
         TypicallyConnectToRandomReadReplica connectionStrategy = new TypicallyConnectToRandomReadReplica();
-        connectionStrategy.setDiscoveryService( readReplicaTopologyService );
+        connectionStrategy.setTopologyService( topologyService );
 
         List<MemberId> responses = new ArrayList<>();
 
@@ -66,10 +66,10 @@ public class TypicallyConnectToRandomReadReplicaTest
         assertThat( responses, hasItem( theCoreMemberId ) );
     }
 
-    private ReadReplicaTopologyService fakeTopologyService( CoreTopology coreTopology,
+    private TopologyService fakeTopologyService( CoreTopology coreTopology,
             ReadReplicaTopology readReplicaTopology )
     {
-        return new ReadReplicaTopologyService()
+        return new TopologyService()
         {
             @Override
             public CoreTopology coreServers()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoaderTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import java.util.Set;
 
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -41,7 +41,7 @@ public class UpstreamDatabaseStrategiesLoaderTest
         config.augment( stringMap( "causal_clustering.upstream_selection_strategy", "dummy" ) );
 
         UpstreamDatabaseStrategiesLoader
-                strategies = new UpstreamDatabaseStrategiesLoader( mock( ReadReplicaTopologyService.class ), config );
+                strategies = new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config );
 
         // when
         Set<UpstreamDatabaseSelectionStrategy> upstreamDatabaseSelectionStrategies = asSet( strategies.iterator() );
@@ -62,7 +62,7 @@ public class UpstreamDatabaseStrategiesLoaderTest
 
         // when
         UpstreamDatabaseStrategiesLoader
-                strategies = new UpstreamDatabaseStrategiesLoader( mock( ReadReplicaTopologyService.class ), config );
+                strategies = new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config );
 
         // then
         assertEquals( UpstreamDatabaseStrategySelectorTest.YetAnotherDummyUpstreamDatabaseSelectionStrategy.class,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
-import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
@@ -72,13 +72,13 @@ public class UpstreamDatabaseStrategySelectorTest
     public void shouldDefaultToRandomCoreServerIfNoOtherStrategySpecified() throws Exception
     {
         // given
-        ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
+        TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
-        when( readReplicaTopologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
                 mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServer defaultStrategy = new ConnectToRandomCoreServer();
-        defaultStrategy.setDiscoveryService( readReplicaTopologyService );
+        defaultStrategy.setTopologyService( topologyService );
 
         UpstreamDatabaseStrategySelector selector = new UpstreamDatabaseStrategySelector( defaultStrategy );
 
@@ -93,9 +93,9 @@ public class UpstreamDatabaseStrategySelectorTest
     public void shouldUseSpecifiedStrategyInPreferenceToDefault() throws Exception
     {
         // given
-        ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
+        TopologyService topologyService = mock( TopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
-        when( readReplicaTopologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
+        when( topologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
                 mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServer shouldNotUse = new ConnectToRandomCoreServer();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.neo4j.causalclustering.discovery.CoreAddresses;
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
 import org.neo4j.causalclustering.discovery.CoreTopology;
 import org.neo4j.causalclustering.discovery.ReadReplicaTopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
@@ -75,7 +75,7 @@ public class UpstreamDatabaseStrategySelectorTest
         ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
         when( readReplicaTopologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
-                mapOf( memberId, mock( CoreAddresses.class ) ) ) );
+                mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServer defaultStrategy = new ConnectToRandomCoreServer();
         defaultStrategy.setDiscoveryService( readReplicaTopologyService );
@@ -96,7 +96,7 @@ public class UpstreamDatabaseStrategySelectorTest
         ReadReplicaTopologyService readReplicaTopologyService = mock( ReadReplicaTopologyService.class );
         MemberId memberId = new MemberId( UUID.randomUUID() );
         when( readReplicaTopologyService.coreServers() ).thenReturn( new CoreTopology( new ClusterId( UUID.randomUUID() ), false,
-                mapOf( memberId, mock( CoreAddresses.class ) ) ) );
+                mapOf( memberId, mock( CoreServerInfo.class ) ) ) );
 
         ConnectToRandomCoreServer shouldNotUse = new ConnectToRandomCoreServer();
 
@@ -165,11 +165,11 @@ public class UpstreamDatabaseStrategySelectorTest
         }
     }
 
-    private Map<MemberId,CoreAddresses> mapOf( MemberId memberId, CoreAddresses coreAddresses )
+    private Map<MemberId,CoreServerInfo> mapOf( MemberId memberId, CoreServerInfo coreServerInfo )
     {
-        HashMap<MemberId,CoreAddresses> map = new HashMap<>();
+        HashMap<MemberId,CoreServerInfo> map = new HashMap<>();
 
-        map.put( memberId, coreAddresses );
+        map.put( memberId, coreServerInfo );
 
         return map;
     }


### PR DESCRIPTION
This is the first step in building up the server-side policy based
load balancing strategy. The idea is that servers are tagged
with one or more tags and these are used in a server-side configured
scheme of filters to select those which match. Different policies can
select different sets of tags and there can be other filters attached apart
from tag-based filters.

Every policy has a name which the client can use to bind to a particular
policy by supplying that name in the client supplied context, as supported
by the V2 version of GetServers.