### PR TITLE
Config support for legacy quote escaping in LOAD CSV

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvWithQuotesAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvWithQuotesAcceptanceTest.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.io.PrintWriter
+
+import org.neo4j.csv.reader.MissingEndQuoteException
+import org.neo4j.cypher.internal.{ExecutionEngine, RewindableExecutionResult}
+import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor3_0
+import org.neo4j.cypher.internal.compiler.v3_0.test_helpers.CreateTempFileTestSupport
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, RunWithConfigTestSupport}
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+
+class LoadCsvWithQuotesAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport with RunWithConfigTestSupport with CreateTempFileTestSupport {
+  def csvUrls(f: PrintWriter => Unit) = Seq(
+    createCSVTempFileURL(f),
+    createGzipCSVTempFileURL(f),
+    createZipCSVTempFileURL(f)
+  )
+
+  test("import rows with messy quotes using legacy mode as default") {
+    runWithConfig() { db =>
+      val urls = csvUrls({
+        writer =>
+          writer.println("name,x")
+          writer.println("'Quotes 0',\"\"")
+          writer.println("'Quotes 1',\"\\\"\"")
+          writer.println("'Quotes 2',\"\"\"\"")
+          writer.println("'Quotes 3',\"\\\"\\\"\"")
+          writer.println("'Quotes 4',\"\"\"\"\"\"")
+      })
+      for (url <- urls) {
+        val result = executeUsingCostPlannerOnly(db, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
+        assert(result.toList === List(
+          Map("line.x" -> ""),
+          Map("line.x" -> "\""),
+          Map("line.x" -> "\""),
+          Map("line.x" -> "\"\""),
+          Map("line.x" -> "\"\"")
+        ))
+      }
+    }
+  }
+
+  test("import rows with messy quotes using legacy mode") {
+    runWithConfig(GraphDatabaseSettings.csv_legacy_quote_escaping -> "true") { db =>
+      val urls = csvUrls({
+        writer =>
+          writer.println("name,x")
+          writer.println("'Quotes 0',\"\"")
+          writer.println("'Quotes 1',\"\\\"\"")
+          writer.println("'Quotes 2',\"\"\"\"")
+          writer.println("'Quotes 3',\"\\\"\\\"\"")
+          writer.println("'Quotes 4',\"\"\"\"\"\"")
+      })
+      for (url <- urls) {
+        val result = executeUsingCostPlannerOnly(db, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
+        assert(result.toList === List(
+          Map("line.x" -> ""),
+          Map("line.x" -> "\""),
+          Map("line.x" -> "\""),
+          Map("line.x" -> "\"\""),
+          Map("line.x" -> "\"\"")
+        ))
+      }
+    }
+  }
+
+  test("import rows with messy quotes using rfc4180 mode") {
+    runWithConfig(GraphDatabaseSettings.csv_legacy_quote_escaping -> "false") { db =>
+      val urls = csvUrls({
+        writer =>
+          writer.println("name,x")
+          writer.println("'Quotes 0',\"\"")
+          writer.println("'Quotes 2',\"\"\"\"")
+          writer.println("'Quotes 4',\"\"\"\"\"\"")
+          writer.println("'Quotes 5',\"\\\"\"\"")
+      })
+      for (url <- urls) {
+        val result = executeUsingCostPlannerOnly(db, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
+        assert(result.toList === List(
+          Map("line.x" -> ""),
+          Map("line.x" -> "\""),
+          Map("line.x" -> "\"\""),
+          Map("line.x" -> "\\\"")
+        ))
+      }
+    }
+  }
+
+  test("fail to import rows with java quotes when in rfc4180 mode") {
+    runWithConfig(GraphDatabaseSettings.csv_legacy_quote_escaping -> "false") { db =>
+      val urls = csvUrls({
+        writer =>
+          writer.println("name,x")
+          writer.println("'Quotes 0',\"\"")
+          writer.println("'Quotes 1',\"\\\"\"")
+          writer.println("'Quotes 2',\"\"\"\"")
+      })
+      for (url <- urls) {
+        intercept[MissingEndQuoteException] {
+          executeUsingCostPlannerOnly(db, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
+        }.getMessage should include("which started on line 2")
+      }
+    }
+  }
+
+  def executeUsingCostPlannerOnly(db: GraphDatabaseCypherService, query: String) =
+    new ExecutionEngine(db).execute(s"CYPHER planner=COST $query", Map.empty[String, Any], db.session()) match {
+      case e: ExecutionResultWrapperFor3_0 => RewindableExecutionResult(e)
+    }
+
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
@@ -67,6 +67,7 @@ case class CypherCompilerConfiguration(queryCacheSize: Int,
                                        idpIterationDuration: Long,
                                        errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                                        errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
+                                       legacyCsvQuoteEscaping:Boolean,
                                        nonIndexedLabelWarningThreshold: Long)
 
 object CypherCompilerFactory {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserver.scala
@@ -31,8 +31,8 @@ class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalCSVR
   val updateCounter = new UpdateCounter
   var outerLoadCSVIterator: Option[LoadCsvIterator] = None
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
-    val innerIterator = resources.getCsvIterator(url, fieldTerminator)
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, legacyCsvQuoteEscaping: Boolean = true): Iterator[Array[String]] = {
+    val innerIterator = resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping)
     if (outerLoadCSVIterator.isEmpty) {
       val iterator = new LoadCsvIterator(url, innerIterator)(onNext())
       outerLoadCSVIterator = Some(iterator)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/LoadCSVBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/LoadCSVBuilder.scala
@@ -39,7 +39,8 @@ class LoadCSVBuilder extends PlanBuilder {
     val item: LoadCSV = findLoadCSVItem(plan).get
     plan.copy(
       query = plan.query.copy(start = plan.query.start.replace(Unsolved(item), Solved(item))),
-      pipe = new LoadCSVPipe(plan.pipe, if (item.withHeaders) HasHeaders else NoHeaders, item.url, item.variable, item.fieldTerminator)()
+      pipe = new LoadCSVPipe(plan.pipe, if (item.withHeaders) HasHeaders else NoHeaders, item.url, item.variable,
+        item.fieldTerminator, legacyCsvQuoteEscaping = true)()  // Rule planner supports only legacy quotes
     )
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
@@ -22,11 +22,11 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 import java.net.URL
 
 trait ExternalCSVResource {
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]]
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, legacyCsvQuoteEscaping: Boolean = true): Iterator[Array[String]]
 }
 
 object ExternalCSVResource {
   def empty: ExternalCSVResource = new ExternalCSVResource {
-    override def getCsvIterator(url: URL, fieldTerminator: Option[String]): Iterator[Array[String]] = Iterator.empty
+    override def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean = true): Iterator[Array[String]] = Iterator.empty
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LoadCSVPipe.scala
@@ -39,7 +39,8 @@ case class LoadCSVPipe(source: Pipe,
                        format: CSVFormat,
                        urlExpression: Expression,
                        variable: String,
-                       fieldTerminator: Option[String])
+                       fieldTerminator: Option[String],
+                       legacyCsvQuoteEscaping: Boolean)
                       (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
@@ -105,7 +106,7 @@ case class LoadCSVPipe(source: Pipe,
       val urlString: String = urlExpression(context).asInstanceOf[String]
       val url = getImportURL(urlString, state.query)
 
-      val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator)
+      val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator, legacyCsvQuoteEscaping)
       format match {
         case HasHeaders =>
           val headers = iterator.next().toSeq // First row is headers

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -91,7 +91,8 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
       queryGraphSolver, notificationLogger = notificationLogger, useErrorsOverWarnings = config.useErrorsOverWarnings,
       errorIfShortestPathFallbackUsedAtRuntime = config.errorIfShortestPathFallbackUsedAtRuntime,
       errorIfShortestPathHasCommonNodesAtRuntime = config.errorIfShortestPathHasCommonNodesAtRuntime,
-      config = QueryPlannerConfiguration.default.withUpdateStrategy(updateStrategy))
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping,
+    config = QueryPlannerConfiguration.default.withUpdateStrategy(updateStrategy))
 
     val (periodicCommit, plan) = queryPlanner.plan(unionQuery)(context)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -318,8 +318,8 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       val rowProcessing = ProcedureCallRowProcessing(signature)
       ProcedureCallPipe(source, signature.name, callMode, callArgumentCommands, rowProcessing, call.callResultTypes, call.callResultIndices)()
 
-    case LoadCSVPlan(_, url, variableName, format, fieldTerminator) =>
-      LoadCSVPipe(source, format, toCommandExpression(url), variableName.name, fieldTerminator)()
+    case LoadCSVPlan(_, url, variableName, format, fieldTerminator, legacyCsvQuoteEscaping) =>
+      LoadCSVPipe(source, format, toCommandExpression(url), variableName.name, fieldTerminator, legacyCsvQuoteEscaping)()
 
     case ProduceResult(columns, _) =>
       ProduceResultsPipe(source, columns)()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
@@ -37,6 +37,7 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   useErrorsOverWarnings: Boolean = false,
                                   errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
                                   errorIfShortestPathHasCommonNodesAtRuntime: Boolean = true,
+                                  legacyCsvQuoteEscaping: Boolean = true,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default,
                                   leafPlanUpdater: LogicalPlan => LogicalPlan = identity) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
@@ -27,7 +27,8 @@ case class LoadCSV(source: LogicalPlan,
                    url: Expression,
                    variableName: IdName,
                    format: CSVFormat,
-                   fieldTerminator: Option[String])
+                   fieldTerminator: Option[String],
+                   legacyCsvQuoteEscaping: Boolean)
                   (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan {
 
   override def availableSymbols = source.availableSymbols + variableName

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEager.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEager.scala
@@ -35,7 +35,7 @@ case object cleanUpEager extends Rewriter {
       unwind.copy(left = eager.copy(inner = source)(eager.solved))(eager.solved)
 
     // E LCSV => LCSV E
-    case eager@Eager(loadCSV@LoadCSV(source, _, _, _, _)) =>
+    case eager@Eager(loadCSV@LoadCSV(source, _, _, _, _, _)) =>
       loadCSV.copy(source = eager.copy(inner = source)(eager.solved))(eager.solved)
   })
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -413,7 +413,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
   def planLoadCSV(inner: LogicalPlan, variableName: IdName, url: Expression, format: CSVFormat, fieldTerminator: Option[StringLiteral])
                  (implicit context: LogicalPlanningContext) = {
     val solved = inner.solved.updateTailOrSelf(_.withHorizon(LoadCSVProjection(variableName, url, format, fieldTerminator)))
-    LoadCSVPlan(inner, url, variableName, format, fieldTerminator.map(_.value))(solved)
+    LoadCSVPlan(inner, url, variableName, format, fieldTerminator.map(_.value), context.legacyCsvQuoteEscaping)(solved)
   }
 
   def planUnwind(inner: LogicalPlan, name: IdName, expression: Expression)(implicit context: LogicalPlanningContext) = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
@@ -40,7 +40,7 @@ object CSVResources {
   val DEFAULT_BUFFER_SIZE: Int =  2 * 1024 * 1024
   val DEFAULT_QUOTE_CHAR: Char = '"'
 
-  private val defaultConfig = new Configuration {
+  private def config(legacyCsvQuoteEscaping: Boolean) = new Configuration {
     override def quotationCharacter(): Char = DEFAULT_QUOTE_CHAR
 
     override def bufferSize(): Int = DEFAULT_BUFFER_SIZE
@@ -48,12 +48,14 @@ object CSVResources {
     override def multilineFields(): Boolean = true
 
     override def emptyQuotedStringsAsNull(): Boolean = true
+
+    override def legacyStyleQuoting(): Boolean = legacyCsvQuoteEscaping
   }
 }
 
 class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, legacyCsvQuoteEscaping: Boolean = true): Iterator[Array[String]] = {
     val inputStream = openStream(url)
 
     val reader = if (url.getProtocol == "file") {
@@ -62,7 +64,7 @@ class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
       Readables.wrap(inputStream, url.toString, StandardCharsets.UTF_8)
     }
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
-    val seeker = CharSeekers.charSeeker(reader, CSVResources.defaultConfig, true)
+    val seeker = CharSeekers.charSeeker(reader, CSVResources.config(legacyCsvQuoteEscaping), true)
     val extractor = new Extractors(delimiter).string()
     val intDelimiter = delimiter.toInt
     val mark = new Mark

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForEagerLoadCsvTest.scala
@@ -28,13 +28,13 @@ class CheckForEagerLoadCsvTest extends CypherFunSuite {
   implicit val monitor = mock[PipeMonitor]
 
   test("should notify for EagerPipe on top of LoadCsvPipe") {
-    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None)())()
+    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None, true)())()
 
     checkForEagerLoadCsv(pipe) should equal(Some(EagerLoadCsvNotification))
   }
 
   test("should not notify for LoadCsv on top of eager pipe") {
-    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None)()
+    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None, true)()
 
     checkForEagerLoadCsv(pipe) should equal(None)
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -51,7 +51,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val checker = CheckForLoadCsvAndMatchOnLargeLabel(planContext, THRESHOLD)
 
   test("should notify when doing LoadCsv on top of large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)()
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None, true)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
 
