### PR TITLE
Fixed location of import dir in debian package

### DIFF
--- a/new-packaging/bin/build-debian-package
+++ b/new-packaging/bin/build-debian-package
@@ -59,17 +59,9 @@ fi
 # Make UDC successful
 sed -i 's/unsupported.dbms.udc.source=tarball/unsupported.dbms.udc.source=debian/' ${package_directory}/server/conf/neo4j-wrapper.conf
 
-# Modify directories to match the FHS (https://www.debian.org/doc/packaging-manuals/fhs/fhs-2.3.html)
-configuration_file=${package_directory}/server/conf/neo4j.conf
-sed -i 's/#dbms.directories.data=data/dbms.directories.data=\/var\/lib\/neo4j\/data/'             ${configuration_file}
-sed -i 's/#dbms.directories.plugins=plugins/dbms.directories.plugins=\/var\/lib\/neo4j\/plugins/' ${configuration_file}
-sed -i 's/#dbms.directories.import=import/dbms.directories.import=\/var\/lib\/neo4j\/import/'     ${configuration_file}
-cat src/debian/directories.conf >>${configuration_file}
-
 # Make scripts executable
 chmod 700 ${package_directory}/server/bin/*
 chmod 700 ${scripts_directory}/*
 
 # build package and metadata files
 (cd ${package_directory} && debuild -B -uc -us --lintian-opts --profile debian)
-

--- a/new-packaging/src/debian/neo4j-script
+++ b/new-packaging/src/debian/neo4j-script
@@ -6,4 +6,4 @@ SCRIPT_PATH=""${NEO4J_BIN}"/"${SCRIPT_NAME}""
 
 [ -r /etc/default/neo4j ] && . /etc/default/neo4j
 
-NEO4J_HOME="${NEO4J_HOME:-/usr/share/neo4j}" NEO4J_CONF="${NEO4J_CONF:-/etc/neo4j}" exec "${SCRIPT_PATH}" "$@"
+NEO4J_HOME="${NEO4J_HOME:-/var/lib/neo4j}" NEO4J_CONF="${NEO4J_CONF:-/etc/neo4j}" exec "${SCRIPT_PATH}" "$@"

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -13,6 +13,8 @@
 #dbms.directories.plugins=plugins
 #dbms.directories.certificates=certificates
 #dbms.directories.logs=logs
+#dbms.directories.lib=lib
+#dbms.directories.run=run
 
 # This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or comment it out to
 # allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -13,6 +13,9 @@
 #dbms.directories.plugins=plugins
 #dbms.directories.certificates=certificates
 #dbms.directories.logs=logs
+#dbms.directories.lib=lib
+#dbms.directories.run=run
+#dbms.directories.metrics=metrics
 
 # This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or comment it out to
 # allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`


### PR DESCRIPTION
* Set the correct NEO4J_HOME destination

  Package installations have home located in `/var/lib/neo4j`

* Remove brittle and pointless `sed` invocations

  With the correct NEO4J_HOME set then the default config behaves as
  expected and there is no need to set these. Note that the `sed` for
  the import-entry was broken because the default config ships with an
  un-commented import entry, meaning the `sed` did nothing and ended
  up pointing to the wrong directory.