### PR TITLE
Rule chain order in CoreReplicationIT.

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -58,7 +58,7 @@ public class CoreReplicationIT
             .withTimeout( 1000, TimeUnit.SECONDS )
             .build();
     @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( suppressOutput ).around( timeout ).around( clusterRule );
+    public RuleChain ruleChain = RuleChain.outerRule( suppressOutput ).around( clusterRule ).around( timeout);
 
     private Cluster cluster;
 


### PR DESCRIPTION
Cluster rule should be around timeout rule to be able to shutdown
cluster in case of timeout and normal termination.