@@ -59,7 +59,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   }
 
   test("should not notify when doing LoadCsv on top of a large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)()
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None, true)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelUnderThrehsold), indexFor(labelUnderThrehsold)))()
 
@@ -68,7 +68,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
 
   test("should not notify when doing LoadCsv on top of large label scan") {
     val startPipe = NodeStartPipe(SingleRowPipe(), "foo", NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
-    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None)()
+    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None, true)()
 
     checker(pipe) should equal(None)
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserverTest.scala
@@ -22,10 +22,12 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 import java.net.URL
 
 import org.mockito.Matchers
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalCSVResource
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{QueryTransactionalContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
 class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   var resourceUnderTest: LoadCsvPeriodicCommitObserver = _
@@ -35,7 +37,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   test("writing should not trigger tx restart until next csv line is fetched") {
     // Given
-    when(resource.getCsvIterator(Matchers.eq(url), Matchers.any())).thenReturn(Iterator(Array("yo")))
+    when(resource.getCsvIterator(Matchers.eq(url), any(), any())).thenReturn(Iterator(Array("yo")))
 
     // When
     val iterator = resourceUnderTest.getCsvIterator(url)
@@ -48,7 +50,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   test("multiple iterators are still handled correctly only commit when the first iterator advances") {
     // Given
-    when(resource.getCsvIterator(Matchers.eq(url), Matchers.any())).
+    when(resource.getCsvIterator(Matchers.eq(url), any(), any())).
       thenReturn(Iterator(Array("yo"))).
       thenReturn(Iterator(Array("yo")))
     val iterator1 = resourceUnderTest.getCsvIterator(url)
@@ -65,10 +67,10 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   test("if a custom iterator is specified should be passed to the wrapped resource") {
     // Given
-    resourceUnderTest.getCsvIterator(url, Some(";"))
+    resourceUnderTest.getCsvIterator(url, Some(";"), true)
 
     // When
-    verify(resource, times(1)).getCsvIterator(url, Some(";"))
+    verify(resource, times(1)).getCsvIterator(url, Some(";"), true)
   }
 
   override protected def beforeEach() {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -43,7 +43,8 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false,
-    errorIfShortestPathHasCommonNodesAtRuntime = true
+    errorIfShortestPathHasCommonNodesAtRuntime = true,
+    legacyCsvQuoteEscaping = true
   )
   val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating,
     typeConverter = IdentityTypeConverter)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/PipeEffectsTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/PipeEffectsTest.scala
@@ -58,7 +58,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
   NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])()
     -> Effects(ReadsAllNodes).asLeafEffects,
 
