### PR TITLE
Core members can refuse to become leaders

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -32,6 +32,7 @@ import static org.neo4j.kernel.configuration.Settings.ADVERTISED_SOCKET_ADDRESS;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.MANDATORY;
 import static org.neo4j.kernel.configuration.Settings.STRING;
@@ -53,7 +54,13 @@ public class CausalClusteringSettings
     public static final Setting<Long> leader_election_timeout =
             setting( "causal_clustering.leader_election_timeout", DURATION, "7s" );
 
-    @Description("The maximum batch size when catching up (in unit of entries)")
+    @Description( "Prevents the current instance from volunteering to become Raft leader. Defaults to false, and " +
+            "should only be used in exceptional circumstances by expert users. Using this can result in reduced " +
+            "availability for the cluster." )
+    public static final Setting<Boolean> refuse_to_be_leader =
+            setting( "causal_clustering.refuse_to_be_leader", BOOLEAN, FALSE );
+
+    @Description( "The maximum batch size when catching up (in unit of entries)" )
     public static final Setting<Integer> catchup_batch_size =
             setting( "causal_clustering.catchup_batch_size", INTEGER, "64" );
 
@@ -209,7 +216,7 @@ public class CausalClusteringSettings
             "endpoints or return only read replicas. If there are no read replicas in the cluster, followers are " +
             "returned as read end points regardless the value of this setting." )
     public static final Setting<Boolean> cluster_allow_reads_on_followers =
-            setting( "causal_clustering.cluster_allow_reads_on_followers", BOOLEAN, Settings.FALSE );
+            setting( "causal_clustering.cluster_allow_reads_on_followers", BOOLEAN, FALSE );
 
     @Description( "The size of the ID allocation requests Core servers will make when they run out of NODE IDs. " +
             "Larger values mean less frequent requests but also result in more unused IDs (and unused disk space) " +

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -39,6 +39,7 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     private final Log log;
     private final ClientConnectorAddresses connectorAddresses;
     private final HazelcastConnector connector;
+    private final Config config;
     private final RenewableTimeoutService renewableTimeoutService;
     private HazelcastInstance hazelcastInstance;
     private RenewableTimeoutService.RenewableTimeout readReplicaRefreshTimer;
@@ -49,6 +50,7 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
                      RenewableTimeoutService renewableTimeoutService, long readReplicaTimeToLiveTimeout, long readReplicaRefreshRate )
     {
         this.connector = connector;
+        this.config = config;
         this.renewableTimeoutService = renewableTimeoutService;
         this.readReplicaRefreshRate = readReplicaRefreshRate;
         this.log = logProvider.getLog( getClass() );
@@ -61,8 +63,8 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     {
         try
         {
-            return retry( ( hazelcastInstance ) ->
-                    HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log ) );
+            return retry( ( hazelcastInstance ) -> HazelcastClusterTopology.getCoreTopology( hazelcastInstance,
+                    config, log ) );
         }
         catch ( Exception e )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -250,8 +250,9 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
     @Override
     public void refreshCoreTopology()
     {
-        latestCoreTopology = HazelcastClusterTopology.getCoreTopology( hazelcastInstance, log );
+        latestCoreTopology = HazelcastClusterTopology.getCoreTopology( hazelcastInstance, config, log );
         log.info( "Current core topology is %s", coreServers() );
+
         listenerService.notifyListeners( coreServers() );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -99,7 +99,7 @@ public class RaftMachineBuilder
                         retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, inFlightMap );
         RaftMachine raft = new RaftMachine( member, termState, voteState, raftLog, electionTimeout,
                 heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, inFlightMap, monitors );
+                membershipManager, logShipping, inFlightMap, false, monitors );
         inbound.registerHandler( ( incomingMessage ) -> {
             try
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
@@ -241,7 +241,7 @@ public class HazelcastClientTest
                 .thenReturn( hazelcastInstance2 );
 
         com.hazelcast.core.Cluster cluster = mock( Cluster.class );
-        when( hazelcastInstance1.getCluster() ).thenReturn( cluster )
+        when( hazelcastInstance1.getCluster() ).thenReturn( cluster ).thenReturn( cluster )
                 .thenThrow( new HazelcastInstanceNotActiveException() );
         when( hazelcastInstance2.getCluster() ).thenReturn( cluster );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -36,7 +36,6 @@ import org.neo4j.causalclustering.discovery.ReadReplica;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.causalclustering.ClusterRule;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -276,29 +276,25 @@ public class CoreReplicationIT
         CountDownLatch latch = new CountDownLatch( 1 );
 
         // when
-        Thread thread = new Thread()
+        Thread thread = new Thread( () ->
         {
-            @Override
-            public void run()
+            try
             {
-                try
+                cluster.coreTx( ( db, tx ) ->
                 {
-                    cluster.coreTx( ( db, tx ) ->
-                    {
-                        db.createNode();
-                        tx.success();
+                    db.createNode();
+                    tx.success();
 
-                        cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
-                        cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
-                        latch.countDown();
-                    } );
-                }
-                catch ( Exception e )
-                {
-                    throw new RuntimeException( e );
-                }
+                    cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    cluster.removeCoreMember( cluster.getDbWithAnyRole( Role.FOLLOWER, Role.CANDIDATE ) );
+                    latch.countDown();
+                } );
             }
-        };
+            catch ( Exception e )
+            {
+                throw new RuntimeException( e );
+            }
+        } );
 
         thread.start();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.graphdb.Node;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import static org.neo4j.graphdb.Label.label;
+
+public class WillNotBecomeLeaderIT
+{
+    @Rule
+    public final ClusterRule clusterRule =
+            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+
+    @Rule
+    public ExpectedException exceptionMatcher = ExpectedException.none();
+
+    @Test
+    public void clusterShouldNotElectNewLeader() throws Exception
+    {
+        // given
+        int leaderId = 0;
+
+        clusterRule.withInstanceCoreParam( CausalClusteringSettings.refuse_to_be_leader, ( x ) ->
+        {
+            if ( x == leaderId )
+            {
+                return "false";
+            }
+            else
+            {
+                return "true";
+            }
+        } );
+
+        Cluster cluster = clusterRule.createCluster();
+        cluster.start();
+        assertEquals( leaderId, cluster.awaitLeader().serverId() );
+
+        cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        } );
+
+        // When
+        cluster.removeCoreMemberWithMemberId( leaderId );
+
+        // Then
+        try
+        {
+            cluster.awaitLeader(10, SECONDS);
+
+            fail( "Should not have elected a leader" );
+        }
+        catch ( TimeoutException ex )
+        {
+            // Successful
+        }
+    }
+}


### PR DESCRIPTION
Core members can refuse to trigger an election (and thus become leaders).
This is useful for those (typically multi-DC) scenarios where end-users want to restrict
the servers which can host the leader role. This is, clearly, at the deliberate expense of
availability.