### PR TITLE
Fix racy ProcedureIT.shouldBeAbleToSpawnThreadsCreatingTransactionInProcedures

### DIFF
--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -1557,7 +1558,7 @@ public class ProcedureIT
         }
 
         @Procedure( mode = WRITE )
-        public void supportedProcedure()
+        public void supportedProcedure() throws ExecutionException, InterruptedException
         {
             jobs.submit( () -> {
                 try ( Transaction tx = db.beginTx() )
@@ -1569,7 +1570,7 @@ public class ProcedureIT
                 {
                     exceptionsInProcedure.add( e );
                 }
-            } );
+            } ).get();
         }
 
         @Procedure


### PR DESCRIPTION
Though we join the threads that calls the `supportedProcedure`, that procedure itself did not wait for the tasks _it_ spawned to complete
Therefor the test could observe a node count that was less than the tasks it had started

This is no longer possible, because the procedure now blocks until the tasks it submits have finished

@davidegrohmann @OliviaYtterbrink @boggle Can one of you take a look at this?