### PR TITLE
Fix problems around query plans with missing tokens

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -423,6 +423,16 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
+    public static Expression constantInt( int value )
+    {
+        return constant(value);
+    }
+
+    public static Expression constantLong( long value )
+    {
+        return constant(value);
+    }
+
     public static Expression constant( final Object value )
     {
         TypeReference reference;

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledMathHelper.java
@@ -125,8 +125,8 @@ public final class CompiledMathHelper
             // other numbers we cannot add
         }
 
-        throw new CypherTypeException( "Cannot add " + lhs.getClass().getSimpleName() +
-                                       " and " + rhs.getClass().getSimpleName(), null );
+        throw new CypherTypeException(
+                String.format( "Don't know how to add `%s` and `%s`", lhs, rhs), null );
     }
 
     public static Object subtract( Object lhs, Object rhs )

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/NodeIdWrapperImpl.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/NodeIdWrapperImpl.java
@@ -55,4 +55,10 @@ public final class NodeIdWrapperImpl implements NodeIdWrapper
     {
         return (int) (id ^ (id >>> 32));
     }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "Node[%d]", id );
+    }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/BuildSortTable.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/BuildSortTable.scala
@@ -50,7 +50,7 @@ case class BuildTopTable(opName: String, tableName: String, countExpression: Cod
 
     // Return early on limit <= 0 (this unifies the behaviour with the normal limit implementation)
     val variableName = context.namer.newVarName()
-    generator.declareCounter(variableName, generator.box(countExpression.generateExpression(generator)))
+    generator.declareCounter(variableName, generator.box(countExpression.generateExpression(generator), countExpression.codeGenType))
     generator.ifStatement(generator.checkInteger(variableName, LessThanEqual, 0L)) { onTrue =>
       onTrue.returnSuccessfully()
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/DecreaseAndReturnWhenZero.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/DecreaseAndReturnWhenZero.scala
@@ -28,7 +28,7 @@ case class DecreaseAndReturnWhenZero(opName: String, variableName: String, actio
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
     startValue.init(generator)
-    val expression = generator.box(startValue.generateExpression(generator))
+    val expression = generator.box(startValue.generateExpression(generator), startValue.codeGenType)
     generator.declareCounter(variableName, expression)
     generator.ifStatement(generator.checkInteger(variableName, LessThanEqual, 0L)) { onTrue =>
       onTrue.returnSuccessfully()

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
@@ -24,17 +24,27 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, 
 
 case class NodeCountFromCountStoreInstruction(opName: String, variable: Variable, label: Option[(Option[Int], String)],
                                               inner: Instruction) extends Instruction {
-  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
     generator.trace(opName) { body =>
       body.incrementDbHits()
-      if (label.nonEmpty) {
-        val (token, _) = label.get
-        val expression = token.map(t => body.token(Int.box(t))).getOrElse(body.loadVariable(tokenVar))
-        body.assign(variable.name, variable.codeGenType,
-                    generator.nodeCountFromCountStore(expression))
-      } else {
-        body.assign(variable.name, variable.codeGenType,
-                    generator.nodeCountFromCountStore(generator.wildCardToken))
+
+      label match {
+        //no label specified by the user
+        case None =>
+          body.assign(variable, body.nodeCountFromCountStore(generator.wildCardToken))
+
+        // label specified and token known
+        case Some((Some(token), _)) =>
+          val tokenConstant = body.token(Int.box(token))
+          body.assign(variable, generator.nodeCountFromCountStore(tokenConstant))
+
+        // label specified, but token did not exists at compile time
+        case Some((None, labelName)) =>
+          val tokenConstant: E = generator.lookupLabelIdE(labelName)
+          val isMissing = generator.primitiveEquals(tokenConstant, generator.wildCardToken)
+          val zero = body.constantExpression(0.asInstanceOf[AnyRef])
+          val getFromCountStore = body.nodeCountFromCountStore(tokenConstant)
+          body.assign(variable, body.ternaryOperator(isMissing, zero, getFromCountStore))
       }
       inner.body(body)
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/NodeCountFromCountStoreInstruction.scala
@@ -42,7 +42,7 @@ case class NodeCountFromCountStoreInstruction(opName: String, variable: Variable
         case Some((None, labelName)) =>
           val tokenConstant: E = generator.lookupLabelIdE(labelName)
           val isMissing = generator.primitiveEquals(tokenConstant, generator.wildCardToken)
-          val zero = body.constantExpression(0.asInstanceOf[AnyRef])
+          val zero = body.constantExpression(0L.asInstanceOf[AnyRef])
           val getFromCountStore = body.nodeCountFromCountStore(tokenConstant)
           body.assign(variable, body.ternaryOperator(isMissing, zero, getFromCountStore))
       }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/RelationshipCountFromCountStoreInstruction.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/RelationshipCountFromCountStoreInstruction.scala
@@ -29,7 +29,7 @@ case class RelationshipCountFromCountStoreInstruction(opName: String, variable: 
   private val hasTokens = opName + "hasTokens"
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
-    generator.assign(variable, generator.constantPrimitiveExpression(0))
+    generator.assign(variable, generator.constantPrimitiveExpression(0L))
     generator.trace(opName) { body =>
 
       body.ifStatement(body.loadVariable(hasTokens)) { ifBody =>

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/SkipInstruction.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/SkipInstruction.scala
@@ -28,7 +28,7 @@ case class SkipInstruction(opName: String, variableName: String, action: Instruc
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit = {
     numberToSkip.init(generator)
-    val expression = generator.box(numberToSkip.generateExpression(generator))
+    val expression = generator.box(numberToSkip.generateExpression(generator), numberToSkip.codeGenType)
     generator.declareCounter(variableName, expression)
     action.init(generator)
   }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/UnwindPrimitiveCollection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/UnwindPrimitiveCollection.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
 
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenExpression, CodeGenType, ListReferenceType}
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenExpression, CodeGenType, CypherCodeGenType, ListReferenceType}
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, Variable}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols
@@ -38,7 +38,7 @@ case class UnwindPrimitiveCollection(opName: String, collection: CodeGenExpressi
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
                              (implicit context: CodeGenContext): Unit = {
     val elementType = collection.codeGenType match {
-      case CodeGenType(symbols.ListType(innerCt), ListReferenceType(innerRepr)) => CodeGenType(innerCt, innerRepr)
+      case CypherCodeGenType(symbols.ListType(innerCt), ListReferenceType(innerRepr)) => CypherCodeGenType(innerCt, innerRepr)
       case _ => throw new IllegalArgumentException(s"CodeGenType $collection.codeGenType not supported as primitive iterator")
     }
     val next = generator.primitiveIteratorNext(generator.loadVariable(iterVar), collection.codeGenType)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Addition.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Addition.scala
@@ -35,18 +35,19 @@ case class Addition(lhs: CodeGenExpression, rhs: CodeGenExpression) extends Code
 
     // Collections
     case (ListType(left), ListType(right)) =>
-      CodeGenType(ListType(left leastUpperBound right), ReferenceType)
+      CypherCodeGenType(ListType(left leastUpperBound right), ReferenceType)
     case (ListType(innerType), singleElement) =>
-      CodeGenType(ListType(innerType leastUpperBound singleElement), ReferenceType)
-    case (singleElement, ListType(innerType)) => CodeGenType(ListType(innerType leastUpperBound singleElement), ReferenceType)
+      CypherCodeGenType(ListType(innerType leastUpperBound singleElement), ReferenceType)
+    case (singleElement, ListType(innerType)) =>
+      CypherCodeGenType(ListType(innerType leastUpperBound singleElement), ReferenceType)
 
     // Strings
-    case (CTString, _) => CodeGenType(CTString, ReferenceType)
-    case (_, CTString) => CodeGenType(CTString, ReferenceType)
+    case (CTString, _) => CypherCodeGenType(CTString, ReferenceType)
+    case (_, CTString) => CypherCodeGenType(CTString, ReferenceType)
 
     // Numbers
-    case (CTInteger, CTInteger) => CodeGenType(CTInteger, ReferenceType)
-    case (Number(_), Number(_)) => CodeGenType(CTFloat, ReferenceType)
+    case (CTInteger, CTInteger) => CypherCodeGenType(CTInteger, ReferenceType)
+    case (Number(_), Number(_)) => CypherCodeGenType(CTFloat, ReferenceType)
 
     // Runtime we'll figure it out
     case _ => CodeGenType.Any

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/AnyProjection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/AnyProjection.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
+import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 
 case class AnyProjection(variable: Variable) extends CodeGenExpression {
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
@@ -31,5 +32,9 @@ case class AnyProjection(variable: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext): Boolean = variable.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = variable.codeGenType
+  override def codeGenType(implicit context: CodeGenContext): CypherCodeGenType = variable.codeGenType match {
+    case x: CypherCodeGenType => x
+    case _ => throw new InternalException("Tried to create a Cypher value from a non-cypher-value variable")
+  }
+
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/BinaryOperator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/BinaryOperator.scala
@@ -39,14 +39,14 @@ trait BinaryOperator {
 
   override final def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     def isListOf(codeGenType: CodeGenType, cType: CypherType) = codeGenType match {
-      case CodeGenType(ListType(inner),_) if inner == cType => true
+      case CypherCodeGenType(ListType(inner),_) if inner == cType => true
       case _ => false
     }
     (lhs.codeGenType, rhs.codeGenType) match {
-      case (CodeGenType(CTBoolean, _), t) if !(isListOf(t, CTAny) || isListOf(t, CTBoolean)) =>
+      case (CypherCodeGenType(CTBoolean, _), t) if !(isListOf(t, CTAny) || isListOf(t, CTBoolean)) =>
         throw new CypherTypeException(s"Cannot $name a boolean and ${rhs.codeGenType.ct}")
 
-      case (t, CodeGenType(CTBoolean, _)) if !(isListOf(t, CTAny) || isListOf(t, CTBoolean)) =>
+      case (t, CypherCodeGenType(CTBoolean, _)) if !(isListOf(t, CTAny) || isListOf(t, CTBoolean)) =>
         throw new CypherTypeException(s"Cannot $name a ${rhs.codeGenType.ct} and a boolean")
 
       case (t1, t2) if t1.isPrimitive && t2.isPrimitive =>
@@ -67,8 +67,8 @@ trait BinaryOperator {
 
   override def codeGenType(implicit context: CodeGenContext) =
     (lhs.codeGenType.ct, rhs.codeGenType.ct) match {
-      case (CTInteger, CTInteger) => CodeGenType(CTInteger, ReferenceType)
-      case (Number(_), Number(_)) => CodeGenType(CTFloat, ReferenceType)
+      case (CTInteger, CTInteger) => CypherCodeGenType(CTInteger, ReferenceType)
+      case (Number(_), Number(_)) => CypherCodeGenType(CTFloat, ReferenceType)
       // Runtime we'll figure it out - can't store it in a primitive field unless we are 100% of the type
       case _ => CodeGenType.Any
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/BinaryOperator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/BinaryOperator.scala
@@ -50,15 +50,15 @@ trait BinaryOperator {
         throw new CypherTypeException(s"Cannot $name a ${rhs.codeGenType.ct} and a boolean")
 
       case (t1, t2) if t1.isPrimitive && t2.isPrimitive =>
-        generator(structure)(context)(structure.box(lhs.generateExpression(structure)),
-                                      structure.box(rhs.generateExpression(structure)))
+        generator(structure)(context)(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
+                                      structure.box(rhs.generateExpression(structure), rhs.codeGenType))
 
       case (t, _) if t.isPrimitive =>
-        generator(structure)(context)(structure.box(lhs.generateExpression(structure)),
+        generator(structure)(context)(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
                                       rhs.generateExpression(structure))
       case (_, t) if t.isPrimitive =>
         generator(structure)(context)(lhs.generateExpression(structure),
-                                      structure.box(rhs.generateExpression(structure)))
+                                      structure.box(rhs.generateExpression(structure), rhs.codeGenType))
 
       case _ => generator(structure)(context)(lhs.generateExpression(structure),
                                               rhs.generateExpression(structure))

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CastToCollection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CastToCollection.scala
@@ -32,5 +32,5 @@ case class CastToCollection(expression: CodeGenExpression) extends CodeGenExpres
 
   override def nullable(implicit context: CodeGenContext) = expression.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTList(CTAny), ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTList(CTAny), ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenExpression.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenExpression.scala
@@ -26,5 +26,5 @@ trait CodeGenExpression {
   def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
   def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext): E
   def nullable(implicit context: CodeGenContext): Boolean
-  def codeGenType(implicit context: CodeGenContext): CodeGenType
+  def codeGenType(implicit context: CodeGenContext): CypherCodeGenType
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenType.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenType.scala
@@ -22,23 +22,32 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.frontend.v3_2.symbols
 import org.neo4j.cypher.internal.frontend.v3_2.symbols.CypherType
 
-case class CodeGenType(ct: CypherType, repr: RepresentationType) {
+trait CodeGenType {
+  def isPrimitive: Boolean
+
+  def canBeNullable: Boolean
+
+  def repr: RepresentationType
+}
+
+object CodeGenType {
+  val Any = CypherCodeGenType(symbols.CTAny, ReferenceType)
+  val primitiveNode = CypherCodeGenType(symbols.CTNode, LongType)
+  val primitiveRel = CypherCodeGenType(symbols.CTRelationship, LongType)
+  val primitiveInt = CypherCodeGenType(symbols.CTInteger, LongType)
+  val primitiveFloat = CypherCodeGenType(symbols.CTFloat, FloatType)
+  val primitiveBool = CypherCodeGenType(symbols.CTBoolean, BoolType)
+  val javaInt = JavaCodeGenType(IntType)
+}
+
+case class JavaCodeGenType(repr: RepresentationType) extends CodeGenType {
+  override def isPrimitive = RepresentationType.isPrimitive(repr)
+
+  override def canBeNullable: Boolean = false
+}
+
+case class CypherCodeGenType(ct: CypherType, repr: RepresentationType) extends CodeGenType {
   def isPrimitive = RepresentationType.isPrimitive(repr)
 
   def canBeNullable = !isPrimitive || (ct == symbols.CTNode) || (ct == symbols.CTRelationship)
 }
-
-object CodeGenType {
-  val Any = CodeGenType(symbols.CTAny, ReferenceType)
-  val primitiveNode = CodeGenType(symbols.CTNode, IntType)
-  val primitiveRel = CodeGenType(symbols.CTRelationship, IntType)
-  val primitiveInt = CodeGenType(symbols.CTInteger, IntType)
-  val primitiveFloat = CodeGenType(symbols.CTFloat, FloatType)
-  val primitiveBool = CodeGenType(symbols.CTBoolean, BoolType)
-}
-
-
-
-
-
-

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenType.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenType.scala
@@ -38,6 +38,7 @@ object CodeGenType {
   val primitiveFloat = CypherCodeGenType(symbols.CTFloat, FloatType)
   val primitiveBool = CypherCodeGenType(symbols.CTBoolean, BoolType)
   val javaInt = JavaCodeGenType(IntType)
+  val javaLong = JavaCodeGenType(LongType)
 }
 
 case class JavaCodeGenType(repr: RepresentationType) extends CodeGenType {

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Equals.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Equals.scala
@@ -29,7 +29,7 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 
   override def codeGenType(implicit context: CodeGenContext) =
-    if (nullable) CodeGenType(CTBoolean, ReferenceType)
+    if (nullable) CypherCodeGenType(CTBoolean, ReferenceType)
     else CodeGenType.primitiveBool
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
@@ -92,7 +92,7 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
         structure.unbox(
           structure.threeValuedEqualsExpression(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
                                                 structure.box(rhs.generateExpression(structure), rhs.codeGenType)),
-          CodeGenType(CTBoolean, ReferenceType))
+          CypherCodeGenType(CTBoolean, ReferenceType))
       }
   }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ExpressionConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ExpressionConverter.scala
@@ -45,7 +45,7 @@ object ExpressionConverter {
       override def nullable(implicit context: CodeGenContext) = false
 
       override def codeGenType(implicit context: CodeGenContext) =
-        if (nullable) CodeGenType(CTBoolean, ReferenceType)
+        if (nullable) CypherCodeGenType(CTBoolean, ReferenceType)
         else expression.codeGenType
     }
   }
@@ -83,31 +83,31 @@ object ExpressionConverter {
     val variable = context.getVariable(variableQueryVariable)
 
     variable.codeGenType match {
-      case CodeGenType(CTNode, _) => NodeProjection(variable)
-      case CodeGenType(CTRelationship, _) => RelationshipProjection(variable)
-      case CodeGenType(CTString, _) |
-           CodeGenType(CTBoolean, _) |
-           CodeGenType(CTInteger, _) |
-           CodeGenType(CTFloat, _) =>
+      case CypherCodeGenType(CTNode, _) => NodeProjection(variable)
+      case CypherCodeGenType(CTRelationship, _) => RelationshipProjection(variable)
+      case CypherCodeGenType(CTString, _) |
+           CypherCodeGenType(CTBoolean, _) |
+           CypherCodeGenType(CTInteger, _) |
+           CypherCodeGenType(CTFloat, _) =>
         LoadVariable(variable)
-      case CodeGenType(ListType(CTInteger), ListReferenceType(IntType)) =>
+      case CypherCodeGenType(ListType(CTInteger), ListReferenceType(LongType)) =>
         // TODO: PrimitiveProjection(variable)
         AnyProjection(variable) // Temporarily resort to runtime projection
-      case CodeGenType(ListType(CTFloat), ListReferenceType(FloatType)) =>
+      case CypherCodeGenType(ListType(CTFloat), ListReferenceType(FloatType)) =>
         // TODO: PrimitiveProjection(variable)
         AnyProjection(variable) // Temporarily resort to runtime projection
-      case CodeGenType(ListType(CTBoolean), ListReferenceType(BoolType)) =>
+      case CypherCodeGenType(ListType(CTBoolean), ListReferenceType(BoolType)) =>
         // TODO: PrimitiveProjection(variable)
         AnyProjection(variable) // Temporarily resort to runtime projection
-      case CodeGenType(ListType(CTString), _) |
-           CodeGenType(ListType(CTBoolean), _) |
-           CodeGenType(ListType(CTInteger), _) |
-           CodeGenType(ListType(CTFloat), _) =>
+      case CypherCodeGenType(ListType(CTString), _) |
+           CypherCodeGenType(ListType(CTBoolean), _) |
+           CypherCodeGenType(ListType(CTInteger), _) |
+           CypherCodeGenType(ListType(CTFloat), _) =>
         LoadVariable(variable)
-      case CodeGenType(CTAny, _) => AnyProjection(variable)
-      case CodeGenType(CTMap, _) => AnyProjection(variable)
-      case CodeGenType(ListType(_), _) => AnyProjection(variable) // TODO: We could have a more specialized projection when the inner type is known to be node or relationship
-      case _ => throw new CantCompileQueryException(s"The compiled runtime cannot handle results of type ${variable.codeGenType.ct}")
+      case CypherCodeGenType(CTAny, _) => AnyProjection(variable)
+      case CypherCodeGenType(CTMap, _) => AnyProjection(variable)
+      case CypherCodeGenType(ListType(_), _) => AnyProjection(variable) // TODO: We could have a more specialized projection when the inner type is known to be node or relationship
+      case _ => throw new CantCompileQueryException(s"The compiled runtime cannot handle results of type ${variable.codeGenType}")
     }
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
@@ -45,5 +45,5 @@ case class HasLabel(nodeVariable: Variable, labelVariable: String, labelName: St
   override def nullable(implicit context: CodeGenContext) = nodeVariable.nullable
 
   override def codeGenType(implicit context: CodeGenContext) =
-    if (nullable) CodeGenType(CTBoolean, ReferenceType) else CodeGenType(CTBoolean, BoolType)
+    if (nullable) CypherCodeGenType(CTBoolean, ReferenceType) else CodeGenType.primitiveBool
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
@@ -37,7 +37,7 @@ case class HasLabel(nodeVariable: Variable, labelVariable: String, labelName: St
     if (nodeVariable.nullable)
       structure.nullableReference(nodeVariable.name, CodeGenType.primitiveNode,
                                   structure.box(
-                                    structure.hasLabel(nodeVariable.name, labelVariable, localName)))
+                                    structure.hasLabel(nodeVariable.name, labelVariable, localName), CodeGenType.primitiveBool))
     else
       structure.hasLabel(nodeVariable.name, labelVariable, localName)
   }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ListLiteral.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ListLiteral.scala
@@ -34,7 +34,7 @@ case class ListLiteral(expressions: Seq[CodeGenExpression]) extends CodeGenExpre
 
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     codeGenType match {
-      case cType@CodeGenType(ListType(_), ListReferenceType(innerRepr)) if RepresentationType.isPrimitive(innerRepr) =>
+      case cType@CypherCodeGenType(ListType(_), ListReferenceType(innerRepr)) if RepresentationType.isPrimitive(innerRepr) =>
         structure.asPrimitiveStream(expressions.map(e => {
           e.generateExpression(structure)
         }), cType)
@@ -54,6 +54,6 @@ case class ListLiteral(expressions: Seq[CodeGenExpression]) extends CodeGenExpre
         symbols.CTAny
 
     val elementType = LiteralTypeSupport.deriveCodeGenType(commonType)
-    CodeGenType(symbols.CTList(commonType), ListReferenceType(elementType.repr))
+    CypherCodeGenType(symbols.CTList(commonType), ListReferenceType(elementType.repr))
   }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/LoadVariable.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/LoadVariable.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, Variable}
+import org.neo4j.cypher.internal.frontend.v3_2.InternalException
 
 case class LoadVariable(variable: Variable) extends CodeGenExpression {
 
@@ -31,5 +32,8 @@ case class LoadVariable(variable: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext): Boolean = variable.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = variable.codeGenType
+  override def codeGenType(implicit context: CodeGenContext) = variable.codeGenType match {
+    case x: CypherCodeGenType => x
+    case _ => throw new InternalException("Tried to create a Cypher value from a non-cypher-value variable")
+  }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Modulo.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Modulo.scala
@@ -28,7 +28,7 @@ case class Modulo(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
   override protected def generator[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = structure.modulusExpression
   override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTFloat, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTFloat, ReferenceType)
 
   override def name: String = "modulo"
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/MyMap.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/MyMap.scala
@@ -36,5 +36,5 @@ case class MyMap(instructions: Map[String, CodeGenExpression]) extends CodeGenEx
 
   override def nullable(implicit context: CodeGenContext) = false
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTMap, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTMap, ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeExpression.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeExpression.scala
@@ -34,5 +34,5 @@ case class NodeExpression(nodeIdVar: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext) = nodeIdVar.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = nodeIdVar.codeGenType
+  override def codeGenType(implicit context: CodeGenContext) = CodeGenType.primitiveNode
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProjection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProjection.scala
@@ -25,7 +25,8 @@ import org.neo4j.cypher.internal.frontend.v3_2.symbols
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class NodeProjection(nodeIdVar: Variable) extends CodeGenExpression {
-  assert(nodeIdVar.codeGenType.ct == symbols.CTNode)
+
+  assert(nodeIdVar.codeGenType.asInstanceOf[CypherCodeGenType].ct == symbols.CTNode)
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
@@ -39,5 +40,5 @@ case class NodeProjection(nodeIdVar: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext) = nodeIdVar.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTNode, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTNode, ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Not.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Not.scala
@@ -41,5 +41,5 @@ case class Not(inner: CodeGenExpression) extends CodeGenExpression {
 
   override def codeGenType(implicit context: CodeGenContext) =
     if (!nullable) CodeGenType.primitiveBool
-    else  CodeGenType(CTBoolean, ReferenceType)
+    else CypherCodeGenType(CTBoolean, ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Not.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Not.scala
@@ -32,10 +32,10 @@ case class Not(inner: CodeGenExpression) extends CodeGenExpression {
   override def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) =
     if (!nullable) inner.codeGenType match {
       case t if t.isPrimitive => structure.notExpression (inner.generateExpression (structure) )
-      case t => structure.unbox(structure.threeValuedNotExpression(structure.box(inner.generateExpression(structure))),
+      case t => structure.unbox(structure.threeValuedNotExpression(structure.box(inner.generateExpression(structure), inner.codeGenType)),
                                 CodeGenType.primitiveBool)
     }
-    else structure.threeValuedNotExpression(structure.box(inner.generateExpression(structure)))
+    else structure.threeValuedNotExpression(structure.box(inner.generateExpression(structure), inner.codeGenType))
 
   override def nullable(implicit context: CodeGenContext) = inner.nullable
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Or.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Or.scala
@@ -29,7 +29,7 @@ case class Or(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExp
 
   override def codeGenType(implicit context: CodeGenContext) =
     if (!nullable) CodeGenType.primitiveBool
-    else CodeGenType(CTBoolean, ReferenceType)
+    else CypherCodeGenType(CTBoolean, ReferenceType)
 
   override final def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     lhs.init(generator)
@@ -47,7 +47,7 @@ case class Or(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExp
       case _ =>
         structure.unbox(
           structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure)), structure.box(rhs.generateExpression(structure))),
-          CodeGenType(CTBoolean, ReferenceType))
+          CypherCodeGenType(CTBoolean, ReferenceType))
     }
     else structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure)),
                                            structure.box(rhs.generateExpression(structure)))

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Or.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Or.scala
@@ -46,9 +46,9 @@ case class Or(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExp
         structure.orExpression(structure.unbox(lhs.generateExpression(structure), t1), rhs.generateExpression(structure))
       case _ =>
         structure.unbox(
-          structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure)), structure.box(rhs.generateExpression(structure))),
+          structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure), lhs.codeGenType), structure.box(rhs.generateExpression(structure), rhs.codeGenType)),
           CypherCodeGenType(CTBoolean, ReferenceType))
     }
-    else structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure)),
-                                           structure.box(rhs.generateExpression(structure)))
+    else structure.threeValuedOrExpression(structure.box(lhs.generateExpression(structure), lhs.codeGenType),
+                                           structure.box(rhs.generateExpression(structure), rhs.codeGenType))
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Parameter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/Parameter.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
 
-case class Parameter(key: String, variableName: String, cType: CodeGenType = CodeGenType.Any) extends CodeGenExpression {
+case class Parameter(key: String, variableName: String, cType: CypherCodeGenType = CodeGenType.Any) extends CodeGenExpression {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
     generator.expectParameter(key, variableName, cType)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RelationshipExpression.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RelationshipExpression.scala
@@ -33,5 +33,5 @@ case class RelationshipExpression(relId: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = relId.codeGenType
+  override def codeGenType(implicit context: CodeGenContext) = CodeGenType.primitiveRel
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RelationshipProjection.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RelationshipProjection.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.symbols
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class RelationshipProjection(relId: Variable) extends CodeGenExpression {
-  assert(relId.codeGenType.ct == symbols.CTRelationship)
+  assert(relId.codeGenType.asInstanceOf[CypherCodeGenType].ct == symbols.CTRelationship)
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
@@ -39,5 +39,5 @@ case class RelationshipProjection(relId: Variable) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTRelationship, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTRelationship, ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RepresentationType.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/RepresentationType.scala
@@ -20,11 +20,13 @@
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 
 /**
-  * Type representation of a CodeGenExpression
+  * Type representation of a CodeGenExpression - these are the JVM types that will be used!
   */
 sealed trait RepresentationType
 
 case object IntType extends RepresentationType
+
+case object LongType extends RepresentationType
 
 case object BoolType extends RepresentationType
 
@@ -35,8 +37,8 @@ case object ReferenceType extends RepresentationType
 case class ListReferenceType(inner: RepresentationType) extends RepresentationType
 
 object RepresentationType {
-  def isPrimitive(repr: RepresentationType) = repr match {
-    case IntType | FloatType | BoolType => true
+  def isPrimitive(repr: RepresentationType): Boolean = repr match {
+    case IntType | LongType | FloatType | BoolType => true
     case _ => false
   }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ToSet.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/ToSet.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
 
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
-import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
 case class ToSet(expression: CodeGenExpression) extends CodeGenExpression {
 
@@ -32,5 +31,5 @@ case class ToSet(expression: CodeGenExpression) extends CodeGenExpression {
 
   override def nullable(implicit context: CodeGenContext) = false
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTList(CTAny), ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CodeGenType.Any
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/TypeOf.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/TypeOf.scala
@@ -30,7 +30,7 @@ case class TypeOf(relId: Variable)
 
   def generateExpression[E](structure: MethodStructure[E])(implicit context: CodeGenContext) = {
     val typeName = context.namer.newVarName()
-    structure.declareAndInitialize(typeName, CodeGenType(CTString, ReferenceType))
+    structure.declareAndInitialize(typeName, CypherCodeGenType(CTString, ReferenceType))
     if (nullable) {
       structure.ifNotStatement(structure.isNull(relId.name, CodeGenType.primitiveRel)) { body =>
         body.relType(relId.name, typeName)
@@ -45,5 +45,5 @@ case class TypeOf(relId: Variable)
 
   override def nullable(implicit context: CodeGenContext) = relId.nullable
 
-  override def codeGenType(implicit context: CodeGenContext) = CodeGenType(CTString, ReferenceType)
+  override def codeGenType(implicit context: CodeGenContext) = CypherCodeGenType(CTString, ReferenceType)
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/functions/CodeGenFunction1.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/functions/CodeGenFunction1.scala
@@ -46,7 +46,7 @@ case object IdCodeGenFunction extends CodeGenFunction1 {
 
     override def nullable(implicit context: CodeGenContext): Boolean = false
 
-    override def codeGenType(implicit context: CodeGenContext): CodeGenType = CodeGenType.primitiveInt
+    override def codeGenType(implicit context: CodeGenContext): CypherCodeGenType = CodeGenType.primitiveInt
   }
 }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi
 
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.Variable
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.CodeGenType
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 
@@ -42,6 +43,7 @@ trait MethodStructure[E] {
   def updateFlag(name: String, newValue: Boolean)
   def declarePredicate(name: String): Unit
   def assign(varName: String, codeGenType: CodeGenType, value: E): Unit
+  def assign(v: Variable, value: E): Unit = assign(v.name, v.codeGenType, value)
   def declareAndInitialize(varName: String, codeGenType: CodeGenType): Unit
   def declare(varName: String, codeGenType: CodeGenType): Unit
   def declareProperty(name: String): Unit
@@ -56,9 +58,11 @@ trait MethodStructure[E] {
 
   def incrementInteger(name: String): Unit
   def decrementInteger(name: String): Unit
+  def incrementInteger(name: String, value: E): Unit
   def checkInteger(variableName: String, comparator: Comparator, value: Long): E
   def newTableValue(targetVar: String, tupleDescriptor: TupleDescriptor): E
-  def constantExpression(value: Object): E
+  def constantExpression(value: AnyRef): E
+  def constantPrimitiveExpression(value: AnyVal): E = constantExpression(value.asInstanceOf[AnyRef])
   def asMap(map: Map[String, E]): E
   def asList(values: Seq[E]): E
   def asPrimitiveStream(values: E, codeGenType: CodeGenType): E
@@ -110,6 +114,7 @@ trait MethodStructure[E] {
   def threeValuedEqualsExpression(lhs: E, rhs: E): E
   def threeValuedPrimitiveEqualsExpression(lhs: E, rhs: E, codeGenType: CodeGenType): E
   def equalityExpression(lhs: E, rhs: E, codeGenType: CodeGenType): E
+  def primitiveEquals(lhs: E, rhs: E): E
   def orExpression(lhs: E, rhs: E): E
   def threeValuedOrExpression(lhs: E, rhs: E): E
 
@@ -139,7 +144,9 @@ trait MethodStructure[E] {
   def hasLabel(nodeVar: String, labelVar: String, predVar: String): E
   def allNodesScan(iterVar: String): Unit
   def lookupLabelId(labelIdVar: String, labelName: String): Unit
+  def lookupLabelIdE(labelName: String): E
   def lookupRelationshipTypeId(typeIdVar: String, typeName: String): Unit
+  def lookupRelationshipTypeIdE(typeName: String): E
   def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, direction: SemanticDirection): Unit
   def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, direction: SemanticDirection, typeVars: Seq[String]): Unit
   def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, toNode:String)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -124,7 +124,7 @@ trait MethodStructure[E] {
   def nullableReference(varName: String, codeGenType: CodeGenType, onSuccess: E): E
   def isNull(name: String, codeGenType: CodeGenType): E
   def notNull(name: String, codeGenType: CodeGenType): E
-  def box(expression:E, codeGenType: CodeGenType = CodeGenType.Any): E
+  def box(expression:E, codeGenType: CodeGenType): E
   def unbox(expression:E, codeGenType: CodeGenType): E
   def toFloat(expression:E): E
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/helpers/LiteralTypeSupport.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/helpers/LiteralTypeSupport.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.helpers
 
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{IsList, IsMap}
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
@@ -37,19 +37,19 @@ object LiteralTypeSupport {
     case _                                  => CTAny
   }
 
-  def deriveCodeGenType(obj: Any): CodeGenType = deriveCodeGenType(deriveCypherType(obj))
+  def deriveCodeGenType(obj: Any): CypherCodeGenType = deriveCodeGenType(deriveCypherType(obj))
 
-  def deriveCodeGenType(ct: CypherType): CodeGenType = ct match {
-    case ListType(innerCt) => CodeGenType(CTList(innerCt), ListReferenceType(toRepresentationType(innerCt)))
-    case _ => CodeGenType(ct, toRepresentationType(ct))
+  def deriveCodeGenType(ct: CypherType): CypherCodeGenType = ct match {
+    case ListType(innerCt) => CypherCodeGenType(CTList(innerCt), ListReferenceType(toRepresentationType(innerCt)))
+    case _ => CypherCodeGenType(ct, toRepresentationType(ct))
   }
 
   private def toRepresentationType(ct: CypherType): RepresentationType = ct match {
-    case CTInteger => IntType
+    case CTInteger => LongType
     case CTFloat => expressions.FloatType
     case CTBoolean => BoolType
-    case CTNode => IntType
-    case CTRelationship => IntType
+    case CTNode => LongType
+    case CTRelationship => LongType
     case _ => ReferenceType
   }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenExpressionTypesTest.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/CodeGenExpressionTypesTest.scala
@@ -28,8 +28,8 @@ class CodeGenExpressionTypesTest extends CypherFunSuite {
   val int = Literal(1: java.lang.Integer)
   val double = Literal(1.1: java.lang.Double)
   val string = Literal("apa")
-  val node = NodeProjection(Variable("a", CodeGenType(CTNode, ReferenceType)))
-  val rel = RelationshipProjection(Variable("a", CodeGenType(CTRelationship, ReferenceType)))
+  val node = NodeProjection(Variable("a", CypherCodeGenType(CTNode, ReferenceType)))
+  val rel = RelationshipProjection(Variable("a", CypherCodeGenType(CTRelationship, ReferenceType)))
   val intCollection = ListLiteral(Seq(int))
   val doubleCollection = ListLiteral(Seq(double))
   val stringCollection = ListLiteral(Seq(string))
@@ -49,14 +49,14 @@ class CodeGenExpressionTypesTest extends CypherFunSuite {
   test("add") {
     implicit val context: CodeGenContext = null
 
-    Addition(int, double).codeGenType should equal(CodeGenType(CTFloat, ReferenceType))
-    Addition(string, int).codeGenType should equal(CodeGenType(CTString, ReferenceType))
-    Addition(string, string).codeGenType should equal(CodeGenType(CTString, ReferenceType))
-    Addition(intCollection, int).codeGenType should equal(CodeGenType(CTList(CTInteger), ReferenceType))
-    Addition(int, intCollection).codeGenType should equal(CodeGenType(CTList(CTInteger), ReferenceType))
-    Addition(double, intCollection).codeGenType should equal(CodeGenType(CTList(CTNumber), ReferenceType))
-    Addition(doubleCollection, intCollection).codeGenType should equal(CodeGenType(CTList(CTNumber), ReferenceType))
-    Addition(stringCollection, string).codeGenType should equal(CodeGenType(CTList(CTString), ReferenceType))
-    Addition(string, stringCollection).codeGenType should equal(CodeGenType(CTList(CTString), ReferenceType))
+    Addition(int, double).codeGenType should equal(CypherCodeGenType(CTFloat, ReferenceType))
+    Addition(string, int).codeGenType should equal(CypherCodeGenType(CTString, ReferenceType))
+    Addition(string, string).codeGenType should equal(CypherCodeGenType(CTString, ReferenceType))
+    Addition(intCollection, int).codeGenType should equal(CypherCodeGenType(CTList(CTInteger), ReferenceType))
+    Addition(int, intCollection).codeGenType should equal(CypherCodeGenType(CTList(CTInteger), ReferenceType))
+    Addition(double, intCollection).codeGenType should equal(CypherCodeGenType(CTList(CTNumber), ReferenceType))
+    Addition(doubleCollection, intCollection).codeGenType should equal(CypherCodeGenType(CTList(CTNumber), ReferenceType))
+    Addition(stringCollection, string).codeGenType should equal(CypherCodeGenType(CTList(CTString), ReferenceType))
+    Addition(string, stringCollection).codeGenType should equal(CypherCodeGenType(CTList(CTString), ReferenceType))
   }
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/AuxGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/AuxGenerator.scala
@@ -24,7 +24,7 @@ import org.neo4j.codegen.Parameter.param
 import org.neo4j.codegen._
 import org.neo4j.cypher.internal.codegen.CompiledEquivalenceUtils
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.CodeGenContext
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenType, ReferenceType, RepresentationType}
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenType, CypherCodeGenType, ReferenceType, RepresentationType}
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi._
 import org.neo4j.cypher.internal.compiler.v3_2.common.CypherOrderability
 import org.neo4j.cypher.internal.frontend.v3_2.helpers._
@@ -146,7 +146,7 @@ class AuxGenerator(val packageName: String, val generator: CodeGenerator) {
             codeGenType match {
               // TODO: Primitive nodes and relationships including correct ordering of nulls
               // TODO: Extract shared code between cases
-              case CodeGenType(symbols.CTInteger, reprType) => {
+              case CypherCodeGenType(symbols.CTInteger, reprType) => {
                 /*
                 E.g.
                 long thisValue_a = this.a
@@ -167,7 +167,7 @@ class AuxGenerator(val packageName: String, val generator: CodeGenerator) {
                   l3.returns(Expression.constant(greaterThanSortResult(sortOrder)))
                 }
               }
-              case CodeGenType(symbols.CTFloat, reprType) => {
+              case CypherCodeGenType(symbols.CTFloat, reprType) => {
                 // We use Double.compare(double, double) which handles float equality properly
                 /*
                 E.g.
@@ -194,7 +194,7 @@ class AuxGenerator(val packageName: String, val generator: CodeGenerator) {
                   l3.returns(compareResult)
                 }
               }
-              case CodeGenType(symbols.CTBoolean, reprType) => {
+              case CypherCodeGenType(symbols.CTBoolean, reprType) => {
                 /*
                 E.g.
                 boolean thisValue_a = this.a

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -221,22 +221,23 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
   }
 
   def lowerType(cType: CodeGenType): TypeReference = cType match {
-    case CodeGenType(symbols.CTNode, IntType) => typeRef[Long]
-    case CodeGenType(symbols.CTRelationship, IntType) => typeRef[Long]
-    case CodeGenType(symbols.CTInteger, IntType) => typeRef[Long]
-    case CodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
-    case CodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
-    case CodeGenType(symbols.ListType(symbols.CTNode), ListReferenceType(IntType)) => typeRef[PrimitiveNodeStream]
-    case CodeGenType(symbols.ListType(symbols.CTRelationship), ListReferenceType(IntType)) => typeRef[PrimitiveRelationshipStream]
-    case CodeGenType(symbols.ListType(_), ListReferenceType(IntType)) => typeRef[LongStream]
-    case CodeGenType(symbols.ListType(_), ListReferenceType(FloatType)) => typeRef[DoubleStream]
-    case CodeGenType(symbols.ListType(_), ListReferenceType(BoolType)) => typeRef[IntStream]
+    case CypherCodeGenType(symbols.CTNode, LongType) => typeRef[Long]
+    case CypherCodeGenType(symbols.CTRelationship, LongType) => typeRef[Long]
+    case CypherCodeGenType(symbols.CTInteger, LongType) => typeRef[Long]
+    case CypherCodeGenType(symbols.CTFloat, FloatType) => typeRef[Double]
+    case CypherCodeGenType(symbols.CTBoolean, BoolType) => typeRef[Boolean]
+    case CypherCodeGenType(symbols.ListType(symbols.CTNode), ListReferenceType(LongType)) => typeRef[PrimitiveNodeStream]
+    case CypherCodeGenType(symbols.ListType(symbols.CTRelationship), ListReferenceType(LongType)) => typeRef[PrimitiveRelationshipStream]
+    case CypherCodeGenType(symbols.ListType(_), ListReferenceType(LongType)) => typeRef[LongStream]
+    case CypherCodeGenType(symbols.ListType(_), ListReferenceType(FloatType)) => typeRef[DoubleStream]
+    case CypherCodeGenType(symbols.ListType(_), ListReferenceType(BoolType)) => typeRef[IntStream]
+    case CodeGenType.javaInt => typeRef[Int]
     case _ => typeRef[Object]
   }
 
-  def nullValue(cType: CodeGenType) = cType match {
-    case CodeGenType(symbols.CTNode, IntType) => constant(-1L)
-    case CodeGenType(symbols.CTRelationship, IntType) => constant(-1L)
+  def nullValue(cType: CodeGenType): Expression = cType match {
+    case CypherCodeGenType(symbols.CTNode, LongType) => constant(-1L)
+    case CypherCodeGenType(symbols.CTRelationship, LongType) => constant(-1L)
     case _ => constant(null)
   }
 }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
@@ -22,9 +22,9 @@ package org.neo4j.cypher.internal.compiled_runtime.spi.v3_2
 import java.util
 
 import org.neo4j.codegen.bytecode.ByteCode
-import org.neo4j.codegen.source.{Configuration, SourceCode}
+import org.neo4j.codegen.source.SourceCode
 import org.neo4j.codegen.{CodeGenerationStrategy, CodeGenerator, Expression, MethodDeclaration}
-import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenType, ReferenceType}
+import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.{CodeGenType, CypherCodeGenType, ReferenceType}
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, QueryExecutionTracer}
 import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{Completable, Provider}
@@ -157,7 +157,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         }),
         Operation("rel type", m => {
           m.createRelExtractor("bar")
-          m.declareAndInitialize("foo", CodeGenType(symbols.CTString, ReferenceType))
+          m.declareAndInitialize("foo", CypherCodeGenType(symbols.CTString, ReferenceType))
           m.relType("bar", "foo")
         }),
         Operation("all relationships for node and types", (m) => {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/TypeConversionTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/TypeConversionTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiled_runtime.v3_2
+
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.InternalExecutionResult
+import org.neo4j.cypher.{CypherTypeException, ExecutionEngineFunSuite}
+
+class TypeConversionTest extends ExecutionEngineFunSuite {
+  test("should not allow adding node and number") {
+    val x = createNode()
+    val failure = intercept[CypherTypeException] {
+      val result = execute("debug=generate_java_source debug=show_java_source profile match (n) return n + {x} as res", "x" -> 5)
+      // should not get here, if we do, this is for debugging:
+      println(result.executionPlanDescription())
+    }
+
+    failure.getMessage should equal(s"Don't know how to add `$x` and `5`")
+  }
+
+  test("shouldHandlePatternMatchingWithParameters") {
+    val x = createNode()
+
+    val result = execute("match (x) where x = {startNode} return x", "startNode" -> x)
+
+    result.toList should equal(List(Map("x" -> x)))
+  }
+
+  override def execute(q: String, params: (String, Any)*): InternalExecutionResult =
+    super.execute(s"cypher runtime=compiled $q", params:_*)
+}


### PR DESCRIPTION
When planning compiled queries using labels and/or relationship types that
are new to the database, we need to do a little extra work to load the
tokens at runtime. This was not done correctly before, and queries would
behave in weird ways in these situations.
