### PR TITLE
Log warnings about deprecated config settings

### DIFF
--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
@@ -35,13 +35,18 @@ public class ConfigOptions
     private final SettingGroup<?> settingGroup;
     private final Optional<String> description;
     private final Optional<String> documentedDefaultValue;
+    private final boolean deprecated;
+    private final Optional<String> replacement;
 
     public ConfigOptions( @Nonnull SettingGroup<?> settingGroup, @Nonnull Optional<String> description,
-            Optional<String> documentedDefaultValue )
+            @Nonnull Optional<String> documentedDefaultValue, boolean deprecated,
+            @Nonnull Optional<String> replacement )
     {
         this.settingGroup = settingGroup;
         this.description = description;
         this.documentedDefaultValue = documentedDefaultValue;
+        this.deprecated = deprecated;
+        this.replacement = replacement;
     }
 
     @Nonnull
@@ -65,7 +70,19 @@ public class ConfigOptions
     public List<ConfigValue> asConfigValues( @Nonnull Map<String,String> validConfig )
     {
         return settingGroup.values( validConfig ).entrySet().stream()
-                .map( val -> new ConfigValue( val.getKey(), description(), Optional.ofNullable( val.getValue() ) ) )
+                .map( val -> new ConfigValue( val.getKey(), description(), Optional.ofNullable( val.getValue() ),
+                        deprecated, replacement ) )
                 .collect( Collectors.toList() );
+    }
+
+    public boolean deprecated()
+    {
+        return deprecated;
+    }
+
+    @Nonnull
+    public Optional<String> replacement()
+    {
+        return replacement;
     }
 }

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -30,12 +30,17 @@ public class ConfigValue
     private final String name;
     private final Optional<String> description;
     private final Optional<?> value;
+    private final boolean deprecated;
+    private final Optional<String> replacement;
 
-    public ConfigValue( @Nonnull String name, @Nonnull Optional<String> description, @Nonnull Optional<?> value )
+    public ConfigValue( @Nonnull String name, @Nonnull Optional<String> description, @Nonnull Optional<?> value,
+            boolean deprecated, @Nonnull Optional<String> replacement )
     {
         this.name = name;
         this.description = description;
         this.value = value;
+        this.deprecated = deprecated;
+        this.replacement = replacement;
     }
 
     @Nonnull
@@ -60,5 +65,16 @@ public class ConfigValue
     public String toString()
     {
         return value.map( Object::toString ).orElse( "null" );
+    }
+
+    public boolean deprecated()
+    {
+        return deprecated;
+    }
+
+    @Nonnull
+    public Optional<String> replacement()
+    {
+        return replacement;
     }
 }

--- a/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/LoadableConfig.java
@@ -74,8 +74,22 @@ public interface LoadableConfig
                         documentedDefaultValue = Optional.of( defValue.value() );
                     }
 
+                    final Deprecated deprecatedAnnotation = f.getAnnotation( Deprecated.class );
+                    final boolean deprecated = deprecatedAnnotation != null;
+
+                    final ReplacedBy replacedByAnnotation = f.getAnnotation( ReplacedBy.class );
+                    final Optional<String> replacement;
+                    if (replacedByAnnotation == null )
+                    {
+                        replacement = Optional.empty();
+                    }
+                    else
+                    {
+                        replacement = Optional.of( replacedByAnnotation.value() );
+                    }
+
                     configOptions.add( new ConfigOptions( (SettingGroup) publicSetting, description,
-                            documentedDefaultValue ) );
+                            documentedDefaultValue, deprecated, replacement ) );
                 }
             }
             catch ( IllegalAccessException ignored )

