### PR TITLE
Log if node was created in tx or not

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
@@ -226,9 +226,10 @@ public abstract class Command implements StorageCommand
 
         private boolean writeNodeRecord( WritableChannel channel, NodeRecord record ) throws IOException
         {
-            byte flags = bitFlags(  bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
-                                    bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
-                                    bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ) );
+            byte flags = bitFlags( bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
+                                   bitFlag( record.isCreated(), Record.CREATED_IN_TX ),
+                                   bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
+                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ) );
             channel.put( flags );
             if ( record.inUse() )
             {


### PR DESCRIPTION
In transaction log, write if the transaction think it is the
creator or not of the node it modifies. Much like how it is
done for relationships.

This is not printed when dumping logical log, but having the
information bit is enough.

Note: I don't think this count as a log format change but please challenge this statement.