### PR TITLE
GBPTree checkpoint/close can write header data

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
@@ -46,8 +46,6 @@ public class Header
         void write( PageCursor from, int length, PageCursor to );
     }
 
-    final Consumer<PageCursor> CARRY_OVER = cursor -> {};
-
     static final Writer CARRY_OVER_PREVIOUS_HEADER = (from,length,to) ->
     {
         from.copyTo( from.getOffset(), to, to.getOffset(), length );

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Header.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree;
+
+import java.util.function.Consumer;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+
+/**
+ * Defines interfaces and common implementations of header reader/writer for {@link GBPTree}.
+ */
+public class Header
+{
+    /**
+     * Writes a header into a {@link GBPTree} state page during
+     * {@link GBPTree#checkpoint(org.neo4j.io.pagecache.IOLimiter)}.
+     */
+    public interface Writer
+    {
+        /**
+         * Writes header data into {@code to} with previous valid header data found in {@code from} of {@code length}
+         * bytes in size.
+         *
+         * @param from {@link PageCursor} positioned at the header data written in the previous check point.
+         * @param length size in bytes of the previous header data.
+         * @param to {@link PageCursor} to write new header into.
+         */
+        void write( PageCursor from, int length, PageCursor to );
+    }
+
+    final Consumer<PageCursor> CARRY_OVER = cursor -> {};
+
+    static final Writer CARRY_OVER_PREVIOUS_HEADER = (from,length,to) ->
+    {
+        from.copyTo( from.getOffset(), to, to.getOffset(), length );
+    };
+
+    static Writer replace( Consumer<PageCursor> writer )
+    {
+        // Discard the previous state, just write the new
+        return (from,length,to) -> writer.accept( to );
+    }
+
+    /**
+     * Reads a header from a {@link GBPTree} state page during opening it.
+     */
+    public interface Reader
+    {
+        /**
+         * Called when it's time to read header data from the most up to date and valid state page.
+         * Due to the nature of the underlying {@link PageCache} this method may be called several times,
+         * some times with invalid data in the {@link PageCursor}. Because of this there mustn't be any
+         * exceptions thrown or decisions made based on the read data until the GBPTree constructor has been
+         * completely executed.
+         *
+         * @param from {@link PageCursor} positioned at beginning of the header data to read.
+         * @param length number of bytes available to read in the header data.
+         */
+        void read( PageCursor from, int length );
+    }
+}

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -20,7 +20,6 @@
 package org.neo4j.index.internal.gbptree;
 
 import java.util.Objects;
-
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
@@ -49,6 +49,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -96,7 +98,7 @@ public class FormatCompatibilityTest
         // THEN everything should work, otherwise there has likely been a format change
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
         try ( GBPTree<MutableLong,MutableLong> tree =
-                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR ) )
+                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER ) )
         {
             try
             {
@@ -172,7 +174,7 @@ public class FormatCompatibilityTest
     {
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
         try ( GBPTree<MutableLong,MutableLong> tree =
-                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR ) )
+                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER ) )
         {
             MutableLong insertKey = new MutableLong();
             MutableLong insertValue = new MutableLong();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
@@ -60,6 +60,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
+
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -105,7 +107,7 @@ public class GBPTreeConcurrencyIT
         PageCache pageCache =
                 pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER );
     }
 
     @After
@@ -219,7 +221,7 @@ public class GBPTreeConcurrencyIT
         // Instructions for reader
         private final boolean forwardsSeek;
         private final double writePercentage;
-        private AtomicReference<ReaderInstruction> currentReaderInstruction;
+        private final AtomicReference<ReaderInstruction> currentReaderInstruction;
         TreeSet<Long> readersShouldSee;
 
         // Progress

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
@@ -45,6 +45,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
+
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -74,7 +76,7 @@ public class GBPTreeIT
     {
         pageCache = pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER );
     }
 
     @After

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
 
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
 import static org.neo4j.io.pagecache.IOLimiter.unlimited;
@@ -363,7 +364,7 @@ public class GBPTreeRecoveryTest
 
     private static GBPTree<MutableLong,MutableLong> createIndex( PageCache pageCache, File file ) throws IOException
     {
-        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR );
+        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER );
     }
 
     private PageCache createPageCache()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -45,6 +45,7 @@ import org.neo4j.storageengine.api.schema.LabelScanReader;
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
 import static org.neo4j.helpers.collection.Iterators.iterator;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 
 /**
@@ -318,7 +319,7 @@ public class NativeLabelScanStore implements LabelScanStore
 
     private void instantiateTree() throws IOException
     {
-        index = new GBPTree<>( pageCache, storeFile, new LabelScanLayout(), pageSize, GBPTree.NO_MONITOR );
+        index = new GBPTree<>( pageCache, storeFile, new LabelScanLayout(), pageSize, GBPTree.NO_MONITOR, NO_HEADER );
     }
 
     private void drop() throws IOException


### PR DESCRIPTION
Which is stored in the selected state page, after the other state information.
Checkpoint/close methods come in two variants, one with header writer and one w/o.
The one with header writer will replace the header data with new data,
whereas the variants w/o will keep/carry over the previous header data to
the new state page.

When opening a GBPTree the (newly introduced) supplied header reader can access
the header data.