### PR TITLE
Properly closes IndexHits

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/LegacyIndexProxy.java
@@ -336,6 +336,12 @@ public class LegacyIndexProxy<T extends PropertyContainer> implements Index<T>
                 }
                 return null;
             }
+
+            @Override
+            public void close()
+            {
+                ids.close();
+            }
         };
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
@@ -2127,13 +2127,13 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         node.setProperty( key, value1 );
         index.add( node, key, value1 );
         restartTx();
-        assertEquals( 1, index.query( "*:*" ).size() );
+        assertEquals( 1, countHits( index.query( "*:*" ) ) );
 
         // WHEN adding one more property to the index
         node.setProperty( key, value2 );
         index.add( node, key, value2 ); // intentionally just add to the index
         restartTx();
-        assertEquals( 1, index.query( "*:*" ).size() );
+        assertEquals( 1, countHits( index.query( "*:*" ) ) );
 
         // and WHEN removing by node and key
         node.removeProperty( key );
@@ -2141,7 +2141,19 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         restartTx();
 
         // THEN
-        assertEquals( 0, index.query( "*:*" ).size() );
+        assertEquals( 0, countHits( index.query( "*:*" ) ) );
+    }
+
+    private long countHits( IndexHits<Node> query )
+    {
+        try
+        {
+            return count( query );
+        }
+        finally
+        {
+            query.close();
+        }
     }
 
     private void queryAndSortNodesByNumericProperty( Index<Node> index, String numericProperty )


### PR DESCRIPTION
This happened in a test, but also discovered that the IndexHits exposed to
users would not delegate close call back to internal lucene searcher,
which should currently cause problems with growing number of open files.