### PR TITLE
Revert "Doesn't build label scan store as part of import"

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/DeleteDuplicateNodesStage.java
@@ -38,6 +38,7 @@ public class DeleteDuplicateNodesStage extends Stage
             BatchingNeoStores neoStore )
     {
         super( "DEDUP", config );
-        add( new DeleteDuplicateNodesStep( control(), config, duplicateNodeIds, neoStore.getNodeStore() ) );
+        add( new DeleteDuplicateNodesStep( control(), config, duplicateNodeIds,
+                neoStore.getNodeStore(), neoStore.getLabelScanStore() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -65,7 +65,7 @@ public class NodeStage extends Stage
 
     public NodeStage( Configuration config, IoMonitor writeMonitor,
             InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
-            BatchingNeoStores neoStore, InputCache inputCache,
+            BatchingNeoStores neoStore, InputCache inputCache, LabelScanStore labelScanStore,
             EntityStoreUpdaterStep.Monitor storeUpdateMonitor,
             NodeRelationshipCache cache,
             StatsProvider memoryUsage ) throws IOException
@@ -83,6 +83,7 @@ public class NodeStage extends Stage
         add( new PropertyEncoderStep<>( control(), config, neoStore.getPropertyKeyRepository(), propertyStore ) );
         add( new NodeEncoderStep( control(), config, idMapper, idGenerator,
                 neoStore.getLabelRepository(), nodeStore, memoryUsage ) );
+        add( new LabelScanStorePopulationStep( control(), config, labelScanStore ) );
         add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore, writeMonitor,
                 storeUpdateMonitor ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -180,7 +180,7 @@ public class ParallelBatchImporter implements BatchImporter
 
             // Stage 1 -- nodes, properties, labels
             NodeStage nodeStage = new NodeStage( config, writeMonitor,
-                    nodes, idMapper, idGenerator, neoStore, inputCache,
+                    nodes, idMapper, idGenerator, neoStore, inputCache, neoStore.getLabelScanStore(),
                     storeUpdateMonitor, nodeRelationshipCache, memoryUsageStats );
             executeStages( nodeStage );
             if ( idMapper.needsPreparation() )


### PR DESCRIPTION
This reverts commit 5bbc486aee3ff73ae78da90eae6c28648088803f.

Which means that label scan store will be built as part of neo4j-import again.
This is possible since page size is fixed now.