### PR TITLE
Added ability to ignore bad data in `neo4j-admin import`

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -66,57 +66,6 @@ class CsvImporter implements Importer
     private final boolean ignoreDuplicateNodes;
     private final boolean ignoreExtraColumns;
 
-    public static String description()
-    {
-        return "--mode=csv\n" +
-                "        Import a database from a collection of CSV files.\n" +
-                "--report-file=<filename>\n" +
-                "        File name in which to store the report of the import.\n" +
-                "        Defaults to " + ImportCommand.DEFAULT_REPORT_FILE_NAME + " in the current directory.\n" +
-                "--nodes[:Label1:Label2]=\"<file1>,<file2>,...\"\n" +
-                "        Node CSV header and data. Multiple files will be logically seen as\n" +
-                "        one big file from the perspective of the importer. The first line\n" +
-                "        must contain the header. Multiple data sources like these can be\n" +
-                "        specified in one import, where each data source has its own header.\n" +
-                "        Note that file groups must be enclosed in quotation marks.\n" +
-                "--relationships[:RELATIONSHIP_TYPE]=\"<file1>,<file2>,...\"\n" +
-                "        Relationship CSV header and data. Multiple files will be logically\n" +
-                "        seen as one big file from the perspective of the importer. The first\n" +
-                "        line must contain the header. Multiple data sources like these can be\n" +
-                "        specified in one import, where each data source has its own header.\n" +
-                "        Note that file groups must be enclosed in quotation marks.\n" +
-                "--id-type=<id-type>\n" +
-                "        Each node must provide a unique id. This is used to find the correct\n" +
-                "        nodes when creating relationships. Must be one of:\n" +
-                "            STRING: (default) arbitrary strings for identifying nodes.\n" +
-                "            INTEGER: arbitrary integer values for identifying nodes.\n" +
-                "            ACTUAL: (advanced) actual node ids. The default option is STRING.\n" +
-                "        For more information on id handling, please see the Neo4j Manual:\n" +
-                "        https://neo4j.com/docs/operations-manual/current/tools/import/\n" +
-                "--input-encoding=<character-set>\n" +
-                "        Character set that input data is encoded in. Defaults to UTF-8.\n" +
-                "--ignore-extra-columns=<true|false>\n" +
-                "        If un-identified columns should be ignored during the import. Defaults to false.\n" +
-                "--ignore-duplicate-nodes=<true|false>\n" +
-                "        If duplicate nodes should be ignored during the import. Defaults to false.\n" +
-                "--ignore-missing-nodes=<true|false>\n" +
-                "        If relationships referring to missing nodes should be ignored during the import.\n" +
-                "        Defaults to false.\n";
-    }
-
-    public static String arguments()
-    {
-        return "[--report-file=<filename>] " +
-                "[--nodes[:Label1:Label2]=\"<file1>,<file2>,...\"] " +
-                "[--relationships[:RELATIONSHIP_TYPE]=\"<file1>,<file2>,...\"] " +
-                "[--id-type=<id-type>] " +
-                "[--input-encoding=<character-set>] " +
-                "[--page-size=<page-size>]" +
-                "[--ignore-extra-columns=<true|false>" +
-                "[--ignore-duplicate-nodes=<true|false>" +
-                "[--ignore-missing-nodes=<true|false>";
-    }
-
     CsvImporter( Args args, Config config, OutsideWorld outsideWorld ) throws IncorrectUsage
     {
         this.args = args;

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -115,6 +115,6 @@ class CsvImporter implements Importer
 
     private boolean isIgnoringSomething()
     {
-        return ignoreBadRelationships | ignoreDuplicateNodes | ignoreExtraColumns;
+        return ignoreBadRelationships || ignoreDuplicateNodes || ignoreExtraColumns;
     }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
@@ -34,20 +34,6 @@ import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 
 class DatabaseImporter implements Importer
 {
-    public static String arguments()
-    {
-        return "[--from=<source-directory>]";
-    }
-
-    public static String description()
-    {
-        return "--mode=database\n" +
-                "        Import a database from a pre-3.0 Neo4j installation.\n" +
-                "--from=<source-directory>\n" +
-                "        <source-directory> is the location of the pre-3.0 database\n" +
-                "        (e.g. <neo4j-root>/data/graph.db).\n";
-    }
-
     private final File from;
     private final Config config;
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -21,9 +21,7 @@ package org.neo4j.commandline.dbms;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,9 +31,9 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
@@ -91,7 +89,13 @@ public class ImportCommand implements AdminCommand
                     "For more information on id handling, please see the Neo4j Manual: " +
                     "https://neo4j.com/docs/operations-manual/current/tools/import/" ) )
             .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",
