### PR TITLE
Fixes issue restoring sort fields in legacy lucene index

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
@@ -56,6 +56,8 @@ import org.neo4j.index.lucene.ValueContext;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
+import static org.neo4j.index.impl.lucene.legacy.LuceneLegacyIndex.isValidKey;
+
 public abstract class IndexType
 {
     public static final IndexType EXACT = new IndexType( LuceneDataSource.KEYWORD_ANALYZER, false )
@@ -233,7 +235,8 @@ public abstract class IndexType
 
     protected boolean isStoredField( IndexableField field )
     {
-        return field.fieldType().stored() && !FullTxData.TX_STATE_KEY.equals( field.name() );
+        return isValidKey( field.name() ) &&
+                field.fieldType().stored() && !FullTxData.TX_STATE_KEY.equals( field.name() );
     }
 
     private static boolean parseBoolean( String string, boolean valueIfNull )

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -358,8 +358,7 @@ public class LuceneDataSource extends LifecycleAdapter
         List<IndexableField> fields = document.getFields();
         for ( IndexableField field : fields )
         {
-            if ( !(LuceneLegacyIndex.KEY_DOC_ID.equals( field.name() ) || LuceneLegacyIndex.KEY_END_NODE_ID.equals( field.name() ) || LuceneLegacyIndex.KEY_START_NODE_ID
-                    .equals( field.name() )) )
+            if ( LuceneLegacyIndex.isValidKey( field.name() ) )
             {
                 return false;
             }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneLegacyIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneLegacyIndex.java
@@ -123,9 +123,14 @@ public abstract class LuceneLegacyIndex implements LegacyIndex
         return result;
     }
 
+    static boolean isValidKey( String key )
+    {
+        return !FORBIDDEN_KEYS.contains( key );
+    }
+
     private static void assertValidKey( String key )
     {
-        if ( FORBIDDEN_KEYS.contains( key ) )
+        if ( !isValidKey( key ) )
         {
             throw new IllegalArgumentException( "Key " + key + " forbidden" );
         }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
@@ -84,6 +84,7 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.index.Neo4jTestCase.assertContains;
 import static org.neo4j.index.Neo4jTestCase.assertContainsInOrder;
 import static org.neo4j.index.impl.lucene.legacy.LuceneIndexImplementation.EXACT_CONFIG;
+import static org.neo4j.index.impl.lucene.legacy.LuceneIndexImplementation.FULLTEXT_CONFIG;
 import static org.neo4j.index.lucene.QueryContext.numericRange;
 import static org.neo4j.index.lucene.ValueContext.numeric;
 
@@ -2138,6 +2139,35 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         {
             // THEN Good
         }
+    }
+
+    @Test
+    public void shouldRemoveAllMatchingIndexEntriesWhenCallingRemoveWithEntityAndKey() throws Exception
+    {
+        // GIVEN
+        Index<Node> index = nodeIndex( FULLTEXT_CONFIG );
+        String key = "the-key";
+        String value1 = "First";
+        String value2 = "Second";
+        Node node = graphDb.createNode();
+        node.setProperty( key, value1 );
+        index.add( node, key, value1 );
+        restartTx();
+        assertEquals( 1, index.query( "*:*" ).size() );
+
+        // WHEN adding one more property to the index
+        node.setProperty( key, value2 );
+        index.add( node, key, value2 ); // intentionally just add to the index
+        restartTx();
+        assertEquals( 1, index.query( "*:*" ).size() );
+
+        // and WHEN removing by node and key
+        node.removeProperty( key );
+        index.remove( node, key );
+        restartTx();
+
+        // THEN
+        assertEquals( 0, index.query( "*:*" ).size() );
     }
 
     private void queryAndSortNodesByNumericProperty( Index<Node> index, String numericProperty )


### PR DESCRIPTION
for fulltext indexes, where the internal keys were duplicated into the
"_e" form by mistake. This would leave empty documents still in the index.

cl [lucene-index] Fixes an issue where adding multiple key/value pairs for a node or relationship for a legacy index in separate transactions would duplicate some internal keys by mistake so that the lucene documents wouldn't be seen as empty when it really was empty later on. This would make such documents, which should have been removed, lingering in the index.