### PR TITLE
Fixed `neo4j-admin set-default-admin` to exit with error if user doesn't exist

### DIFF
--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
@@ -97,7 +98,7 @@ public class SetDefaultAdminCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Args parsedArgs = validateArgs(args);
+        Args parsedArgs = validateArgs( args );
 
         try
         {
@@ -109,8 +110,7 @@ public class SetDefaultAdminCommand implements AdminCommand
         }
         catch ( Throwable throwable )
         {
-            throw new CommandFailed( "Failed to execute 'set-default-admin' command: " + throwable.getMessage(),
-                    new RuntimeException( throwable ) );
+            throw new CommandFailed( throwable.getMessage(), new RuntimeException( throwable ) );
         }
     }
 
@@ -119,33 +119,60 @@ public class SetDefaultAdminCommand implements AdminCommand
         Args parsedArgs = Args.parse( args );
         if ( parsedArgs.orphans().size() < 1 )
         {
-            throw new IncorrectUsage( "No username specified." );
+            throw new IncorrectUsage( "no username specified." );
         }
         if ( parsedArgs.orphans().size() > 1 )
         {
-            throw new IncorrectUsage( "Too many arguments." );
+            throw new IncorrectUsage( "too many arguments." );
         }
         return parsedArgs;
     }
 
     private void setDefaultAdmin( String username ) throws Throwable
     {
+        FileSystemAbstraction fileSystem = outsideWorld.fileSystem();
         Config config = loadNeo4jConfig();
+
+        FileUserRepository users = CommunitySecurityModule.getUserRepository( config, NullLogProvider.getInstance(),
+                fileSystem );
+
+        users.init();
+        users.start();
+        Set<String> userNames = users.getAllUsernames();
+        users.stop();
+        users.shutdown();
+
+        if ( userNames.isEmpty() )
+        {
+            FileUserRepository initialUsers = CommunitySecurityModule.getInitialUserRepository( config,
+                    NullLogProvider.getInstance(),
+                    fileSystem );
+            initialUsers.init();
+            initialUsers.start();
+            userNames = initialUsers.getAllUsernames();
+            initialUsers.stop();
+            initialUsers.shutdown();
+        }
+
+        if ( !userNames.contains( username ) )
+        {
+            throw new CommandFailed( String.format( "no such user: '%s'", username ) );
+        }
+
         File adminIniFile = new File( CommunitySecurityModule.getUserRepositoryFile( config ).getParentFile(),
                 ADMIN_INI );
-        FileSystemAbstraction fileSystem = outsideWorld.fileSystem();
         if ( fileSystem.fileExists( adminIniFile ) )
         {
             fileSystem.deleteFile( adminIniFile );
         }
-        UserRepository users = new FileUserRepository( fileSystem, adminIniFile, NullLogProvider.getInstance() );
-        users.init();
-        users.start();
-        users.create( new User.Builder( username, Credential.INACCESSIBLE ).build() );
-        users.stop();
-        users.shutdown();
+        UserRepository admins = new FileUserRepository( fileSystem, adminIniFile, NullLogProvider.getInstance() );
+        admins.init();
+        admins.start();
+        admins.create( new User.Builder( username, Credential.INACCESSIBLE ).build() );
+        admins.stop();
+        admins.shutdown();
 
-        outsideWorld.stdOutLine( "Set default admin to '" + username + "'." );
+        outsideWorld.stdOutLine( "default admin user set to '" + username + "'" );
     }
 
     Config loadNeo4jConfig()

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -63,8 +63,8 @@ public class CommunitySecurityModule extends SecurityModule
         procedures.registerProcedure( AuthProcedures.class );
     }
 
-    private static final String USER_STORE_FILENAME = "auth";
-    private static final String INITIAL_USER_STORE_FILENAME = "auth.ini";
+    public static final String USER_STORE_FILENAME = "auth";
+    public static final String INITIAL_USER_STORE_FILENAME = "auth.ini";
 
     public static FileUserRepository getUserRepository( Config config, LogProvider logProvider,
             FileSystemAbstraction fileSystem )

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.commandline.admin.security;
 
+import java.io.File;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
 
 import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.commandline.admin.BlockerLocator;
@@ -31,7 +31,10 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.server.security.auth.CommunitySecurityModule;
+import org.neo4j.server.security.auth.Credential;
 import org.neo4j.server.security.auth.FileUserRepository;