-                    "Character set that input data is encoded in." ) );
+                    "Character set that input data is encoded in." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-extra-columns", false,
+                    "If un-specified columns should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
+                    "If duplicate nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
+                    "If relationships referring to missing nodes should be ignored during the import." ) );
     private static final Arguments allArguments = new Arguments()
             .withDatabase()
             .withAdditionalConfig()
@@ -122,7 +126,13 @@ public class ImportCommand implements AdminCommand
                     "For more information on id handling, please see the Neo4j Manual: " +
                     "https://neo4j.com/docs/operations-manual/current/tools/import/" ) )
             .withArgument( new OptionalNamedArg( "input-encoding", "character-set", "UTF-8",
-                    "Character set that input data is encoded in." ) );
+                    "Character set that input data is encoded in." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-extra-columns", false,
+                    "If un-specified columns should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
+                    "If duplicate nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
+                    "If relationships referring to missing nodes should be ignored during the import." ) );
 
     public static Arguments databaseArguments()
     {

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -163,6 +163,9 @@ public class ImportCommandTest
                             "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]%n" +
                             "                          [--id-type=<STRING|INTEGER|ACTUAL>]%n" +
                             "                          [--input-encoding=<character-set>]%n" +
+                            "                          [--ignore-extra-columns[=<true|false>]]%n" +
+                            "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
+                            "                          [--ignore-missing-nodes[=<true|false>]]%n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--from=<source-directory>]%n" +
@@ -205,7 +208,15 @@ public class ImportCommandTest
                             "      https://neo4j.com/docs/operations-manual/current/tools/import/%n" +
                             "      [default:STRING]%n" +
                             "  --input-encoding=<character-set>%n" +
-                            "      Character set that input data is encoded in. [default:UTF-8]%n" ),
+                            "      Character set that input data is encoded in. [default:UTF-8]%n" +
+                            "  --ignore-extra-columns=<true|false>%n" +
+                            "      If un-specified columns should be ignored during the import.%n" +
+                            "      [default:false]%n" +
+                            "  --ignore-duplicate-nodes=<true|false>%n" +
+                            "      If duplicate nodes should be ignored during the import. [default:false]%n" +
+                            "  --ignore-missing-nodes=<true|false>%n" +
+                            "      If relationships referring to missing nodes should be ignored during the%n" +
+                            "      import. [default:false]%n" ),
                     baos.toString() );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -59,6 +59,7 @@ public class BadCollector implements Collector
     // volatile since one importer thread calls collect(), where this value is incremented and later the "main"
     // thread calls badEntries() to get a count.
     private volatile int badEntries;
+    public static final int UNLIMITED_TOLERANCE = -1;
 
     public BadCollector( OutputStream out, int tolerance, int collect )
     {
@@ -170,7 +171,7 @@ public class BadCollector implements Collector
             badEntries++;
         }
 
