### PR TITLE
Support Top in the compiled runtime

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -300,16 +300,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         TopNPipe(source, sortItems.map(translateSortDescription).toList, buildExpression(limit))(id = id)
 
       case LimitPlan(_, count, DoNotIncludeTies) =>
-        (source, count) match {
-          case (SortPipe(inner, sortDescription), SignedDecimalIntegerLiteral("1")) =>
-            Top1Pipe(inner, sortDescription.toList)(id = id)
-
-          case (SortPipe(inner, sortDescription), _) =>
-            TopNPipe(inner, sortDescription.toList, buildExpression(count))(id = id)
-
-          case _ =>
-            LimitPipe(source, buildExpression(count))(id = id)
-        }
+        LimitPipe(source, buildExpression(count))(id = id)
 
       case LimitPlan(_, count, IncludeTies) =>
         (source, count) match {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -293,6 +293,12 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       case SkipPlan(_, count) =>
         SkipPipe(source, buildExpression(count))(id = id)
 
+      case Top(_, sortItems, SignedDecimalIntegerLiteral("1")) =>
+        Top1Pipe(source, sortItems.map(translateSortDescription).toList)(id = id)
+
+      case Top(_, sortItems, limit) =>
+        TopNPipe(source, sortItems.map(translateSortDescription).toList, buildExpression(limit))(id = id)
+
       case LimitPlan(_, count, DoNotIncludeTies) =>
         (source, count) match {
           case (SortPipe(inner, sortDescription), SignedDecimalIntegerLiteral("1")) =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -249,6 +249,9 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
       case Sort(_, orderBy) =>
         PlanDescriptionImpl(id, "Sort", children, Seq(KeyNames(orderBy.map(_.id.name))), variables)
 
+      case Top(_, orderBy, limit) =>
+        PlanDescriptionImpl(id, "Top", children, Seq(KeyNames(orderBy.map(_.id.name)), Expression(limit)), variables)
+
       case UnwindCollection(_, _, expression) =>
         PlanDescriptionImpl(id, "Unwind", children, Seq(Expression(expression)), variables)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Top.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Top.scala
@@ -1,0 +1,15 @@
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.SortDescription
+import org.neo4j.cypher.internal.compiler.v3_2.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_2.ast.Expression
+import org.neo4j.cypher.internal.ir.v3_2.IdName
+
+case class Top(left: LogicalPlan, sortItems: Seq[SortDescription], limit: Expression)
+              (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with EagerLogicalPlan {
+  override def lhs: Option[LogicalPlan] = Some(left)
+
+  override def rhs: Option[LogicalPlan] = None
+
+  override def availableSymbols: Set[IdName] = left.availableSymbols
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -45,7 +45,8 @@ case class PlanRewriter(rewriterSequencer: String => RewriterStepSequencer) exte
     unnestOptional,
     predicateRemovalThroughJoins,
     removeIdenticalPlans,
-    pruningVarExpander
+    pruningVarExpander,
+    useTop
   ).rewriter)
 }
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/UseTopTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/UseTopTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.v3_2.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Ascending
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
+import org.neo4j.cypher.internal.frontend.v3_2.ast.AstConstructionTestSupport
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+
+class UseTopTest extends CypherFunSuite with LogicalPlanningTestSupport with AstConstructionTestSupport {
+  private val leaf = newMockedLogicalPlan()
+  private val sortDescription = Seq(Ascending("x"))
+  private val sort = Sort(leaf, sortDescription)(solved)
+  private val lit10 = literalInt(10)
+
+  test("should use Top when possible") {
+    val limit = Limit(sort, lit10, DoNotIncludeTies)(solved)
+
+    rewrite(limit) should equal(Top(leaf, sortDescription, lit10)(solved))
+  }
+
+  test("should not use Top when including ties") {
+    val original = Limit(sort, lit10, IncludeTies)(solved)
+
+    rewrite(original) should equal(original)
+  }
+
+  private def rewrite(p: LogicalPlan): LogicalPlan =
+    fixedPoint((p: LogicalPlan) => p.endoRewrite(useTop))(p)
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
@@ -894,8 +894,6 @@ object LdbcQueries {
       Map("personId" -> 3, "commentContent" -> "C12", "commentId" -> 12, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 2, "personFirstName" -> "friend"),
       Map("personId" -> 3, "commentContent" -> "C01", "commentId" -> 10, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"),
       Map("personId" -> 3, "commentContent" -> "C11", "commentId" -> 11, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"))
-
-    override def supportedInCompiledRuntime: Boolean = true
   }
 
   object Query9 extends LdbcQuery {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher
 
-import org.joda.time.{DateTimeZone, DateTime}
+import org.joda.time.{DateTime, DateTimeZone}
 
 /**
  * These are the 14 LDBC stream that runs in the LDBC projects. The stream are (semi-)generated so the idea is rather
@@ -894,6 +894,8 @@ object LdbcQueries {
       Map("personId" -> 3, "commentContent" -> "C12", "commentId" -> 12, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 2, "personFirstName" -> "friend"),
       Map("personId" -> 3, "commentContent" -> "C01", "commentId" -> 10, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"),
       Map("personId" -> 3, "commentContent" -> "C11", "commentId" -> 11, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"))
+
+    override def supportedInCompiledRuntime = true
   }
 
   object Query9 extends LdbcQuery {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -55,3 +55,6 @@ Get node degree via length of pattern expression that specifies a relationship t
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order
 ORDER BY relationships should return null results last in ascending order
+
+//SkipLimitAcceptance.feature - Unsupported limit syntax
+Negative parameter for LIMIT should not generate errors

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -106,3 +106,29 @@ Feature: OrderByAcceptance
       |  4  | 'd' |
 
     And no side effects
+
+  Scenario: ORDER BY two node properties with LIMIT
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:L {a: 3, b: "a"}),
+             (:L {a: 1, b: "b"}),
+             (:L {a: 3, b: "c"}),
+             (:L {a: 4, b: "d"}),
+             (:L {a: 2, b: "e"})
+      """
+    When executing query:
+      """
+      MATCH (n:L)
+      WITH n.a AS a, n.b AS b
+      ORDER BY a, b DESC
+      LIMIT 3
+      RETURN a, b
+      """
+    Then the result should be, in order:
+      |  a  |  b  |
+      |  1  | 'b' |
+      |  2  | 'e' |
+      |  3  | 'c' |
+
+    And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2002-2017 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+Feature: SkipLimitAcceptance.feature
+
+  Background:
+    Given an empty graph
+
+  Scenario: Negative parameter for LIMIT should not generate errors
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | -1 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT $limit
+      """
+    Then the result should be, in order:
+      | name |
+    And no side effects
+
+  Scenario: Negative LIMIT should fail with a syntax exception
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT -1
+      """
+    Then a SyntaxError should be raised at compile time: NegativeIntegerArgument

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -24,10 +24,11 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.aggregation.Ag
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.aggregation.Distinct
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.ExpressionConverter._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions._
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.SortItem
 import org.neo4j.cypher.internal.compiler.v3_2.commands.{ManyQueryExpression, QueryExpression, RangeQueryExpression, SingleQueryExpression}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{One, ZeroOneOrMany}
-import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{SortDescription, plans}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CantCompileQueryException, logical}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.Eagerly.immutableMapValues
@@ -48,6 +49,7 @@ object LogicalPlanConverter {
     case p: NodeHashJoin => nodeHashJoinAsCodeGenPlan(p)
     case p: CartesianProduct => cartesianProductAsCodeGenPlan(p)
     case p: Selection => selectionAsCodeGenPlan(p)
+    case p: Top => topAsCodeGenPlan(p)
     case p: plans.Limit => limitAsCodeGenPlan(p)
     case p: plans.Skip => skipAsCodeGenPlan(p)
     case p: ProduceResult => produceResultsAsCodeGenPlan(p)
@@ -611,28 +613,20 @@ object LogicalPlanConverter {
     override val logicalPlan = sort
 
     override def consume(context: CodeGenContext, child: CodeGenPlan) = {
-      val variablesToKeep = context.getProjectedVariables // TODO: Intersect/replace with usedVariables(innerBlock)
-
-      val sortItems = sort.sortItems.map {
-        case logical.Ascending(IdName(name)) => spi.SortItem(name, spi.Ascending)
-        case logical.Descending(IdName(name)) => spi.SortItem(name, spi.Descending)
-      }
-      val additionalSortVariables = sortItems.collect {
-        case spi.SortItem(name, _) if !variablesToKeep.isDefinedAt(name) => (name, context.getVariable(name))
-      }
-      val tupleVariables = variablesToKeep ++ additionalSortVariables
-
       val opName = context.registerOperator(logicalPlan)
 
-      val sortTableName = context.namer.newVarName()
+      val (variablesToKeep: Map[String, Variable],
+           sortItems: Seq[SortItem],
+           tupleVariables: Map[String, Variable],
+           sortTableName: String) = prepareSortTableInfo(context, sort.sortItems)
 
-      val buildSortTableInstruction = BuildSortTable(opName, sortTableName, tupleVariables, sortItems)(context)
+      val estimatedCardinality = sort.solved.estimatedCardinality.amount
+
+      val buildSortTableInstruction =
+        BuildSortTable(opName, sortTableName, tupleVariables, sortItems, estimatedCardinality)(context)
 
       // Update the context for parent consumers to use the new outgoing variable names
-      buildSortTableInstruction.sortTableInfo.fieldToVariableInfo.foreach {
-        case (_, info) =>
-          context.updateVariable(info.queryVariableName, info.outgoingVariable)
-      }
+      updateContextWithSortTableInfo(context, buildSortTableInstruction.sortTableInfo)
 
       val (methodHandle, innerBlock :: tl) = context.popParent().consume(context, this)
 
@@ -640,6 +634,62 @@ object LogicalPlanConverter {
       val continuation = GetSortedResult(opName, variablesToKeep, buildSortTableInstruction.sortTableInfo, innerBlock)
 
       (methodHandle, buildSortTableInstruction :: sortInstruction :: continuation :: tl)
+    }
+  }
+
+  private def topAsCodeGenPlan(top: Top) = new CodeGenPlan with SingleChildPlan {
+
+    override val logicalPlan = top
+
+    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+      val opName = context.registerOperator(logicalPlan)
+
+      val (variablesToKeep: Map[String, Variable],
+           sortItems: Seq[SortItem],
+           tupleVariables: Map[String, Variable],
+           sortTableName: String) = prepareSortTableInfo(context, top.sortItems)
+
+      val countExpression = createExpression(top.limit)(context)
+
+      val buildTopTableInstruction = BuildTopTable(opName, sortTableName, countExpression, tupleVariables, sortItems)(context)
+
+      // Update the context for parent consumers to use the new outgoing variable names
+      updateContextWithSortTableInfo(context, buildTopTableInstruction.sortTableInfo)
+
+      val (methodHandle, innerBlock :: tl) = context.popParent().consume(context, this)
+
+      val sortInstruction = SortInstruction(opName, buildTopTableInstruction.sortTableInfo)
+      val continuation = GetSortedResult(opName, variablesToKeep, buildTopTableInstruction.sortTableInfo, innerBlock)
+
+      (methodHandle, buildTopTableInstruction :: sortInstruction :: continuation :: tl)
+    }
+  }
+
+  // Helper shared by sortAsCodeGenPlan and topAsCodeGenPlan
+  private def prepareSortTableInfo(context: CodeGenContext, inputSortItems: Seq[SortDescription]):
+    (Map[String, Variable], Seq[SortItem], Map[String, Variable], String) = {
+
+    val variablesToKeep = context.getProjectedVariables // TODO: Intersect/replace with usedVariables(innerBlock)
+
+    val sortItems = inputSortItems.map {
+      case logical.Ascending(IdName(name)) => spi.SortItem(name, spi.Ascending)
+      case logical.Descending(IdName(name)) => spi.SortItem(name, spi.Descending)
+    }
+    val additionalSortVariables = sortItems.collect {
+      case spi.SortItem(name, _) if !variablesToKeep.isDefinedAt(name) => (name, context.getVariable(name))
+    }
+    val tupleVariables = variablesToKeep ++ additionalSortVariables
+
+    val sortTableName = context.namer.newVarName()
+
+    (variablesToKeep, sortItems, tupleVariables, sortTableName)
+  }
+
+  // Helper shared by sortAsCodeGenPlan and topAsCodeGenPlan
+  private def updateContextWithSortTableInfo(context: CodeGenContext, sortTableInfo: SortTableInfo) = {
+    sortTableInfo.fieldToVariableInfo.foreach {
+      case (_, info) =>
+        context.updateVariable(info.queryVariableName, info.outgoingVariable)
     }
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/DecreaseAndReturnWhenZero.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/DecreaseAndReturnWhenZero.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
 
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.CodeGenExpression
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.{Equal, MethodStructure}
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.{LessThanEqual, MethodStructure}
 
 case class DecreaseAndReturnWhenZero(opName: String, variableName: String, action: Instruction, startValue: CodeGenExpression)
   extends Instruction {
@@ -30,7 +30,7 @@ case class DecreaseAndReturnWhenZero(opName: String, variableName: String, actio
     startValue.init(generator)
     val expression = generator.box(startValue.generateExpression(generator))
     generator.declareCounter(variableName, expression)
-    generator.ifStatement(generator.checkInteger(variableName, Equal, 0L)) { onTrue =>
+    generator.ifStatement(generator.checkInteger(variableName, LessThanEqual, 0L)) { onTrue =>
       onTrue.returnSuccessfully()
     }
     action.init(generator)
@@ -42,7 +42,7 @@ case class DecreaseAndReturnWhenZero(opName: String, variableName: String, actio
     generator.trace(opName) { l1 =>
       l1.incrementRows()
       l1.decrementInteger(variableName)
-      l1.ifStatement(l1.checkInteger(variableName, Equal, 0L)) { l2 =>
+      l1.ifStatement(l1.checkInteger(variableName, LessThanEqual, 0L)) { l2 =>
         l2.returnSuccessfully()
       }
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/GetSortedResult.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/GetSortedResult.scala
@@ -36,7 +36,7 @@ case class GetSortedResult(opName: String,
         case (_, FieldAndVariableInfo(fieldName, queryVariableName, incoming, outgoing))
           if variablesToKeep.isDefinedAt(queryVariableName) => (outgoing.name, fieldName)
       }
-      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.tupleDescriptor, variablesToGetFromFields) { l2 =>
+      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.tableDescriptor, variablesToGetFromFields) { l2 =>
         l2.incrementRows()
         action.body(l2)
       }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -86,10 +86,10 @@ trait MethodStructure[E] {
   def newMapOfSets(name: String, keyTypes: IndexedSeq[CodeGenType], elementType: CodeGenType)
   def checkDistinct(name: String, key: Map[String,(CodeGenType, E)], keyVar: String, value: E, valueType: CodeGenType)(block: MethodStructure[E] => Unit)
 
-  def allocateSortTable(name: String, initialCapacity: Int, tupleDescriptor: OrderableTupleDescriptor): Unit
-  def sortTableAdd(name: String, tupleDescriptor: OrderableTupleDescriptor, value: E): Unit
-  def sortTableSort(name: String, tupleDescriptor: OrderableTupleDescriptor): Unit
-  def sortTableIterate(name: String, tupleDescriptor: OrderableTupleDescriptor,
+  def allocateSortTable(name: String, tableDescriptor: SortTableDescriptor, count: E): Unit
+  def sortTableAdd(name: String, tableDescriptor: SortTableDescriptor, value: E): Unit
+  def sortTableSort(name: String, tableDescriptor: SortTableDescriptor): Unit
+  def sortTableIterate(name: String, tableDescriptor: SortTableDescriptor,
                        varNameToField: Map[String, String])
                       (block: (MethodStructure[E]) => Unit): Unit
 
@@ -222,3 +222,10 @@ case class SimpleTupleDescriptor(structure: Map[String, CodeGenType]) extends Tu
 case class HashableTupleDescriptor(structure: Map[String, CodeGenType]) extends TupleDescriptor
 case class OrderableTupleDescriptor(structure: Map[String, CodeGenType],
                                     sortItems: Iterable[SortItem]) extends TupleDescriptor
+
+sealed trait SortTableDescriptor {
+  val tupleDescriptor: TupleDescriptor
+}
+
+case class FullSortTableDescriptor(tupleDescriptor: OrderableTupleDescriptor) extends SortTableDescriptor
+case class TopTableDescriptor(tupleDescriptor: OrderableTupleDescriptor) extends SortTableDescriptor

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.ArrayList;
+
+/**
+ * The default implementation of a table used for a full sort by the generated code
+ *
+ * It accepts tuples as boxed objects that implements Comparable
+ *
+ * Implements the following interface:
+ * (since the code is generated it does not actually need to declare it with implements)
+ *
+ * public interface SortTable<T extends Comparable<?>>
+ * {
+ *     boolean add( T e );
+ *
+ *     void sort();
+ *
+ *     Iterator<T> iterator();
+ * }
+ *
+ * This implementation just adapts Java's standard ArrayList
+ */
+public class DefaultFullSortTable<T extends Comparable<?>> extends ArrayList<T> // implements SortTable<T>
+{
+    public DefaultFullSortTable( int initialCapacity )
+    {
+        super( initialCapacity );
+    }
+
+    public void sort()
+    {
+        // Sort using the default array sort implementation (currently ComparableTimSort)
+        sort( null );
+    }
+}

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+
+/**
+ * The default implementation of a Top N table used by the generated code
+ *
+ * It accepts tuples as boxed objects that implements Comparable
+ *
+ * Implements the following interface:
+ * (since the code is generated it does not actually need to declare it with implements)
+ *
+ * public interface SortTable<T extends Comparable<?>>
+ * {
+ *     boolean add( T e );
+ *
+ *     void sort();
+ *
+ *     Iterator<T> iterator();
+ * }
+ *
+ * Uses a max heap (Java's standard PriorityQueue) to collect a maximum of totalCount tuples in reverse order.
+ * When sort() is called it collects them in reverse sorted order into an array.
+ * The iterator() then traverses this array backwards.
+ */
+public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T> // implements SortTable<T>
+{
+    private int totalCount;
+    private PriorityQueue<Object> heap;
+    private Object[] array; // TODO: Use Guava's MinMaxPriorityQueue to avoid having this array
+
+    public DefaultTopTable( int totalCount )
+    {
+        this.totalCount = totalCount;
+
+        heap = new PriorityQueue<>( totalCount, Collections.reverseOrder() );
+        array = new Object[ totalCount ];
+    }
+
+    @SuppressWarnings( "unchecked" )
+    // Because of an issue with getting the same runtime-types with generics and byte code generation we use Object for now
+    public boolean add( Object e )
+    {
+        if ( heap.size() < totalCount )
+        {
+            return heap.offer( e );
+        }
+        else
+        {
+            T head = (T) heap.peek();
+            if ( head.compareTo( e ) > 0 )
+            {
+                heap.poll();
+                return heap.offer( e );
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+    public void sort()
+    {
+        // We keep the values in reverse order so that we can write from start to end
+        for ( int i = 0; i < this.totalCount; i++ )
+        {
+            array[i] = heap.poll();
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new Iterator<T>()
+        {
+            private int cursor = totalCount;
+
+            @Override
+            public boolean hasNext()
+            {
+                return cursor > 0;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public T next()
+            {
+                return (T) array[--cursor];
+            }
+        };
+    }
+}

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
@@ -52,6 +52,10 @@ public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T
 
     public DefaultTopTable( int totalCount )
     {
+        if ( totalCount <= 0 )
+        {
+            throw new IllegalArgumentException( "Top table size must be greater than 0" );
+        }
         this.totalCount = totalCount;
 
         heap = new PriorityQueue<>( totalCount, Collections.reverseOrder() );

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
@@ -47,6 +47,7 @@ import java.util.PriorityQueue;
 public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T> // implements SortTable<T>
 {
     private int totalCount;
+    private int count = -1;
     private PriorityQueue<Object> heap;
     private Object[] array; // TODO: Use Guava's MinMaxPriorityQueue to avoid having this array
 
@@ -87,8 +88,10 @@ public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T
 
     public void sort()
     {
+        count = heap.size();
+
         // We keep the values in reverse order so that we can write from start to end
-        for ( int i = 0; i < this.totalCount; i++ )
+        for ( int i = 0; i < count; i++ )
         {
             array[i] = heap.poll();
         }
@@ -97,9 +100,14 @@ public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T
     @Override
     public Iterator<T> iterator()
     {
+        if ( count == -1 )
+        {
+            // This should never happen in generated code but is here to simplify debugging if used incorrectly
+            throw new IllegalStateException( "sort() needs to be called before requesting an iterator" );
+        }
         return new Iterator<T>()
         {
-            private int cursor = totalCount;
+            private int cursor = count;
 
             @Override
             public boolean hasNext()

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
@@ -17,25 +17,39 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
+package org.neo4j.cypher.internal.codegen;
 
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
+import org.junit.Test;
 
-case class SortInstruction(opName: String,
-                           sortTableInfo: SortTableInfo)
-  extends Instruction {
+import java.util.Iterator;
 
-  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-  }
+import static org.junit.Assert.*;
 
-  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
-      body.sortTableSort(sortTableInfo.tableName, sortTableInfo.tableDescriptor)
+public class DefaultTopTableTest
+{
+    private static Long[] testValues = new Long[] {
+        7L, 4L, 5L, 0L, 3L, 4L, 8L, 6L, 1L, 9L, 2L
+    };
+
+    @Test
+    public void shouldOrderValuesCorrectly()
+    {
+        DefaultTopTable table = new DefaultTopTable( 5 );
+        for ( Long i : testValues )
+        {
+            table.add( i );
+        }
+
+        table.sort();
+
+        Iterator<Object> iterator = table.iterator();
+
+        for ( int i = 0; i < 5; i++ )
+        {
+            assertTrue( iterator.hasNext() );
+            long value = (long) iterator.next();
+            assertEquals( i, value );
+        }
+        assertFalse( iterator.hasNext() );
     }
-  }
-
-  override protected def children: Seq[Instruction] = Seq.empty
-
-  override protected def operatorId = Set(opName)
 }


### PR DESCRIPTION
`Top` used to be a physical operator before this change. 

Since we will have the same operator on both runtimes, moving the decision to use it to the logical plan stage saves us from duplicating this when creating the physical operators.