### PR TITLE
Raise availability guard when core or read replica copy store

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -161,7 +161,7 @@ public class CatchUpClient extends LifecycleAdapter
     }
 
     @Override
-    public void stop() throws Throwable
+    public void stop()
     {
         log.info( "CatchUpClient stopping" );
         try

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -46,7 +46,10 @@ import static org.neo4j.kernel.AvailabilityGuard.availabilityRequirement;
 
 public class LocalDatabase implements Lifecycle
 {
-    private static final AvailabilityRequirement NOT_STOPPED = availabilityRequirement( "Database is stopped" );
+    private static final AvailabilityRequirement NOT_STOPPED =
+            availabilityRequirement( "Database is stopped" );
+    private static final AvailabilityRequirement NOT_COPYING_STORE =
+            availabilityRequirement( "Database is stopped to copy store from another cluster member" );
 
     private final File storeDir;
 
@@ -60,7 +63,7 @@ public class LocalDatabase implements Lifecycle
 
     private volatile StoreId storeId;
     private volatile DatabaseHealth databaseHealth;
-    private boolean started = false;
+    private AvailabilityRequirement currentRequirement;
 
     private volatile TransactionCommitProcess localCommit;
 
@@ -79,7 +82,7 @@ public class LocalDatabase implements Lifecycle
         this.availabilityGuard = availabilityGuard;
         this.log = logProvider.getLog( getClass() );
 
-        raiseAvailabilityGuard();
+        raiseAvailabilityGuard( NOT_STOPPED );
     }
 
     @Override
@@ -97,24 +100,28 @@ public class LocalDatabase implements Lifecycle
         dataSourceManager.start();
 
         dropAvailabilityGuard();
-        started = true;
     }
 
     @Override
-    public synchronized void stop() throws Throwable
+    public void stop() throws Throwable
     {
-        log.info( "Stopping" );
-        databaseHealth = null;
-        localCommit = null;
-        dataSourceManager.stop();
+        stopWithRequirement( NOT_STOPPED );
+    }
 
-        raiseAvailabilityGuard();
-        started = false;
+    /**
+     * Stop database to perform a store copy. This will raise {@link AvailabilityGuard} with
+     * a more friendly blocking requirement.
+     *
+     * @throws Throwable if any of the components are unable to stop.
+     */
+    public void stopForStoreCopy() throws Throwable
+    {
+        stopWithRequirement( NOT_COPYING_STORE );
     }
 
     public boolean isAvailable()
     {
-        return started;
+        return currentRequirement == null;
     }
 
     @Override
@@ -125,7 +132,7 @@ public class LocalDatabase implements Lifecycle
 
     public synchronized StoreId storeId()
     {
-        if ( started )
+        if ( isAvailable() )
         {
             return storeId;
         }
@@ -226,13 +233,31 @@ public class LocalDatabase implements Lifecycle
         return localCommit;
     }
 
-    private void raiseAvailabilityGuard()
+    private synchronized void stopWithRequirement( AvailabilityRequirement requirement ) throws Throwable
     {
-        availabilityGuard.require( NOT_STOPPED );
+        log.info( "Stopping, reason: " + requirement.description() );
+        databaseHealth = null;
+        localCommit = null;
+        dataSourceManager.stop();
+
+        raiseAvailabilityGuard( requirement );
+    }
+
+    private void raiseAvailabilityGuard( AvailabilityRequirement requirement )
+    {
+        // it is possible for the local database to be created and stopped right after that to perform a store copy
+        // in this case we need to impose new requirement and drop the old one
+        availabilityGuard.require( requirement );
+        if ( currentRequirement != null )
+        {
+            dropAvailabilityGuard();
+        }
+        currentRequirement = requirement;
     }
 
     private void dropAvailabilityGuard()
     {
-        availabilityGuard.fulfill( NOT_STOPPED );
+        availabilityGuard.fulfill( currentRequirement );
+        currentRequirement = null;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -236,11 +236,10 @@ public class LocalDatabase implements Lifecycle
     private synchronized void stopWithRequirement( AvailabilityRequirement requirement ) throws Throwable
     {
         log.info( "Stopping, reason: " + requirement.description() );
+        raiseAvailabilityGuard( requirement );
         databaseHealth = null;
         localCommit = null;
         dataSourceManager.stop();
-
-        raiseAvailabilityGuard( requirement );
     }
 
     private void raiseAvailabilityGuard( AvailabilityRequirement requirement )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -63,7 +63,7 @@ public class LocalDatabase implements Lifecycle
 
     private volatile StoreId storeId;
     private volatile DatabaseHealth databaseHealth;
-    private AvailabilityRequirement currentRequirement;
+    private volatile AvailabilityRequirement currentRequirement;
 
     private volatile TransactionCommitProcess localCommit;
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -305,7 +305,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
     {
         try
         {
-            localDatabase.stop();
+            localDatabase.stopForStoreCopy();
             startStopOnStoreCopy.stop();
         }
         catch ( Throwable throwable )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -146,7 +146,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
 
         LocalDatabase localDatabase = new LocalDatabase( platformModule.storeDir, new StoreFiles( fileSystem ),
                 platformModule.dataSourceManager, platformModule.pageCache, fileSystem, databaseHealthSupplier,
-                logProvider );
+                platformModule.availabilityGuard, logProvider );
 
         IdentityModule identityModule = new IdentityModule( platformModule, clusterStateDirectory.get() );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -83,7 +83,7 @@ public class CoreStateDownloader
             }
 
             startStopOnStoreCopy.stop();