-        if ( !collect || badEntries > tolerance )
+        if ( !collect || (tolerance != BadCollector.UNLIMITED_TOLERANCE && badEntries > tolerance) )
         {
             InputException exception = report.exception();
             throw collect

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -73,7 +73,7 @@ public class BadCollector implements Collector
     {
         checkTolerance( BAD_RELATIONSHIPS, new ProblemReporter()
         {
-            private final String message = format( "%s refering to missing node %s", relationship, specificValue );
+            private final String message = format( "%s referring to missing node %s", relationship, specificValue );
 
             @Override
             public String message()

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -35,6 +35,9 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static org.neo4j.unsafe.impl.batchimport.input.BadCollector.COLLECT_ALL;
+import static org.neo4j.unsafe.impl.batchimport.input.BadCollector.UNLIMITED_TOLERANCE;
 import static org.neo4j.unsafe.impl.batchimport.input.BadCollectorTest.InputRelationshipBuilder.inputRelationship;
 
 public class BadCollectorTest
@@ -201,6 +204,23 @@ public class BadCollectorTest
         assertArrayEquals( new long[] {8, 10, 12}, nodeIds );
     }
 
+    @Test
+    public void shouldCollectUnlimitedNumberOfBadEntriesIfToldTo() throws Exception
+    {
+        // GIVEN
+        BadCollector collector = new BadCollector( new NullOutputStream(), UNLIMITED_TOLERANCE, COLLECT_ALL );
+
+        // WHEN
+        int count = 10_000;
+        for ( int i = 0; i < count; i++ )
+        {
+            collector.collectDuplicateNode( i, i, "group", "first", "other" );
+        }
+
+        // THEN
+        assertEquals( count, collector.badEntries() );
+    }
+
     private OutputStream badOutputFile() throws IOException
     {
         File badDataPath = new File( "/tmp/foo2" ).getAbsoluteFile();
@@ -238,5 +258,13 @@ public class BadCollectorTest
         fileSystem.mkdir( badDataPath.getParentFile() );
         fileSystem.create( badDataPath );
         return badDataPath;
+    }
+
+    private static class NullOutputStream extends OutputStream
+    {
+        @Override
+        public void write( int b ) throws IOException
+        {   // Don't
+        }
     }
 }


### PR DESCRIPTION
## Updated help text

```
usage: neo4j-admin import [--mode=csv] [--database=<name>]
                          [--additional-config=<config-file-path>]
                          [--report-file=<filename>]
                          [--nodes[:Label1:Label2]=<"file1,file2,...">]
                          [--relationships[:RELATIONSHIP_TYPE]=<"file1,file2,...">]
                          [--id-type=<STRING|INTEGER|ACTUAL>]
                          [--input-encoding=<character-set>]
                          [--ignore-extra-columns[=<true|false>]]
                          [--ignore-duplicate-nodes[=<true|false>]]
                          [--ignore-missing-nodes[=<true|false>]]
usage: neo4j-admin import --mode=database [--database=<name>]
                          [--additional-config=<config-file-path>]
                          [--from=<source-directory>]

Import a collection of CSV files with --mode=csv (default), or a database from a
pre-3.0 installation with --mode=database.

options:
  --database=<name>
      Name of database. [default:graph.db]
  --additional-config=<config-file-path>
      Configuration file to supply additional configuration in. [default:]
  --mode=<database|csv>
      Import a collection of CSV files or a pre-3.0 installation. [default:csv]
  --from=<source-directory>
      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).
      [default:]
  --report-file=<filename>
      File in which to store the report of the csv-import.
      [default:import.report]
  --nodes[:Label1:Label2]=<"file1,file2,...">
      Node CSV header and data. Multiple files will be logically seen as one big
      file from the perspective of the importer. The first line must contain the
      header. Multiple data sources like these can be specified in one import,
      where each data source has its own header. Note that file groups must be
      enclosed in quotation marks. [default:]
  --relationships[:RELATIONSHIP_TYPE]=<"file1,file2,...">
      Relationship CSV header and data. Multiple files will be logically seen as
      one big file from the perspective of the importer. The first line must
      contain the header. Multiple data sources like these can be specified in
      one import, where each data source has its own header. Note that file
      groups must be enclosed in quotation marks. [default:]
  --id-type=<STRING|INTEGER|ACTUAL>
      Each node must provide a unique id. This is used to find the correct nodes
      when creating relationships. Possible values are:
        STRING: arbitrary strings for identifying nodes,
        INTEGER: arbitrary integer values for identifying nodes,
        ACTUAL: (advanced) actual node ids.
      For more information on id handling, please see the Neo4j Manual:
      https://neo4j.com/docs/operations-manual/current/tools/import/
      [default:STRING]
  --input-encoding=<character-set>
      Character set that input data is encoded in. [default:UTF-8]
  --ignore-extra-columns=<true|false>
      If un-specified columns should be ignored during the import.
      [default:false]
  --ignore-duplicate-nodes=<true|false>
      If duplicate nodes should be ignored during the import. [default:false]
  --ignore-missing-nodes=<true|false>
      If relationships referring to missing nodes should be ignored during the
      import. [default:false]
```