### PR TITLE
Support Top N in the compiled runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OrderByAcceptance.feature
@@ -106,3 +106,29 @@ Feature: OrderByAcceptance
       |  4  | 'd' |
 
     And no side effects
+
+  Scenario: ORDER BY two node properties with LIMIT
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:L {a: 3, b: "a"}),
+             (:L {a: 1, b: "b"}),
+             (:L {a: 3, b: "c"}),
+             (:L {a: 4, b: "d"}),
+             (:L {a: 2, b: "e"})
+      """
+    When executing query:
+      """
+      MATCH (n:L)
+      WITH n.a AS a, n.b AS b
+      ORDER BY a, b DESC
+      LIMIT 3
+      RETURN a, b
+      """
+    Then the result should be, in order:
+      |  a  |  b  |
+      |  1  | 'b' |
+      |  2  | 'e' |
+      |  3  | 'c' |
+
+    And no side effects

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.aggregation.Ag
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.aggregation.Distinct
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.ExpressionConverter._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions._
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.SortItem
 import org.neo4j.cypher.internal.compiler.v3_2.commands.{ManyQueryExpression, QueryExpression, RangeQueryExpression, SingleQueryExpression}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{One, ZeroOneOrMany}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans
@@ -48,6 +49,7 @@ object LogicalPlanConverter {
     case p: NodeHashJoin => nodeHashJoinAsCodeGenPlan(p)
     case p: CartesianProduct => cartesianProductAsCodeGenPlan(p)
     case p: Selection => selectionAsCodeGenPlan(p)
+    case limit@plans.Limit(sort@Sort(_, _), _, _) => topAsCodeGenPlan(sort, limit)
     case p: plans.Limit => limitAsCodeGenPlan(p)
     case p: plans.Skip => skipAsCodeGenPlan(p)
     case p: ProduceResult => produceResultsAsCodeGenPlan(p)
@@ -611,28 +613,20 @@ object LogicalPlanConverter {
     override val logicalPlan = sort
 
     override def consume(context: CodeGenContext, child: CodeGenPlan) = {
-      val variablesToKeep = context.getProjectedVariables // TODO: Intersect/replace with usedVariables(innerBlock)
-
-      val sortItems = sort.sortItems.map {
-        case logical.Ascending(IdName(name)) => spi.SortItem(name, spi.Ascending)
-        case logical.Descending(IdName(name)) => spi.SortItem(name, spi.Descending)
-      }
-      val additionalSortVariables = sortItems.collect {
-        case spi.SortItem(name, _) if !variablesToKeep.isDefinedAt(name) => (name, context.getVariable(name))
-      }
-      val tupleVariables = variablesToKeep ++ additionalSortVariables
-
       val opName = context.registerOperator(logicalPlan)
 
-      val sortTableName = context.namer.newVarName()
+      val (variablesToKeep: Map[String, Variable],
+           sortItems: Seq[SortItem],
+           tupleVariables: Map[String, Variable],
+           sortTableName: String) = prepareSortTableInfo(context, sort)
 
-      val buildSortTableInstruction = BuildSortTable(opName, sortTableName, tupleVariables, sortItems)(context)
+      val estimatedCardinality = sort.solved.estimatedCardinality.amount
+
+      val buildSortTableInstruction =
+        BuildSortTable(opName, sortTableName, tupleVariables, sortItems, estimatedCardinality)(context)
 
       // Update the context for parent consumers to use the new outgoing variable names
-      buildSortTableInstruction.sortTableInfo.fieldToVariableInfo.foreach {
-        case (_, info) =>
-          context.updateVariable(info.queryVariableName, info.outgoingVariable)
-      }
+      updateContextWithSortTableInfo(context, buildSortTableInstruction.sortTableInfo)
 
       val (methodHandle, innerBlock :: tl) = context.popParent().consume(context, this)
 
@@ -640,6 +634,62 @@ object LogicalPlanConverter {
       val continuation = GetSortedResult(opName, variablesToKeep, buildSortTableInstruction.sortTableInfo, innerBlock)
 
       (methodHandle, buildSortTableInstruction :: sortInstruction :: continuation :: tl)
+    }
+  }
+
+  private def topAsCodeGenPlan(sort: plans.Sort, limit: plans.Limit) = new CodeGenPlan with SingleChildPlan {
+
+    override val logicalPlan = sort // TODO: Reintroduce a logical plan Top instead
+
+    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+      val opName = context.registerOperator(logicalPlan)
+
+      val (variablesToKeep: Map[String, Variable],
+           sortItems: Seq[SortItem],
+           tupleVariables: Map[String, Variable],
+           sortTableName: String) = prepareSortTableInfo(context, sort)
+
+      val countExpression = createExpression(limit.count)(context)
+
+      val buildTopTableInstruction = BuildTopTable(opName, sortTableName, countExpression, tupleVariables, sortItems)(context)
+
+      // Update the context for parent consumers to use the new outgoing variable names
+      updateContextWithSortTableInfo(context, buildTopTableInstruction.sortTableInfo)
+
+      val (methodHandle, innerBlock :: tl) = context.popParent().consume(context, this)
+
+      val sortInstruction = SortInstruction(opName, buildTopTableInstruction.sortTableInfo)
+      val continuation = GetSortedResult(opName, variablesToKeep, buildTopTableInstruction.sortTableInfo, innerBlock)
+
+      (methodHandle, buildTopTableInstruction :: sortInstruction :: continuation :: tl)
+    }
+  }
+
+  // Helper shared by sortAsCodeGenPlan and topAsCodeGenPlan
+  private def prepareSortTableInfo(context: CodeGenContext, sort: Sort):
+    (Map[String, Variable], Seq[SortItem], Map[String, Variable], String) = {
+
+    val variablesToKeep = context.getProjectedVariables // TODO: Intersect/replace with usedVariables(innerBlock)
+
+    val sortItems = sort.sortItems.map {
+      case logical.Ascending(IdName(name)) => spi.SortItem(name, spi.Ascending)
+      case logical.Descending(IdName(name)) => spi.SortItem(name, spi.Descending)
+    }
+    val additionalSortVariables = sortItems.collect {
+      case spi.SortItem(name, _) if !variablesToKeep.isDefinedAt(name) => (name, context.getVariable(name))
+    }
+    val tupleVariables = variablesToKeep ++ additionalSortVariables
+
+    val sortTableName = context.namer.newVarName()
+
+    (variablesToKeep, sortItems, tupleVariables, sortTableName)
+  }
+
+  // Helper shared by sortAsCodeGenPlan and topAsCodeGenPlan
+  private def updateContextWithSortTableInfo(context: CodeGenContext, sortTableInfo: SortTableInfo) = {
+    sortTableInfo.fieldToVariableInfo.foreach {
+      case (_, info) =>
+        context.updateVariable(info.queryVariableName, info.outgoingVariable)
     }
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/GetSortedResult.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/GetSortedResult.scala
@@ -36,7 +36,7 @@ case class GetSortedResult(opName: String,
         case (_, FieldAndVariableInfo(fieldName, queryVariableName, incoming, outgoing))
           if variablesToKeep.isDefinedAt(queryVariableName) => (outgoing.name, fieldName)
       }
-      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.tupleDescriptor, variablesToGetFromFields) { l2 =>
+      l1.sortTableIterate(sortTableInfo.tableName, sortTableInfo.tableDescriptor, variablesToGetFromFields) { l2 =>
         l2.incrementRows()
         action.body(l2)
       }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -86,10 +86,10 @@ trait MethodStructure[E] {
   def newMapOfSets(name: String, keyTypes: IndexedSeq[CodeGenType], elementType: CodeGenType)
   def checkDistinct(name: String, key: Map[String,(CodeGenType, E)], keyVar: String, value: E, valueType: CodeGenType)(block: MethodStructure[E] => Unit)
 
-  def allocateSortTable(name: String, initialCapacity: Int, tupleDescriptor: OrderableTupleDescriptor): Unit
-  def sortTableAdd(name: String, tupleDescriptor: OrderableTupleDescriptor, value: E): Unit
-  def sortTableSort(name: String, tupleDescriptor: OrderableTupleDescriptor): Unit
-  def sortTableIterate(name: String, tupleDescriptor: OrderableTupleDescriptor,
+  def allocateSortTable(name: String, tableDescriptor: SortTableDescriptor, count: E): Unit
+  def sortTableAdd(name: String, tableDescriptor: SortTableDescriptor, value: E): Unit
+  def sortTableSort(name: String, tableDescriptor: SortTableDescriptor): Unit
+  def sortTableIterate(name: String, tableDescriptor: SortTableDescriptor,
                        varNameToField: Map[String, String])
                       (block: (MethodStructure[E]) => Unit): Unit
 
@@ -222,3 +222,10 @@ case class SimpleTupleDescriptor(structure: Map[String, CodeGenType]) extends Tu
 case class HashableTupleDescriptor(structure: Map[String, CodeGenType]) extends TupleDescriptor
 case class OrderableTupleDescriptor(structure: Map[String, CodeGenType],
                                     sortItems: Iterable[SortItem]) extends TupleDescriptor
+
+sealed trait SortTableDescriptor {
+  val tupleDescriptor: TupleDescriptor
+}
+
+case class FullSortTableDescriptor(tupleDescriptor: OrderableTupleDescriptor) extends SortTableDescriptor
+case class TopTableDescriptor(tupleDescriptor: OrderableTupleDescriptor) extends SortTableDescriptor

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultFullSortTable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.ArrayList;
+
+/**
+ * The default implementation of a table used for a full sort by the generated code
+ *
+ * It accepts tuples as boxed objects that implements Comparable
+ *
+ * Implements the following interface:
+ * (since the code is generated it does not actually need to declare it with implements)
+ *
+ * public interface SortTable<T extends Comparable<?>>
+ * {
+ *     boolean add( T e );
+ *
+ *     void sort();
+ *
+ *     Iterator<T> iterator();
+ * }
+ *
+ * This implementation just adapts Java's standard ArrayList
+ */
+public class DefaultFullSortTable<T extends Comparable<?>> extends ArrayList<T> // implements SortTable<T>
+{
+    public DefaultFullSortTable( int initialCapacity )
+    {
+        super( initialCapacity );
+    }
+
+    public void sort()
+    {
+        // Sort using the default array sort implementation (currently ComparableTimSort)
+        sort( null );
+    }
+}

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/DefaultTopTable.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+
+/**
+ * The default implementation of a Top N table used by the generated code
+ *
+ * It accepts tuples as boxed objects that implements Comparable
+ *
+ * Implements the following interface:
+ * (since the code is generated it does not actually need to declare it with implements)
+ *
+ * public interface SortTable<T extends Comparable<?>>
+ * {
+ *     boolean add( T e );
+ *
+ *     void sort();
+ *
+ *     Iterator<T> iterator();
+ * }
+ *
+ * Uses a max heap (Java's standard PriorityQueue) to collect a maximum of totalCount tuples in reverse order.
+ * When sort() is called it collects them in reverse sorted order into an array.
+ * The iterator() then traverses this array backwards.
+ */
+public class DefaultTopTable<T extends Comparable<Object>> implements Iterable<T> // implements SortTable<T>
+{
+    private int totalCount;
+    private PriorityQueue<Object> heap;
+    private Object[] array; // TODO: Use Guava's MinMaxPriorityQueue to avoid having this array
+
+    public DefaultTopTable( int totalCount )
+    {
+        this.totalCount = totalCount;
+
+        heap = new PriorityQueue<>( totalCount, Collections.reverseOrder() );
+        array = new Object[ totalCount ];
+    }
+
+    @SuppressWarnings( "unchecked" )
+    // Because of an issue with getting the same runtime-types with generics and byte code generation we use Object for now
+    public boolean add( Object e )
+    {
+        if ( heap.size() < totalCount )
+        {
+            return heap.offer( e );
+        }
+        else
+        {
+            T head = (T) heap.peek();
+            if ( head.compareTo( e ) > 0 )
+            {
+                heap.poll();
+                return heap.offer( e );
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+    public void sort()
+    {
+        // We keep the values in reverse order so that we can write from start to end
+        for ( int i = 0; i < this.totalCount; i++ )
+        {
+            array[i] = heap.poll();
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new Iterator<T>()
+        {
+            private int cursor = totalCount;
+
+            @Override
+            public boolean hasNext()
+            {
+                return cursor > 0;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public T next()
+            {
+                return (T) array[--cursor];
+            }
+        };
+    }
+}

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/DefaultTopTableTest.java
@@ -17,25 +17,39 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
+package org.neo4j.cypher.internal.codegen;
 
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
+import org.junit.Test;
 
-case class SortInstruction(opName: String,
-                           sortTableInfo: SortTableInfo)
-  extends Instruction {
+import java.util.Iterator;
 
-  override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-  }
+import static org.junit.Assert.*;
 
-  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.trace(opName, Some(this.getClass.getSimpleName)) { body =>
-      body.sortTableSort(sortTableInfo.tableName, sortTableInfo.tableDescriptor)
+public class DefaultTopTableTest
+{
+    private static Long[] testValues = new Long[] {
+        7L, 4L, 5L, 0L, 3L, 4L, 8L, 6L, 1L, 9L, 2L
+    };
+
+    @Test
+    public void shouldOrderValuesCorrectly()
+    {
+        DefaultTopTable table = new DefaultTopTable( 5 );
+        for ( Long i : testValues )
+        {
+            table.add( i );
+        }
+
+        table.sort();
+
+        Iterator<Object> iterator = table.iterator();
+
+        for ( int i = 0; i < 5; i++ )
+        {
+            assertTrue( iterator.hasNext() );
+            long value = (long) iterator.next();
+            assertEquals( i, value );
+        }
+        assertFalse( iterator.hasNext() );
     }
-  }
-
-  override protected def children: Seq[Instruction] = Seq.empty
-
-  override protected def operatorId = Set(opName)
 }


### PR DESCRIPTION
Adds specialized support for the combination of ORDER BY and LIMIT that
only needs to keep the LIMIT number of rows sorted (also known as Top).

Also uses estimated cardinality for initial size of full sort table.