### PR TITLE
Fixed failure during init resulting in no admin

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -242,15 +242,16 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
 
             if ( numberOfRoles() == 0 )
             {
-                for ( String role : PredefinedRolesBuilder.roles.keySet() )
-                {
-                    newRole( role );
-                }
-
                 if ( newAdmins.isEmpty() )
                 {
                     Set<String> usernames = userRepository.getAllUsernames();
-                    if ( defaultAdminRepository.numberOfUsers() > 0 )
+                    if ( defaultAdminRepository.numberOfUsers() > 1 )
+                    {
+                        throw new InvalidArgumentsException(
+                                "No roles defined, and multiple users defined as default admin user. Please use `" +
+                                        SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+                    }
+                    else if ( defaultAdminRepository.numberOfUsers() == 1 )
                     {
                         // We currently support only one default admin
                         String newAdminUsername = defaultAdminRepository.getAllUsernames().iterator().next();
@@ -260,7 +261,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
                                     "No roles defined, and default admin user '" + newAdminUsername + "' does not exist. " +
                                     "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
                         }
-                        newAdmins.addAll( defaultAdminRepository.getAllUsernames() );
+                        newAdmins.add( newAdminUsername );
                     }
                     else if ( usernames.size() == 1 )
                     {
@@ -276,6 +277,11 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
                                 "No roles defined, and cannot determine which user should be admin. " +
                                 "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
                     }
+                }
+
+                for ( String role : PredefinedRolesBuilder.roles.keySet() )
+                {
+                    newRole( role );
                 }
             }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -248,8 +248,9 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
                     if ( defaultAdminRepository.numberOfUsers() > 1 )
                     {
                         throw new InvalidArgumentsException(
-                                "No roles defined, and multiple users defined as default admin user. Please use `" +
-                                        SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+                                "No roles defined, and multiple users defined as default admin user." +
+                                        " Please use `neo4j-admin " + SetDefaultAdminCommand.COMMAND_NAME +
+                                        "` to select a valid admin." );
                     }
                     else if ( defaultAdminRepository.numberOfUsers() == 1 )
                     {
@@ -258,8 +259,9 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
                         if ( userRepository.getUserByName( newAdminUsername ) == null )
                         {
                             throw new InvalidArgumentsException(
-                                    "No roles defined, and default admin user '" + newAdminUsername + "' does not exist. " +
-                                    "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+                                    "No roles defined, and default admin user '" + newAdminUsername +
+                                            "' does not exist. Please use `neo4j-admin " +
+                                            SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
                         }
                         newAdmins.add( newAdminUsername );
                     }
@@ -275,7 +277,8 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
                     {
                         throw new InvalidArgumentsException(
                                 "No roles defined, and cannot determine which user should be admin. " +
-                                "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
+                                        "Please use `neo4j-admin " + SetDefaultAdminCommand.COMMAND_NAME +
+                                        "` to select an " + "admin." );
                     }
                 }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -27,30 +27,39 @@ import org.apache.shiro.cache.MemoryConstrainedCacheManager;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.neo4j.commandline.admin.security.SetDefaultAdminCommand;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
+import org.neo4j.server.security.auth.Credential;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
 import org.neo4j.server.security.auth.ListSnapshot;
 import org.neo4j.server.security.auth.PasswordPolicy;
 import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
 import org.neo4j.server.security.auth.User;
 import org.neo4j.server.security.auth.UserRepository;
