### PR TITLE
Faster refresh of read replica topology

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -310,7 +310,7 @@ public class CausalClusteringSettings
 
     @Description( "Time between scanning the cluster to refresh current server's view of topology" )
     public static final Setting<Long> cluster_topology_refresh =
-            setting( "causal_clustering.cluster_topology_refresh", DURATION, "1m", min(1_000L) );
+            setting( "causal_clustering.cluster_topology_refresh", DURATION, "5s", min(1_000L) );
 
     @Description( "Require authorization for access to the Causal Clustering status endpoints." )
     public static final Setting<Boolean> status_auth_enabled =

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -83,6 +83,7 @@ public class CoreClusterMember implements ClusterMember
         config.put( CausalClusteringSettings.discovery_listen_address.name(), "127.0.0.1:" + hazelcastPort );
         config.put( CausalClusteringSettings.transaction_listen_address.name(), "127.0.0.1:" + txPort );
         config.put( CausalClusteringSettings.raft_listen_address.name(), "127.0.0.1:" + raftPort );
+        config.put( CausalClusteringSettings.cluster_topology_refresh.name(), "1000ms" );
         config.put( CausalClusteringSettings.expected_core_cluster_size.name(), String.valueOf( clusterSize ) );
         config.put( CausalClusteringSettings.leader_election_timeout.name(), "500ms" );
         config.put( CausalClusteringSettings.raft_messages_log_enable.name(), Settings.TRUE );


### PR DESCRIPTION
The default was 1 minute for the product and this can be a surprisingly long
time. There should be no harm of lowering this to 5 seconds.

For tests the default was lowered to 1 second to speed up tests
relying on this timing. An extra 1 minute is unnecessarily long.

changelog: Decrease default topology refresh timeout from 1 minute to 5 seconds.