### PR TITLE
Fixed log rotation on Windows

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -160,7 +160,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
                     rotationExecutor, new RotatingFileOutputStreamSupplier.RotationListener()
             {
                 @Override
-                public void outputFileCreated( OutputStream newStream, OutputStream oldStream )
+                public void outputFileCreated( OutputStream newStream )
                 {
                     FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( newStream );
                     logProvider.getLog( StoreLogService.class ).info( "Opened new internal log file" );
@@ -168,15 +168,14 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
                 }
 
                 @Override
-                public void rotationCompleted( OutputStream newStream, OutputStream oldStream )
+                public void rotationCompleted( OutputStream newStream )
                 {
                     FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( newStream );
                     logProvider.getLog( StoreLogService.class ).info( "Rotated internal log file" );
                 }
 
                 @Override
-                public void rotationError( @SuppressWarnings( "unused" ) Exception e,
-                        @SuppressWarnings( "unused" ) OutputStream outStream )
+                public void rotationError( Exception e, OutputStream outStream )
                 {
                     FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( outStream );
                     logProvider.getLog( StoreLogService.class ).info( "Rotation of internal log file failed:", e );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -165,7 +165,21 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
                     FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( newStream );
                     logProvider.getLog( StoreLogService.class ).info( "Opened new internal log file" );
                     rotationListener.accept( logProvider );
+                }
+
+                @Override
+                public void rotationCompleted( OutputStream newStream, OutputStream oldStream )
+                {
+                    FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( newStream );
                     logProvider.getLog( StoreLogService.class ).info( "Rotated internal log file" );
+                }
+
+                @Override
+                public void rotationError( @SuppressWarnings( "unused" ) Exception e,
+                        @SuppressWarnings( "unused" ) OutputStream outStream )
+                {
+                    FormattedLogProvider logProvider = internalLogBuilder.toOutputStream( outStream );
+                    logProvider.getLog( StoreLogService.class ).info( "Rotation of internal log file failed:", e );
                 }
             } );
             internalLogProvider = internalLogBuilder.toOutputStream( rotatingSupplier );

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -83,12 +83,11 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
     private final List<WeakReference<OutputStream>> archivedStreams = new LinkedList<>();
 
     // Used only in case no new output file can be created during rotation
-    private static final OutputStream stdErrStream = new OutputStream()
+    private static final OutputStream nullStream = new OutputStream()
     {
         @Override
         public void write( int i ) throws IOException
         {
-            System.err.write( i );
         }
     };
 
@@ -290,7 +289,8 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
                     }
                     catch ( IOException e )
                     {
-                        newStream = stdErrStream;
+                        System.err.println( "Failed to open log file after log rotation: " + e.getMessage() );
+                        newStream = nullStream;
                         rotationListener.rotationError( e, streamWrapper );
                         rotating.set( false );
                     }

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -214,7 +214,8 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
 
     private boolean rotationThresholdExceeded()
     {
-        return rotationThresholdBytes == 0 || !fileSystem.fileExists( outputFile ) || fileSystem.getFileSize( outputFile ) >= rotationThresholdBytes;
+        return fileSystem.fileExists( outputFile ) && rotationThresholdBytes > 0 &&
+                fileSystem.getFileSize( outputFile ) >= rotationThresholdBytes;
     }
 
     private boolean rotationDelayExceeded()

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -49,6 +49,7 @@ import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.RotatingFileOutputStreamSupplier.RotationListener;
+import org.neo4j.test.RepeatRule.Repeat;
 import org.neo4j.test.TargetDirectory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -416,7 +417,7 @@ public class RotatingFileOutputStreamSupplierTest
 
         // run cleanly for a while, to allow it to fill any gaps left in log archive numbers
         adversary.setProbabilityFactor( 0 );
-        writeLines( supplier, 1000 );
+        writeLines( supplier, 10000 );
 
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.logging;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -33,9 +31,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.adversaries.Adversary;
 import org.neo4j.adversaries.RandomAdversary;
