### PR TITLE
Adding /db/server/core/read-only so load balancers can send reads to …

### DIFF
--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
@@ -43,6 +43,7 @@ public class CoreDatabaseAvailabilityService implements AdvertisableService
     public static final String BASE_PATH = "server/core";
     public static final String IS_WRITABLE_PATH = "/writable";
     public static final String IS_AVAILABLE_PATH = "/available";
+    public static final String IS_READ_ONLY_PATH = "/read-only";
 
     private final OutputFormat output;
     private final CoreGraphDatabase coreDatabase;
@@ -83,6 +84,23 @@ public class CoreDatabaseAvailabilityService implements AdvertisableService
         }
 
         if ( coreDatabase.getRole() == Role.LEADER )
+        {
+            return positiveResponse();
+        }
+
+        return negativeResponse();
+    }
+
+    @GET
+    @Path(IS_READ_ONLY_PATH)
+    public Response isReadOnly() throws BadInputException
+    {
+        if ( coreDatabase == null )
+        {
+            return status( FORBIDDEN ).build();
+        }
+
+        if ( coreDatabase.getRole() == Role.FOLLOWER || coreDatabase.getRole() == Role.CANDIDATE )
         {
             return positiveResponse();
         }


### PR DESCRIPTION
…follower/candidate

changelog: Adds /db/server/core/read-only so load balancers can send reads to follower/candidate instances