### PR TITLE
Make IndexEntryConflictException handle composite indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
@@ -22,7 +22,10 @@ package org.neo4j.kernel.api.exceptions.index;
 import java.util.Arrays;
 
 import org.neo4j.helpers.Strings;
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
@@ -35,18 +38,17 @@ import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
  */
 public class IndexEntryConflictException extends Exception
 {
-    private final Object propertyValue;
+    private final OrderedPropertyValues propertyValues;
     private final long addedNodeId;
     private final long existingNodeId;
 
-    // TODO: support composite indexes
-    public IndexEntryConflictException( long existingNodeId, long addedNodeId, Object propertyValue )
+    public IndexEntryConflictException( long existingNodeId, long addedNodeId, OrderedPropertyValues propertyValues )
     {
         super( format( "Both node %d and node %d share the property value %s",
-                existingNodeId, addedNodeId, quote( propertyValue ) ) );
+                existingNodeId, addedNodeId, quote( propertyValues ) ) );
         this.existingNodeId = existingNodeId;
         this.addedNodeId = addedNodeId;
-        this.propertyValue = propertyValue;
+        this.propertyValues = propertyValues;
     }
 
     /**
@@ -61,23 +63,32 @@ public class IndexEntryConflictException extends Exception
                 descriptor.userDescription( SchemaUtil.idTokenNameLookup ) ), this );
     }
 
-    public String evidenceMessage( String labelName, String propertyKey )
+    public String evidenceMessage( TokenNameLookup tokenNameLookup, LabelSchemaDescriptor schema )
     {
+        assert schema.getPropertyIds().length == propertyValues.values().length;
+
+        String labelName = tokenNameLookup.labelGetName( schema.getLabelId() );
         if ( addedNodeId == NO_SUCH_NODE )
         {
-            return format( "Node(%d) already exists with label `%s` and property `%s` = %s",
-                    existingNodeId, labelName, propertyKey, quote( propertyValue ) );
+            return format( "Node(%d) already exists with label `%s` and %s",
+                    existingNodeId, labelName, propertyString( tokenNameLookup, schema.getPropertyIds() ) );
         }
         else
         {
-            return format( "Both Node(%d) and Node(%d) have the label `%s` and property `%s` = %s",
-                    existingNodeId, addedNodeId, labelName, propertyKey, quote( propertyValue ) );
+            return format( "Both Node(%d) and Node(%d) have the label `%s` and %s",
+                    existingNodeId, addedNodeId, labelName, propertyString( tokenNameLookup, schema.getPropertyIds() ) );
         }
     }
 
-    public Object getPropertyValue()
+    public OrderedPropertyValues getPropertyValues()
     {
-        return propertyValue;
+        return propertyValues;
+    }
+
+    public Object getSinglePropertyValue()
+    {
+        assert propertyValues.values().length == 1;
+        return propertyValues.values()[0];
     }
 
     public long getAddedNodeId()
@@ -106,13 +117,13 @@ public class IndexEntryConflictException extends Exception
 
         return addedNodeId == that.addedNodeId &&
                 existingNodeId == that.existingNodeId &&
-                !(propertyValue != null ? !propertyValue.equals( that.propertyValue ) : that.propertyValue != null);
+                !(propertyValues != null ? !propertyValues.equals( that.propertyValues ) : that.propertyValues != null);
     }
 
     @Override
     public int hashCode()
     {
-        int result = propertyValue != null ? propertyValue.hashCode() : 0;
+        int result = propertyValues != null ? propertyValues.hashCode() : 0;
         result = 31 * result + (int) (addedNodeId ^ (addedNodeId >>> 32));
         result = 31 * result + (int) (existingNodeId ^ (existingNodeId >>> 32));
         return result;
@@ -122,13 +133,43 @@ public class IndexEntryConflictException extends Exception
     public String toString()
     {
         return "IndexEntryConflictException{" +
-               "propertyValue=" + Strings.prettyPrint( propertyValue ) +
-               ", addedNodeId=" + addedNodeId +
-               ", existingNodeId=" + existingNodeId +
-               '}';
+                "propertyValues=" + Strings.prettyPrint( propertyValues.values() ) +
+                ", addedNodeId=" + addedNodeId +
+                ", existingNodeId=" + existingNodeId +
+                '}';
     }
 
-    protected static String quote( Object propertyValue )
+    private String propertyString( TokenNameLookup tokenNameLookup, int[] propertyIds )
+    {
+        StringBuilder sb = new StringBuilder();
+        String sep = propertyIds.length > 1 ? "properties " : "property ";
+        for ( int i = 0; i < propertyIds.length; i++ )
+        {
+            sb.append( sep );
+            sep = ", ";
+            sb.append( '`' );
+            sb.append( tokenNameLookup.propertyKeyGetName( propertyIds[i] ) );
+            sb.append( "` = " );
+            sb.append( quote( propertyValues.values()[i] ) );
+        }
+        return sb.toString();
+    }
+
+    private static String quote( OrderedPropertyValues propertyValues )
+    {
+        StringBuilder sb = new StringBuilder();
+        String sep = "( ";
+        for ( Object value : propertyValues.values() )
+        {
+            sb.append( sep );
+            sep = ", ";
+            sb.append( quote( value ) );
+        }
+        sb.append( " )" );
+        return sb.toString();
+    }
+
+    private static String quote( Object propertyValue )
     {
         if ( propertyValue instanceof String )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
@@ -60,9 +60,7 @@ public class UniquePropertyValueValidationException extends ConstraintValidation
         for ( Iterator<IndexEntryConflictException> iterator = conflicts.iterator(); iterator.hasNext(); )
         {
             IndexEntryConflictException conflict = iterator.next();
-            message.append( conflict.evidenceMessage(
-                    tokenNameLookup.labelGetName( schema.getLabelId() ),
-                    tokenNameLookup.propertyKeyGetName( schema.getPropertyId() ) ) );
+            message.append( conflict.evidenceMessage( tokenNameLookup, schema ) );
             if ( iterator.hasNext() )
             {
                 message.append( System.lineSeparator() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
@@ -21,6 +21,9 @@ package org.neo4j.kernel.api.schema_new;
 
 import java.util.Arrays;
 
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+
 /**
  * Holder for n property values, ordered according to a schema descriptor property id order
  */