@@ -46,10 +49,10 @@ import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.RotatingFileOutputStreamSupplier.RotationListener;
+import org.neo4j.test.TargetDirectory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -65,17 +68,38 @@ public class RotatingFileOutputStreamSupplierTest
 {
     private static final java.util.concurrent.Executor DIRECT_EXECUTOR = Runnable::run;
 
+
     private FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
-    private File logFile = new File( "/tmp/logfile.log" );
-    private File archiveLogFile1 = new File( "/tmp/logfile.log.1" );
-    private File archiveLogFile2 = new File( "/tmp/logfile.log.2" );
-    private File archiveLogFile3 = new File( "/tmp/logfile.log.3" );
-    private File archiveLogFile4 = new File( "/tmp/logfile.log.4" );
-    private File archiveLogFile5 = new File( "/tmp/logfile.log.5" );
-    private File archiveLogFile6 = new File( "/tmp/logfile.log.6" );
-    private File archiveLogFile7 = new File( "/tmp/logfile.log.7" );
-    private File archiveLogFile8 = new File( "/tmp/logfile.log.8" );
-    private File archiveLogFile9 = new File( "/tmp/logfile.log.9" );
+
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass(), fileSystem );
+
+    private File logFile;
+    private File archiveLogFile1;
+    private File archiveLogFile2;
+    private File archiveLogFile3;
+    private File archiveLogFile4;
+    private File archiveLogFile5;
+    private File archiveLogFile6;
+    private File archiveLogFile7;
+    private File archiveLogFile8;
+    private File archiveLogFile9;
+
+    @Before
+    public void setup()
+    {
+        File logDir = testDirectory.directory();
+        logFile = new File( logDir, "logfile.log" );
+        archiveLogFile1 = new File( logDir, "logfile.log.1" );
+        archiveLogFile2 = new File( logDir, "logfile.log.2" );
+        archiveLogFile3 = new File( logDir, "logfile.log.3" );
+        archiveLogFile4 = new File( logDir, "logfile.log.4" );
+        archiveLogFile5 = new File( logDir, "logfile.log.5" );
+        archiveLogFile6 = new File( logDir, "logfile.log.6" );
+        archiveLogFile7 = new File( logDir, "logfile.log.7" );
+        archiveLogFile8 = new File( logDir, "logfile.log.8" );
+        archiveLogFile9 = new File( logDir, "logfile.log.9" );
+    }
 
     @Test
     public void createsLogOnConstruction() throws Exception
@@ -87,24 +111,23 @@ public class RotatingFileOutputStreamSupplierTest
     @Test
     public void rotatesLogWhenSizeExceeded() throws Exception
     {
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, DIRECT_EXECUTOR );
-        OutputStream outputStream = supplier.get();
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, DIRECT_EXECUTOR );
+
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( false ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
-        OutputStream outputStream2 = supplier.get();
-        assertThat( outputStream2, not( outputStream ) );
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( false ) );
 
-        write( outputStream2, "Short" );
-        assertThat( supplier.get(), is( outputStream2 ) );
+        write( supplier, "Short" );
+        write( supplier, "A string longer than 10 bytes" );
 
-        write( outputStream2, "A string longer than 10 bytes" );
-        OutputStream outputStream3 = supplier.get();
-        assertThat( outputStream3, not( outputStream2 ) );
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( true ) );
@@ -113,26 +136,29 @@ public class RotatingFileOutputStreamSupplierTest
     @Test
     public void limitsNumberOfArchivedLogs() throws Exception
     {
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 2, DIRECT_EXECUTOR );
-        OutputStream outputStream = supplier.get();
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 2,
+                DIRECT_EXECUTOR );
+
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( false ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
-        OutputStream outputStream2 = supplier.get();
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( false ) );
 
-        write( outputStream2, "A string longer than 10 bytes" );
-        OutputStream outputStream3 = supplier.get();
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile3 ), is( false ) );
 
-        write( outputStream3, "A string longer than 10 bytes" );
-        supplier.get();
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( true ) );
@@ -140,52 +166,31 @@ public class RotatingFileOutputStreamSupplierTest
     }
 
     @Test
