### PR TITLE
Replacing neo4j.version with project.version for pom consistency

### DIFF
--- a/community/consistency-check/pom.xml
+++ b/community/consistency-check/pom.xml
@@ -56,12 +56,12 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-lucene-index</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -93,7 +93,7 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -119,12 +119,12 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-dbms</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-io</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -245,7 +245,7 @@
           <dependency>
             <groupId>org.neo4j.build</groupId>
             <artifactId>licensecheck-config</artifactId>
-            <version>${neo4j.version}</version>
+            <version>${project.version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -304,7 +304,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-import-tool</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -164,12 +164,12 @@ terms of the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j.app</groupId>
       <artifactId>neo4j-server</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -162,12 +162,12 @@ terms of the relevant Commercial Agreement.
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-enterprise</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.neo4j.app</groupId>
       <artifactId>neo4j-server-enterprise</artifactId>
-      <version>${neo4j.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Currently there is a property neo4j.version which is being assigned to project.version. This adversely effects certain maven tools such as maven-release-plugin release:update-versions which fails when trying to update dependencies because of this linked property chain.

The update here is to replace neo4j.version with project.version in dependency sections to bring poms into a working structure for the maven-release-plugin.

This command fails without these changes:
mvn release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=3.1.3-SNAPSHOT