### PR TITLE
Do not start multiple file watchers for core state

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileSystemWatcherService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/watcher/DefaultFileSystemWatcherService.java
@@ -53,6 +53,7 @@ public class DefaultFileSystemWatcherService implements FileSystemWatcherService
     @Override
     public void start() throws Throwable
     {
+        assert watcher == null;
         watcher = fileWatchers.newThread( eventWatcher );
         watcher.start();
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -88,11 +88,16 @@ public class LocalDatabase implements Lifecycle
     public void init() throws Throwable
     {
         dataSourceManager.init();
+        watcherService.init();
     }
 
     @Override
     public synchronized void start() throws Throwable
     {
+        if ( isAvailable() )
+        {
+            return;
+        }
         storeId = readStoreIdFromDisk();
         log.info( "Starting with storeId: " + storeId );
 
@@ -127,6 +132,7 @@ public class LocalDatabase implements Lifecycle
     @Override
     public void shutdown() throws Throwable
     {
+        watcherService.shutdown();
         dataSourceManager.shutdown();
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -169,7 +169,6 @@ public class EnterpriseCoreEditionModule extends EditionModule
         watcherService = createFileSystemWatcherService( fileSystem, storeDir, logging,
                 platformModule.jobScheduler, fileWatcherFileNameFilter() );
         dependencies.satisfyDependencies( watcherService );
-        life.add( watcherService );
         LocalDatabase localDatabase = new LocalDatabase( platformModule.storeDir,
                 new StoreFiles( fileSystem, platformModule.pageCache ),
                 platformModule.dataSourceManager,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -130,7 +130,6 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         watcherService = createFileSystemWatcherService( fileSystem, storeDir, logging,
                 platformModule.jobScheduler, fileWatcherFileNameFilter() );
         dependencies.satisfyDependencies( watcherService );
-        life.add( watcherService );
 
         GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
 


### PR DESCRIPTION
Prevent starting of multiple file watchers from for LocalDatabase that can be started multiple times,
add additional assertion that will prevent multiple watcher threads in future.