+import org.neo4j.server.security.auth.User;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -69,22 +72,58 @@ public class SetDefaultAdminCommandIT
     @Test
     public void shouldSetDefaultAdmin() throws Throwable
     {
+        insertUser( "jane", false );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
         assertAdminIniFile( "jane" );
 
-        verify( out ).stdOutLine( "Set default admin to 'jane'." );
+        verify( out ).stdOutLine( "default admin user set to 'jane'" );
+    }
+
+    @Test
+    public void shouldSetDefaultAdminForInitialUser() throws Throwable
+    {
+        insertUser( "jane", true );
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
+        assertAdminIniFile( "jane" );
+
+        verify( out ).stdOutLine( "default admin user set to 'jane'" );
     }
 
     @Test
     public void shouldOverwrite() throws Throwable
     {
+        insertUser( "jane", false );
+        insertUser( "janette", false );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
         assertAdminIniFile( "jane" );
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "janette" );
         assertAdminIniFile( "janette" );
 
-        verify( out ).stdOutLine( "Set default admin to 'jane'." );
-        verify( out ).stdOutLine( "Set default admin to 'janette'." );
+        verify( out ).stdOutLine( "default admin user set to 'jane'" );
+        verify( out ).stdOutLine( "default admin user set to 'janette'" );
+    }
+
+    @Test
+    public void shouldErrorWithNoSuchUser() throws Throwable
+    {
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "bob" );
+        verify( out ).stdErrLine( "command failed: no such user: 'bob'" );
+        verify( out ).exit( 1 );
+        verify( out, times( 0 ) ).stdOutLine( anyString() );
+    }
+
+    @Test
+    public void shouldIgnoreInitialUserIfUsersExist() throws Throwable
+    {
+        insertUser( "jane", false );
+        insertUser( "janette", true );
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "jane" );
+        assertAdminIniFile( "jane" );
+        tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "janette" );
+
+        verify( out ).stdOutLine( "default admin user set to 'jane'" );
+        verify( out ).stdErrLine( "command failed: no such user: 'janette'" );
+        verify( out ).exit( 1 );
     }
 
     @Test
@@ -93,7 +132,7 @@ public class SetDefaultAdminCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "No username specified." );
+        verify( out ).stdErrLine( "no username specified." );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
         verify( out, times( 2 ) ).stdErrLine( "" );
@@ -111,7 +150,7 @@ public class SetDefaultAdminCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "foo", "bar" );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "Too many arguments." );
+        verify( out ).stdErrLine( "too many arguments." );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
         verify( out, times( 2 ) ).stdErrLine( "" );
@@ -123,6 +162,19 @@ public class SetDefaultAdminCommandIT
         verify( out, times( 0 ) ).stdOutLine( anyString() );
     }
 
+    private void insertUser( String username, boolean initial ) throws Throwable
+    {
+        File userFile = getAuthFile( initial ? CommunitySecurityModule.INITIAL_USER_STORE_FILENAME :
+                CommunitySecurityModule.USER_STORE_FILENAME );
+        FileUserRepository userRepository = new FileUserRepository( fileSystem, userFile,
+                NullLogProvider.getInstance() );
+        userRepository.start();
+        userRepository.create( new User.Builder( username, Credential.INACCESSIBLE ).build() );
+        assertTrue( userRepository.getAllUsernames().contains( username ) );
+        userRepository.stop();
+        userRepository.shutdown();
+    }
+
     private void assertAdminIniFile( String username ) throws Throwable
     {
         File adminIniFile = getAuthFile( SetDefaultAdminCommand.ADMIN_INI );
@@ -131,6 +183,8 @@ public class SetDefaultAdminCommandIT
                 NullLogProvider.getInstance() );
         userRepository.start();
         assertThat( userRepository.getAllUsernames(), containsInAnyOrder( username ) );
+        userRepository.stop();
+        userRepository.shutdown();
     }
 
     private void assertNoAuthIniFile()
@@ -145,7 +199,7 @@ public class SetDefaultAdminCommandIT
 
     private void resetOutsideWorldMock()
     {
-        reset(out);
+        reset( out );
         when( out.fileSystem() ).thenReturn( fileSystem );
     }
 }


### PR DESCRIPTION
This is otherwise a source of potential silent failures.