### PR TITLE
Fixes auto index issue removing one out of many indexed keys

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/legacyindex/InternalAutoIndexOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/legacyindex/InternalAutoIndexOperations.java
@@ -220,7 +220,7 @@ public class InternalAutoIndexOperations implements AutoIndexOperations
                 if ( propertyKeysToInclude.get().contains( name ) )
                 {
                     ensureIndexExists( ops );
-                    type.remove( ops, entityId );
+                    type.remove( ops, entityId, name );
                 }
             }
             catch ( LegacyIndexNotFoundKernelException | EntityNotFoundException e )


### PR DESCRIPTION
Given e.g. a node having multiple auto-indexed keys, removing one of them
would previously remove all indexed keys for the node from the auto-index.
This fix will have only the specific key to be removed from the auto index.

cl [lucene-index] Fixes an issue where removing one key from a node or relationship which had multiple keys auto-indexed would remove all other keys for that entity from the auto-index too by mistake.