### PR TITLE
Fixes issue with tx event handler data for deleted relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -289,7 +289,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             RelationshipProxy cached = relationshipsReadFromStore.get( relId );
             if ( cached != null )
             {
-                return relationship;
+                return cached;
             }
 
             try


### PR DESCRIPTION
Where delted relationships wouldn't have their RelationshipProxy instances
that were returned to the user in TransactionEventHandler#afterCommit
filled with data about the relationship. This would have accessor methods like
Relationship#toString fail reporting to not being a transaction when it wanted
to load that data.