### PR TITLE
Remove tests for null-parameters; covered by non-null annotations

### DIFF
--- a/community/logging/src/test/java/org/neo4j/logging/FormattedLogTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/FormattedLogTest.java
@@ -52,25 +52,6 @@ public class FormattedLogTest
     }
 
     @Test
-    public void logShouldFailAndWriteNothingForNullMessage()
-    {
-        // Given
-        StringWriter writer = new StringWriter();
-        Log log = newFormattedLog( writer );
-
-        try
-        {
-            // When
-            log.info( null );
-            fail( "Should have thrown " + NullPointerException.class );
-        } catch ( NullPointerException npe )
-        {
-            // Then
-            assertThat( writer.toString(), equalTo( "" ) );
-        }
-    }
-
-    @Test
     public void logShouldWriteMessageAndThrowable()
     {
         // Given
@@ -84,42 +65,6 @@ public class FormattedLogTest
         assertThat(
                 writer.toString(),
                 equalTo( format( "1984-10-26 04:23:24.343+0000 INFO  [test] Hasta la vista, baby <message>%n<stacktrace>" ) )
-        );
-    }
-
-    @Test
-    public void logShouldFailAndWriteNothingForNullMessageAndNotNullThrowable()
-    {
-        // Given
-        StringWriter writer = new StringWriter();
-        Log log = newFormattedLog( writer );
-
-        try
-        {
-            // When
-            log.info( null, newThrowable( "<message>", "<stacktrace>" ) );
-            fail( "Should have thrown " + NullPointerException.class );
-        } catch ( NullPointerException npe )
-        {
-            // Then
-            assertThat( writer.toString(), equalTo( "" ) );
-        }
-    }
-
-    @Test
-    public void logShouldWriteMessageForNotNullMessageAndNullThrowable()
-    {
-        // Given
-        StringWriter writer = new StringWriter();
-        Log log = newFormattedLog( writer );
-
-        // When
-        log.info( "I'll take care of the police", (Throwable) null );
-
-        // Then
-        assertThat(
-                writer.toString(),
-                equalTo( format( "1984-10-26 04:23:24.343+0000 INFO  [test] I'll take care of the police%n" ) )
         );
     }
 
@@ -158,25 +103,6 @@ public class FormattedLogTest
     }
 
     @Test
-    public void logShouldFailAndWriteNothingForNullMessageFormat()
-    {
-        // Given
-        StringWriter writer = new StringWriter();
-        Log log = newFormattedLog( writer );
-
-        try
-        {
-            // When
-            log.info( null, "foo", "bar", "baz" );
-            fail( "Should have thrown " + NullPointerException.class );
-        } catch ( NullPointerException npe )
-        {
-            // Then
-            assertThat( writer.toString(), equalTo( "" ) );
-        }
-    }
-
-    @Test
     public void logShouldWriteNotFormattedMessageWhenNoParametersGiven()
     {
         // Given
@@ -185,23 +111,6 @@ public class FormattedLogTest
 
         // When
         log.info( "Come with me if you %s to live!", new Object[]{} );
-
-        // Then
-        assertThat(
-                writer.toString(),
-                equalTo( format( "1984-10-26 04:23:24.343+0000 INFO  [test] Come with me if you %%s to live!%n" ) )
-        );
-    }
-
-    @Test
-    public void logShouldWriteNotFormattedMessageWhenParametersArrayIsNull()
-    {
-        // Given
-        StringWriter writer = new StringWriter();
-        Log log = newFormattedLog( writer );
-
-        // When
-        log.info( "Come with me if you %s to live!", (Object[]) null );
 
         // Then
         assertThat(


### PR DESCRIPTION
These tests can't succeed when runtime assertions on nonnull
annotations are enabled.