-            localDatabase.stop();
+            localDatabase.stopForStoreCopy();
 
             log.info( "Downloading snapshot from core server at %s", source );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -28,9 +28,9 @@ import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.storecopy.CopiedStoreRecovery;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
+import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyClient;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
-import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreFiles;
 import org.neo4j.causalclustering.catchup.tx.BatchingTxApplier;
 import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
@@ -38,10 +38,10 @@ import org.neo4j.causalclustering.catchup.tx.TransactionLogCatchUpFactory;
 import org.neo4j.causalclustering.catchup.tx.TxPullClient;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.consensus.schedule.DelayedRenewableTimeoutService;
-import org.neo4j.causalclustering.helper.ExponentialBackoffStrategy;
 import org.neo4j.causalclustering.discovery.DiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.discovery.procedures.ReadReplicaRoleProcedure;
+import org.neo4j.causalclustering.helper.ExponentialBackoffStrategy;
 import org.neo4j.causalclustering.messaging.routing.ConnectToRandomCoreMember;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -200,6 +200,7 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
                 pageCache,
                 fileSystem,
                 databaseHealthSupplier,
+                platformModule.availabilityGuard,
                 logProvider );
 
         RemoteStore remoteStore = new RemoteStore( platformModule.logging.getInternalLogProvider(),

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import java.io.File;
 import java.time.Clock;
@@ -37,8 +38,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 public class LocalDatabaseTest
 {
@@ -98,9 +102,45 @@ public class LocalDatabaseTest
         assertDatabaseIsStoppedForStoreCopyAndUnavailable( guard );
     }
 
+    @Test
+    public void availabilityGuardRaisedBeforeDataSourceManagerIsStopped() throws Throwable
+    {
+        AvailabilityGuard guard = mock( AvailabilityGuard.class );
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard, dataSourceManager );
+        localDatabase.stop();
+
+        InOrder inOrder = inOrder( guard, dataSourceManager );
+        // guard should be raised twice - once during construction and once during stop
+        inOrder.verify( guard, times( 2 ) ).require( any() );
+        inOrder.verify( dataSourceManager ).stop();
+    }
+
+    @Test
+    public void availabilityGuardRaisedBeforeDataSourceManagerIsStoppedForStoreCopy() throws Throwable
+    {
+        AvailabilityGuard guard = mock( AvailabilityGuard.class );
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard, dataSourceManager );
+        localDatabase.stopForStoreCopy();
+
+        InOrder inOrder = inOrder( guard, dataSourceManager );
+        // guard should be raised twice - once during construction and once during stop
+        inOrder.verify( guard, times( 2 ) ).require( any() );
+        inOrder.verify( dataSourceManager ).stop();
+    }
+
     private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
     {
-        return new LocalDatabase( new File( "." ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
+        return newLocalDatabase( availabilityGuard, mock( DataSourceManager.class ) );
+    }
+
+    private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard,
+            DataSourceManager dataSourceManager )
+    {
+        return new LocalDatabase( new File( "." ), mock( StoreFiles.class ), dataSourceManager,
                 mock( PageCache.class, RETURNS_MOCKS ), mock( FileSystemAbstraction.class ),
                 () -> mock( DatabaseHealth.class ), availabilityGuard, NullLogProvider.getInstance() );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 
 public class LocalDatabaseTest
@@ -99,9 +100,9 @@ public class LocalDatabaseTest
 
     private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
     {
-        return new LocalDatabase( mock( File.class ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
-                mock( PageCache.class ), mock( FileSystemAbstraction.class ), () -> mock( DatabaseHealth.class ),
-                availabilityGuard, NullLogProvider.getInstance() );
+        return new LocalDatabase( new File( "." ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
+                mock( PageCache.class, RETURNS_MOCKS ), mock( FileSystemAbstraction.class ),
+                () -> mock( DatabaseHealth.class ), availabilityGuard, NullLogProvider.getInstance() );
     }
 
     private static AvailabilityGuard newAvailabilityGuard()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -81,6 +81,22 @@ public class LocalDatabaseTest
         assertDatabaseIsStoppedAndUnavailable( guard );
     }
 
+    @Test
+    public void availabilityGuardRaisedOnStopForStoreCopy() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+
+        localDatabase.stopForStoreCopy();
+        assertDatabaseIsStoppedForStoreCopyAndUnavailable( guard );
+    }
+
     private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
     {
         return new LocalDatabase( mock( File.class ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
@@ -97,5 +113,11 @@ public class LocalDatabaseTest
     {
         assertFalse( guard.isAvailable() );
         assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped" ) );
+    }
+
+    private static void assertDatabaseIsStoppedForStoreCopyAndUnavailable( AvailabilityGuard guard )
+    {
+        assertFalse( guard.isAvailable() );
+        assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped to copy store" ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.catchup.storecopy;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.time.Clock;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+import org.neo4j.kernel.internal.DatabaseHealth;
+import org.neo4j.logging.NullLog;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class LocalDatabaseTest
+{
+    @Test
+    public void availabilityGuardRaisedOnCreation() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+
+        assertNotNull( localDatabase );
+        assertDatabaseIsStoppedAndUnavailable( guard );
+    }
+
+    @Test
+    public void availabilityGuardDroppedOnStart() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+    }
+
+    @Test
+    public void availabilityGuardRaisedOnStop() throws Throwable
+    {
+        AvailabilityGuard guard = newAvailabilityGuard();
+        assertTrue( guard.isAvailable() );
+
+        LocalDatabase localDatabase = newLocalDatabase( guard );
+        assertFalse( guard.isAvailable() );
+
+        localDatabase.start();
+        assertTrue( guard.isAvailable() );
+
+        localDatabase.stop();
+        assertDatabaseIsStoppedAndUnavailable( guard );
+    }
+
+    private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard )
+    {
+        return new LocalDatabase( mock( File.class ), mock( StoreFiles.class ), mock( DataSourceManager.class ),
+                mock( PageCache.class ), mock( FileSystemAbstraction.class ), () -> mock( DatabaseHealth.class ),
+                availabilityGuard, NullLogProvider.getInstance() );
+    }
+
+    private static AvailabilityGuard newAvailabilityGuard()
+    {
+        return new AvailabilityGuard( Clock.systemUTC(), NullLog.getInstance() );
+    }
+
+    private static void assertDatabaseIsStoppedAndUnavailable( AvailabilityGuard guard )
+    {
+        assertFalse( guard.isAvailable() );
+        assertThat( guard.describeWhoIsBlocking(), containsString( "Database is stopped" ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcessTest.java
@@ -170,7 +170,7 @@ public class CatchupPollingProcessTest
         timeoutService.invokeTimeout( TX_PULLER_TIMEOUT );
 
         // then
-        verify( localDatabase ).stop();
+        verify( localDatabase ).stopForStoreCopy();
         verify( startStopOnStoreCopy ).stop();
         verify( storeCopyProcess ).replaceWithStoreFrom( any( MemberId.class ), eq( storeId ) );
         verify( localDatabase ).start();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -27,9 +27,9 @@ import java.util.UUID;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
+import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
-import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.core.state.CoreState;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -100,7 +100,7 @@ public class CoreStateDownloaderTest
 
         // then
         verify( startStopLife ).stop();
-        verify( localDatabase ).stop();
+        verify( localDatabase ).stopForStoreCopy();
         verify( localDatabase ).start();
         verify( startStopLife ).start();
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -116,7 +116,6 @@ public class ReadReplica implements ClusterMember
     }
 
     @Override
-
     public void start()
     {
         database = new ReadReplicaGraphDatabase( storeDir, config,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.causalclustering.ClusterRule;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -81,6 +82,7 @@ public class ReadReplicaStoreCopyIT
             catch ( Exception e )
             {
                 assertThat( e, instanceOf( TransactionFailureException.class ) );
+                assertThat( e.getMessage(), containsString( "Database is stopped to copy store" ) );
             }
         }
         finally

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.causalclustering.discovery.ReadReplica;
+import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.test.assertion.Assert.assertEventually;
+
+public class ReadReplicaStoreCopyIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withSharedCoreParam( GraphDatabaseSettings.keep_logical_logs, FALSE )
+            .withNumberOfCoreMembers( 3 )
+            .withNumberOfReadReplicas( 1 );
+
+    @Test( timeout = 120_000 )
+    public void shouldNotBePossibleToStartTransactionsWhenReadReplicaCopiesStore() throws Throwable
+    {
+        Cluster cluster = clusterRule.startCluster();
+
+        ReadReplica readReplica = cluster.findAnyReadReplica();
+
+        readReplica.txPollingClient().stop();
+
+        writeSomeDataAndForceLogRotations( cluster );
+        Semaphore storeCopyBlockingSemaphore = addStoreCopyBlockingMonitor( readReplica );
+        try
+        {
+            readReplica.txPollingClient().start();
+            waitForStoreCopyToStartAndBlock( storeCopyBlockingSemaphore );
+
+            ReadReplicaGraphDatabase replicaGraphDatabase = readReplica.database();
+            try
+            {
+                replicaGraphDatabase.beginTx();
+                fail( "Exception expected" );
+            }
+            catch ( Exception e )
+            {
+                assertThat( e, instanceOf( TransactionFailureException.class ) );
+            }
+        }
+        finally
+        {
+            // release all waiters of the semaphore
+            storeCopyBlockingSemaphore.release( Integer.MAX_VALUE );
+        }
+    }
+
+    private static void writeSomeDataAndForceLogRotations( Cluster cluster ) throws Exception
+    {
+        for ( int i = 0; i < 20; i++ )
+        {
+            cluster.coreTx( ( db, tx ) ->
+            {
+                db.execute( "CREATE ()" );
+                tx.success();
+            } );
+
+            forceLogRotationOnAllCores( cluster );
+        }
+    }
+
+    private static void forceLogRotationOnAllCores( Cluster cluster )
+    {
+        for ( CoreClusterMember core : cluster.coreMembers() )
+        {
+            forceLogRotationAndPruning( core );
+        }
+    }
+
+    private static void forceLogRotationAndPruning( CoreClusterMember core )
+    {
+        try
+        {
+            DependencyResolver dependencyResolver = core.database().getDependencyResolver();
+            dependencyResolver.resolveDependency( LogRotation.class ).rotateLogFile();
+            SimpleTriggerInfo info = new SimpleTriggerInfo( "test" );
+            dependencyResolver.resolveDependency( CheckPointer.class ).forceCheckPoint( info );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private static Semaphore addStoreCopyBlockingMonitor( ReadReplica readReplica )
+    {
+        DependencyResolver dependencyResolver = readReplica.database().getDependencyResolver();
+        Monitors monitors = dependencyResolver.resolveDependency( Monitors.class );
+
+        Semaphore semaphore = new Semaphore( 0 );
+
+        monitors.addMonitorListener( (FileCopyMonitor) file ->
+        {
+            try
+            {
+                semaphore.acquire();
+            }
+            catch ( InterruptedException e )
+            {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException( e );
+            }
+        } );
+
+        return semaphore;
+    }
+
+    private static void waitForStoreCopyToStartAndBlock( Semaphore storeCopyBlockingSemaphore ) throws Exception
+    {
+        assertEventually( "Read replica did not copy files", storeCopyBlockingSemaphore::hasQueuedThreads,
+                is( true ), 60, TimeUnit.SECONDS );
+    }
+}


### PR DESCRIPTION
PR consists of two commits:

* _Raise availability guard when core or read replica copy store_
Instance might be forced to copy store from another instance if it requires to pull a transaction log that has already been pruned away. This could happen when transaction pulling (catch up) experience problems like network outage. Database is not operational during store copy, most components including the datasource are shutdown so no transactions can be served.
However it was possible for users (bolt or embedded) to attempt start new transactions which would hang because of kernel components being stopped. In similar situations availability guard must be raised to block new transactions.
This commit makes `LocalDatabase` raise availability guard when it is stopped. `LocalDatabase` is the component used by cores and read replicas to manage the lifecycle of the datasource. It is restarted during store copying.

 * _Better error message when db stopped for store copy_
This commit improves error message when users (bolt or embedded) try to start a transaction while cluster member is copying store. It is done using a special `AvailabilityRequirement` for the `AvailabilityGuard` when local database is stopped to perform a store copy.

PR targets 3.1 instead of https://github.com/neo4j/neo4j/pull/8841 for 3.2.