### PR TITLE
Drops label indexes from unselected providers

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.legacyindex.AutoIndexing;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.dependency.DeleteStoresFromOtherLabelScanStoreProviders;
 import org.neo4j.kernel.extension.dependency.HighestSelectionStrategy;
 import org.neo4j.kernel.extension.dependency.NamedLabelScanStoreSelectionStrategy;
 import org.neo4j.kernel.guard.Guard;
@@ -405,6 +406,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
 
         labelScanStoreProvider = dependencyResolver.resolveDependency( LabelScanStoreProvider.class,
                 new NamedLabelScanStoreSelectionStrategy( config ) );
+        dependencyResolver.resolveDependency( LabelScanStoreProvider.class,
+                new DeleteStoresFromOtherLabelScanStoreProviders( labelScanStoreProvider ) );
 
         IndexConfigStore indexConfigStore = new IndexConfigStore( storeDir, fs );
         dependencies.satisfyDependency( lockService );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -131,4 +131,9 @@ public interface LabelScanStore extends Lifecycle
      * @throws IOException on I/O error.
      */
     void drop() throws IOException;
+
+    /**
+     * @return whether or not this index is read-only.
+     */
+    boolean isReadOnly();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -124,4 +124,11 @@ public interface LabelScanStore extends Lifecycle
      */
     @Override
     void shutdown() throws IOException;
+
+    /**
+     * Drops any persistent storage backing this store.
+     *
+     * @throws IOException on I/O error.
+     */
+    void drop() throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/DeleteStoresFromOtherLabelScanStoreProviders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/DeleteStoresFromOtherLabelScanStoreProviders.java
@@ -53,7 +53,10 @@ public class DeleteStoresFromOtherLabelScanStoreProviders implements DependencyR
             {
                 try
                 {
-                    provider.drop();
+                    if ( !provider.isReadOnly() )
+                    {
+                        provider.drop();
+                    }
                 }
                 catch ( IOException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/DeleteStoresFromOtherLabelScanStoreProviders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/extension/dependency/DeleteStoresFromOtherLabelScanStoreProviders.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.extension.dependency;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+
+/**
+ * Given an already selected {@link LabelScanStoreProvider}, tell all the other {@link LabelScanStoreProvider}
+ * to {@link LabelScanStoreProvider#drop() drop} their stores, so that there's only one authoritative provider.
+ */
+public class DeleteStoresFromOtherLabelScanStoreProviders implements DependencyResolver.SelectionStrategy
+{
+    private final LabelScanStoreProvider providerToKeep;
+
+    public DeleteStoresFromOtherLabelScanStoreProviders( LabelScanStoreProvider providerToKeep )
+    {
+        this.providerToKeep = providerToKeep;
+    }
+
+    @Override
+    public <T> T select( Class<T> type, Iterable<T> candidates ) throws IllegalArgumentException
+    {
+        for ( T candidate : candidates )
+        {
+            if ( !(candidate instanceof LabelScanStoreProvider) )
+            {
+                throw new IllegalArgumentException( "May only be used for " + LabelScanStoreProvider.class );
+            }
+
+            LabelScanStoreProvider provider = (LabelScanStoreProvider) candidate;
+            if ( provider != providerToKeep )
+            {
+                try
+                {
+                    provider.drop();
+                }
+                catch ( IOException e )
+                {
+                    throw new UncheckedIOException( e );
+                }
+            }
+        }
+        return (T) providerToKeep;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -83,6 +83,11 @@ public class LabelScanStoreProvider extends LifecycleAdapter
         }
     }
 
+    public boolean isReadOnly()
+    {
+        return labelScanStore.isReadOnly();
+    }
+
     public void drop() throws IOException
     {
         labelScanStore.drop();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -82,4 +82,9 @@ public class LabelScanStoreProvider extends LifecycleAdapter
             return fullStoreStream.applyTo( writer );
         }
     }
+
+    public void drop() throws IOException
+    {
+        labelScanStore.drop();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -292,7 +292,7 @@ public class NativeLabelScanStore implements LabelScanStore
         {
             // GBPTree is corrupt. Try to rebuild.
             monitor.notValidIndex();
-            drop();
+            dropStrict();
             instantiateTree();
             needsRebuild = true;
         }
@@ -323,6 +323,18 @@ public class NativeLabelScanStore implements LabelScanStore
 
     @Override
     public void drop() throws IOException
+    {
+        try
+        {
+            dropStrict();
+        }
+        catch ( NoSuchFileException e )
+        {
+            // Even better, it didn't even exist
+        }
+    }
+
+    private void dropStrict() throws IOException
     {
         storeFileHandle().delete();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -321,7 +321,8 @@ public class NativeLabelScanStore implements LabelScanStore
         index = new GBPTree<>( pageCache, storeFile, new LabelScanLayout(), pageSize, GBPTree.NO_MONITOR );
     }
 
-    private void drop() throws IOException
+    @Override
+    public void drop() throws IOException
     {
         storeFileHandle().delete();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -395,4 +395,10 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         index.close();
     }
+
+    @Override
+    public boolean isReadOnly()
+    {
+        return readOnly;
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -68,7 +68,6 @@ import org.neo4j.kernel.api.labelscan.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
-import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -1503,6 +1502,11 @@ public class BatchInsertTest
         public boolean isEmpty() throws IOException
         {
             return allUpdates.isEmpty();
+        }
+
+        @Override
+        public void drop() throws IOException
+        {
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1527,6 +1527,12 @@ public class BatchInsertTest
                 }
             };
         }
+
+        @Override
+        public boolean isReadOnly()
+        {
+            return false;
+        }
     }
 
     interface NoDependencies

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
@@ -183,4 +183,10 @@ public class LuceneLabelScanStore implements LabelScanStore
     {
         return luceneIndex.getLabelScanWriter();
     }
