### PR TITLE
Fixed directories specified in Debian/RPM config

### DIFF
--- a/new-packaging/bin/build-debian-package
+++ b/new-packaging/bin/build-debian-package
@@ -61,10 +61,14 @@ sed -i 's/unsupported.dbms.udc.source=tarball/unsupported.dbms.udc.source=debian
 
 # Modify directories to match the FHS (https://www.debian.org/doc/packaging-manuals/fhs/fhs-2.3.html)
 configuration_file=${package_directory}/server/conf/neo4j.conf
-sed -i 's/#dbms.directories.data=data/dbms.directories.data=\/var\/lib\/neo4j\/data/'             ${configuration_file}
-sed -i 's/#dbms.directories.plugins=plugins/dbms.directories.plugins=\/var\/lib\/neo4j\/plugins/' ${configuration_file}
-sed -i 's/#dbms.directories.import=import/dbms.directories.import=\/var\/lib\/neo4j\/import/'     ${configuration_file}
-cat src/debian/directories.conf >>${configuration_file}
+sed -i 's/#*dbms.directories.data=.*/dbms.directories.data=\/var\/lib\/neo4j\/data/'             ${configuration_file}
+sed -i 's/#*dbms.directories.plugins=.*/dbms.directories.plugins=\/var\/lib\/neo4j\/plugins/' ${configuration_file}
+sed -i 's/#*dbms.directories.import=.*/dbms.directories.import=\/var\/lib\/neo4j\/import/'     ${configuration_file}
+sed -i 's/#*dbms.directories.logs=.*/dbms.directories.logs=\/var\/log\/neo4j/'     ${configuration_file}
+sed -i 's/#*dbms.directories.run=.*/dbms.directories.run=\/var\/run\/neo4j/'     ${configuration_file}
+sed -i 's/#*dbms.directories.lib=.*/dbms.directories.lib=\/usr\/share\/neo4j\/lib/'     ${configuration_file}
+sed -i 's/#*dbms.directories.certificates=.*/dbms.directories.certificates=\/var\/lib\/neo4j\/certificates/'     ${configuration_file}
+sed -i 's/#*dbms.directories.metrics=.*/dbms.directories.metric=\/var\/lib\/neo4j\/metrics/'     ${configuration_file}
 
 # Make scripts executable
 chmod 700 ${package_directory}/server/bin/*
@@ -72,4 +76,3 @@ chmod 700 ${scripts_directory}/*
 
 # build package and metadata files
 (cd ${package_directory} && debuild -B -uc -us --lintian-opts --profile debian)
-

--- a/new-packaging/src/debian/directories.conf
+++ b/new-packaging/src/debian/directories.conf
@@ -1,6 +1,0 @@
-
-# Directory settings.
-dbms.directories.logs=/var/log/neo4j
-dbms.directories.run=/var/run/neo4j
-dbms.directories.lib=/usr/share/neo4j/lib
-dbms.directories.certificates=/var/lib/neo4j/certificates

--- a/new-packaging/src/debian/neo4j-script
+++ b/new-packaging/src/debian/neo4j-script
@@ -6,4 +6,4 @@ SCRIPT_PATH=""${NEO4J_BIN}"/"${SCRIPT_NAME}""
 
 [ -r /etc/default/neo4j ] && . /etc/default/neo4j
 
-NEO4J_HOME="${NEO4J_HOME:-/usr/share/neo4j}" NEO4J_CONF="${NEO4J_CONF:-/etc/neo4j}" exec "${SCRIPT_PATH}" "$@"
+NEO4J_HOME="${NEO4J_HOME:-/var/lib/neo4j}" NEO4J_CONF="${NEO4J_CONF:-/etc/neo4j}" exec "${SCRIPT_PATH}" "$@"

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -13,6 +13,8 @@
 #dbms.directories.plugins=plugins
 #dbms.directories.certificates=certificates
 #dbms.directories.logs=logs
+#dbms.directories.lib=lib
+#dbms.directories.run=run
 
 # This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or comment it out to
 # allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -13,6 +13,9 @@
 #dbms.directories.plugins=plugins
 #dbms.directories.certificates=certificates
 #dbms.directories.logs=logs
+#dbms.directories.lib=lib
+#dbms.directories.run=run
+#dbms.directories.metrics=metrics
 
 # This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or comment it out to
 # allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`


### PR DESCRIPTION
Previously the import directory would mistakenly be pointed at
`/usr/share/neo4j/import` because

* it was a relative path and NEO4J_HOME was incorrectly set.
* the `sed` invocation was hardcoded to require a commented entry

This changes the `sed` invocations to not care if the entry is
commented or not, or what the value is. It also expands to make all
configurable paths absolute.

Note than when forward merging this might give some conflicts with the RPM building so the same `sed` invocations should be duplicated there.