### PR TITLE
shutdown read replicas first in tests

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -95,6 +95,8 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     @Override
     public synchronized void stop() throws Throwable
     {
+        readReplicaRefreshTimer.cancel();
+
         if ( hazelcastInstance != null )
         {
             try
@@ -110,8 +112,6 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
                 log.warn( "Unable to shutdown Hazelcast", t );
             }
         }
-
-        readReplicaRefreshTimer.cancel();
     }
 
     private synchronized <T> T retry( Function<HazelcastInstance, T> hazelcastOperation )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -181,8 +181,8 @@ public class Cluster
 
     public void shutdown() throws ExecutionException, InterruptedException
     {
-        shutdownCoreMembers();
         shutdownReadReplicas();
+        shutdownCoreMembers();
     }
 
     public void shutdownCoreMembers() throws InterruptedException, ExecutionException


### PR DESCRIPTION
Read replicas are hazelcast clients and the process is faster
if the hazelcast servers are shutdown last since on shutdown
the read replicas try to remove themselves from a shared map.