+
+    @Override
+    public boolean isReadOnly()
+    {
+        return luceneIndex.isReadOnly();
+    }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
@@ -87,6 +87,12 @@ public class LuceneLabelScanStore implements LabelScanStore
     }
 
     @Override
+    public void drop() throws IOException
+    {
+        luceneIndex.drop();
+    }
+
+    @Override
     public void init() throws IOException
     {
         monitor.init();
@@ -102,7 +108,7 @@ public class LuceneLabelScanStore implements LabelScanStore
             else if ( !luceneIndex.isValid() )
             {
                 monitor.notValidIndex();
-                luceneIndex.drop();
+                drop();
                 luceneIndex.create();
                 needsRebuild = true;
             }

--- a/community/neo4j/src/test/java/org/neo4j/store/label/DropOtherLabelIndexesIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/store/label/DropOtherLabelIndexesIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.store.label;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestLabels;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class DropOtherLabelIndexesIT
+{
+    private static final TestLabels LABEL = TestLabels.LABEL_ONE;
+
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory();
+
+    /**
+     * Flip between different label index providers and assert that the unselected label indexes
+     * gets deleted so that the selected index will not miss updates if it wasn't the selected index in all sessions.
+     */
+    @Test
+    public void shouldDropUnselectedLabelIndexes() throws Exception
+    {
+        // GIVEN
+        GraphDatabaseService db = db( LabelIndex.NATIVE );
+        Node nodeA = createNode( db );
+        assertNodes( db, nodeA );
+        db.shutdown();
+
+        // WHEN
+        db = db( LabelIndex.LUCENE );
+        Node nodeB = createNode( db );
+        assertNodes( db, nodeA, nodeB );
+        db.shutdown();
+
+        // THEN
+        db = db( LabelIndex.NATIVE );
+        Node nodeC = createNode( db );
+        assertNodes( db, nodeA, nodeB, nodeC );
+        db.shutdown();
+    }
+
+    private void assertNodes( GraphDatabaseService db, Node... expectedNodes )
+    {
+        try ( Transaction tx = db.beginTx();
+                ResourceIterator<Node> found = db.findNodes( LABEL ) )
+        {
+            assertEquals( asSet( expectedNodes ), asSet( found ) );
+            tx.success();
+        }
+    }
+
+    private Node createNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( LABEL );
+            tx.success();
+            return node;
+        }
+    }
+
+    private GraphDatabaseService db( LabelIndex index )
+    {
+        return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( directory.absolutePath() )
+                .setConfig( GraphDatabaseSettings.label_index, index.name() )
+                .newGraphDatabase();
+    }
+}

--- a/community/neo4j/src/test/java/org/neo4j/store/label/DropOtherLabelIndexesIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/store/label/DropOtherLabelIndexesIT.java
@@ -72,7 +72,7 @@ public class DropOtherLabelIndexesIT
         }
     }
 
-    private void assertNodes( GraphDatabaseService db, Set<Node> expectedNodes )
+    private static void assertNodes( GraphDatabaseService db, Set<Node> expectedNodes )
     {
         try ( Transaction tx = db.beginTx();
                 ResourceIterator<Node> found = db.findNodes( LABEL ) )
@@ -82,7 +82,7 @@ public class DropOtherLabelIndexesIT
         }
     }
 
