### PR TITLE
Restore ability to skip cypher compilation

### DIFF
--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -32,13 +32,23 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
-  <modules>
-    <module>frontend-3.0</module>
-    <module>cypher-compiler-3.0</module>
-    <module>cypher</module>
-    <module>acceptance</module>
-    <module>compatibility-suite</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>include-cypher</id>
+      <activation>
+        <property>
+          <name>!skipCypher</name>
+        </property>
+      </activation>
+      <modules>
+        <module>frontend-3.0</module>
+        <module>cypher-compiler-3.0</module>
+        <module>cypher</module>
+        <module>acceptance</module>
+        <module>compatibility-suite</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>


### PR DESCRIPTION
Note that later branches will need to do the same thing under enterprise cypher modules

Then you can uncheck cypher in IntelliJ and go on with your merry life:

![selection_002](https://cloud.githubusercontent.com/assets/223655/23130999/b4069da8-f788-11e6-838d-a43f7b4d01f7.png)