+import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
+import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.time.Clocks;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -62,6 +71,9 @@ import static org.neo4j.server.security.enterprise.auth.AuthTestUtil.listOf;
 
 public class InternalFlatFileRealmTest
 {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     private MultiRealmAuthManager authManager;
     private TestRealm testRealm;
 
@@ -129,6 +141,174 @@ public class InternalFlatFileRealmTest
         assertSetUsersAndRolesNTimes( false, true, 0, 1 );
         assertSetUsersAndRolesNTimes( true, false, 1, 0 );
         assertSetUsersAndRolesNTimes( true, true, 1, 1 );
+    }
+
+    @Test
+    public void shouldAssignAdminRoleToDefaultUser() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm = internalTestRealmWithUsers( Collections.emptyList(), Collections.emptyList() );
+
+        // When
+        realm.initialize();
+        realm.start();
+
+        // Then
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ),
+                contains( InternalFlatFileRealm.INITIAL_USER_NAME ) );
+    }
+
+    @Test
+    public void shouldAssignAdminRoleToSpecifiedUser() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm = internalTestRealmWithUsers( Arrays.asList( "neo4j", "morpheus", "trinity" ),
+                Collections.singletonList( "morpheus" ) );
+
+        // When
+        realm.initialize();
+        realm.start();
+
+        // Then
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ), contains( "morpheus" ) );
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ).size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void shouldAssignAdminRoleToOnlyUser() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm =
+                internalTestRealmWithUsers( Collections.singletonList( "morpheus" ), Collections.emptyList() );
+
+        // When
+        realm.initialize();
+        realm.start();
+
+        // Then
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ), contains( "morpheus" ) );
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ).size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void shouldNotAssignAdminToNonExistentUser() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm = internalTestRealmWithUsers( Collections.singletonList( "neo4j" ),
+                Collections.singletonList( "morpheus" ) );
+
+        // Expect
+        exception.expect( InvalidArgumentsException.class );
+        exception.expectMessage( "No roles defined, and default admin user 'morpheus' does not exist. Please use `" +
+                SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+
+        // When
+        realm.initialize();
+        realm.start();
+    }
+
+    @Test
+    public void shouldGiveErrorOnMultipleUsersNoDefault() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm =
+                internalTestRealmWithUsers( Arrays.asList( "morpheus", "trinity" ), Collections.emptyList() );
+
+        // Expect
+        exception.expect( InvalidArgumentsException.class );
+        exception.expectMessage( "No roles defined, and cannot determine which user should be admin. Please use `" +
+                SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
+
+        // When
+        realm.initialize();
+        realm.start();
+    }
+
+    @Test
+    public void shouldAssignAdminMultipleDefinedUsers() throws Throwable
+    {
+        // Given
+        InternalFlatFileRealm realm = internalTestRealmWithUsers( Arrays.asList( "morpheus", "trinity", "tank" ),
+                Arrays.asList( "morpheus", "trinity" ) );
+
+        // Expect
+        exception.expect( InvalidArgumentsException.class );
+        exception.expectMessage( "No roles defined, and multiple users defined as default admin user. Please use `" +
+                SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+
+        // When
+        realm.initialize();
+        realm.start();
+    }
+
+    @Test
+    public void shouldAssignAdminRoleAfterBadSetting() throws Throwable
+    {
+        UserRepository userRepository = new InMemoryUserRepository();
+        UserRepository initialUserRepository = new InMemoryUserRepository();
+        UserRepository adminUserRepository = new InMemoryUserRepository();
+        RoleRepository roleRepository = new InMemoryRoleRepository();
+        userRepository.create( newUser( "morpheus", "123", false ) );
+        userRepository.create( newUser( "trinity", "123", false ) );
+
+        InternalFlatFileRealm realm = new InternalFlatFileRealm(
+                userRepository,
+                roleRepository,
+                new BasicPasswordPolicy(),
+                new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 ),
+                new InternalFlatFileRealmIT.TestJobScheduler(),
+                initialUserRepository,
+                adminUserRepository
+        );
+
+        try
+        {
+            realm.initialize();
+            realm.start();
+            fail( "Multiple users, no default admin provided" );
+        }
+        catch ( InvalidArgumentsException e )
+        {
+            realm.stop();
+            realm.shutdown();
+        }
+        adminUserRepository.create( new User.Builder( "trinity", Credential.INACCESSIBLE ).build() );
+        realm.initialize();
+        realm.start();
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ).size(), equalTo( 1 ) );
+        assertThat( realm.getUsernamesForRole( PredefinedRoles.ADMIN ), contains( "trinity" ) );
+    }
+
+    private InternalFlatFileRealm internalTestRealmWithUsers( List<String> existing, List<String> defaultAdmin )
+            throws Throwable
+    {
+        UserRepository userRepository = new InMemoryUserRepository();
+        UserRepository initialUserRepository = new InMemoryUserRepository();
+        UserRepository adminUserRepository = new InMemoryUserRepository();
+        RoleRepository roleRepository = new InMemoryRoleRepository();
+        for ( String user : existing )
+        {
+            userRepository.create( newUser( user, "123", false ) );
+        }
+        for ( String user : defaultAdmin )
+        {
+            adminUserRepository.create( new User.Builder( user, Credential.INACCESSIBLE ).build() );
+        }
+        return new InternalFlatFileRealm(
+                userRepository,
+                roleRepository,
+                new BasicPasswordPolicy(),
+                new RateLimitedAuthenticationStrategy( Clocks.systemClock(), 3 ),
+                new InternalFlatFileRealmIT.TestJobScheduler(),
+                initialUserRepository,
+                adminUserRepository
+        );
+    }
+
+    private User newUser( String userName, String password, boolean pwdChange )
+    {
+        return new User.Builder( userName, Credential.forPassword( password ) ).withRequiredPasswordChange( pwdChange )
+            .build();
     }
 
     private void assertSetUsersAndRolesNTimes( boolean usersChanged, boolean rolesChanged,

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -199,8 +199,9 @@ public class InternalFlatFileRealmTest
 
         // Expect
         exception.expect( InvalidArgumentsException.class );
-        exception.expectMessage( "No roles defined, and default admin user 'morpheus' does not exist. Please use `" +
-                SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+        exception.expectMessage(
+                "No roles defined, and default admin user 'morpheus' does not exist. Please use `neo4j-admin " +
+                        SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
 
         // When
         realm.initialize();
@@ -216,8 +217,9 @@ public class InternalFlatFileRealmTest
 
         // Expect
         exception.expect( InvalidArgumentsException.class );
-        exception.expectMessage( "No roles defined, and cannot determine which user should be admin. Please use `" +
-                SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
+        exception.expectMessage(
+                "No roles defined, and cannot determine which user should be admin. Please use `neo4j-admin " +
+                        SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
 
         // When
         realm.initialize();
@@ -225,7 +227,7 @@ public class InternalFlatFileRealmTest
     }
 
     @Test
-    public void shouldAssignAdminMultipleDefinedUsers() throws Throwable
+    public void shouldFailToAssignMultipleDefaultAdmins() throws Throwable
     {
         // Given
         InternalFlatFileRealm realm = internalTestRealmWithUsers( Arrays.asList( "morpheus", "trinity", "tank" ),
@@ -233,8 +235,9 @@ public class InternalFlatFileRealmTest
 
         // Expect
         exception.expect( InvalidArgumentsException.class );
-        exception.expectMessage( "No roles defined, and multiple users defined as default admin user. Please use `" +
-                SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+        exception.expectMessage(
+                "No roles defined, and multiple users defined as default admin user. Please use `neo4j-admin " +
+                        SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
 
         // When
         realm.initialize();

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -158,7 +158,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTests
 
         expect.expect( InvalidArgumentsException.class );
         expect.expectMessage( "No roles defined, and cannot determine which user should be admin. " +
-                              "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
+                              "Please use `neo4j-admin " + SetDefaultAdminCommand.COMMAND_NAME + "` to select an admin." );
 
         manager.start();
     }
@@ -182,7 +182,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTests
 
         expect.expect( InvalidArgumentsException.class );
         expect.expectMessage( "No roles defined, and default admin user 'foo' does not exist. " +
-                              "Please use `" + SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
+                              "Please use `neo4j-admin " + SetDefaultAdminCommand.COMMAND_NAME + "` to select a valid admin." );
 
         manager.start();
     }


### PR DESCRIPTION
When starting database first time default roles get created and a user is made admin.
If there is a failure due to multiple users existing and no default admin is specified
subsequent database start would not try to promote user to admin, resulting in
there being no admin.