### PR TITLE
Removed RPM dependency on javapackages-tools

### DIFF
--- a/new-packaging/src/rpm/neo4j.spec
+++ b/new-packaging/src/rpm/neo4j.spec
@@ -8,7 +8,7 @@ License: ${LICENSE}
 URL: http://neo4j.org/
 #Source: https://github.com/neo4j/neo4j/archive/%{version}.tar.gz
 
-Requires: java-1.8.0-headless, javapackages-tools
+Requires: java-1.8.0-headless
 
 BuildArch:      noarch
 


### PR DESCRIPTION
This is not a required dependency. It was added because it was
recommended by the Fedora guidelines to do so here:

<https://fedoraproject.org/wiki/Packaging:Java>

This dependency however blocks installation on CentOS 6. Hence
removing it.

fixes #8810 

Image showing successful dependency resolution:

![selection_001](https://cloud.githubusercontent.com/assets/223655/22936492/fa0a1c2e-f2d5-11e6-8488-dad88679bb5c.png)
