### PR TITLE
Add a flag for verifying generated bytecode

### DIFF
--- a/community/codegen/pom.xml
+++ b/community/codegen/pom.xml
@@ -12,6 +12,7 @@
     <bundle.namespace>org.neo4j.codegen</bundle.namespace>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <asm.version>5.2</asm.version>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,21 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>5.2</version>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>${asm.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>${asm.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCode.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCode.java
@@ -46,6 +46,7 @@ public enum ByteCode implements CodeGeneratorOption
             return "BYTECODE";
         }
     };
+    public static final CodeGeneratorOption VERIFY_GENERATED_BYTECODE = load( "Verifier" );
 
     @Override
     public void applyTo( Object target )
@@ -53,6 +54,19 @@ public enum ByteCode implements CodeGeneratorOption
         if ( target instanceof Configuration )
         {
             ((Configuration) target).withFlag( this );
+        }
+    }
+
+    private static CodeGeneratorOption load( String option )
+    {
+        try
+        {
+            return (CodeGeneratorOption) Class.forName( ByteCode.class.getName() + option )
+                    .getDeclaredMethod( "load" + option ).invoke( null );
+        }
+        catch ( Throwable e )
+        {
+            return BLANK_OPTION;
         }
     }
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeChecker.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeChecker.java
@@ -19,29 +19,12 @@
  */
 package org.neo4j.codegen.bytecode;
 
