### PR TITLE
Introduce page cache hit metric

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -242,6 +242,7 @@ abstract class MuninnPageCursor extends PageCursor
                 if ( locked & page.isBoundTo( swapper, filePageId ) )
                 {
                     pinCursorToPage( page, filePageId, swapper );
+                    pinEvent.hit();
                     return;
                 }
                 if ( locked )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
@@ -46,6 +46,11 @@ public interface PageCacheCounters
      long unpins();
 
     /**
+     * @return The number of page cache hits so far.
+     */
+    long hits();
+
+    /**
      * @return The number of page flushes observed thus far.
      */
     long flushes();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -34,6 +34,7 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     protected final LongAdder evictions = new LongAdder();
     protected final LongAdder pins = new LongAdder();
     protected final LongAdder unpins = new LongAdder();
+    protected final LongAdder hits = new LongAdder();
     protected final LongAdder flushes = new LongAdder();
     protected final LongAdder bytesRead = new LongAdder();
     protected final LongAdder bytesWritten = new LongAdder();
@@ -188,6 +189,12 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     }
 
     @Override
+    public long hits()
+    {
+        return hits.sum();
+    }
+
+    @Override
     public long flushes()
     {
         return flushes.sum();
@@ -233,6 +240,12 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     public void unpins( long unpins )
     {
         this.unpins.add( unpins );
+    }
+
+    @Override
+    public void hits( long hits )
+    {
+        this.hits.add( hits );
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
@@ -89,6 +89,12 @@ public interface PageCacheTracer extends PageCacheCounters
         }
 
         @Override
+        public long hits()
+        {
+            return 0;
+        }
+
+        @Override
         public long flushes()
         {
             return 0;
@@ -131,6 +137,11 @@ public interface PageCacheTracer extends PageCacheCounters
 
         @Override
         public void unpins( long unpins )
+        {
+        }
+
+        @Override
+        public void hits( long hits )
         {
         }
 
@@ -211,6 +222,12 @@ public interface PageCacheTracer extends PageCacheCounters
      * @param unpins number of unpins
      */
     void unpins( long unpins );
+
+    /**
+     * Report number of observer hits
+     * @param hits number of hits
+     */
+    void hits( long hits );
 
     /**
      * Report number of observed faults

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PinEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PinEvent.java
@@ -41,6 +41,11 @@ public interface PinEvent
         }
 
         @Override
+        public void hit()
+        {
+        }
+
+        @Override
         public void done()
         {
         }
@@ -55,6 +60,11 @@ public interface PinEvent
      * The page we want to pin is not in memory, so being a page fault to load it in.
      */
     PageFaultEvent beginPageFault();
+
+    /**
+     * Page found and bounded.
+     */
+    void hit();
 
     /**
      * The pinning has completed and the page is now unpinned.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorCounters.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorCounters.java
@@ -45,6 +45,11 @@ public interface PageCursorCounters
     long unpins();
 
     /**
+     * @return The number of page hits observed so far.
+     */
+    long hits();
+
+    /**
      * @return The sum total of bytes read in through page faults thus far.
      */
     long bytesRead();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/cursor/PageCursorTracer.java
@@ -56,6 +56,12 @@ public interface PageCursorTracer extends PageCursorCounters
         }
 
         @Override
+        public long hits()
+        {
+            return 0;
+        }
+
+        @Override
         public long bytesRead()
         {
             return 0;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
@@ -42,21 +42,6 @@ public class DefaultPageCacheTracerTest
         swapper = new DummyPageSwapper( "filename" );
     }
 
-    private void assertCounts( long pins, long unpins, long faults, long evictions, long evictionExceptions,
-                               long flushes, long bytesRead, long bytesWritten, long filesMapped, long filesUnmapped )
-    {
-        assertThat( "pins", tracer.pins(), is( pins ) );
-        assertThat( "unpins", tracer.unpins(), is( unpins ) );
-        assertThat( "faults", tracer.faults(), is( faults ) );
-        assertThat( "evictions", tracer.evictions(), is( evictions ) );
-        assertThat( "evictionExceptions", tracer.evictionExceptions(), is( evictionExceptions ) );
-        assertThat( "flushes", tracer.flushes(), is( flushes ) );
-        assertThat( "bytesRead", tracer.bytesRead(), is( bytesRead ) );
-        assertThat( "bytesWritten", tracer.bytesWritten(), is( bytesWritten ) );
-        assertThat( "filesMapped", tracer.filesMapped(), is( filesMapped ) );
-        assertThat( "filesUnmapped", tracer.filesUnmapped(), is( filesUnmapped ) );
-    }
-
     @Test
     public void mustCountEvictions()
     {
@@ -88,7 +73,7 @@ public class DefaultPageCacheTracerTest
             evictionRunEvent.beginEviction().close();
         }
 
-        assertCounts( 0, 0, 0, 4, 2, 3, 0, 36, 0, 0 );
+        assertCounts( 0, 0, 0, 0, 4, 2, 3, 0, 36, 0, 0 );
     }
 
     @Test