-  LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None)()
+  LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None, true)()
     -> Effects(),
 
   EmptyResultPipe(SingleRowPipe())

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -124,7 +124,8 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
                                       useErrorsOverWarnings: Boolean = false): LogicalPlanningContext =
     LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
-      notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings, config = QueryPlannerConfiguration.default)
+      notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
+      legacyCsvQuoteEscaping = config.legacyCsvQuoteEscaping, config = QueryPlannerConfiguration.default)
 
   def newMockedStatistics = mock[GraphStatistics]
   def hardcodedStatistics = HardcodedGraphStatistics
@@ -184,6 +185,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false,
     errorIfShortestPathHasCommonNodesAtRuntime = true,
+    legacyCsvQuoteEscaping = true,
     nonIndexedLabelWarningThreshold = 10000
   )
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEagerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEagerTest.scala
@@ -78,17 +78,17 @@ class cleanUpEagerTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("should move eager on top of load csv to below it") {
     val leaf = newMockedLogicalPlan()
     val url = StringLiteral("file:///tmp/foo.csv")(pos)
-    val loadCSV = LoadCSV(leaf, url, IdName("a"), NoHeaders, None)(solved)
+    val loadCSV = LoadCSV(leaf, url, IdName("a"), NoHeaders, None, true)(solved)
     val eager = Eager(loadCSV)(solved)
     val topPlan = Projection(eager, Map.empty)(solved)
 
-    rewrite(topPlan) should equal(Projection(LoadCSV(Eager(leaf)(solved), url, IdName("a"), NoHeaders, None)(solved), Map.empty)(solved))
+    rewrite(topPlan) should equal(Projection(LoadCSV(Eager(leaf)(solved), url, IdName("a"), NoHeaders, None, true)(solved), Map.empty)(solved))
   }
 
   test("should not rewrite plan with eager below load csv") {
     val leaf = newMockedLogicalPlan()
     val eager = Eager(leaf)(solved)
-    val loadCSV = LoadCSV(eager, StringLiteral("file:///tmp/foo.csv")(pos), IdName("a"), NoHeaders, None)(solved)
+    val loadCSV = LoadCSV(eager, StringLiteral("file:///tmp/foo.csv")(pos), IdName("a"), NoHeaders, None, true)(solved)
     val topPlan = Projection(loadCSV, Map.empty)(solved)
 
     rewrite(topPlan) should equal(topPlan)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -73,6 +73,7 @@ class CypherCompiler(graph: GraphDatabaseQueryService,
                      idpIterationDuration: Long,
                      errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                      errorIfShortestPathHasCommonNodesAtRuntime: Boolean,
+                     legacyCsvQuoteEscaping: Boolean,
                      logProvider: LogProvider) {
   import org.neo4j.cypher.internal.CypherCompiler._
 
@@ -87,6 +88,7 @@ class CypherCompiler(graph: GraphDatabaseQueryService,
     idpIterationDuration = idpIterationDuration,
     errorIfShortestPathFallbackUsedAtRuntime = errorIfShortestPathFallbackUsedAtRuntime,
     errorIfShortestPathHasCommonNodesAtRuntime = errorIfShortestPathHasCommonNodesAtRuntime,
+    legacyCsvQuoteEscaping = legacyCsvQuoteEscaping,
     nonIndexedLabelWarningThreshold = getNonIndexedLabelWarningThreshold
   )
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -227,6 +227,10 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
       queryService, GraphDatabaseSettings.forbid_shortestpath_common_nodes,
       GraphDatabaseSettings.forbid_shortestpath_common_nodes.getDefaultValue.toBoolean
     )
+    val legacyCsvQuoteEscaping = optGraphSetting[java.lang.Boolean](
+      queryService, GraphDatabaseSettings.csv_legacy_quote_escaping,
+      GraphDatabaseSettings.csv_legacy_quote_escaping.getDefaultValue.toBoolean
+    )
 
     if (((version != CypherVersion.v2_3) || (version != CypherVersion.v3_0)) && (planner == CypherPlanner.greedy || planner == CypherPlanner.idp || planner == CypherPlanner.dp)) {
       val message = s"Cannot combine configurations: ${GraphDatabaseSettings.cypher_parser_version.name}=${version.name} " +
@@ -234,7 +238,9 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
       log.error(message)
       throw new IllegalStateException(message)
     }
-    new CypherCompiler(queryService, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime, errorIfShortestPathHasCommonNodesAtRuntime, logProvider)
+    new CypherCompiler(queryService, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings,
+      idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime,
+      errorIfShortestPathHasCommonNodesAtRuntime, legacyCsvQuoteEscaping, logProvider)
   }
 
   private def getPlanCacheSize: Int =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -112,6 +112,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
         errorIfShortestPathHasCommonNodesAtRuntime = true,