-    public void shouldReturnSameStreamWhilstRotationOccurs() throws Exception
-    {
-        ManualExecutor executor = new ManualExecutor();
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, executor );
-        OutputStream outputStream = supplier.get();
-
-        write( outputStream, "A string longer than 10 bytes" );
-        assertThat( supplier.get(), is( outputStream ) );
-        assertThat( executor.isScheduled(), is( true ) );
-
-        write( outputStream, "A string longer than 10 bytes" );
-        assertThat( supplier.get(), is( outputStream ) );
-
-        executor.runTask();
-
-        assertThat( supplier.get(), not( outputStream ) );
-    }
-
-    @Test
-    public void shouldNotRotatesLogWhenSizeExceededByNotDelay() throws Exception
+    public void shouldNotRotateLogWhenSizeExceededButNotDelay() throws Exception
     {
         UpdatableLongSupplier clock = new UpdatableLongSupplier( System.currentTimeMillis() );
         RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( clock, fileSystem, logFile,
                 10, SECONDS.toMillis( 60 ), 10, DIRECT_EXECUTOR, new RotationListener() );
-        OutputStream outputStream = supplier.get();
+
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( false ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
-        OutputStream outputStream2 = supplier.get();
-        assertThat( outputStream2, not( outputStream ) );
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( false ) );
 
-        write( outputStream2, "A string longer than 10 bytes" );
-        assertThat( supplier.get(), is( outputStream2 ) );
+        write( supplier, "A string longer than 10 bytes" );
 
         clock.setValue( clock.getAsLong() + SECONDS.toMillis( 59 ) );
-        write( outputStream2, "A string longer than 10 bytes" );
-        assertThat( supplier.get(), is( outputStream2 ) );
+        write( supplier, "A string longer than 10 bytes" );
 
         clock.setValue( clock.getAsLong() + SECONDS.toMillis( 1 ) );
-        write( outputStream2, "A string longer than 10 bytes" );
-        OutputStream outputStream3 = supplier.get();
-        assertThat( outputStream3, not( outputStream2 ) );
+        write( supplier, "A string longer than 10 bytes" );
+
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile2 ), is( true ) );
@@ -201,38 +206,36 @@ public class RotatingFileOutputStreamSupplierTest
         RotationListener rotationListener = spy( new RotationListener()
         {
             @Override
-            public void outputFileCreated( OutputStream newStream, OutputStream oldStream )
+            public void outputFileCreated( OutputStream out )
             {
                 try
                 {
-                    allowRotationComplete.await();
-                } catch ( InterruptedException e )
+                    allowRotationComplete.await( 1L, TimeUnit.SECONDS );
+                }
+                catch ( InterruptedException e )
                 {
                     throw new RuntimeException( e );
                 }
             }
 
             @Override
-            public void rotationCompleted( OutputStream newStream, OutputStream oldStream )
+            public void rotationCompleted( OutputStream out )
             {
                 rotationComplete.countDown();
             }
         } );
 
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, Executors.newSingleThreadExecutor(), rotationListener );
-        OutputStream outputStream = supplier.get();
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, Executors.newSingleThreadExecutor(), rotationListener );
 
-        write( outputStream, "A string longer than 10 bytes" );
-        assertThat( supplier.get(), is( outputStream ) );
+        write( supplier, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
 
         allowRotationComplete.countDown();
-        rotationComplete.await();
+        rotationComplete.await( 1L, TimeUnit.SECONDS );
 
-        OutputStream outputStream2 = supplier.get();
-        assertThat( outputStream2, not( outputStream ) );
-
-        verify( rotationListener ).outputFileCreated( outputStream2, outputStream );
-        verify( rotationListener ).rotationCompleted( outputStream2, outputStream );
+        verify( rotationListener ).outputFileCreated( supplier.get() );
+        verify( rotationListener ).rotationCompleted( supplier.get() );
     }
 
     @Test
@@ -240,13 +243,14 @@ public class RotatingFileOutputStreamSupplierTest
     {
         RotationListener rotationListener = mock( RotationListener.class );
         Executor executor = mock( Executor.class );
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, executor, rotationListener );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, executor, rotationListener );
         OutputStream outputStream = supplier.get();
 
         RejectedExecutionException exception = new RejectedExecutionException( "text exception" );
         doThrow( exception ).when( executor ).execute( any( Runnable.class ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );
 
         verify( rotationListener ).rotationError( exception, outputStream );
@@ -257,13 +261,14 @@ public class RotatingFileOutputStreamSupplierTest
     {
         RotationListener rotationListener = mock( RotationListener.class );
         Executor executor = mock( Executor.class );
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, executor, rotationListener );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, executor, rotationListener );
         OutputStream outputStream = supplier.get();
 
         RejectedExecutionException exception = new RejectedExecutionException( "text exception" );
         doThrow( exception ).when( executor ).execute( any( Runnable.class ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );
         assertThat( supplier.get(), is( outputStream ) );
 
@@ -275,13 +280,14 @@ public class RotatingFileOutputStreamSupplierTest
     {
         RotationListener rotationListener = mock( RotationListener.class );
         FileSystemAbstraction fs = spy( fileSystem );
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fs, logFile, 10, 0, 10, DIRECT_EXECUTOR, rotationListener );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fs, logFile, 10, 0, 10,
+                DIRECT_EXECUTOR, rotationListener );
         OutputStream outputStream = supplier.get();
 
         IOException exception = new IOException( "text exception" );
         doThrow( exception ).when( fs ).renameFile( any( File.class ), any( File.class ) );
 
