### PR TITLE
Do not plan count store lookup for loops

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
@@ -88,12 +88,15 @@ case object countStorePlanner {
       val lpp = context.logicalPlanProducer
       val aggregation1 = lpp.planCountStoreNodeAggregation(query, IdName(columnName), label, argumentIds)(context)
       labelCheck(label)(Some(aggregation1))
-    } else if (patternRelationships.size == 1) { // MATCH ()-[r]->(), MATCH ()-[r:X]->(), MATCH ()-[r:X|Y]->()
+    } else if (patternRelationships.size == 1 && notLoop(patternRelationships.head)) { // MATCH ()-[r]->(), MATCH ()-[r:X]->(), MATCH ()-[r:X|Y]->()
       labelCheck(None)(
         trySolveRelationshipAggregation(query, columnName, variableName, patternRelationships, argumentIds, selections)
       )
     } else None
   }
+
+  // the counts store counts loops twice
+  private def notLoop(r: PatternRelationship) = r.nodes._1 != r.nodes._2
 
   private def trySolveRelationshipAggregation(query: PlannerQuery, columnName: String, variableName: Option[String],
                                               patternRelationships: Set[PatternRelationship], argumentIds: Set[IdName],


### PR DESCRIPTION
The counts store call is not designed to take into account the constraint
that a relationship is a loop. Cypher previously returned a count of all
relationships that matched the label and type predicates without honoring
the topology constraint (loop).

Fixes #8324 

changelog: Cypher now reports the correct count for self-relationships (loops)