### PR TITLE
Raise availability guard when core or read replica copy store

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -161,7 +161,7 @@ public class CatchUpClient extends LifecycleAdapter
     }
 
     @Override
-    public void stop() throws Throwable
+    public void stop()
     {
         log.info( "CatchUpClient stopping" );
         try

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -217,11 +217,10 @@ public class LocalDatabase implements Lifecycle
     private synchronized void stopWithRequirement( AvailabilityRequirement requirement ) throws Throwable
     {
         log.info( "Stopping, reason: " + requirement.description() );
+        raiseAvailabilityGuard( requirement );
         databaseHealth = null;
         localCommit = null;
         dataSourceManager.stop();
-
-        raiseAvailabilityGuard( requirement );
     }
 
     private void raiseAvailabilityGuard( AvailabilityRequirement requirement )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -62,7 +62,7 @@ public class LocalDatabase implements Lifecycle
 
     private volatile StoreId storeId;
     private volatile DatabaseHealth databaseHealth;
-    private AvailabilityRequirement currentRequirement;
+    private volatile AvailabilityRequirement currentRequirement;
 
     private volatile TransactionCommitProcess localCommit;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -307,7 +307,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
     {
         try
         {
-            localDatabase.stop();
+            localDatabase.stopForStoreCopy();
             startStopOnStoreCopy.stop();
         }
         catch ( Throwable throwable )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -157,6 +157,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
                 new StoreFiles( fileSystem, platformModule.pageCache ),
                 platformModule.dataSourceManager,
                 databaseHealthSupplier,
+                platformModule.availabilityGuard,
                 logProvider );
 
         IdentityModule identityModule = new IdentityModule( platformModule, clusterStateDirectory.get() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -83,7 +83,7 @@ public class CoreStateDownloader
             }
 
             startStopOnStoreCopy.stop();
-            localDatabase.stop();
+            localDatabase.stopForStoreCopy();
 
             log.info( "Downloading snapshot from core server at %s", source );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -206,7 +206,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         StoreFiles storeFiles = new StoreFiles( fileSystem, pageCache );
         LocalDatabase localDatabase =
                 new LocalDatabase( platformModule.storeDir, storeFiles, platformModule.dataSourceManager,
-                        databaseHealthSupplier, logProvider );
+                        databaseHealthSupplier, platformModule.availabilityGuard, logProvider );
 
         RemoteStore remoteStore =
                 new RemoteStore( platformModule.logging.getInternalLogProvider(), fileSystem, platformModule.pageCache,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.time.Clock;
+
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+import org.neo4j.kernel.internal.DatabaseHealth;
+import org.neo4j.logging.NullLog;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class LocalDatabaseTest
+{
+    @Test
+    public void availabilityGuardRaisedOnCreation() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+
+        assertNotNull( localDatabase );
+        assertDatabaseIsStoppedAndUnavailable( guard );
+    }
+
+    @Test
+    public void availabilityGuardDroppedOnStart() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+    }
+
+    @Test
+    public void availabilityGuardRaisedOnStop() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+
+        localDatabase.stop();
+        assertDatabaseIsStoppedAndUnavailable( guard );
+    }
+
+    private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
+    {
+        return new LocalDatabase( mock( File.class ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
+                () -> mock( DatabaseHealth.class ), availabilityGuard, NullLogProvider.getInstance() );
+    }
+
+    private static AvailabilityGuard newAvailabilityGuard()
+    {
+        return new AvailabilityGuard( Clock.systemUTC(), NullLog.getInstance() );
+    }
+
+    private static void assertDatabaseIsStoppedAndUnavailable( AvailabilityGuard guard )
+    {
+        assertFalse( guard.isAvailable() );
+        assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped" ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -79,6 +79,22 @@ public class LocalDatabaseTest
         assertDatabaseIsStoppedAndUnavailable( guard );
     }
 
+    @Test
+    public void availabilityGuardRaisedOnStopForStoreCopy() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+
+        localDatabase.stopForStoreCopy();
+        assertDatabaseIsStoppedForStoreCopyAndUnavailable( guard );
+    }
+
     private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
     {
         return new LocalDatabase( mock( File.class ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
@@ -94,5 +110,11 @@ public class LocalDatabaseTest
     {
         assertFalse( guard.isAvailable() );
         assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped" ) );
+    }
+
+    private static void assertDatabaseIsStoppedForStoreCopyAndUnavailable( AvailabilityGuard guard )
+    {
+        assertFalse( guard.isAvailable() );
+        assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped to copy store" ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
@@ -169,7 +169,7 @@ public class CatchupPollingProcessTest
         timeoutService.invokeTimeout( TX_PULLER_TIMEOUT );
 
         // then
-        verify( localDatabase ).stop();
+        verify( localDatabase ).stopForStoreCopy();
         verify( startStopOnStoreCopy ).stop();
         verify( storeCopyProcess ).replaceWithStoreFrom( any( MemberId.class ), eq( storeId ) );
         verify( localDatabase ).start();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -28,9 +28,9 @@ import java.util.UUID;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
+import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
-import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.core.state.CoreState;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -101,7 +101,7 @@ public class CoreStateDownloaderTest
 
         // then
         verify( startStopLife ).stop();
-        verify( localDatabase ).stop();
+        verify( localDatabase ).stopForStoreCopy();
         verify( localDatabase ).start();
         verify( startStopLife ).start();
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -114,7 +114,6 @@ public class ReadReplica implements ClusterMember
     }
 
     @Override
-
     public void start()
     {
         database = new ReadReplicaGraphDatabase( storeDir, Config.embeddedDefaults( config ),

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.causalclustering.ClusterRule;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -81,6 +82,7 @@ public class ReadReplicaStoreCopyIT
             catch ( Exception e )
             {
                 assertThat( e, instanceOf( TransactionFailureException.class ) );
+                assertThat( e.getMessage(), containsString( "Database is stopped to copy store" ) );
             }
         }
         finally

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.causalclustering.discovery.ReadReplica;
+import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.test.assertion.Assert.assertEventually;
+
+public class ReadReplicaStoreCopyIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withSharedCoreParam( GraphDatabaseSettings.keep_logical_logs, FALSE )
+            .withNumberOfCoreMembers( 3 )
+            .withNumberOfReadReplicas( 1 );
+
+    @Test( timeout = 120_000 )
+    public void shouldNotBePossibleToStartTransactionsWhenReadReplicaCopiesStore() throws Throwable
+    {
+        Cluster cluster = clusterRule.startCluster();
+
+        ReadReplica readReplica = cluster.findAnyReadReplica();
+
+        readReplica.txPollingClient().stop();
+
+        writeSomeDataAndForceLogRotations( cluster );
+        Semaphore storeCopyBlockingSemaphore = addStoreCopyBlockingMonitor( readReplica );
+        try
+        {
+            readReplica.txPollingClient().start();
+            waitForStoreCopyToStartAndBlock( storeCopyBlockingSemaphore );
+
+            ReadReplicaGraphDatabase replicaGraphDatabase = readReplica.database();
+            try
+            {
+                replicaGraphDatabase.beginTx();
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( TransactionFailureException.class ) );
+            }
+        }
+        finally
+        {
+            // release all waiters of the semaphore
+            storeCopyBlockingSemaphore.release( Integer.MAX_VALUE );
+        }
+    }
+
+    private static void writeSomeDataAndForceLogRotations( Cluster cluster ) throws Exception
+    {
+        for ( int i = 0; i < 20; i++ )
+        {
+            cluster.coreTx( ( db, tx ) ->
+            {
+                db.execute( "CREATE ()" );
+                tx.success();
+            } );
+
+            forceLogRotationOnAllCores( cluster );
+        }
+    }
+
+    private static void forceLogRotationOnAllCores( Cluster cluster )
+    {
+        for ( CoreClusterMember core : cluster.coreMembers() )
+        {
+            forceLogRotationAndPruning( core );
+        }
+    }
+
+    private static void forceLogRotationAndPruning( CoreClusterMember core )
+    {
+        try
+        {
+            DependencyResolver dependencyResolver = core.database().getDependencyResolver();
+            dependencyResolver.resolveDependency( LogRotation.class ).rotateLogFile();
+            SimpleTriggerInfo info = new SimpleTriggerInfo( "test" );
+            dependencyResolver.resolveDependency( CheckPointer.class ).forceCheckPoint( info );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private static Semaphore addStoreCopyBlockingMonitor( ReadReplica readReplica )
+    {
+        DependencyResolver dependencyResolver = readReplica.database().getDependencyResolver();
+        Monitors monitors = dependencyResolver.resolveDependency( Monitors.class );
+
+        Semaphore semaphore = new Semaphore( 0 );
+
+        monitors.addMonitorListener( (FileCopyMonitor) file ->
+        {
+            try
+            {
+                semaphore.acquire();
+            }
+            catch ( InterruptedException e )
+            {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException( e );
+            }
+        } );
+
+        return semaphore;
+    }
+
+    private static void waitForStoreCopyToStartAndBlock( Semaphore storeCopyBlockingSemaphore ) throws Exception
+    {
+        assertEventually( "Read replica did not copy files", storeCopyBlockingSemaphore::hasQueuedThreads,
+                is( true ), 60, TimeUnit.SECONDS );
+    }
+}


### PR DESCRIPTION
PR consists of two commits:

* _Raise availability guard when core or read replica copy store_
Instance might be forced to copy store from another instance if it requires to pull a transaction log that has already been pruned away. This could happen when transaction pulling (catch up) experience problems like network outage. Database is not operational during store copy, most components including the datasource are shutdown so no transactions can be served.
However it was possible for users (bolt or embedded) to attempt start new transactions which would hang because of kernel components being stopped. In similar situations availability guard must be raised to block new transactions.
This commit makes `LocalDatabase` raise availability guard when it is stopped. `LocalDatabase` is the component used by cores and read replicas to manage the lifecycle of the datasource. It is restarted during store copying.

 * _Better error message when db stopped for store copy_
This commit improves error message when users (bolt or embedded) try to start a transaction while cluster member is copying store. It is done using a special `AvailabilityRequirement` for the `AvailabilityGuard` when local database is stopped to perform a store copy.