-    private Node createNode( GraphDatabaseService db )
+    private static Node createNode( GraphDatabaseService db )
     {
         try ( Transaction tx = db.beginTx() )
         {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupLabelIndexIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupLabelIndexIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestLabels;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.backup.BackupServer.DEFAULT_PORT;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class BackupLabelIndexIT
+{
+    private static final TestLabels LABEL = TestLabels.LABEL_ONE;
+
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory();
+
+    @Test
+    public void shouldHandleBackingUpFromSourceThatSwitchesLabelIndexProviderAllIndexConfigMatching() throws Exception
+    {
+        // GIVEN
+        LabelIndex[] types = LabelIndex.values();
+        Set<Node> expectedNodes = new HashSet<>();
+        File sourceDir = directory.absolutePath();
+        File backupDir = directory.directory( "backup" );
+        for ( int i = 0; i < 5; i++ )
+        {
+            // WHEN
+            LabelIndex index = random.among( types );
+            GraphDatabaseService db = db( sourceDir, index, true );
+            Node node = createNode( db );
+            expectedNodes.add( node );
+
+            // THEN
+            backupTo( index, backupDir );
+            GraphDatabaseService backupDb = db( backupDir, index, false );
+            assertNodes( backupDb, expectedNodes );
+            backupDb.shutdown();
+            db.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldHandleBackingUpFromSourceThatSwitchesLabelIndexProviderBackupHasDifferentIndex() throws Exception
+    {
+        // GIVEN
+        LabelIndex[] types = LabelIndex.values();
+        Set<Node> expectedNodes = new HashSet<>();
+        File sourceDir = directory.absolutePath();
+        File backupDir = directory.directory( "backup" );
+        for ( int i = 0; i < 5; i++ )
+        {
+            // WHEN
+            LabelIndex index = random.among( types );
+            GraphDatabaseService db = db( sourceDir, index, true );
+            Node node = createNode( db );
+            expectedNodes.add( node );
+
+            // THEN
+            LabelIndex indexForBackup = random.among( types );
+            backupTo( indexForBackup, backupDir );
+            GraphDatabaseService backupDb = db( backupDir, indexForBackup, false );
+            assertNodes( backupDb, expectedNodes );
+            backupDb.shutdown();
+            db.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldHandleBackingUpFromSourceThatSwitchesLabelIndexProviderBackupHasDifferentIndexAlsoInternally()
+            throws Exception
+    {
+        // GIVEN
+        LabelIndex[] types = LabelIndex.values();
+        Set<Node> expectedNodes = new HashSet<>();
+        File sourceDir = directory.absolutePath();
+        File backupDir = directory.directory( "backup" );
+        for ( int i = 0; i < 5; i++ )
+        {
+            // WHEN
+            LabelIndex index = random.among( types );
+            GraphDatabaseService db = db( sourceDir, index, true );
+            Node node = createNode( db );
+            expectedNodes.add( node );
+
+            // THEN
+            backupTo( random.among( types ), backupDir );
+            GraphDatabaseService backupDb = db( backupDir, random.among( types ), false );
+            assertNodes( backupDb, expectedNodes );
+            backupDb.shutdown();
+            db.shutdown();
+        }
+    }
+
+    private static void backupTo( LabelIndex index, File toDir )
+    {
+        Config config = Config.embeddedDefaults( stringMap( GraphDatabaseSettings.label_index.name(), index.name() ) );
+        new BackupService( DefaultFileSystemAbstraction::new, NullLogProvider.getInstance(), new Monitors() )
+                .doIncrementalBackupOrFallbackToFull( "localhost", DEFAULT_PORT, toDir,
+                        ConsistencyCheck.FULL, config, BackupClient.BIG_READ_TIMEOUT, false );
+    }
+
+    private static void assertNodes( GraphDatabaseService db, Set<Node> expectedNodes )
+    {
+        try ( Transaction tx = db.beginTx();
+                ResourceIterator<Node> found = db.findNodes( LABEL ) )
+        {
+            assertEquals( expectedNodes, asSet( found ) );
+            tx.success();
+        }
+    }
+
+    private static Node createNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( LABEL );
+            tx.success();
+            return node;
+        }
+    }
+
+    private static GraphDatabaseService db( File storeDir, LabelIndex index, boolean backupEnabled )
+    {
+        GraphDatabaseBuilder builder =
+                new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.label_index, index.name() );
+        if ( backupEnabled )
+        {
+            builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
+                   .setConfig( OnlineBackupSettings.online_backup_server, "localhost:" + DEFAULT_PORT );
+
+        }
+        return builder.newGraphDatabase();
+    }
+}


### PR DESCRIPTION
This helps keeping a correct and up to date label index even when
potentially flipping between different providers, even tho it's generally
very uncommon.