### PR TITLE
Fix bug with combined aggregation and sorting

### DIFF
--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/aggregation/AggregationConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/aggregation/AggregationConverter.scala
@@ -33,6 +33,7 @@ object AggregationConverter {
   def aggregateExpressionConverter(opName: String, groupingVariables: Iterable[Variable], name: String, e: ast.Expression) (implicit context: CodeGenContext): AggregateExpression = {
     val variable = Variable(context.namer.newVarName(), CodeGenType.primitiveInt)
     context.addVariable(name, variable)
+    context.addProjectedVariable(name, variable)
     e match {
       case func: ast.FunctionInvocation => func.function match {
         case ast.functions.Count if groupingVariables.isEmpty =>


### PR DESCRIPTION
Fixes bug in compiled runtime with combined aggregation and sorting related
to the tracking of projected variables in the context.
Aggregation should only retain any grouping variables, and project
the aggregation variables that it introduces, so that Sort can pick up the
correct set of available variables from the context.