--- a/community/configuration/src/main/java/org/neo4j/configuration/ReplacedBy.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ReplacedBy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to indicate what setting have/will replace a deprecated setting.
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target( {ElementType.TYPE, ElementType.FIELD} )
+public @interface ReplacedBy
+{
+    String value();
+}

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigOptionsTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigOptionsTest.java
@@ -71,7 +71,7 @@ public class ConfigOptionsTest
     @Before
     public void setup()
     {
-        this.configOptions = new ConfigOptions( setting, Optional.empty(), Optional.empty() );
+        this.configOptions = new ConfigOptions( setting, Optional.empty(), Optional.empty(), false, Optional.empty() );
     }
 
     @Test

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -24,24 +24,42 @@ import org.junit.Test;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ConfigValueTest
 {
     @Test
     public void handlesEmptyValue() throws Exception
     {
-        ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty() );
+        ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), false, Optional.empty() );
 
         assertEquals( Optional.empty(), value.value() );
         assertEquals( "null", value.toString() );
+        assertFalse( value.deprecated() );
+        assertEquals( Optional.empty(), value.replacement() );
     }
 
     @Test
     public void handlesNonEmptyValue() throws Exception
     {
-        ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.of( 1 ) );
+        ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.of( 1 ), false, Optional.empty() );
 
         assertEquals( Optional.of( 1 ), value.value() );
         assertEquals( "1", value.toString() );