@@ -28,7 +31,12 @@ public class OrderedPropertyValues
 {
     private final Object[] values;
 
-    public OrderedPropertyValues( Object... values )
+    public static OrderedPropertyValues of( Object... values )
+    {
+        return new OrderedPropertyValues( values );
+    }
+
+    private OrderedPropertyValues( Object[] values )
     {
         this.values = values;
     }
@@ -59,5 +67,70 @@ public class OrderedPropertyValues
     public int hashCode()
     {
         return Arrays.deepHashCode( values );
+    }
+
+    public int size()
+    {
+        return values.length;
+    }
+
+    public Object getSinglePropertyValue()
+    {
+        assert values.length == 1 : "Assumed single property but had " + values.length;
+        return values[0];
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        String sep = "( ";
+        for ( Object value : values )
+        {
+            sb.append( sep );
+            sep = ", ";
+            sb.append( quote( value ) );
+        }
+        sb.append( " )" );
+        return sb.toString();
+    }
+
+    public static String quote( Object propertyValue )
+    {
+        if ( propertyValue instanceof String )
+        {
+            return format( "'%s'", propertyValue );
+        }
+        else if ( propertyValue.getClass().isArray() )
+        {
+            Class<?> type = propertyValue.getClass().getComponentType();
+            if ( type == Boolean.TYPE )
+            {
+                return Arrays.toString( (boolean[]) propertyValue );
+            } else if ( type == Byte.TYPE )
+            {
+                return Arrays.toString( (byte[]) propertyValue );
+            } else if ( type == Short.TYPE )
+            {
+                return Arrays.toString( (short[]) propertyValue );
+            } else if ( type == Character.TYPE )
+            {
+                return Arrays.toString( (char[]) propertyValue );
+            } else if ( type == Integer.TYPE )
+            {
+                return Arrays.toString( (int[]) propertyValue );
+            } else if ( type == Long.TYPE )
+            {
+                return Arrays.toString( (long[]) propertyValue );
+            } else if ( type == Float.TYPE )
+            {
+                return Arrays.toString( (float[]) propertyValue );
+            } else if ( type == Double.TYPE )
+            {
+                return Arrays.toString( (double[]) propertyValue );
+            }
+            return Arrays.toString( (Object[]) propertyValue );
+        }
+        return valueOf( propertyValue );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.schema_new;
+
+import java.util.Arrays;
+
+/**
+ * Holder for n property values, ordered according to a schema descriptor property id order
+ */
+public class OrderedPropertyValues
+{
+    private final Object[] values;
+
+    public OrderedPropertyValues( Object... values )
+    {
+        this.values = values;
+    }
+
+    public Object[] values()
+    {
+        return values;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        OrderedPropertyValues that = (OrderedPropertyValues) o;
+
+        return Arrays.deepEquals( values, that.values );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.deepHashCode( values );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -180,7 +180,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             {
                 throw new UniquePropertyValueValidationException( constraint,
                         ConstraintValidationException.Phase.VALIDATION,
-                        new IndexEntryConflictException( existing, NO_SUCH_NODE, new OrderedPropertyValues( value ) ) );
+                        new IndexEntryConflictException( existing, NO_SUCH_NODE, value ) );
             }
         }
         catch ( IndexNotFoundKernelException | IndexBrokenKernelException | IndexNotApplicableKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.IndexQuery;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
@@ -179,7 +180,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             {
                 throw new UniquePropertyValueValidationException( constraint,
                         ConstraintValidationException.Phase.VALIDATION,
-                        new IndexEntryConflictException( existing, NO_SUCH_NODE, value ) );
+                        new IndexEntryConflictException( existing, NO_SUCH_NODE, new OrderedPropertyValues( value ) ) );
             }
         }
         catch ( IndexNotFoundKernelException | IndexBrokenKernelException | IndexNotApplicableKernelException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
@@ -38,8 +38,7 @@ public class IndexEntryConflictExceptionTest
     public void shouldMakeEntryConflicts()
     {
         LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2 );
-        OrderedPropertyValues values = new OrderedPropertyValues( "hi" );
-        IndexEntryConflictException e = new IndexEntryConflictException( 0L, 1L, values );
+        IndexEntryConflictException e = new IndexEntryConflictException( 0L, 1L, "hi" );
 
         assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),
                 equalTo( "Both Node(0) and Node(1) have the label `label[1]` and property `property[2]` = 'hi'" ) );