-        write( outputStream, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );
 
         verify( rotationListener ).rotationError( exception, outputStream );
@@ -295,22 +301,24 @@ public class RotatingFileOutputStreamSupplierTest
         RotationListener rotationListener = spy( new RotationListener()
         {
             @Override
-            public void outputFileCreated( OutputStream newStream, OutputStream oldStream )
+            public void outputFileCreated( OutputStream out )
             {
                 try
                 {
                     allowRotationComplete.await();
-                } catch ( InterruptedException e )
+                }
+                catch ( InterruptedException e )
                 {
                     throw new RuntimeException( e );
                 }
             }
         } );
 
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, Executors.newSingleThreadExecutor(), rotationListener );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, Executors.newSingleThreadExecutor(), rotationListener );
         OutputStream outputStream = supplier.get();
 
-        write( outputStream, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
         assertThat( supplier.get(), is( outputStream ) );
 
         allowRotationComplete.countDown();
@@ -322,17 +330,15 @@ public class RotatingFileOutputStreamSupplierTest
     @Test
     public void shouldCloseAllOutputStreams() throws Exception
     {
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0, 10, DIRECT_EXECUTOR );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile, 10, 0,
+                10, DIRECT_EXECUTOR );
         OutputStream outputStream = supplier.get();
 
-        write( outputStream, "A string longer than 10 bytes" );
-        OutputStream outputStream2 = supplier.get();
-        assertThat( outputStream2, not( outputStream ) );
+        write( supplier, "A string longer than 10 bytes" );
 
         supplier.close();
 
         assertStreamClosed( outputStream );
-        assertStreamClosed( outputStream2 );
     }
 
     @Test
@@ -350,19 +356,15 @@ public class RotatingFileOutputStreamSupplierTest
             }
         };
 
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fs, logFile, 10, 0, 10, DIRECT_EXECUTOR );
-        OutputStream outputStream = supplier.get();
-        assertThat( outputStream, sameInstance( mockStreams.get( 0 ) ) );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( fs, logFile, 10, 0, 10,
+                DIRECT_EXECUTOR );
 
-        write( outputStream, "A string longer than 10 bytes" );
-        OutputStream outputStream2 = supplier.get();
-        assertThat( outputStream2, sameInstance( mockStreams.get( 1 ) ) );
+        write( supplier, "A string longer than 10 bytes" );
+        write( supplier, "A string longer than 10 bytes" );
 
-        IOException exception1 = new IOException( "test exception" );
-        doThrow( exception1 ).when( outputStream ).close();
-
-        IOException exception2 = new IOException( "test exception" );
-        doThrow( exception2 ).when( outputStream2 ).close();
+        IOException exception = new IOException( "test exception" );
+        OutputStream mockStream = mockStreams.get( 1 );
+        doThrow( exception ).when( mockStream ).close();
 
         try
         {
@@ -370,9 +372,9 @@ public class RotatingFileOutputStreamSupplierTest
         }
         catch ( IOException e )
         {
-            assertThat( e, sameInstance( exception2 ) );
+            assertThat( e, sameInstance( exception ) );
         }
-        verify( outputStream ).close();
+        verify( mockStream ).close();
     }
 
     @Test
@@ -381,8 +383,10 @@ public class RotatingFileOutputStreamSupplierTest
         final RandomAdversary adversary = new RandomAdversary( 0.1, 0.1, 0 );
         adversary.setProbabilityFactor( 0 );
 
-        AdversarialFileSystemAbstraction adversarialFileSystem = new SensibleAdversarialFileSystemAbstraction( adversary, fileSystem );
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( adversarialFileSystem, logFile, 1000, 0, 9, DIRECT_EXECUTOR );
+        AdversarialFileSystemAbstraction adversarialFileSystem = new SensibleAdversarialFileSystemAbstraction(
+                adversary, fileSystem );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( adversarialFileSystem,
+                logFile, 1000, 0, 9, DIRECT_EXECUTOR );
 
         adversary.setProbabilityFactor( 1 );
         writeLines( supplier, 10000 );
@@ -403,9 +407,9 @@ public class RotatingFileOutputStreamSupplierTest
         assertThat( fileSystem.fileExists( archiveLogFile9 ), is( true ) );
     }
 
-    private void write( OutputStream outputStream, String line )
+    private void write( RotatingFileOutputStreamSupplier supplier, String line )
     {
-        PrintWriter writer = new PrintWriter( outputStream );
+        PrintWriter writer = new PrintWriter( supplier.get() );
         writer.println( line );
         writer.flush();
     }
