### PR TITLE
Fixed tests that were passing as a side effect of planner ordering

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
@@ -243,7 +243,11 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     case (_: AllNodesScan, _) => 1000.0
     case (_: NodeByLabelScan, _) => 50.0
     case (_: NodeIndexScan, _) => 10.0
-    case (_: NodeIndexSeek, _) => 1.0
+    case (nodeIndexSeek: NodeIndexSeek, _) =>
+      val planCardinality = nodeIndexSeek.solved.estimatedCardinality.amount
+      val rowCost = 1.0
+      val costForThisPlan = rowCost * planCardinality / 1000.0
+      costForThisPlan
     case (Selection(_, plan), input) => nodeIndexScanCost((plan, input))
     case _ => Double.MaxValue
   }


### PR DESCRIPTION
Fixed tests that were passing as a side effect of planner ordering, not actual cost comparisons. In later versions of Neo4j, notably 3.2, enhancements to the planner changed the generation order of plans to consider, and caused these tests to fail. It seems reasonable to fix this as far back as 2.3 so that they do not complicate any potential bug-fixing that might affect planner ordering.