### PR TITLE
Add utilities for debugging through generated code

### DIFF
--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenConfiguration.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenConfiguration.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen
 
+import java.nio.file.{Path, Paths}
+
 import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 
 /**
@@ -46,6 +48,7 @@ case object ByteCodeMode extends CodeGenMode
 case class CodeGenConfiguration(mode: CodeGenMode = CodeGenMode.default,
                                 showSource: Boolean = false,
                                 showByteCode: Boolean = false,
+                                saveSource: Option[Path] = None,
                                 packageName: String = "org.neo4j.cypher.internal.compiler.v3_2.generated"
                                )
 
@@ -57,7 +60,8 @@ object CodeGenConfiguration {
       throw new InternalException("Can only 'debug=show_java_source' if 'debug=generate_java_source'.")
     }
     val show_bytecode = debugOptions.contains("show_bytecode")
-    CodeGenConfiguration(mode, show_java_source, show_bytecode)
+    val saveSource = Option(System.getProperty("org.neo4j.cypher.DEBUG.generated_source_location")).map(Paths.get(_))
+    CodeGenConfiguration(mode, show_java_source, show_bytecode, saveSource)
   }
 }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/SaveGeneratedSource.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/SaveGeneratedSource.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiled_runtime.v3_2
+
+import java.nio.file.FileVisitResult.CONTINUE
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.SaveGeneratedSource.GENERATED_SOURCE_LOCATION
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherTestSupport
+
+/**
+  * This trait allows debugging generated queries, by generating queries through java source, then making sure that
+  * the generated source is written to a place where Intellij can find it.
+  *
+  * How to use:
+  * 1. Add this trait to the test class containing your test.
+  * 2. Prefix your query with `CYPHER debug=generate_java_source`
+  * 3. When running the test make sure that the Working Directory is set to
+  *    the directory of the maven module containing your test.
+  * 4. Mark `[your-maven-module]/target/generated-test-sources/cypher` as "Generated Sources Root".
+  * 5. Make sure you have a breakpoint set to somewhere before execution enters the generated code,
+  *    but after the code has been generated.
+  * 6. When you run you test, as the first breakpoint triggers, find the directory
+  *    `[your-maven-module]/target/generated-test-sources/cypher`, right click and select "Synchronize 'cypher'"
+  *    If you have not done so before, this is a good time to "Mark Directory as" "Generated Sources Root".
+  * 7. Now you should see the source file for the generated query, and be able to set breakpoints in that code,
+  *    as well as stepping through it.
+  * 8. Note that every time you re-run your test, you will have to repeat steps 5 to 7, since new code will be
+  *    generated each time.
+  */
+trait SaveGeneratedSource extends CypherTestSupport {
+  private var generatedSources: Option[Path] = None
+
+  override protected def initTest(): Unit = {
+    super.initTest()
+    val cwd = Paths.get(".").normalize.toRealPath()
+    // If CWD is set up correctly, we assign the generated source location
+    if(Files.isRegularFile(cwd.resolve("src/test/scala").resolve(getClass.getName.replace('.', '/') + ".scala"))
+      && Files.isDirectory(cwd.resolve("target"))) {
+      setLocation(cwd.resolve("target").resolve("generated-test-sources").resolve("cypher"))
+    }
+  }
+
+
+  private def setLocation(location: Path) = {
+    System.err.println(s"Will save generated sources to $location")
+    generatedSources = Some(location)
+    System.setProperty(GENERATED_SOURCE_LOCATION, location.toString)
+  }
+
+  override protected def stopTest(): Unit = {
+    System.clearProperty(GENERATED_SOURCE_LOCATION)
+    generatedSources.foreach { location =>
+      Files.walkFileTree(location, new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          CONTINUE
+        }
+      })
+    }
+    super.stopTest()
+  }
+}
+
+private object SaveGeneratedSource {
+  private val GENERATED_SOURCE_LOCATION = "org.neo4j.cypher.DEBUG.generated_source_location"
+  private val RELATIVE = Set("", "..")
+}


### PR DESCRIPTION
How to use:

1. Add this trait to the test class containing your test.
2. Prefix your query with `CYPHER debug=generate_java_source`
3. When running the test make sure that the Working Directory is set to the directory of the maven module containing your test.
4. Mark `[your-maven-module]/target/generated-test-sources/cypher` as "Generated Sources Root".
5. Make sure you have a breakpoint set to somewhere before execution enters the generated code, but after the code has been generated.
6. When you run you test, as the first breakpoint triggers, find the directory `[your-maven-module]/target/generated-test-sources/cypher`, right click and select "Synchronize 'cypher'"
  _(If you have not done so before, this is a good time to "Mark Directory as" "Generated Sources Root".)_
7. Now you should see the source file for the generated query, and be able to set breakpoints in that code, as well as stepping through it.
8. Note that every time you re-run your test, you will have to repeat steps 5 to 7, since new code will be generated each time.