### PR TITLE
Run acceptance tests in source code mode

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
@@ -74,6 +74,24 @@ public class AcceptanceSpecSuiteTest
     @RunWith( Cucumber.class )
     @CucumberOptions(
             plugin = {
+                    DB_CONFIG + "cost-compiled.json",
+                    HTML_REPORT + SUITE_NAME + "/cost-compiled",
+                    JSON_REPORT + SUITE_NAME + "/cost-compiled",
+                    BLACKLIST_PLUGIN + "cost-compiled.txt",
+                    CYPHER_OPTION_PLUGIN + "cost-compiled-sourcecode.txt"
+            },
+            glue = { GLUE_PATH },
+            features = { FEATURE_PATH + FEATURE_TO_RUN },
+            tags = { "~@pending" },
+            strict = true
+    )
+    public static class CostCompiledSourceCode
+    {
+    }
+
+    @RunWith( Cucumber.class )
+    @CucumberOptions(
+            plugin = {
                     DB_CONFIG + "compatibility-23.json",
                     HTML_REPORT + SUITE_NAME + "/compatibility-23",
                     JSON_REPORT + SUITE_NAME + "/compatibility-23",

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
@@ -75,8 +75,8 @@ public class AcceptanceSpecSuiteTest
     @CucumberOptions(
             plugin = {
                     DB_CONFIG + "cost-compiled.json",
-                    HTML_REPORT + SUITE_NAME + "/cost-compiled",
-                    JSON_REPORT + SUITE_NAME + "/cost-compiled",
+                    HTML_REPORT + SUITE_NAME + "/cost-compiled-sourcecode",
+                    JSON_REPORT + SUITE_NAME + "/cost-compiled-sourcecode",
                     BLACKLIST_PLUGIN + "cost-compiled.txt",
                     CYPHER_OPTION_PLUGIN + "cost-compiled-sourcecode.txt"
             },

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher-options/cost-compiled-sourcecode.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher-options/cost-compiled-sourcecode.txt
@@ -1,0 +1,2 @@
+// Compiled runtime should generate source code
+CYPHER codeGenMode=sourcecode

--- a/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
@@ -74,6 +74,24 @@ public class CompatibilitySpecSuiteTest
     @RunWith( Cucumber.class )
     @CucumberOptions(
             plugin = {
+                    DB_CONFIG + "cost-compiled.json",
+                    HTML_REPORT + SUITE_NAME + "/cost-compiled",
+                    JSON_REPORT + SUITE_NAME + "/cost-compiled",
+                    BLACKLIST_PLUGIN + "cost-compiled.txt",
+                    CYPHER_OPTION_PLUGIN + "cost-compiled-sourcecode.txt"
+            },
+            glue = { GLUE_PATH },
+            features = { FEATURE_PATH + FEATURE_TO_RUN },
+            tags = { "~@pending" },
+            strict = true
+    )
+    public static class CostCompiledSourceCode
+    {
+    }
+
+    @RunWith( Cucumber.class )
+    @CucumberOptions(
+            plugin = {
                     DB_CONFIG + "compatibility-23.json",
                     HTML_REPORT + SUITE_NAME + "/compatibility-23",
                     JSON_REPORT + SUITE_NAME + "/compatibility-23",

--- a/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
@@ -75,8 +75,8 @@ public class CompatibilitySpecSuiteTest
     @CucumberOptions(
             plugin = {
                     DB_CONFIG + "cost-compiled.json",
-                    HTML_REPORT + SUITE_NAME + "/cost-compiled",
-                    JSON_REPORT + SUITE_NAME + "/cost-compiled",
+                    HTML_REPORT + SUITE_NAME + "/cost-compiled-sourcecode",
+                    JSON_REPORT + SUITE_NAME + "/cost-compiled-sourcecode",
                     BLACKLIST_PLUGIN + "cost-compiled.txt",
                     CYPHER_OPTION_PLUGIN + "cost-compiled-sourcecode.txt"
             },

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/cypher-options/cost-compiled-sourcecode.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/cypher-options/cost-compiled-sourcecode.txt
@@ -1,0 +1,2 @@
+// Compiled runtime should generate source code
+CYPHER codeGenMode=sourcecode

--- a/enterprise/cypher/spec-suite-tools/src/main/scala/cypher/cucumber/CypherOptionPlugin.scala
+++ b/enterprise/cypher/spec-suite-tools/src/main/scala/cypher/cucumber/CypherOptionPlugin.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package cypher.cucumber
+
+import java.io.FileNotFoundException
+import java.net.URI
+import java.nio.charset.StandardCharsets
+
+import gherkin.formatter.model.{Match, Result}
+
+import scala.io.Source
+
+object CypherOptionPlugin {
+  private var _options: String = ""
+
+  def options = _options
+}
+
+class CypherOptionPlugin(optionUri: URI) extends CucumberAdapter {
+
+  override def before(`match`: Match, result: Result): Unit = {
+    val url = getClass.getResource(optionUri.getPath)
+    if (url == null) throw new FileNotFoundException(s"Cypher option file not found at: $optionUri")
+    val itr = Source.fromFile(url.getPath, StandardCharsets.UTF_8.name()).getLines()
+    CypherOptionPlugin._options = itr.foldLeft("") {
+      case (optionString, line) =>
+        if (line.isEmpty || line.startsWith("//")) optionString else optionString + " " + line
+    }
+  }
+
+  override def after(`match`: Match, result: Result) = {
+    CypherOptionPlugin._options = ""
+  }
+}

--- a/enterprise/cypher/spec-suite-tools/src/test/java/cypher/SpecSuiteConstants.java
+++ b/enterprise/cypher/spec-suite-tools/src/test/java/cypher/SpecSuiteConstants.java
@@ -26,4 +26,5 @@ interface SpecSuiteConstants
     String HTML_REPORT = "html:target/";
     String JSON_REPORT = "cypher.feature.reporting.CypherResultReporter:target/";
     String BLACKLIST_PLUGIN = "cypher.cucumber.BlacklistPlugin:/blacklists/";
+    String CYPHER_OPTION_PLUGIN = "cypher.cucumber.CypherOptionPlugin:/cypher-options/";
 }

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteSteps.scala
@@ -23,13 +23,14 @@ import java.util
 
 import cucumber.api.DataTable
 import cypher.SpecSuiteResources
+import cypher.cucumber.CypherOptionPlugin
 import cypher.cucumber.db.DatabaseConfigProvider._
 import cypher.cucumber.db.{GraphArchive, GraphArchiveImporter, GraphArchiveLibrary, GraphFileRepository}
 import cypher.feature.parser._
 import cypher.feature.parser.matchers.ResultWrapper
 import org.neo4j.collection.RawIterator
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.{CypherType, _}
-import org.neo4j.graphdb.factory.{EnterpriseGraphDatabaseFactory, GraphDatabaseFactory, GraphDatabaseSettings}
+import org.neo4j.graphdb.factory.{EnterpriseGraphDatabaseFactory, GraphDatabaseSettings}
 import org.neo4j.graphdb.{GraphDatabaseService, QueryStatistics, Result, Transaction}
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.api.exceptions.ProcedureException
@@ -37,7 +38,7 @@ import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
 import org.neo4j.kernel.api.proc.{Context, Neo4jTypes}
 import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.procedure.Mode
-import org.neo4j.test.{TestEnterpriseGraphDatabaseFactory, TestGraphDatabaseFactory}
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 import org.opencypher.tools.tck.TCKCucumberTemplate
 import org.opencypher.tools.tck.constants.TCKStepDefinitions._
 import org.scalatest.{FunSuiteLike, Matchers}
@@ -108,7 +109,7 @@ trait SpecSuiteSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
 
   When(EXECUTING_QUERY) { (query: String) =>
     scenarioBuilder.exec { (g: GraphDatabaseAPI, params: util.Map[String, Object]) =>
-      g.execute(query, params)
+      g.execute(s"${CypherOptionPlugin.options} $query", params)
     }
   }
 


### PR DESCRIPTION
Run the cucumber acceptance and compatibility spec suite tests also
with source code generation mode for the compiled runtime.

This adds a cucumber plugin for prepending Cypher pre-parser options to the executing queries.
