### PR TITLE
Fixed location of logs on Windows

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -49,7 +49,7 @@ Function Get-Neo4jPrunsrv
   param (
     [Parameter(Mandatory=$true,ValueFromPipeline=$false)]
     [PSCustomObject]$Neo4jServer
-        
+
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInstallInvoke')]
     [switch]$ForServerInstall
 
@@ -59,11 +59,11 @@ Function Get-Neo4jPrunsrv
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ConsoleInvoke')]
     [switch]$ForConsole
   )
-  
+
   Begin
   {
   }
-  
+
   Process
   {
     $JavaCMD = Get-Java -Neo4jServer $Neo4jServer -ForServer -ErrorAction Stop
@@ -72,14 +72,14 @@ Function Get-Neo4jPrunsrv
       Write-Error 'Unable to locate Java'
       return 255
     }
-    
+
     # JVMDLL is in %JAVA_HOME%\bin\server\jvm.dll
     $JvmDLL = Join-Path -Path (Join-Path -Path (Split-Path $JavaCMD.java -Parent) -ChildPath 'server') -ChildPath 'jvm.dll'
     if (-Not (Test-Path -Path $JvmDLL)) { Throw "Could not locate JVM.DLL at $JvmDLL" }
 
     # Get the Service Name
     $Name = Get-Neo4jWindowsServiceName -Neo4jServer $Neo4jServer -ErrorAction Stop
-    
+
     # Find PRUNSRV for this architecture
     # This check will return the OS architecture even when running a 32bit app on 64bit OS
     switch ( (Get-WMIObject -Class Win32_Processor | Select-Object -First 1).Addresswidth ) {
@@ -116,9 +116,9 @@ Function Get-Neo4jPrunsrv
           "`"--Description=Neo4j Graph Database - $($Neo4jServer.Home)`"",
           "`"--DisplayName=Neo4j Graph Database - $Name`"",
           "`"--Jvm=$($JvmDLL)`"",
-          '--LogPath=logs',
-          '--StdOutput=logs\neo4j.log',
-          '--StdError=logs\service-error.log',
+          "--LogPath=$($Neo4jServer.LogDir)",
+          "--StdOutput=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'neo4j.log')",
+          "--StdError=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'service-error.log')",
           '--LogPrefix=neo4j-service',
           '--Classpath=lib/*;plugins/*',
           "`"--JvmOptions=$($JvmOptions -join ';')`"",
@@ -144,7 +144,7 @@ Function Get-Neo4jPrunsrv
         if ($Neo4jServer.ServerType -eq 'Enterprise') { $serverMainClass = 'org.neo4j.server.enterprise.EnterpriseEntryPoint' }
         if ($Neo4jServer.ServerType -eq 'Community') { $serverMainClass = 'org.neo4j.server.CommunityEntryPoint' }
         if ($Neo4jServer.DatabaseMode.ToUpper() -eq 'ARBITER') { $serverMainClass = 'org.neo4j.server.enterprise.ArbiterEntryPoint' }
-        if ($serverMainClass -eq '') { Write-Error "Unable to determine the Server Main Class from the server information"; return $null }    
+        if ($serverMainClass -eq '') { Write-Error "Unable to determine the Server Main Class from the server information"; return $null }
         $PrunArgs += @("--StopClass=$($serverMainClass)",
                        "--StartClass=$($serverMainClass)")
       }
@@ -155,10 +155,10 @@ Function Get-Neo4jPrunsrv
         return $null
       }
     }
-    
+
     Write-Output @{'cmd' = $PrunsrvCMD; 'args' = $PrunArgs}
   }
-  
+
   End
   {
   }

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Merge-Neo4jJavaSettings.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Merge-Neo4jJavaSettings.ps1
@@ -44,7 +44,7 @@ Function Merge-Neo4jJavaSettings
     [Parameter(Mandatory=$true)]
     [AllowEmptyCollection()]
     [Array]$Source
-        
+
     ,[Parameter(Mandatory=$true,ValueFromPipeline=$false,ParameterSetName='ServerInstallInvoke')]
     [AllowEmptyCollection()]
     [Array]$Additional
@@ -52,7 +52,7 @@ Function Merge-Neo4jJavaSettings
 
   $SettingNameRegEx = '^(?:-D|-XX:[+-]?)([^=]+)(?:$|=.+$)'
 
-  # Populate the initial hashtable with extracted setting anems
+  # Populate the initial hashtable with extracted setting names
   $SettingOutput = @{}
   $Source | ForEach-Object -Process {
     if ($matches -ne $null) { $matches.Clear() }
@@ -65,31 +65,26 @@ Function Merge-Neo4jJavaSettings
 
   $Additional | ForEach-Object -Process {
     $thisSetting = $_
-    If (-not $Source.contains($thisSetting)) {
-      if ($matches -ne $null) { $matches.Clear() }
-      if ($thisSetting -match $SettingNameRegEx) {
-        $thisSettingName = $matches[1]
+    if ($matches -ne $null) { $matches.Clear() }
+    if ($thisSetting -match $SettingNameRegEx) {
+      $thisSettingName = $matches[1]
 
-        $oldValue = $null
-        $SettingOutput.GetEnumerator() | ForEach-Object -Process {
-          if ($_.Value -eq $thisSettingName) { $oldValue = $_.Key}
-        }
-
-        if ($oldValue -eq $null) {
-          Write-Verbose "Adding '$thisSetting'"
-          $SettingOutput.Add($thisSetting,'')
-        } else {
-          Write-Verbose "Merging '$thisSetting'"
-          $SettingOutput.Remove($oldValue)
-          $SettingOutput.Add($thisSetting,$thisSettingName)
-        }
-      } else {
-        Write-Verbose "Adding '$thisSetting'"
-        $SettingOutput.Add($thisSetting,'')
+      $oldValue = $null
+      $SettingOutput.GetEnumerator() | ForEach-Object -Process {
+        if ($_.Value -eq $thisSettingName) { $oldValue = $_.Key}
       }
 
+      if ($oldValue -eq $null) {
+        Write-Verbose "Adding '$thisSetting'"
+        $SettingOutput.Add($thisSetting,'')
+      } else {
+        Write-Verbose "Merging '$thisSetting'"
+        $SettingOutput.Remove($oldValue)
+        $SettingOutput.Add($thisSetting,$thisSettingName)
+      }
     } else {
-      Write-Verbose "Ignoring '$thisSetting' as it is already defined"
+      Write-Verbose "Adding '$thisSetting'"
+      $SettingOutput.Add($thisSetting,'')
     }
   }
 


### PR DESCRIPTION
### Summary

* Backports a fix for Windows7 which was done on 3.1
* Installation of Windows service now resolves relative log directories relative to the Neo4jHome path
* Installation of Windows service now respects configuration value of `dbms.directories.logs`

### Default behavior

Note the values in yellow for `--LogPath`, `--StdOutput`, and `--StdError`.

![windowsdefault](https://cloud.githubusercontent.com/assets/223655/23264351/55691ebe-f9e1-11e6-863f-e764585a9969.png)

### Absolute path in configuration

![windowsabsolute](https://cloud.githubusercontent.com/assets/223655/23264361/5bd90a7a-f9e1-11e6-9eb5-dda68ddbef8d.png)

### Relative path in configuration

![windowsrelative](https://cloud.githubusercontent.com/assets/223655/23264368/621a4192-f9e1-11e6-80a7-3dbb64547b63.png)