@@ -413,9 +417,10 @@ public class RotatingFileOutputStreamSupplierTest
     private void writeLines( Supplier<OutputStream> outputStreamSupplier, int count ) throws InterruptedException
     {
         Supplier<PrintWriter> printWriterSupplier = Suppliers.adapted( outputStreamSupplier, OUTPUT_STREAM_CONVERTER );
-        for (; count >= 0; --count )
+        for ( ; count >= 0; --count )
         {
-            printWriterSupplier.get().println( "We are what we repeatedly do. Excellence, then, is not an act, but a habit." );
+            printWriterSupplier.get().println(
+                    "We are what we repeatedly do. Excellence, then, is not an act, but a habit." );
             Thread.yield();
         }
     }
@@ -426,7 +431,8 @@ public class RotatingFileOutputStreamSupplierTest
         {
             stream.write( 0 );
             fail( "Expected ClosedChannelException" );
-        } catch ( ClosedChannelException e )
+        }
+        catch ( ClosedChannelException e )
         {
             // expected
         }

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
@@ -44,7 +43,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.DefaultFileSystemRule;
-import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -53,7 +51,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.function.Predicates.await;
 
 public class QueryLoggerIT
 {
@@ -108,9 +105,9 @@ public class QueryLoggerIT
         Map<String,Object> props = new LinkedHashMap<>(); // to be sure about ordering in the last assertion
         props.put( "name", "Roland" );
         props.put( "position", "Gunslinger" );
-        props.put( "followers", Arrays.asList("Jake", "Eddie", "Susannah") );
+        props.put( "followers", Arrays.asList( "Jake", "Eddie", "Susannah" ) );
 
-        Map<String, Object> params = new HashMap<>();
+        Map<String,Object> params = new HashMap<>();
         params.put( "props", props );
 
         String query = "CREATE ({props})";
@@ -120,7 +117,7 @@ public class QueryLoggerIT
         assertEquals( 1, logLines.size() );
         assertThat( logLines.get( 0 ), endsWith( String.format(
                 " ms: %s - %s - {props: {name: Roland, position: Gunslinger, followers: [Jake, Eddie, Susannah]}}",
-                QueryEngineProvider.embeddedSession( null ), query) ) );
+                QueryEngineProvider.embeddedSession( null ), query ) ) );
     }
 
     @Test
@@ -132,7 +129,7 @@ public class QueryLoggerIT
                 .setConfig( GraphDatabaseSettings.logs_directory, logsDirectory.getPath() )
                 .newGraphDatabase();
 
-        Map<String, Object> params = new HashMap<>();
+        Map<String,Object> params = new HashMap<>();
         params.put( "ids", Arrays.asList( 0, 1, 2 ) );
         String query = "MATCH (n) WHERE id(n) in {ids} RETURN n.name";
         executeQueryAndShutdown( database, query, params );
@@ -142,7 +139,7 @@ public class QueryLoggerIT
         assertThat( logLines.get( 0 ),
                 endsWith( String.format(
                         " ms: %s - %s - {ids: [0, 1, 2]}",
-                        QueryEngineProvider.embeddedSession( null ), query) ) );
+                        QueryEngineProvider.embeddedSession( null ), query ) ) );
     }
 
     @Test
@@ -220,10 +217,10 @@ public class QueryLoggerIT
 
     private void executeQueryAndShutdown( GraphDatabaseService database )
     {
-       executeQueryAndShutdown( database, QUERY, Collections.emptyMap() );
+        executeQueryAndShutdown( database, QUERY, Collections.emptyMap() );
     }
 
-    private void executeQueryAndShutdown( GraphDatabaseService database, String query, Map<String, Object> params )
+    private void executeQueryAndShutdown( GraphDatabaseService database, String query, Map<String,Object> params )
     {
         Result execute = database.execute( query, params );
         execute.close();
@@ -241,7 +238,7 @@ public class QueryLoggerIT
         try ( BufferedReader reader = new BufferedReader(
                 fs.openAsReader( logFilename, StandardCharsets.UTF_8 ) ) )
         {
-            for ( String line; (line = reader.readLine()) != null; )
+            for ( String line; ( line = reader.readLine() ) != null; )
             {
                 logLines.add( line );
             }


### PR DESCRIPTION
Synchronizes the operations on logs to make sure that we can safely
close the file stream before performing rotation.

Previously we did not close the stream which prevented log rotation
from ever working on Windows.