+        assertFalse( value.deprecated() );
+        assertEquals( Optional.empty(), value.replacement() );
+    }
+
+    @Test
+    public void handlesDeprecationAndReplacement() throws Exception
+    {
+        ConfigValue value = new ConfigValue( "old_name", Optional.empty(), Optional.of( 1 ), true,
+                Optional.of( "new_name" ) );
+
+        assertEquals( Optional.of( 1 ), value.value() );
+        assertEquals( "1", value.toString() );
+        assertTrue( value.deprecated() );
+        assertEquals( "new_name", value.replacement().get() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.LoadableConfig;
+import org.neo4j.configuration.ReplacedBy;
 import org.neo4j.csv.reader.Configuration;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -353,6 +354,7 @@ public class GraphDatabaseSettings implements LoadableConfig
                  "This configuration setting is no longer applicable as from Neo4j 3.0.3. " +
                  "Please use dbms.index_sampling.sample_size_limit instead.")
     @Deprecated
+    @ReplacedBy( "dbms.index_sampling.sample_size_limit" )
     public static final Setting<Long> index_sampling_buffer_size = setting("dbms.index_sampling.buffer_size", BYTES, "64m",
                     min( /* 1m */ 1048576L ), max( (long) Integer.MAX_VALUE ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BoltConnector.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.configuration;
 
 import org.neo4j.configuration.Description;
+import org.neo4j.configuration.ReplacedBy;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
@@ -40,6 +41,8 @@ public class BoltConnector extends Connector
 
     @Description( "Address the connector should bind to. " +
             "This setting is deprecated and will be replaced by `+listen_address+`" )
+    @Deprecated
+    @ReplacedBy( "dbms.connector.X.listen_address" )
     public final Setting<ListenSocketAddress> address;
 
     @Description( "Address the connector should bind to" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -428,22 +428,24 @@ public class Config implements DiagnosticsProvider, Configuration
         params.putAll( validSettings );
 
         // Warn about deprecations
-        configFile.ifPresent(
-                file -> configOptions.stream()
-                        .map( it -> it.asConfigValues( params ) )
-                        .flatMap( List::stream )
-                        .filter( ConfigValue::deprecated )
-                        .forEach( c ->
+        if ( configFile.isPresent() ) {
+            configOptions.stream()
+                    .map( it -> it.asConfigValues( params ) )
+                    .flatMap( List::stream )
+                    .filter( c -> params.containsKey( c.name() ) )
+                    .filter( ConfigValue::deprecated )
+                    .forEach( c ->
+                    {
+                        if ( c.replacement().isPresent() )
                         {
-                            if ( c.replacement().isPresent() )
-                            {
-                                log.warn( "%s is deprecated. Replaced by %s", c.name(), c.replacement().get() );
-                            }
-                            else
-                            {
-                                log.warn( "%s is deprecated.", c.name() );
-                            }
-                        } ) );
+                            log.warn( "%s is deprecated. Replaced by %s", c.name(), c.replacement().get() );
+                        }
+                        else
+                        {
+                            log.warn( "%s is deprecated.", c.name() );
+                        }
+                    } );
+        }
     }
 
     @Nonnull

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -428,12 +428,22 @@ public class Config implements DiagnosticsProvider, Configuration
         params.putAll( validSettings );
 
         // Warn about deprecations
-        configOptions.stream()
-                .map( it -> it.asConfigValues( params ) )
-                .flatMap( List::stream )
-                .filter( ConfigValue::deprecated )
-                .forEach( c -> c.replacement()
-                        .ifPresent( s -> log.warn( "%s is deprecated. Replaced by %s", c.name(), s ) ) );
+        configFile.ifPresent(
+                file -> configOptions.stream()
+                        .map( it -> it.asConfigValues( params ) )
+                        .flatMap( List::stream )
+                        .filter( ConfigValue::deprecated )
+                        .forEach( c ->
+                        {
+                            if ( c.replacement().isPresent() )
+                            {
+                                log.warn( "%s is deprecated. Replaced by %s", c.name(), c.replacement().get() );
+                            }
+                            else
+                            {
+                                log.warn( "%s is deprecated.", c.name() );
+                            }
+                        } ) );
     }
 
     @Nonnull

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/HttpConnector.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.configuration;
 
 import org.neo4j.configuration.Description;
+import org.neo4j.configuration.ReplacedBy;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
@@ -42,6 +43,7 @@ public class HttpConnector extends Connector
     @Description( "Address the connector should bind to. " +
             "This setting is deprecated and will be replaced by `+listen_address+`" )
     @Deprecated
+    @ReplacedBy( "dbms.connector.X.listen_address" )
     public final Setting<ListenSocketAddress> address;
 
     @Description( "Address the connector should bind to" )

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -205,17 +205,21 @@ public class ConfigTest
         File confFile = testDirectory.file( "test.conf" );
         assertTrue( confFile.createNewFile() );
 
-        Config first = Config(
-                stringMap( GraphDatabaseSettings.strict_config_validation.name(), "false",
-                        MySettingsWithDefaults.oldHello.name(), "baah",
-                        MySettingsWithDefaults.oldSetting.name(), "booh" ) );
+        Config config =
+                new Config( Optional.of( confFile ),
+                        stringMap( MySettingsWithDefaults.oldHello.name(), "baah",
+                                MySettingsWithDefaults.oldSetting.name(), "booh" ),
+                        s -> {},
+                        Collections.emptyList(), Optional.empty(),
+                        Arrays.asList( mySettingsWithDefaults, myMigratingSettings ) );
 
         // When
-        first.setLogger( log );
+        config.setLogger( log );
 
         // Then
         verify( log ).warn( "%s is deprecated. Replaced by %s", MySettingsWithDefaults.oldHello.name(),
                 MySettingsWithDefaults.hello.name() );
+        verify( log ).warn( "%s is deprecated.", MySettingsWithDefaults.oldSetting.name() );
         verifyNoMoreInteractions( log );
     }
 


### PR DESCRIPTION
Output with a deprecated config value added to the config:

```
$ bin/neo4j console
Starting Neo4j.
WARNING: Max 1024 open files allowed, minimum of 40000 recommended. See the Neo4j manual.
2017-03-02 10:55:25.140+0000 WARN  WARNING! Deprecated configuration options used. See manual for details
2017-03-02 10:55:25.141+0000 WARN  dbms.index_sampling.buffer_size has been replaced with dbms.index_sampling.sample_size_limit.
2017-03-02 10:55:25.381+0000 INFO  Starting...
2017-03-02 10:55:26.131+0000 INFO  Bolt enabled on localhost:7687.
2017-03-02 10:55:26.145+0000 INFO  Initiating metrics...
2017-03-02 10:55:28.673+0000 INFO  Started.
2017-03-02 10:55:28.988+0000 INFO  Mounted REST API at: /db/manage
2017-03-02 10:55:29.773+0000 INFO  Remote interface available at http://localhost:7474/
```

Edit: updated example output