### PR TITLE
Allow custom implementation of PageCursorTracerSupplier

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
@@ -20,6 +20,8 @@
 package org.neo4j.kernel.monitoring.tracing;
 
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
@@ -76,5 +78,16 @@ public interface TracerFactory
     default LockTracer createLockTracer( Monitors monitors, JobScheduler jobScheduler )
     {
         return LockTracer.NONE;
+    }
+
+    /**
+     * Create a new PageCursorTracerSupplier instance.
+     * @param monitors the monitoring manager
+     * @param jobScheduler a scheduler for async jobs
+     * @return The created instance.
+     */
+    default PageCursorTracerSupplier createPageCursorTracerSupplier( Monitors monitors, JobScheduler jobScheduler )
+    {
+        return DefaultPageCursorTracerSupplier.INSTANCE;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
@@ -21,9 +21,9 @@ package org.neo4j.kernel.monitoring.tracing;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
-import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.kernel.impl.locking.LockTracer;
 import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -100,7 +100,7 @@ import org.neo4j.logging.Log;
 public class Tracers
 {
     public final PageCacheTracer pageCacheTracer;
-    public final PageCursorTracerSupplier pageCursorTracerSupplier = DefaultPageCursorTracerSupplier.INSTANCE;
+    public final PageCursorTracerSupplier pageCursorTracerSupplier;
     public final TransactionTracer transactionTracer;
     public final CheckPointTracer checkPointTracer;
     public final LockTracer lockTracer;
@@ -119,6 +119,7 @@ public class Tracers
     {
         if ( "null".equalsIgnoreCase( desiredImplementationName ) )
         {
+            pageCursorTracerSupplier = DefaultPageCursorTracerSupplier.NULL;
             pageCacheTracer = PageCacheTracer.NULL;
             transactionTracer = TransactionTracer.NULL;
             checkPointTracer = CheckPointTracer.NULL;
@@ -151,6 +152,7 @@ public class Tracers
                 msgLog.warn( "Using default tracer implementations instead of '%s'", desiredImplementationName );
             }
 
+            pageCursorTracerSupplier = foundFactory.createPageCursorTracerSupplier( monitors, jobScheduler );
             pageCacheTracer = foundFactory.createPageCacheTracer( monitors, jobScheduler );
             transactionTracer = foundFactory.createTransactionTracer( monitors, jobScheduler );
             checkPointTracer = foundFactory.createCheckPointTracer( monitors, jobScheduler );

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.impl.api.DefaultTransactionTracer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.DefaultCheckPointerTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
@@ -57,6 +59,7 @@ public class TracersTest
     {
         Tracers tracers = new Tracers( "null", log, monitors, jobScheduler );
         assertThat( tracers.pageCacheTracer, is( PageCacheTracer.NULL ) );
+        assertThat( tracers.pageCursorTracerSupplier, is( PageCursorTracerSupplier.NULL ) );
         assertThat( tracers.transactionTracer, is( TransactionTracer.NULL ) );
         assertNoWarning();
     }
@@ -66,6 +69,7 @@ public class TracersTest
     {
         Tracers tracers = new Tracers( "NuLl", log, monitors, jobScheduler );
         assertThat( tracers.pageCacheTracer, is( PageCacheTracer.NULL ) );
+        assertThat( tracers.pageCursorTracerSupplier, is( PageCursorTracerSupplier.NULL ) );
         assertThat( tracers.transactionTracer, is( TransactionTracer.NULL ) );
         assertNoWarning();
     }
@@ -107,6 +111,7 @@ public class TracersTest
         assertThat( tracers.pageCacheTracer, instanceOf( DefaultPageCacheTracer.class ) );
         assertThat( tracers.transactionTracer, instanceOf( DefaultTransactionTracer.class ) );
         assertThat( tracers.checkPointTracer, instanceOf( DefaultCheckPointerTracer.class ) );
+        assertThat( tracers.pageCursorTracerSupplier, instanceOf( DefaultPageCursorTracerSupplier.class ) );
     }
 
     private void assertNoWarning()


### PR DESCRIPTION
Make PageCursorTracerSupplier configurable to allow custom implementations
to be supplier.
Default tracer factory will provide DefaultPageCursorTracerSupplier.INSTANCE
as default implementation.