### PR TITLE
Catch and log exceptions when refreshing topology

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -119,8 +119,15 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         JobScheduler.Group group = new JobScheduler.Group( "Scheduler", POOLED );
         jobHandle = this.scheduler.scheduleRecurring( group, () ->
         {
-            refreshCoreTopology();
-            refreshReadReplicaTopology();
+            try
+            {
+                refreshCoreTopology();
+                refreshReadReplicaTopology();
+            }
+            catch ( Throwable e )
+            {
+                log.info( "Failed to refresh topology", e );
+            }
         }, config.get( CausalClusteringSettings.cluster_topology_refresh ), MILLISECONDS );
     }
 


### PR DESCRIPTION
At the moment if a refresh throws an exception the
refreshing job doesn't get called again.

Now it will.