+        legacyCsvQuoteEscaping = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       Clock.systemUTC(),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -255,6 +255,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false,
-    errorIfShortestPathHasCommonNodesAtRuntime = true
+    errorIfShortestPathHasCommonNodesAtRuntime = true,
+    legacyCsvQuoteEscaping = true
   )
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -193,6 +193,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
         errorIfShortestPathHasCommonNodesAtRuntime = true,
+        legacyCsvQuoteEscaping = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock = CLOCK,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -58,7 +58,8 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     idpIterationDuration = 1000,
     nonIndexedLabelWarningThreshold = 10000,
     errorIfShortestPathFallbackUsedAtRuntime = true,
-    errorIfShortestPathHasCommonNodesAtRuntime = true
+    errorIfShortestPathHasCommonNodesAtRuntime = true,
+    legacyCsvQuoteEscaping = true
   )
 
   val compilers = Seq[(String, GraphDatabaseQueryService => CypherCompiler)](

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -50,6 +50,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
         idpIterationDuration = 1000,
         errorIfShortestPathFallbackUsedAtRuntime = false,
         errorIfShortestPathHasCommonNodesAtRuntime = true,
+        legacyCsvQuoteEscaping = true,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock,

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -209,6 +209,14 @@ public abstract class GraphDatabaseSettings
                   + "directory, restricting access to only those files within that directory and its subdirectories." )
     public static Setting<File> load_csv_file_url_root = pathSetting( "dbms.directories.import", NO_DEFAULT );
 
+    @Description( "Selects whether to conform to the standard https://tools.ietf.org/html/rfc4180 for interpreting " +
+                  "escaped quotation characters in CSV files loaded using `LOAD CSV`. Setting this to `false` will use" +
+                  " the standard, interpreting repeated quotes '\"\"' as a single in-lined quote, while `true` will " +
+                  "use the legacy convention originally supported in Neo4j 3.0 and 3.1, requiring a backslash to " +
+                  "include quotes in-lined in fields." )
+    public static Setting<Boolean> csv_legacy_quote_escaping =
+            setting( "dbms.import.csv.legacy_quote_escaping", BOOLEAN, TRUE );
+
     @Description( "The maximum amount of time to wait for the database to become available, when " +
                   "starting a new transaction." )
     @Internal


### PR DESCRIPTION
Added a new config setting `dbms.import.csv.legacy_quote_escaping` to select whether to conform to the standard https://tools.ietf.org/html/rfc4180 for interpreting escaped quotation characters in CSV files loaded using `LOAD CSV`. Setting this to `false` will use the standard, interpreting repeated quotes '\"\"' as a single in-lined quote, while `true` will use the legacy convention originally supported in Neo4j 3.0 and 3.1, allowing a backslash to include quotes in-lined in fields.