-class Configuration
+import java.util.Collection;
+
+import org.neo4j.codegen.ByteCodes;
+import org.neo4j.codegen.CompilationFailureException;
+
+interface ByteCodeChecker
 {
-    private ByteCodeChecker bytecodeChecker;
-
-    public Configuration withFlag( ByteCode flag )
-    {
-        return this;
-    }
-
-    public void withBytecodeChecker( ByteCodeChecker checker )
-    {
-        if ( bytecodeChecker == null )
-        {
-            bytecodeChecker = checker;
-        }
-        else
-        {
-            throw new UnsupportedOperationException( "multiple bytecode checkers" );
-        }
-    }
-
-    ByteCodeChecker bytecodeChecker()
-    {
-        return bytecodeChecker;
-    }
+    void check( ClassLoader classpathLoader, Collection<ByteCodes> byteCodes ) throws CompilationFailureException;
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeGenerator.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.codegen.bytecode;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.codegen.ByteCodes;
@@ -28,12 +30,12 @@ import org.neo4j.codegen.CodeGenerator;
 import org.neo4j.codegen.CompilationFailureException;
 import org.neo4j.codegen.TypeReference;
 
-public class ByteCodeGenerator extends CodeGenerator
+class ByteCodeGenerator extends CodeGenerator
 {
     private final Configuration configuration;
     private final Map<TypeReference,ClassByteCodeWriter> classes = new HashMap<>();
 
-    public ByteCodeGenerator( ClassLoader parentClassLoader, Configuration configuration)
+    ByteCodeGenerator( ClassLoader parentClassLoader, Configuration configuration )
     {
         super( parentClassLoader );
         this.configuration = configuration;
@@ -58,6 +60,16 @@ public class ByteCodeGenerator extends CodeGenerator
 
     protected Iterable<? extends ByteCodes> compile( ClassLoader classpathLoader ) throws CompilationFailureException
     {
-        return classes.values().stream().map( ClassByteCodeWriter::toByteCodes )::iterator;
+        List<ByteCodes> byteCodes = new ArrayList<>( classes.size() );
+        for ( ClassByteCodeWriter writer : classes.values() )
+        {
+            byteCodes.add( writer.toByteCodes() );
+        }
+        ByteCodeChecker checker = configuration.bytecodeChecker();
+        if ( checker != null )
+        {
+            checker.check( classpathLoader, byteCodes );
+        }
+        return byteCodes;
     }
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeVerifier.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeVerifier.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.codegen.bytecode;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.function.IntFunction;
+import javax.tools.Diagnostic;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TryCatchBlockNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.SimpleVerifier;
+import org.objectweb.asm.tree.analysis.Value;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceMethodVisitor;
+
+import org.neo4j.codegen.ByteCodes;
+import org.neo4j.codegen.CodeGeneratorOption;
+import org.neo4j.codegen.CompilationFailureException;
+
+import static org.objectweb.asm.ClassReader.SKIP_DEBUG;
+
+@SuppressWarnings( "unused"/*used through reflection, since it depends on optional code*/ )
+class ByteCodeVerifier implements ByteCodeChecker, CodeGeneratorOption
+{
+    /**
+     * Invoked by {@link ByteCode#load(String)} to load this class.
+     *
+     * @return an instance of this class, if all dependencies are available.
+     */
+    static CodeGeneratorOption loadVerifier()
+    {
+        if ( Analyzer.class.getName().isEmpty() || CheckClassAdapter.class.getName().isEmpty() )
+        {
+            throw new AssertionError( "This code is here to ensure the optional ASM classes are on the classpath" );
+        }
+        return new ByteCodeVerifier();
+    }
+
+    /**
+     * Add this verification step to the configuration, if applicable.
+     *
+     * @param target
+     *         the configuration to add this verification step to.
+     */
+    @Override
+    public void applyTo( Object target )
+    {
+        if ( target instanceof Configuration )
+        {
+            ((Configuration) target).withBytecodeChecker( this );
+        }
+    }
+
+    /**
+     * Check the bytecode from one round of bytecode generation.
+     *
+     * @param classpathLoader
+     *         the ClassLoader to use for loading classes from the classpath.
+     * @param byteCodes
+     *         the bytecodes generated in this round.
+     * @throws CompilationFailureException
+     *         if any issue is discovered in the verification.
+     */
+    @Override
+    public void check( ClassLoader classpathLoader, Collection<ByteCodes> byteCodes ) throws CompilationFailureException
+    {
+        List<ClassNode> classes = new ArrayList<>( byteCodes.size() );
+        List<Failure> failures = new ArrayList<>();
+        // load (and verify) the structure of the generated classes
+        for ( ByteCodes byteCode : byteCodes )
+        {
+            try
+            {
+                classes.add( classNode( byteCode.bytes() ) );
+            }
+            catch ( Exception e )
+            {
+                failures.add( new Failure( e, e.toString() ) );
+            }
+        }
+        // if there are problems with the structure of the generated classes,
+        // we are not going to be able to verify their methods
+        if ( !failures.isEmpty() )
+        {
+            throw compilationFailure( failures );
+        }
+        // continue with verifying the methods of the classes
+        AssignmentChecker check = new AssignmentChecker( classpathLoader, classes );
+        for ( ClassNode clazz : classes )
+        {
+            verify( check, clazz, failures );
+        }
+        if ( !failures.isEmpty() )
+        {
+            throw compilationFailure( failures );
+        }
+    }
+
+    /**
+     * Verify the methods of a single class.
+     *
+     * @param check
+     *         a helper for verifying assignments.
+     * @param clazz
+     *         the class to check the methods of.
+     * @param failures
+     *         where any detected errors are added.
+     */
+    private static void verify( AssignmentChecker check, ClassNode clazz, List<Failure> failures )
+    {
+        Verifier verifier = new Verifier( clazz, check );
+        for ( MethodNode method : (Iterable<MethodNode>) clazz.methods )
+        {
+            Analyzer analyzer = new Analyzer( verifier );
+            try
+            {
+                analyzer.analyze( clazz.name, method );
+            }
+            catch ( Exception cause )
+            {
+                failures.add( new Failure( cause, detailedMessage(
+                        cause.getMessage(),
+                        method,
+                        analyzer.getFrames(),
+                        cause instanceof AnalyzerException ? ((AnalyzerException) cause).node : null ) ) );
+            }
+        }
+    }
+
+    private static ClassNode classNode( ByteBuffer bytecode )
+    {
+        byte[] bytes;
+        if ( bytecode.hasArray() )
+        {
+            bytes = bytecode.array();
+        }
+        else
+        {
+            bytes = new byte[bytecode.limit()];
+            bytecode.get( bytes );
+        }
+        ClassNode classNode = new ClassNode();
+        new ClassReader( bytes ).accept( new CheckClassAdapter( classNode, false ), SKIP_DEBUG );
+        return classNode;
+    }
+
+    private static CompilationFailureException compilationFailure( List<Failure> failures )
+    {
+        List<Diagnostic<?>> diagnostics = new ArrayList<>( failures.size() );
+        for ( Failure failure : failures )
+        {
+            diagnostics.add( new BytecodeDiagnostic( failure.message ) );
+        }
+        CompilationFailureException exception = new CompilationFailureException( diagnostics );
+        for ( Failure failure : failures )
+        {
+            exception.addSuppressed( failure.cause );
+        }
+        return exception;
+    }
+
+    private static class Failure
+    {
+        final Throwable cause;
+        final String message;
+
+        Failure( Throwable cause, String message )
+        {
+            this.cause = cause;
+            this.message = message;
+        }
+    }
+
+    private static String detailedMessage(
+            String errorMessage,
+            MethodNode method,
+            Frame[] frames,
+            AbstractInsnNode errorLocation )
+    {
+        StringWriter message = new StringWriter();
+        try ( PrintWriter out = new PrintWriter( message ) )
+        {
+            List<Integer> localLengths = new ArrayList<>(), stackLengths = new ArrayList<>();
+            for ( Frame frame : frames )
+            {
+                if ( frame != null )
+                {
+                    for ( int i = 0; i < frame.getLocals(); i++ )
+                    {
+                        insert( i, frame.getLocal( i ), localLengths );
+                    }
+                    for ( int i = 0; i < frame.getStackSize(); i++ )
+                    {
+                        insert( i, frame.getStack( i ), stackLengths );
+                    }
+                }
+            }
+            Textifier formatted = new Textifier();
+            TraceMethodVisitor mv = new TraceMethodVisitor( formatted );
+
+            out.println( errorMessage );
+            out.append( "\t\tin " ).append( method.name ).append( method.desc ).println();
+            for ( int i = 0; i < method.instructions.size(); i++ )
+            {
+                AbstractInsnNode insn = method.instructions.get( i );
+                insn.accept( mv );
+                Frame frame = frames[i];
+                out.append( "\t\t" );
+                out.append( insn == errorLocation ? ">>> " : "    " );
+                out.format( "%05d [", i );
+                if ( frame == null )
+                {
+                    padding( out, localLengths.listIterator(), '?' );
+                    out.append( " : " );
+                    padding( out, stackLengths.listIterator(), '?' );
+                }
+                else
+                {
+                    emit( out, localLengths, frame::getLocal, frame.getLocals() );
+                    padding( out, localLengths.listIterator( frame.getLocals() ), '-' );
+                    out.append( " : " );
+                    emit( out, stackLengths, frame::getStack, frame.getStackSize() );
+                    padding( out, stackLengths.listIterator( frame.getStackSize() ), ' ' );
+                }
+                out.print( "] : " );
+                out.print( formatted.text.get( formatted.text.size() - 1 ) );
+            }
+            for ( int j = 0; j < method.tryCatchBlocks.size(); j++ )
+            {
+                ((TryCatchBlockNode) method.tryCatchBlocks.get( j )).accept( mv );
+                out.print( " " + formatted.text.get( formatted.text.size() - 1 ) );
+            }
+        }
+        return message.toString();
+    }
+
+    private static void emit( PrintWriter out, List<Integer> lengths, IntFunction<Value> valueLookup, int values )
+    {
+        for ( int i = 0; i < values; i++ )
+        {
+            if ( i > 0 )
+            {
+                out.append( ' ' );
+            }
+            String name = shortName( valueLookup.apply( i ).toString() );
+            for ( int pad = lengths.get( i ) - name.length(); pad-- > 0; )
+            {
+                out.append( ' ' );
+            }
+            out.append( name );
+        }
+    }
+
+    private static void padding( PrintWriter out, ListIterator<Integer> lengths, char var )
+    {
+        while ( lengths.hasNext() )
+        {
+            if ( lengths.nextIndex() > 0 )
+            {
+                out.append( ' ' );
+            }
+            for ( int length = lengths.next(); length-- > 1; )
+            {
+                out.append( ' ' );
+            }
+            out.append( var );
+        }
+    }
+
+    private static void insert( int i, Value value, List<Integer> values )
+    {
+        int length = shortName( value.toString() ).length();
+        while ( i >= values.size() )
+        {
+            values.add( 1 );
+        }
+        if ( length > values.get( i ) )
+        {
+            values.set( i, length );
+        }
+    }
+
+    private static String shortName( String name )
+    {
+        int start = name.lastIndexOf( '/' );
+        int end = name.length();
+        if ( name.charAt( end - 1 ) == ';' )
+        {
+            end--;
+        }
+        return start == -1 ? name : name.substring( start + 1, end );
+    }
+
+    // This class might look failed in the IDE, but javac will accept it
+    // The reason is because the base class has been re-written to work on old JVMs - generics have been dropped.
+    private static class Verifier extends SimpleVerifier
+    {
+        private final AssignmentChecker check;
+
+        Verifier( ClassNode clazz, AssignmentChecker check )
+        {
+            super( Type.getObjectType( clazz.name ), superClass( clazz ), interfaces( clazz ),
+                    isInterfaceNode( clazz ) );
+            this.check = check;
+        }
+
+        @Override
+        protected boolean isAssignableFrom( Type target, Type value )
+        {
+            return check.isAssignableFrom( target, value );
+        }
+
+        @Override
+        protected boolean isSubTypeOf( BasicValue value, BasicValue expected )
+        {
+            return super.isSubTypeOf( value, expected ) || check
+                    .invokableInterface( expected.getType(), value.getType() );
+        }
+
+        private static Type superClass( ClassNode clazz )
+        {
+            return clazz.superName == null ? null : Type.getObjectType( clazz.superName );
+        }
+
+        @SuppressWarnings( "unchecked" )
+        private static List<Type> interfaces( ClassNode clazz )
+        {
+            List<Type> interfaces = new ArrayList<>( clazz.interfaces.size() );
+            for ( String iFace : (Iterable<String>) clazz.interfaces )
+            {
+                interfaces.add( Type.getObjectType( iFace ) );
+            }
+            return interfaces;
+        }
+    }
+
+    private static class AssignmentChecker
+    {
+        private final ClassLoader classpathLoader;
+        private final Map<Type,ClassNode> classes = new HashMap<>();
+
+        AssignmentChecker( ClassLoader classpathLoader, List<ClassNode> classes )
+        {
+            this.classpathLoader = classpathLoader;
+            for ( ClassNode node : classes )
+            {
+                this.classes.put( Type.getObjectType( node.name ), node );
+            }
+        }
+
+        boolean invokableInterface( Type target, Type value )
+        {
+            // this method allows a bit too much through,
+            // it really ought to only be used for the target type of INVOKEINTERFACE,
+            // since any object type is allowed as target for INVOKEINTERFACE,
+            // this allows fewer CHECKCAST instructions when using generics.
+            ClassNode targetNode = classes.get( target );
+            if ( targetNode != null )
+            {
+                if ( isInterfaceNode( targetNode ) )
+                {
+                    return value.getSort() == Type.OBJECT || value.getSort() == Type.ARRAY;
+                }
+                return false;
+            }
+            Class<?> targetClass = getClass( target );
+            if ( targetClass.isInterface() )
+            {
+                return value.getSort() == Type.OBJECT || value.getSort() == Type.ARRAY;
+            }
+            return false;
+        }
+
+        boolean isAssignableFrom( Type target, Type value )
+        {
+            if ( target.equals( value ) )
+            {
+                return true;
+            }
+            ClassNode targetNode = classes.get( target ), valueNode = classes.get( value );
+            if ( targetNode != null && valueNode == null )
+            {
+                // if the target is among the types we have generated and the value isn't, then
+                // the value type either doesn't exist, or it is defined in the class loader, and thus cannot
+                // be a subtype of the target type
+                return false;
+            }
+            else if ( valueNode != null )
+            {
+                return isAssignableFrom( target, valueNode );
+            }
+            else
+            {
+                return getClass( target ).isAssignableFrom( getClass( value ) );
+            }
+        }
+
+        private boolean isAssignableFrom( Type target, ClassNode value )
+        {
+            if ( value.superName != null && isAssignableFrom( target, Type.getObjectType( value.superName ) ) )
+            {
+                return true;
+            }
+            for ( String iFace : (Iterable<String>) value.interfaces )
+            {
+                if ( isAssignableFrom( target, Type.getObjectType( iFace ) ) )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private Class<?> getClass( Type type )
+        {
+            try
+            {
+                if ( type.getSort() == Type.ARRAY )
+                {
+                    return Class.forName( type.getDescriptor().replace( '/', '.' ), false, classpathLoader );
+                }
+                return Class.forName( type.getClassName(), false, classpathLoader );
+            }
+            catch ( ClassNotFoundException e )
+            {
+                throw new RuntimeException( e.toString() );
+            }
+        }
+    }
+
+    private static boolean isInterfaceNode( ClassNode clazz )
+    {
+        return (clazz.access & Opcodes.ACC_INTERFACE) != 0;
+    }
+}
+

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/BytecodeDiagnostic.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/BytecodeDiagnostic.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.codegen.bytecode;
+
+import java.util.Locale;
+import javax.tools.Diagnostic;
+
+class BytecodeDiagnostic implements Diagnostic<Void>
+{
+    private final String message;
+
+    BytecodeDiagnostic( String message )
+    {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage( Locale locale )
+    {
+        return message;
+    }
+
+    @Override
+    public Kind getKind()
+    {
+        return Kind.ERROR;
+    }
+
+    @Override
+    public Void getSource()
+    {
+        return null;
+    }
+
+    @Override
+    public long getPosition()
+    {
+        return NOPOS;
+    }
+
+    @Override
+    public long getStartPosition()
+    {
+        return NOPOS;
+    }
+
+    @Override
+    public long getEndPosition()
+    {
+        return NOPOS;
+    }
+
+    @Override
+    public long getLineNumber()
+    {
+        return NOPOS;
+    }
+
+    @Override
+    public long getColumnNumber()
+    {
+        return NOPOS;
+    }
+
+    @Override
+    public String getCode()
+    {
+        return null;
+    }
+}

--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/MethodByteCodeEmitter.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.codegen.bytecode;
 
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.function.Consumer;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
 
 import org.neo4j.codegen.Expression;
 import org.neo4j.codegen.ExpressionVisitor;
@@ -66,7 +66,7 @@ class MethodByteCodeEmitter implements MethodEmitter
     private final TypeReference base;
     private Deque<Block> stateStack = new LinkedList<>();
 
-    MethodByteCodeEmitter( ClassWriter classWriter, MethodDeclaration declaration, TypeReference base )
+    MethodByteCodeEmitter( ClassVisitor classVisitor, MethodDeclaration declaration, TypeReference base )
     {
         this.declaration = declaration;
         this.base = base;
@@ -75,11 +75,11 @@ class MethodByteCodeEmitter implements MethodEmitter
             TypeReference type = parameter.type();
             if ( type.isInnerClass() && !type.isArray() )
             {
-                classWriter.visitInnerClass( byteCodeName( type ), outerName( type ),
+                classVisitor.visitInnerClass( byteCodeName( type ), outerName( type ),
                         type.simpleName(), type.modifiers() );
             }
         }
-        this.methodVisitor = classWriter.visitMethod( ACC_PUBLIC, declaration.name(), desc( declaration ),
+        this.methodVisitor = classVisitor.visitMethod( ACC_PUBLIC, declaration.name(), desc( declaration ),
                 signature( declaration ), exceptions( declaration ) );
         this.methodVisitor.visitCode();
         this.expressionVisitor = new ByteCodeExpressionVisitor( this.methodVisitor );

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -1753,7 +1753,7 @@ public class CodeGenerationTest
         return MethodHandles.lookup().unreflect( target.getMethod( name, parameters ) );
     }
 
-    static MethodHandle instanceMethod( Object instance, String name, Class<?>... parameters ) throws Exception
+    public static MethodHandle instanceMethod( Object instance, String name, Class<?>... parameters ) throws Exception
     {
         return method( instance.getClass(), name, parameters ).bindTo( instance );
     }
@@ -1768,7 +1768,7 @@ public class CodeGenerationTest
         return MethodHandles.lookup().unreflectConstructor( target.getConstructor( parameters ) );
     }
 
-    private static final String PACKAGE = "org.neo4j.codegen.test";
+    public static final String PACKAGE = "org.neo4j.codegen.test";
     private CodeGenerator generator;
 
     ClassGenerator generateClass( String name, Class<?> firstInterface, Class<?>... more )

--- a/community/codegen/src/test/java/org/neo4j/codegen/bytecode/ByteCodeVerifierTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/bytecode/ByteCodeVerifierTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.codegen.bytecode;
+
+import org.junit.Test;
+
+import org.neo4j.codegen.ClassGenerator;
+import org.neo4j.codegen.ClassHandle;
+import org.neo4j.codegen.CodeBlock;
+import org.neo4j.codegen.CodeGenerator;
+import org.neo4j.codegen.CompilationFailureException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.codegen.CodeGenerationTest.PACKAGE;
+import static org.neo4j.codegen.CodeGenerator.generateCode;
+import static org.neo4j.codegen.Parameter.param;
+import static org.neo4j.codegen.bytecode.ByteCode.BYTECODE;
+import static org.neo4j.codegen.bytecode.ByteCode.VERIFY_GENERATED_BYTECODE;
+
+public class ByteCodeVerifierTest
+{
+    @Test
+    public void shouldVerifyBytecode() throws Throwable
+    {
+        // given
+        CodeGenerator generator = generateCode( BYTECODE, VERIFY_GENERATED_BYTECODE );
+
+        ClassHandle handle;
+        try ( ClassGenerator clazz = generator.generateClass( PACKAGE, "SimpleClass" );
+              CodeBlock code = clazz.generateMethod( Integer.class, "box", param( int.class, "value" ) ) )
+        {
+            handle = clazz.handle();
+            code.returns( code.load( "value" ) );
+        }
+
+        // when
+        try
+        {
+            handle.loadClass();
+            fail( "Should have thrown exception" );
+        }
+        // then
+        catch ( CompilationFailureException expected )
+        {
+            assertThat( expected.toString(), containsString( "box(I)" ) );
+        }
+    }
+}

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -49,6 +49,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <doclint-groups>none</doclint-groups>
+    <asm.version>5.2</asm.version>
   </properties>
 
   <build>
@@ -360,6 +361,21 @@
     <dependency>
       <groupId>net.sf.opencsv</groupId>
       <artifactId>opencsv</artifactId>
+    </dependency>
+
+    <!-- code generation testing -->
+
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>${asm.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>${asm.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- other -->

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedQueryStructure.scala
@@ -26,7 +26,7 @@ import java.util.stream.{DoubleStream, IntStream, LongStream}
 import org.neo4j.codegen.Expression.{constant, invoke, newInstance}
 import org.neo4j.codegen.MethodReference.constructorReference
 import org.neo4j.codegen.TypeReference._
-import org.neo4j.codegen.bytecode.ByteCode.BYTECODE
+import org.neo4j.codegen.bytecode.ByteCode.{BYTECODE, VERIFY_GENERATED_BYTECODE}
 import org.neo4j.codegen.source.SourceCode.SOURCECODE
 import org.neo4j.codegen.source.{SourceCode, SourceVisitor}
 import org.neo4j.codegen.{CodeGenerator, Parameter, _}
@@ -62,6 +62,9 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     }
     if(conf.showByteCode) {
       options += code.saveByteCode
+    }
+    if(getClass.desiredAssertionStatus()) {
+      options += VERIFY_GENERATED_BYTECODE
     }
     conf.saveSource.foreach(path => {
       options += SourceCode.sourceLocation(path)


### PR DESCRIPTION
This flag is enabled by default in tests through inspecting the assertion status on the GeneratedQueryStructure class. If assertions are enabled, the byte code verification will be enabled, otherwise it is not enabled. When running tests, assertions are enabled.

For example, if compiling a simple method that tries to use a primitive `int` where a boxed `java.lang.Integer` is expected, you will now get the following error message from the codegen library:

```
org.neo4j.codegen.CompilationFailureException: Compilation failed with 1 reported issues.
		Error at instruction 1: Expected an object reference, but found I
		in box(I)Ljava/lang/Integer;
		    00000 [SimpleClass I : -] :     ILOAD 1
		>>> 00001 [SimpleClass I : I] :     ARETURN
```

Where `>>>` marks the location where the error was detected.