### PR TITLE
Support new parameter syntax on 3.0

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -28,6 +28,17 @@ import scala.collection.JavaConverters._
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("supports new parameter syntax") {
+    createNode("prop" -> 5)
+    createNode("prop" -> 10)
+
+    val query = "MATCH (n) WHERE n.prop = $param RETURN n.prop AS v"
+
+    val result = executeWithAllPlanners(query, "param" -> 5)
+
+    result.toList should equal(List(Map("v" -> 5)))
+  }
+
   test("make sure non-existing nodes are not returned") {
     executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) = 10 return n") should be(empty)
     executeWithAllPlannersAndCompatibilityMode("match ()-[r]->() where id(r) = 10 return r") should be(empty)

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/Literals.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/Literals.scala
@@ -23,6 +23,8 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.parboiled.scala._
 
+import scala.language.postfixOps
+
 trait Literals extends Parser
   with Base with Strings {
 
@@ -60,6 +62,14 @@ trait Literals extends Parser
   }
 
   def Parameter: Rule1[ast.Parameter] = rule("a parameter") {
+    NewParameter | OldParameter
+  }
+
+  def NewParameter: Rule1[ast.Parameter] = rule("a parameter (new syntax") {
+    ((ch('$') ~~ (UnescapedSymbolicNameString | EscapedSymbolicNameString | UnsignedDecimalInteger ~> (_.toString))) memoMismatches) ~~>> (ast.Parameter(_, CTAny))
+  }
+
+  def OldParameter: Rule1[ast.Parameter] = rule("a parameter (old syntax)") {
     ((ch('{') ~~ (UnescapedSymbolicNameString | EscapedSymbolicNameString | UnsignedDecimalInteger ~> (_.toString)) ~~ ch('}')) memoMismatches) ~~>> (ast.Parameter(_, CTAny))
   }
 

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/matchers/IdentifierStartMatcher.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/matchers/IdentifierStartMatcher.scala
@@ -20,5 +20,5 @@
 package org.neo4j.cypher.internal.frontend.v3_0.parser.matchers
 
 class IdentifierStartMatcher extends ScalaCharMatcher("an identifier") {
-  protected def matchChar(c: Char): Boolean = Character.isJavaIdentifierStart(c)
+  protected def matchChar(c: Char): Boolean = Character.isJavaIdentifierStart(c) && Character.getType(c) != Character.CURRENCY_SYMBOL
 }

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/LiteralsTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/LiteralsTest.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.parser
 
+import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.{DummyPosition, ast}
 import org.parboiled.scala._
 
@@ -52,7 +53,7 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     assertFails("1bcd")
   }
 
-  test("can parse numbersz") {
+  test("can parse numbers") {
     implicit val parserToTest = NumberLiteral
 
     parsing("123") shouldGive ast.SignedDecimalIntegerLiteral("123")(t)
@@ -77,6 +78,22 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     parsing("1E23") shouldGive ast.DecimalDoubleLiteral("1E23")(t)
     parsing("1.34E99") shouldGive ast.DecimalDoubleLiteral("1.34E99")(t)
     parsing("9E-443") shouldGive ast.DecimalDoubleLiteral("9E-443")(t)
+  }
+
+  test("can parse legacy parameter syntax") {
+    implicit val parserToTest = Parameter
+
+    parsing("{p}") shouldGive ast.Parameter("p", CTAny)(t)
+    parsing("{`the funny horse`}") shouldGive ast.Parameter("the funny horse", CTAny)(t)
+    parsing("{0}") shouldGive ast.Parameter("0", CTAny)(t)
+  }
+
+  test("can parse new parameter syntax") {
+    implicit val parserToTest = Parameter
+
+    parsing("$p") shouldGive ast.Parameter("p", CTAny)(t)
+    parsing("$`the funny horse`") shouldGive ast.Parameter("the funny horse", CTAny)(t)
+    parsing("$0") shouldGive ast.Parameter("0", CTAny)(t)
   }
 
   def convert(result: Any): Any = result

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/LiteralsTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/LiteralsTest.scala
@@ -96,5 +96,13 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     parsing("$0") shouldGive ast.Parameter("0", CTAny)(t)
   }
 
+  test("variables are not allowed to start with currency symbols") {
+    implicit val parserToTest = Variable
+
+    Seq("$", "¢", "£", "₲", "₶", "\u20BD", "＄", "﹩").foreach { curr =>
+      assertFails(s"${curr}var")
+    }
+  }
+
   def convert(result: Any): Any = result
 }


### PR DESCRIPTION
This PR is a backport of #7558

changelog: Cypher now supports an updated parameter syntax `$param` and it is no longer possible to start symbolic names (variables, property keys, parameter names) with a currency symbol