### PR TITLE
Postpone logging of log rotation progress until release logFileLock

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -22,25 +22,23 @@ package org.neo4j.causalclustering.scenarios;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 
-import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.core.consensus.roles.Role;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.test.causalclustering.ClusterRule;
+import org.neo4j.test.rule.SuppressOutput;
+import org.neo4j.test.rule.VerboseTimeout;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -49,14 +47,18 @@ import static org.junit.Assert.fail;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
 import static org.neo4j.function.Predicates.await;
 import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.helpers.collection.Iterables.count;
 
 public class CoreReplicationIT
 {
-    @Rule
-    public final ClusterRule clusterRule =
+    private final ClusterRule clusterRule =
             new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
+    private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
+    private final VerboseTimeout timeout = VerboseTimeout.builder()
+            .withTimeout( 40, TimeUnit.SECONDS )
+            .build();
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( timeout ).around( suppressOutput ).around( clusterRule );
 
     private Cluster cluster;
 


### PR DESCRIPTION
Fixing deadlock problem between flushing log (T1) and rotating log (T2).

Problem is the order in which flushing and rotating grab locks.
Flush first grab PrintWriter lock, then log file guard lock.
Rotate first grab log file guard lock then PrintWriter lock.

Solution is to not log rotation progress while holding the log file guard lock
and instead buffer the log messages until lock is released.

Also add a verbose timeout to CoreReplicationIT which suffered from this deadlock.

co-author: @MishaDemianenko 