### PR TITLE
Distinguish kinds of settings

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/config/Setting.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.graphdb.config;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -47,4 +48,14 @@ public interface Setting<T> extends Function<Function<String,String>,T>
     String getDefaultValue();
 
     T from( Configuration config );
+
+    /**
+     * Get the function used to parse this setting.
+     *
+     * @return the parser function
+     */
+    default Optional<Function<String, T>> getParser()
+    {
+        return Optional.empty();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 
 public final class TimeUtil
 {
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
+    public static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
 
     public static final Function<String, Long> parseTimeMillis = timeWithOrWithoutUnit -> {
         int unitIndex = -1;

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.config.Configuration;
@@ -476,7 +477,7 @@ public class Settings
         @Override
         public String toString()
         {
-            return "a duration (valid units are `" + DURATION_UNITS.replace( ", ", "`, `" ) + "`; default unit is `ms`)";
+            return "a duration (valid units are `" + DURATION_UNITS.replace( ", ", "`, `" ) + "`; default unit is `s`)";
         }
     };
 
@@ -996,6 +997,12 @@ public class Settings
         public T from( Configuration config )
         {
             return config.get( this );
+        }
+
+        @Override
+        public Optional<Function<String, T>> getParser()
+        {
+            return Optional.of( parser );
         }
 
         @Override


### PR DESCRIPTION
To generate correct settings docs we need to be able to tell the difference between kinds of settings. This allows us to do so with minimal changes to the settings themselves.

Also use the correct default unit for `DURATION` settings in `#toString`.