@@ -96,11 +81,11 @@ public class DefaultPageCacheTracerTest
     {
         tracer.mappedFile( new File( "a" ) );
 
-        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 );
+        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 );
 
         tracer.unmappedFile( new File( "a" ) );
 
-        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 );
+        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 );
     }
 
     @Test
@@ -113,7 +98,7 @@ public class DefaultPageCacheTracerTest
             cacheFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
         }
 
-        assertCounts( 0, 0, 0, 0, 0, 3, 0, 0, 0, 0 );
+        assertCounts( 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0 );
 
         try ( MajorFlushEvent fileFlush = tracer.beginFileFlush( swapper ) )
         {
@@ -122,6 +107,22 @@ public class DefaultPageCacheTracerTest
             fileFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
         }
 
-        assertCounts( 0, 0, 0, 0, 0, 6, 0, 0, 0, 0 );
+        assertCounts( 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0 );
+    }
+
+    private void assertCounts( long pins, long unpins, long hits, long faults, long evictions, long evictionExceptions,
+            long flushes, long bytesRead, long bytesWritten, long filesMapped, long filesUnmapped )
+    {
+        assertThat( "pins", tracer.pins(), is( pins ) );
+        assertThat( "unpins", tracer.unpins(), is( unpins ) );
+        assertThat( "hits", tracer.hits(), is( hits ) );
+        assertThat( "faults", tracer.faults(), is( faults ) );
+        assertThat( "evictions", tracer.evictions(), is( evictions ) );
+        assertThat( "evictionExceptions", tracer.evictionExceptions(), is( evictionExceptions ) );
+        assertThat( "flushes", tracer.flushes(), is( flushes ) );
+        assertThat( "bytesRead", tracer.bytesRead(), is( bytesRead ) );
+        assertThat( "bytesWritten", tracer.bytesWritten(), is( bytesWritten ) );
+        assertThat( "filesMapped", tracer.filesMapped(), is( filesMapped ) );
+        assertThat( "filesUnmapped", tracer.filesUnmapped(), is( filesUnmapped ) );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCursorTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCursorTracerTest.java
@@ -56,6 +56,40 @@ public class DefaultPageCursorTracerTest
     }
 
     @Test
+    public void noHitForPinEventWithPageFault()
+    {
+        pinFaultAndHit();
+
+        assertEquals( 1, pageCursorTracer.pins() );
+        assertEquals( 1, pageCursorTracer.faults() );
+        assertEquals( 0, pageCursorTracer.hits() );
+    }
+
+    @Test
+    public void hitForPinEventWithoutPageFault()
+    {
+        pinAndHit();
+
+        assertEquals( 1, pageCursorTracer.pins() );
+        assertEquals( 1, pageCursorTracer.hits() );
+    }
+
+    @Test
+    public void countHitsOnlyForPinEventsWithoutPageFaults()
+    {
+        pinAndHit();
+        pinAndHit();
+        pinAndHit();
+        pinFaultAndHit();
+        pinFaultAndHit();
+        pinAndHit();
+        pinAndHit();
+
+        assertEquals( 7, pageCursorTracer.pins() );
+        assertEquals( 5, pageCursorTracer.hits() );
+    }
+
+    @Test
     public void countPageFaultsAndBytesRead()
     {
         PinEvent pinEvent = pageCursorTracer.beginPin( true, 0, swapper );
@@ -192,5 +226,21 @@ public class DefaultPageCursorTracerTest
         DefaultPageCursorTracer pageCursorTracer = new DefaultPageCursorTracer();
         pageCursorTracer.init( cacheTracer );
         return pageCursorTracer;
+    }
+
+    private void pinAndHit()
+    {
+        PinEvent pinEvent = pageCursorTracer.beginPin( true, 0, swapper );
+        pinEvent.hit();
+        pinEvent.done();
+    }
+
+    private void pinFaultAndHit()
+    {
+        PinEvent pinEvent = pageCursorTracer.beginPin( true, 0, swapper );
+        PageFaultEvent pageFaultEvent = pinEvent.beginPageFault();
+        pinEvent.hit();
+        pageFaultEvent.done();
+        pinEvent.done();
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
@@ -62,6 +62,12 @@ public class DelegatingPageCacheTracer implements PageCacheTracer
         return delegate.unpins();
     }
 
