### PR TITLE
Fixed shutdown of `neo4j-shell` to unbind its port

### DIFF
--- a/community/shell/src/main/java/org/neo4j/shell/impl/AbstractClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/AbstractClient.java
@@ -57,11 +57,11 @@ public abstract class AbstractClient implements ShellClient
     private long timeConnection;
     private volatile boolean end;
     private final Collection<String> multiLine = new ArrayList<>();
-    private Serializable id;
+    protected Serializable id;
     private String prompt;
 
-    private final Map<String, Serializable> initialSession;
-    
+    protected final Map<String, Serializable> initialSession;
+
     public AbstractClient( Map<String, Serializable> initialSession, CtrlCHandler signalHandler )
     {
         this.signalHandler = signalHandler;

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemoteClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemoteClient.java
@@ -92,9 +92,11 @@ public class RemoteClient extends AbstractClient
 		try
 		{
 			if ( !shouldTryToReconnect )
-				server.getName();
+			{
+				server.welcome( initialSession );
+			}
 		}
-		catch ( RemoteException e )
+		catch ( RemoteException | ShellException ignored )
 		{
 			shouldTryToReconnect = true;
 		}
@@ -107,14 +109,11 @@ public class RemoteClient extends AbstractClient
 			{
 				this.server = findRemoteServer();
 				if ( hadServer )
-				    getOutput().println( "[Reconnected to server]" );
+				{
+					getOutput().println( "[Reconnected to server]" );
+				}
 			}
-			catch ( ShellException ee )
-			{
-				// Ok
-				originException = ee;
-			}
-			catch ( RemoteException ee )
+			catch ( ShellException | RemoteException ee )
 			{
 				// Ok
 				originException = ee;

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RemotelyAvailableServer.java
@@ -40,6 +40,7 @@ import org.neo4j.shell.Welcome;
 class RemotelyAvailableServer extends UnicastRemoteObject implements ShellServer
 {
     private final ShellServer actual;
+    private RmiLocation location;
 
     RemotelyAvailableServer( ShellServer actual ) throws RemoteException
     {
@@ -90,6 +91,9 @@ class RemotelyAvailableServer extends UnicastRemoteObject implements ShellServer
     {
         try
         {
+            if (this.location != null) {
+                this.location.unbind();
+            }
             unexportObject( this, true );
         }
         catch ( NoSuchObjectException e )
@@ -107,7 +111,8 @@ class RemotelyAvailableServer extends UnicastRemoteObject implements ShellServer
     @Override
     public void makeRemotelyAvailable( String host, int port, String name ) throws RemoteException
     {
-        RmiLocation.location( host, port, name ).bind( this );
+        this.location = RmiLocation.location( host, port, name );
+        this.location.bind( this );
     }
 
     @Override

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
@@ -22,6 +22,7 @@ package org.neo4j.shell.impl;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.rmi.Naming;
+import java.rmi.NoSuchObjectException;
 import java.rmi.NotBoundException;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
@@ -35,165 +36,167 @@ import java.rmi.server.UnicastRemoteObject;
  */
 public class RmiLocation
 {
-	private final String host;
-	private final int port;
-	private final String name;
-	private Registry registry;
+    private final String host;
+    private final int port;
+    private final String name;
+    private Registry registry;
 
-	private RmiLocation( String host, int port, String name )
-	{
-		this.host = host;
-		this.port = port;
-		this.name = name;
-	}
+    private RmiLocation( String host, int port, String name )
+    {
+        this.host = host;
+        this.port = port;
+        this.name = name;
+    }
 
-	/**
-	 * Creates a new RMI location instance.
-	 * @param host the RMI host, f.ex. "localhost".
-	 * @param port the RMI port.
-	 * @param name the RMI name, f.ex. "shell".
-	 * @return a new {@link RmiLocation} instance.
-	 */
-	public static RmiLocation location( String host, int port, String name )
-	{
-		return new RmiLocation( host, port, name );
-	}
+    /**
+     * Creates a new RMI location instance.
+     *
+     * @param host the RMI host, f.ex. "localhost".
+     * @param port the RMI port.
+     * @param name the RMI name, f.ex. "shell".
+     * @return a new {@link RmiLocation} instance.
+     */
+    public static RmiLocation location( String host, int port, String name )
+    {
+        return new RmiLocation( host, port, name );
+    }
 
-	/**
-	 * @return the host of this RMI location.
-	 */
-	public String getHost()
-	{
-		return this.host;
-	}
+    /**
+     * @return the host of this RMI location.
+     */
+    public String getHost()
+    {
+        return this.host;
+    }
 
-	/**
-	 * @return the port of this RMI location.
-	 */
-	public int getPort()
-	{
-		return this.port;
-	}
+    /**
+     * @return the port of this RMI location.
+     */
+    public int getPort()
+    {
+        return this.port;
+    }
 
-	/**
-	 * @return the name of this RMI location.
-	 */
-	public String getName()
-	{
-		return this.name;
-	}
+    /**
+     * @return the name of this RMI location.
+     */
+    public String getName()
+    {
+        return this.name;
+    }
 
-	private static String getProtocol()
-	{
-		return "rmi://";
-	}
+    private static String getProtocol()
+    {
+        return "rmi://";
+    }
 
-	/**
-	 * @return "short" URL, consisting of protocol, host and port, f.ex.
-	 * "rmi://localhost:8080".
-	 */
-	public String toShortUrl()
-	{
-		return getProtocol() + getHost() + ":" + getPort();
-	}
+    /**
+     * @return "short" URL, consisting of protocol, host and port, f.ex.
+     * "rmi://localhost:8080".
+     */
+    public String toShortUrl()
+    {
+        return getProtocol() + getHost() + ":" + getPort();
+    }
 
-	/**
-	 * @return the full RMI URL, f.ex.
-	 * "rmi://localhost:8080/the/shellname".
-	 */
-	public String toUrl()
-	{
-		return getProtocol() + getHost() + ":" + getPort() + "/" + getName();
-	}
+    /**
+     * @return the full RMI URL, f.ex.
+     * "rmi://localhost:8080/the/shellname".
+     */
+    public String toUrl()
+    {
+        return getProtocol() + getHost() + ":" + getPort() + "/" + getName();
+    }
 
-	/**
-	 * Ensures that the RMI registry is created for this JVM instance and port,
-	 * see {@link #getPort()}.
-	 * @return the registry for the port.
-	 * @throws RemoteException RMI error.
-	 */
-	public Registry ensureRegistryCreated()
-		throws RemoteException
-	{
-		try
-		{
-			Naming.list( toShortUrl() );
-			return LocateRegistry.getRegistry( getHost(), getPort() );
-		}
-		catch ( RemoteException e )
-		{
+    /**
+     * Ensures that the RMI registry is created for this JVM instance and port,
+     * see {@link #getPort()}.
+     *
+     * @return the registry for the port.
+     * @throws RemoteException RMI error.
+     */
+    public Registry ensureRegistryCreated() throws RemoteException
+    {
+        try
+        {
+            Naming.list( toShortUrl() );
+            return LocateRegistry.getRegistry( getHost(), getPort() );
+        }
+        catch ( RemoteException e )
+        {
             try
             {
                 return LocateRegistry.createRegistry( getPort(), null, new HostBoundSocketFactory( host ) );
             }
             catch ( UnknownHostException hostException )
             {
-                throw new RemoteException( "Unable to bind to '"+host+"', unknown hostname.", hostException );
+                throw new RemoteException( "Unable to bind to '" + host + "', unknown hostname.", hostException );
             }
         }
-		catch ( java.net.MalformedURLException e )
-		{
-			throw new RemoteException( "Malformed URL", e );
-		}
-	}
+        catch ( java.net.MalformedURLException e )
+        {
+            throw new RemoteException( "Malformed URL", e );
+        }
+    }
 
-	/**
-	 * Binds an object to the RMI location defined by this instance.
-	 * @param object the object to bind.
-	 * @throws RemoteException RMI error.
-	 */
-	public void bind( Remote object ) throws RemoteException
-	{
-		this.registry = ensureRegistryCreated();
-		try
-		{
-			Naming.rebind( toUrl(), object );
-		}
-		catch ( MalformedURLException e )
-		{
-			throw new RemoteException( "Malformed URL", e );
-		}
-	}
+    /**
+     * Binds an object to the RMI location defined by this instance.
+     *
+     * @param object the object to bind.
+     * @throws RemoteException RMI error.
+     */
+    public void bind( Remote object ) throws RemoteException
+    {
+        this.registry = ensureRegistryCreated();
+        try
+        {
+            Naming.rebind( toUrl(), object );
+        }
+        catch ( MalformedURLException e )
+        {
+            throw new RemoteException( "Malformed URL", e );
+        }
+    }
 
-	public void unbind() throws RemoteException
-	{
-		UnicastRemoteObject.unexportObject( this.registry, true );
-	}
+    public void unbind() throws RemoteException
+    {
+        UnicastRemoteObject.unexportObject( this.registry, true );
+    }
 
-	/**
-	 * @return whether or not there's an object bound to the RMI location
-	 * defined by this instance.
-	 */
-	public boolean isBound()
-	{
-		try
-		{
-			getBoundObject();
-			return true;
-		}
-		catch ( RemoteException e )
-		{
-			return false;
-		}
-	}
+    /**
+     * @return whether or not there's an object bound to the RMI location
+     * defined by this instance.
+     */
+    public boolean isBound()
+    {
+        try
+        {
+            getBoundObject();
+            return true;
+        }
+        catch ( RemoteException e )
+        {
+            return false;
+        }
+    }
 
-	/**
-	 * @return the bound object for the RMI location defined by this instance.
-	 * @throws RemoteException if there's no object bound for the RMI location.
-	 */
-	public Remote getBoundObject() throws RemoteException
-	{
-		try
-		{
-			return Naming.lookup( toUrl() );
-		}
-		catch ( NotBoundException e )
-		{
-			throw new RemoteException( "Not bound", e );
-		}
-		catch ( MalformedURLException e )
-		{
-			throw new RemoteException( "Malformed URL", e );
-		}
-	}
+    /**
+     * @return the bound object for the RMI location defined by this instance.
+     * @throws RemoteException if there's no object bound for the RMI location.
+     */
+    public Remote getBoundObject() throws RemoteException
+    {
+        try
+        {
+            return Naming.lookup( toUrl() );
+        }
+        catch ( NoSuchObjectException | NotBoundException e )
+        {
+            throw new RemoteException( "Not bound", e );
+        }
+        catch ( MalformedURLException e )
+        {
+            throw new RemoteException( "Malformed URL", e );
+        }
+    }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/RmiLocation.java
@@ -27,6 +27,7 @@ import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
 
 /**
  * Class for specifying a location of an RMI object
@@ -37,6 +38,7 @@ public class RmiLocation
 	private final String host;
 	private final int port;
 	private final String name;
+	private Registry registry;
 
 	private RmiLocation( String host, int port, String name )
 	{
@@ -142,7 +144,7 @@ public class RmiLocation
 	 */
 	public void bind( Remote object ) throws RemoteException
 	{
-		ensureRegistryCreated();
+		this.registry = ensureRegistryCreated();
 		try
 		{
 			Naming.rebind( toUrl(), object );
@@ -151,6 +153,11 @@ public class RmiLocation
 		{
 			throw new RemoteException( "Malformed URL", e );
 		}
+	}
+
+	public void unbind() throws RemoteException
+	{
+		UnicastRemoteObject.unexportObject( this.registry, true );
 	}
 
 	/**

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -284,5 +284,9 @@ public class GraphDatabaseShellServer extends AbstractAppServer
             transaction.success();
             return welcome;
         }
+        catch ( RuntimeException e )
+        {
+            throw new RemoteException( e.getMessage(), e );
+        }
     }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
@@ -52,7 +52,7 @@ import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.shell.ShellLobby.NO_INITIAL_SESSION;
 import static org.neo4j.shell.ShellLobby.remoteLocation;
 
-public abstract class AbstractShellTest
+public abstract class AbstractShellIT
 {
     protected GraphDatabaseAPI db;
     protected ShellServer shellServer;
@@ -75,10 +75,10 @@ public abstract class AbstractShellTest
 
     protected SameJvmClient newShellClient( ShellServer server ) throws ShellException, RemoteException
     {
-        return newShellClient( server, Collections.<String, Serializable>singletonMap( "quiet", true ) );
+        return newShellClient( server, Collections.<String,Serializable>singletonMap( "quiet", true ) );
     }
 
-    protected SameJvmClient newShellClient( ShellServer server, Map<String, Serializable> session )
+    protected SameJvmClient newShellClient( ShellServer server, Map<String,Serializable> session )
             throws ShellException, RemoteException
     {
         return new SameJvmClient( session, server, new CollectingOutput(), InterruptSignalHandler.getHandler() );
@@ -122,10 +122,10 @@ public abstract class AbstractShellTest
         return newRemoteClient( NO_INITIAL_SESSION );
     }
 
-    protected ShellClient newRemoteClient( Map<String, Serializable> initialSession ) throws Exception
+    protected ShellClient newRemoteClient( Map<String,Serializable> initialSession ) throws Exception
     {
-        return new RemoteClient( initialSession, remoteLocation( remotelyAvailableOnPort ),
-                new CollectingOutput(), InterruptSignalHandler.getHandler() );
+        return new RemoteClient( initialSession, remoteLocation( remotelyAvailableOnPort ), new CollectingOutput(),
+                InterruptSignalHandler.getHandler() );
     }
 
     protected void makeServerRemotelyAvailable() throws RemoteException
@@ -187,8 +187,8 @@ public abstract class AbstractShellTest
         executeCommand( shellClient, command, theseLinesMustExistRegEx );
     }
 
-    public void executeCommand( ShellClient client, String command,
-            String... theseLinesMustExistRegEx ) throws Exception
+    public void executeCommand( ShellClient client, String command, String... theseLinesMustExistRegEx )
+            throws Exception
     {
         CollectingOutput output = new CollectingOutput();
         client.evaluate( command, output );
@@ -208,7 +208,7 @@ public abstract class AbstractShellTest
                 }
             }
             assertTrue( "Was expecting a line matching '" + lineThatMustExist + "', but didn't find any from out of " +
-                        Iterables.asCollection( output ), found != negative );
+                    Iterables.asCollection( output ), found != negative );
         }
     }
 
@@ -225,7 +225,8 @@ public abstract class AbstractShellTest
             String errorMessage = e.getMessage();
             if ( !errorMessage.toLowerCase().contains( errorMessageShouldContain.toLowerCase() ) )
             {
-                fail( "Error message '" + errorMessage + "' should have contained '" + errorMessageShouldContain + "'" );
+                fail( "Error message '" + errorMessage + "' should have contained '" + errorMessageShouldContain +
+                        "'" );
             }
         }
     }
@@ -290,7 +291,7 @@ public abstract class AbstractShellTest
 
     protected Relationship[] createRelationshipChain( RelationshipType type, int length )
     {
-        try( Transaction transaction = db.beginTx() )
+        try ( Transaction transaction = db.beginTx() )
         {
             Relationship[] relationshipChain = createRelationshipChain( db.createNode(), type, length );
             transaction.success();
@@ -298,8 +299,7 @@ public abstract class AbstractShellTest
         }
     }
 
-    protected Relationship[] createRelationshipChain( Node startingFromNode, RelationshipType type,
-            int length )
+    protected Relationship[] createRelationshipChain( Node startingFromNode, RelationshipType type, int length )
     {
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -68,7 +68,7 @@ import static org.neo4j.graphdb.Neo4jMatchers.waitForIndex;
 import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 
-public class TestApps extends AbstractShellTest
+public class AppsIT extends AbstractShellIT
 {
     @Rule
     public SuppressOutput suppressOutput = SuppressOutput.suppressAll();

--- a/community/shell/src/test/java/org/neo4j/shell/ClientReconnectIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ClientReconnectIT.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.shell;
 
+import org.junit.Test;
+
 import java.io.Serializable;
 import java.util.Map;
 
-import org.junit.Test;
 import org.neo4j.helpers.collection.MapUtil;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
-public class TestClientReconnect extends AbstractShellTest
+public class ClientReconnectIT extends AbstractShellIT
 {
     @Test
     public void remoteClientAbleToReconnectAndContinue() throws Exception
@@ -40,14 +41,13 @@ public class TestClientReconnect extends AbstractShellTest
         executeCommand( client, "help", "Available commands" );
         client.shutdown();
     }
-    
+
     @Test
     public void initialSessionValuesSurvivesReconnect() throws Exception
     {
         createRelationshipChain( 2 );
         makeServerRemotelyAvailable();
-        Map<String, Serializable> initialSession = MapUtil.<String, Serializable>genericMap(
-                "TITLE_KEYS", "test" );
+        Map<String,Serializable> initialSession = MapUtil.<String,Serializable>genericMap( "TITLE_KEYS", "test" );
         ShellClient client = newRemoteClient( initialSession );
         String name = "MyTest";
         client.evaluate( "mknode --cd" );

--- a/community/shell/src/test/java/org/neo4j/shell/ConfigurationIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ConfigurationIT.java
@@ -30,7 +30,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 
-public class TestConfiguration
+public class ConfigurationIT
 {
     private GraphDatabaseAPI db;
     private ShellServer server;

--- a/community/shell/src/test/java/org/neo4j/shell/DontShutdownClient.java
+++ b/community/shell/src/test/java/org/neo4j/shell/DontShutdownClient.java
@@ -26,7 +26,7 @@ import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.impl.SystemOutput;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 
-import static org.neo4j.shell.TestRmiPublication.createDefaultConfigFile;
+import static org.neo4j.shell.RmiPublicationIT.createDefaultConfigFile;
 
 public class DontShutdownClient
 {

--- a/community/shell/src/test/java/org/neo4j/shell/DontShutdownLocalServer.java
+++ b/community/shell/src/test/java/org/neo4j/shell/DontShutdownLocalServer.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 
-import static org.neo4j.shell.TestRmiPublication.createDefaultConfigFile;
+import static org.neo4j.shell.RmiPublicationIT.createDefaultConfigFile;
 
 public class DontShutdownLocalServer
 {

--- a/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsIT.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.shell;
 
-import org.junit.Rule;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -28,58 +28,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.test.ImpermanentDatabaseRule;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
-public class ErrorsAndWarningsTest
+public class ErrorsAndWarningsIT extends AbstractShellIT
 {
-    @Rule
-    public ImpermanentDatabaseRule db = null;
-
-    public void startDatabase( final Boolean presentError )
+    @Before
+    public void setup() throws Exception
     {
-        db = new ImpermanentDatabaseRule()
-        {
-            @Override
-            protected void configure( GraphDatabaseBuilder builder )
-            {
-                builder.setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE );
-                builder.setConfig( GraphDatabaseSettings.cypher_hints_error, presentError.toString() );
-            }
-
-            @Override
-            public GraphDatabaseAPI getGraphDatabaseAPI()
-            {
-                try
-                {
-                    before();
-                }
-                catch ( Throwable throwable )
-                {
-                    throwable.printStackTrace();
-                }
-                return super.getGraphDatabaseAPI();
-            }
-        };
-
-        db.getGraphDatabaseAPI();
+        makeServerRemotelyAvailable();
     }
 
     @Test
     public void unsupportedQueryShouldBeSilent() throws IOException
     {
-        // Given
-        // an empty database
-
-        startDatabase( false );
-
         // When
         InputStream realStdin = System.in;
         try

--- a/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
@@ -52,7 +52,6 @@ public class FreePortIT
                 .setConfig( ShellSettings.remote_shell_enabled, "true" )
                 .setConfig( ShellSettings.remote_shell_host, HOST )
                 .setConfig( ShellSettings.remote_shell_port, Integer.toString( PORT ) ).newGraphDatabase();
-        System.err.println( "Neo4j startup succeeded" );
 
         return db;
     }
@@ -71,9 +70,8 @@ public class FreePortIT
             s.bind( new InetSocketAddress( host, port ) );
             return s.isBound();
         }
-        catch ( Throwable e )
+        catch ( Throwable ignored )
         {
-            System.err.println( e );
         }
         finally
         {

--- a/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/FreePortIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.shell;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.function.Predicates.await;
+
+/**
+ * Tests that the shell port is freed on database shutdown
+ */
+public class FreePortIT
+{
+    private static final String HOST = "localhost";
+    private static final int PORT = 13463;
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    public GraphDatabaseService initialize() throws IOException
+    {
+        GraphDatabaseService db;
+        db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( temporaryFolder.newFolder() )
+                .setConfig( ShellSettings.remote_shell_enabled, "true" )
+                .setConfig( ShellSettings.remote_shell_host, HOST )
+                .setConfig( ShellSettings.remote_shell_port, Integer.toString( PORT ) ).newGraphDatabase();
+        System.err.println( "Neo4j startup succeeded" );
+
+        return db;
+    }
+
+    private boolean portAvailable()
+    {
+        return portAvailable( HOST, PORT );
+    }
+
+    private boolean portAvailable( String host, int port )
+    {
+        ServerSocket s = null;
+        try
+        {
+            s = new ServerSocket();
+            s.bind( new InetSocketAddress( host, port ) );
+            return s.isBound();
+        }
+        catch ( Throwable e )
+        {
+            System.err.println( e );
+        }
+        finally
+        {
+            if ( s != null )
+            {
+                try
+                {
+                    s.close();
+                }
+                catch ( Exception e )
+                {
+                }
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void testPort() throws Exception
+    {
+        // Given
+        assertTrue( portAvailable() );
+        GraphDatabaseService db = initialize();
+        assertTrue( db.isAvailable( TimeUnit.SECONDS.toMillis( 5L ) ) );
+        assertFalse( portAvailable() );
+
+        // When
+        db.shutdown();
+
+        // Then
+        await( this::portAvailable, 5L, TimeUnit.SECONDS );
+        assertTrue( portAvailable() );
+    }
+}

--- a/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.shell.kernel.ReadOnlyGraphDatabaseProxy;
 
-public class TestReadOnlyServer extends AbstractShellTest
+public class ReadOnlyServerIT extends AbstractShellIT
 {
     @Override
     protected ShellServer newServer( GraphDatabaseAPI db ) throws ShellException, RemoteException

--- a/community/shell/src/test/java/org/neo4j/shell/RmiPublicationIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/RmiPublicationIT.java
@@ -37,7 +37,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.lang.System.getProperty;
 import static org.junit.Assert.assertEquals;
 
-public class TestRmiPublication
+public class RmiPublicationIT
 {
     public static File createDefaultConfigFile( File path ) throws IOException
     {
@@ -69,15 +69,16 @@ public class TestRmiPublication
     private int spawnJvm( Class<?> mainClass, String name ) throws Exception
     {
         String dir = testDirectory.directory( name ).getAbsolutePath();
-        return waitForExit( getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
-                "-Djava.awt.headless=true", mainClass.getName(), dir } ), 20 );
+        return waitForExit( getRuntime()
+                .exec( new String[]{"java", "-cp", getProperty( "java.class.path" ), "-Djava.awt.headless=true",
+                        mainClass.getName(), dir} ), 20 );
     }
 
     private int waitForExit( Process process, int maxSeconds ) throws InterruptedException
     {
         try
         {
-            long endTime = System.currentTimeMillis() + maxSeconds*1000;
+            long endTime = System.currentTimeMillis() + maxSeconds * 1000;
             ProcessStreamHandler streamHandler = new ProcessStreamHandler( process, false );
             streamHandler.launch();
             try
@@ -94,7 +95,7 @@ public class TestRmiPublication
                     }
                 }
 
-                tempHackToGetThreadDump(process);
+                tempHackToGetThreadDump( process );
 
                 throw new RuntimeException( "Process didn't exit on its own." );
             }
@@ -115,12 +116,12 @@ public class TestRmiPublication
         {
             Field pidField = process.getClass().getDeclaredField( "pid" );
             pidField.setAccessible( true );
-            int pid = (int)pidField.get( process );
+            int pid = (int) pidField.get( process );
 
             ProcessBuilder processBuilder = new ProcessBuilder( "/bin/sh", "-c", "kill -3 " + pid );
             processBuilder.redirectErrorStream( true );
             Process dumpProc = processBuilder.start();
-            ProcessStreamHandler streamHandler = new ProcessStreamHandler(dumpProc, false);
+            ProcessStreamHandler streamHandler = new ProcessStreamHandler( dumpProc, false );
             streamHandler.launch();
             try
             {
@@ -131,7 +132,7 @@ public class TestRmiPublication
                 streamHandler.cancel();
             }
         }
-        catch( Throwable e )
+        catch ( Throwable e )
         {
             e.printStackTrace();
         }

--- a/community/shell/src/test/java/org/neo4j/shell/ServerClientInteractionIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ServerClientInteractionIT.java
@@ -19,36 +19,31 @@
  */
 package org.neo4j.shell;
 
-import java.io.Serializable;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.shell.impl.SameJvmClient;
-import org.neo4j.shell.impl.SimpleAppServer;
-import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.ImpermanentGraphDatabase;
 
 import static java.util.regex.Pattern.compile;
-
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.shell.Variables.PROMPT_KEY;
 
-public class ServerClientInteractionTest
+public class ServerClientInteractionIT extends AbstractShellIT
 {
+    private SilentLocalOutput out = new SilentLocalOutput();
 
-    private GraphDatabaseAPI db;
+    @Before
+    public void setup() throws Exception
+    {
+        makeServerRemotelyAvailable();
+    }
 
     @Test
     public void shouldConsiderAndInterpretCustomClientPrompt() throws Exception
     {
         // GIVEN
-        client.setSessionVariable( PROMPT_KEY, "MyPrompt \\d \\t$ " );
+        shellClient.setSessionVariable( PROMPT_KEY, "MyPrompt \\d \\t$ " );
 
         // WHEN
-        Response response = server.interpretLine( client.getId(), "", out );
+        Response response = shellServer.interpretLine( shellClient.getId(), "", out );
 
         // THEN
         String regexPattern = "MyPrompt .{1,3} .{1,3} \\d{1,2} \\d{2}:\\d{2}:\\d{2}\\$";
@@ -56,23 +51,4 @@ public class ServerClientInteractionTest
                 compile( regexPattern ).matcher( response.getPrompt() ).find() );
     }
 
-    private SimpleAppServer server;
-    private ShellClient client;
-    private SilentLocalOutput out;
-
-    @Before
-    public void before() throws Exception
-    {
-        db = new ImpermanentGraphDatabase(  );
-        server = new GraphDatabaseShellServer( db );
-        out = new SilentLocalOutput();
-        client = new SameJvmClient( MapUtil.<String,Serializable>genericMap(), server, out, InterruptSignalHandler.getHandler() );
-    }
-
-    @After
-    public void after() throws Exception
-    {
-        server.shutdown();
-        db.shutdown();
-    }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/impl/ClientIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/ClientIT.java
@@ -37,9 +37,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
-public class AbstractClientTest
+public class ClientIT
 {
-
     @Test
     public void shouldHandleNormalInput() throws ShellException, RemoteException
     {

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
@@ -29,7 +29,7 @@ import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.neo4j.graphdb.Label.label;
 
-public class TestPECListing extends AbstractShellTest
+public class PECListingIT extends AbstractShellIT
 {
     @Override
     protected GraphDatabaseAPI newDb()


### PR DESCRIPTION
Previously the port would remain bound until the JVM was terminated.

Fixes #8929