@@ -49,8 +48,7 @@ public class IndexEntryConflictExceptionTest
     public void shouldMakeEntryConflictsForOneNode()
     {
         LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2 );
-        OrderedPropertyValues values = new OrderedPropertyValues( "hi" );
-        IndexEntryConflictException e = new IndexEntryConflictException( 0L, StatementConstants.NO_SUCH_NODE, values );
+        IndexEntryConflictException e = new IndexEntryConflictException( 0L, StatementConstants.NO_SUCH_NODE, "hi" );
 
         assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),
                 equalTo( "Node(0) already exists with label `label[1]` and property `property[2]` = 'hi'" ) );
@@ -60,7 +58,7 @@ public class IndexEntryConflictExceptionTest
     public void shouldMakeCompositeEntryConflicts()
     {
         LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2, 3, 4 );
-        OrderedPropertyValues values = new OrderedPropertyValues( true, "hi", new long[]{6L, 4L} );
+        OrderedPropertyValues values = OrderedPropertyValues.of( true, "hi", new long[]{6L, 4L} );
         IndexEntryConflictException e = new IndexEntryConflictException( 0L, 1L, values );
 
         assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictExceptionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.index;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.StatementConstants;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexEntryConflictExceptionTest
+{
+    public static final int labelId = 1;
+
+    @Test
+    public void shouldMakeEntryConflicts()
+    {
+        LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2 );
+        OrderedPropertyValues values = new OrderedPropertyValues( "hi" );
+        IndexEntryConflictException e = new IndexEntryConflictException( 0L, 1L, values );
+
+        assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),
+                equalTo( "Both Node(0) and Node(1) have the label `label[1]` and property `property[2]` = 'hi'" ) );
+    }
+
+    @Test
+    public void shouldMakeEntryConflictsForOneNode()
+    {
+        LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2 );
+        OrderedPropertyValues values = new OrderedPropertyValues( "hi" );
+        IndexEntryConflictException e = new IndexEntryConflictException( 0L, StatementConstants.NO_SUCH_NODE, values );
+
+        assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),
+                equalTo( "Node(0) already exists with label `label[1]` and property `property[2]` = 'hi'" ) );
+    }
+
+    @Test
+    public void shouldMakeCompositeEntryConflicts()
+    {
+        LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, 2, 3, 4 );
+        OrderedPropertyValues values = new OrderedPropertyValues( true, "hi", new long[]{6L, 4L} );
+        IndexEntryConflictException e = new IndexEntryConflictException( 0L, 1L, values );
+
+        assertThat( e.evidenceMessage( SchemaUtil.idTokenNameLookup, schema ),
+                equalTo( "Both Node(0) and Node(1) have the label `label[1]` " +
+                        "and properties `property[2]` = true, `property[3]` = 'hi', `property[4]` = [6, 4]" ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
@@ -81,7 +81,7 @@ public class UniqueIndexPopulatorCompatibility extends IndexProviderCompatibilit
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( nodeId1, conflict.getExistingNodeId() );
-            assertEquals( new OrderedPropertyValues( value ), conflict.getPropertyValues() );
+            assertEquals( OrderedPropertyValues.of( value ), conflict.getPropertyValues() );
             assertEquals( nodeId2, conflict.getAddedNodeId() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueIndexPopulatorCompatibility.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
-import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -81,7 +81,7 @@ public class UniqueIndexPopulatorCompatibility extends IndexProviderCompatibilit
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( nodeId1, conflict.getExistingNodeId() );
-            assertEquals( value, conflict.getPropertyValue() );
+            assertEquals( new OrderedPropertyValues( value ), conflict.getPropertyValues() );
             assertEquals( nodeId2, conflict.getAddedNodeId() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationExcep
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction;
 import org.neo4j.kernel.api.proc.CallableUserFunction;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.SchemaBoundary;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
@@ -118,7 +119,7 @@ public class ConstraintIndexCreatorTest
                 .thenReturn( 2468L );
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getIndexProxy( 2468L ) ).thenReturn( indexProxy );
-        IndexEntryConflictException cause = new IndexEntryConflictException( 2, 1, "a" );
+        IndexEntryConflictException cause = new IndexEntryConflictException( 2, 1, new OrderedPropertyValues( "a" ) );
         doThrow( new IndexPopulationFailedKernelException( SchemaBoundary.map( descriptor ), "some index", cause ) )
                 .when( indexProxy ).awaitStoreScanCompleted();
         PropertyAccessor propertyAccessor = mock( PropertyAccessor.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -119,7 +119,7 @@ public class ConstraintIndexCreatorTest
                 .thenReturn( 2468L );
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getIndexProxy( 2468L ) ).thenReturn( indexProxy );
-        IndexEntryConflictException cause = new IndexEntryConflictException( 2, 1, new OrderedPropertyValues( "a" ) );
+        IndexEntryConflictException cause = new IndexEntryConflictException( 2, 1, "a" );
         doThrow( new IndexPopulationFailedKernelException( SchemaBoundary.map( descriptor ), "some index", cause ) )
                 .when( indexProxy ).awaitStoreScanCompleted();
         PropertyAccessor propertyAccessor = mock( PropertyAccessor.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -119,8 +119,7 @@ class UniqueInMemoryIndex extends InMemoryIndex
                         if ( entries.containsKey( value ) )
                         {
                             long existingNodeId = entries.get( value );
-                            throw new IndexEntryConflictException( existingNodeId, nodeId,
-                                    new OrderedPropertyValues( value ) );
+                            throw new IndexEntryConflictException( existingNodeId, nodeId, value );
                         }
                         entries.put( value, nodeId );
                     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.updater.UniquePropertyIndexUpdater;
 
@@ -118,7 +119,8 @@ class UniqueInMemoryIndex extends InMemoryIndex
                         if ( entries.containsKey( value ) )
                         {
                             long existingNodeId = entries.get( value );
-                            throw new IndexEntryConflictException( existingNodeId, nodeId, value );
+                            throw new IndexEntryConflictException( existingNodeId, nodeId,
+                                    new OrderedPropertyValues( value ) );
                         }
                         entries.put( value, nodeId );
                     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1381,7 +1381,7 @@ public class BatchInsertTest
         catch ( RuntimeException ex )
         {
             // good
-            assertEquals( new IndexEntryConflictException( 0, 1, new OrderedPropertyValues( value ) ), ex.getCause() );
+            assertEquals( new IndexEntryConflictException( 0, 1, value ), ex.getCause() );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -68,7 +68,7 @@ import org.neo4j.kernel.api.labelscan.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
-import org.neo4j.kernel.api.schema.IndexDescriptor;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -1381,7 +1381,7 @@ public class BatchInsertTest
         catch ( RuntimeException ex )
         {
             // good
-            assertEquals( new IndexEntryConflictException( 0, 1, value ), ex.getCause() );
+            assertEquals( new IndexEntryConflictException( 0, 1, new OrderedPropertyValues( value ) ), ex.getCause() );
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
@@ -94,8 +94,7 @@ public class DuplicateCheckingCollector extends SimpleCollector
                 }
                 else if ( property.valueEquals( value ) )
                 {
-                    throw new IndexEntryConflictException( current.nodeId[i], nodeId,
-                            new OrderedPropertyValues( value ) );
+                    throw new IndexEntryConflictException( current.nodeId[i], nodeId, value );
                 }
             }
             current = current.next;

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckingCollector.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 
 public class DuplicateCheckingCollector extends SimpleCollector
 {
@@ -93,7 +94,8 @@ public class DuplicateCheckingCollector extends SimpleCollector
                 }
                 else if ( property.valueEquals( value ) )
                 {
-                    throw new IndexEntryConflictException( current.nodeId[i], nodeId, value );
+                    throw new IndexEntryConflictException( current.nodeId[i], nodeId,
+                            new OrderedPropertyValues( value ) );
                 }
             }
             current = current.next;

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.schema_new.IndexQuery;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
@@ -106,7 +107,8 @@ public class ConstraintIndexConcurrencyTest
             catch ( UniquePropertyValueValidationException e )
             {
                 assertEquals( ConstraintDescriptorFactory.uniqueForLabel( labelId, propertyKeyId ), e.constraint() );
-                assertEquals( conflictingValue, Iterators.single( e.conflicts().iterator() ).getPropertyValue() );
+                IndexEntryConflictException conflict = Iterators.single( e.conflicts().iterator() );
+                assertEquals( conflictingValue, conflict.getSinglePropertyValue() );
             }
 
             tx.success();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -244,7 +244,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( value, conflict.getPropertyValue() );
+            assertEquals( value, conflict.getSinglePropertyValue() );
             assertEquals( 3, conflict.getAddedNodeId() );
         }
     }
@@ -273,7 +273,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( 1, conflict.getPropertyValue() );
+            assertEquals( 1, conflict.getSinglePropertyValue() );
             assertEquals( 3, conflict.getAddedNodeId() );
         }
     }
@@ -305,7 +305,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( "value1", conflict.getPropertyValue() );
+            assertEquals( "value1", conflict.getSinglePropertyValue() );
             assertEquals( 3, conflict.getAddedNodeId() );
         }
     }
@@ -337,7 +337,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( value, conflict.getPropertyValue() );
+            assertEquals( value, conflict.getSinglePropertyValue() );
             assertEquals( 2, conflict.getAddedNodeId() );
         }
     }
@@ -420,7 +420,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( 1, conflict.getPropertyValue() );
+            assertEquals( 1, conflict.getSinglePropertyValue() );
             assertEquals( iterations, conflict.getAddedNodeId() );
         }
     }
@@ -455,7 +455,7 @@ public class UniqueDatabaseIndexPopulatorTest
         catch ( IndexEntryConflictException conflict )
         {
             assertEquals( 1, conflict.getExistingNodeId() );
-            assertEquals( 1, conflict.getPropertyValue() );
+            assertEquals( 1, conflict.getSinglePropertyValue() );
             assertEquals( iterations, conflict.getAddedNodeId() );
         }
     }


### PR DESCRIPTION
Make IndexEntryConflictException handle composite indexes. Also introduces new class OrderedPropertyValues for managing a set of property values that maps to one schema descriptor.