+    @Override
+    public long hits()
+    {
+        return delegate.hits();
+    }
+
     public MajorFlushEvent beginCacheFlush()
     {
         return delegate.beginCacheFlush();
@@ -102,6 +108,12 @@ public class DelegatingPageCacheTracer implements PageCacheTracer
     public void unpins( long unpins )
     {
         delegate.unpins( unpins );
+    }
+
+    @Override
+    public void hits( long hits )
+    {
+        delegate.hits( hits );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
@@ -230,12 +230,14 @@ class HEvents
         private long filePageId;
         private File file;
         private int cachePageId;
+        private boolean hit;
 
         PinHEvent( LinearHistoryTracer tracer, boolean exclusiveLock, long filePageId, PageSwapper swapper )
         {
             super( tracer );
             this.exclusiveLock = exclusiveLock;
             this.filePageId = filePageId;
+            this.hit = true;
             this.file = swapper.file();
         }
 
@@ -248,6 +250,7 @@ class HEvents
         @Override
         public PageFaultEvent beginPageFault()
         {
+            hit = false;
             return tracer.add( new PageFaultHEvent( tracer ) );
         }
 
@@ -269,6 +272,8 @@ class HEvents
             out.print( filePageId );
             out.print( ", cachePageId:" );
             out.print( cachePageId );
+            out.print( ", hit:" );
+            out.print( hit );
             print( out, file );
             out.append( ", exclusiveLock:" );
             out.print( exclusiveLock );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/HEvents.java
@@ -252,6 +252,11 @@ class HEvents
         }
 
         @Override
+        public void hit()
+        {
+        }
+
+        @Override
         public void done()
         {
             close();

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
@@ -103,6 +103,12 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
     }
 
     @Override
+    public long hits()
+    {
+        return 0;
+    }
+
+    @Override
     public long flushes()
     {
         return 0;
@@ -145,6 +151,11 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
 
     @Override
     public void unpins( long unpins )
+    {
+    }
+
+    @Override
+    public void hits( long hits )
     {
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCursorTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCursorTracer.java
@@ -60,6 +60,12 @@ public class LinearHistoryPageCursorTracer implements PageCursorTracer
     }
 
     @Override
+    public long hits()
+    {
+        return 0;
+    }
+
+    @Override
     public long bytesRead()
     {
         return 0;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
@@ -108,6 +108,12 @@ public class RecordingPageCacheTracer extends RecordingTracer implements PageCac
     }
 
     @Override
+    public long hits()
+    {
+        return 0;
+    }
+
+    @Override
     public long flushes()
     {
         return 0;
@@ -151,6 +157,11 @@ public class RecordingPageCacheTracer extends RecordingTracer implements PageCac
 
     @Override
     public void unpins( long unpins )
+    {
+    }
+
+    @Override
+    public void hits( long hits )
     {
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
@@ -70,6 +70,12 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
     }
 
     @Override
+    public long hits()
+    {
+        return 0;
+    }
+
+    @Override
     public long bytesRead()
     {
         return 0;
@@ -141,6 +147,11 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
                     {
                     }
                 };
+            }
+
+            @Override
+            public void hit()
+            {
             }
 
             @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCursorTracer.java
@@ -110,6 +110,8 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
     {
         return new PinEvent()
         {
+            private boolean hit = true;
+
             @Override
             public void setCachePageId( int cachePageId )
             {
@@ -118,6 +120,7 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
             @Override
             public PageFaultEvent beginPageFault()
             {
+                hit = false;
                 return new PageFaultEvent()
                 {
                     @Override
@@ -157,7 +160,7 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
             @Override
             public void done()
             {
-                pinned( filePageId, swapper );
+                pinned( filePageId, swapper, hit );
             }
         };
     }
@@ -182,10 +185,10 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
         record( new Fault( swapper, filePageId ) );
     }
 
-    private void pinned( long filePageId, PageSwapper swapper )
+    private void pinned( long filePageId, PageSwapper swapper, boolean hit )
     {
         pins++;
-        record( new Pin( swapper, filePageId ) );
+        record( new Pin( swapper, filePageId, hit ) );
     }
 
     public static class Fault extends Event
@@ -198,9 +201,18 @@ public class RecordingPageCursorTracer extends RecordingTracer implements PageCu
 
     public static class Pin extends Event
     {
-        private Pin( PageSwapper io, long pageId )
+        private boolean hit;
+
+        private Pin( PageSwapper io, long pageId, boolean hit )
         {
             super( io, pageId );
+            this.hit = hit;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "%s{io=%s, pageId=%s,hit=%s}", getClass().getSimpleName(), io, pageId, hit );
         }
     }
 


### PR DESCRIPTION
Introduce hit metric that will show count of how many requested pages are
retrieved from cache.
Default implementation count hits only if page where retrieved from page cache itself
without page faults. In case if there is already page fault in progress
we will gonna count this page as hit.