### PR TITLE
support explicit halt() and make all() implicit

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/HaltFilter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/HaltFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.load_balancing.plugins.server_policies;
+
+import java.util.Set;
+
+import org.neo4j.causalclustering.load_balancing.filters.Filter;
+
+/**
+ * This filter is not meant for actual use. No more filters nor
+ * rules shall follow a halt.
+ *
+ * In actuality it is implemented by not putting the otherwise
+ * implicit all() rule at the end of a policy.
+ */
+class HaltFilter implements Filter<ServerInfo>
+{
+    public static final HaltFilter INSTANCE = new HaltFilter();
+
+    private HaltFilter()
+    {
+    }
+
+    @Override
+    public Set<ServerInfo> apply( Set<ServerInfo> data )
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/FilterConfigParserTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/FilterConfigParserTest.java
@@ -60,6 +60,18 @@ public class FilterConfigParserTest
                 "ta-gs(tag2)",
                 "tags(tag1),tags(tag2)",
                 "tags(tag1);;tags(tag2)",
+                "tags(tag1)+tags(tag2)",
+                "halt();tags(tag)",
+                "halt();halt()",
+                "tags(tag1);halt();tags(tag2)",
+                "tags(tag1);tags(tag2);halt();tags(tag3)",
+                "tags(tag1) -> halt()",
+                "halt() -> tags(tag1)",
+                "tags(tag1) -> tags(tag2) -> halt()",
+                "tags(tag1) -> halt() -> tags(tag2)",
+                "tags(tag)->all()",
+                "all()->all()",
+                "tags(A)->all()->tags(B)",
         };
 
         // when
@@ -82,45 +94,71 @@ public class FilterConfigParserTest
     {
         Object[][] validConfigs = {
                 {
-                        "min(2)",
-                        filter().min( 2 ).build()
+                        "min(2);",
+                        filter().min( 2 )
+                                .newRule().all() // implicit
+                                .build()
                 },
                 {
-                        "tags(5)",
-                        filter().tags( "5" ).build()
+                        "tags(5);",
+                        filter().tags( "5" )
+                                .newRule().all() // implicit
+                                .build()
                 },
                 {
-                        "tags(tagA)",
-                        filter().tags( "tagA" ).build()
+                        "all()",
+                        filter().all().build()
                 },
                 {
-                        "tags(tagA,tagB)",
+                        "all() -> tags(5);",
+                        filter().tags( "5" )
+                                .newRule().all() // implicit
+                                .build()
+                },
+                {
+                        "all() -> tags(5);all()",
+                        filter().tags( "5" )
+                                .newRule().all()
+                                .build()
+                },
+                {
+                        "all() -> tags(A); all() -> tags(B); halt()",
+                        filter().tags( "A" )
+                                .newRule().tags( "B" )
+                                .build()
+                },
+                {
+                        "tags(tagA);",
+                        filter().tags( "tagA" )
+                                .newRule().all() // implicit
+                                .build()
+                },
+                {
+                        "tags(tagA,tagB); halt()",
                         filter().tags( "tagA", "tagB" ).build()
                 },
                 {
-                        "tags ( tagA , tagB )",
+                        "tags ( tagA , tagB ); halt()",
                         filter().tags( "tagA", "tagB" ).build()
                 },
                 {
-                        "tags(tag1)->tags(tag2)",
+                        "tags(tag1)->tags(tag2); halt()",
                         filter().tags( "tag1" ).tags( "tag2" ).build()
                 },
                 {
-                        "tags(tag1)->tags(tag2);",
+                        "tags(tag1)->tags(tag2); halt();",
                         filter().tags( "tag1" ).tags( "tag2" ).build()
                 },
                 {
-                        "tags(tag1)->tags(tag2)->min(4); tags(tag3,tag4)->min(2);",
-                        filter()
-                                .tags( "tag1" ).tags( "tag2" ).min( 4 ).newRule()
-                                .tags( "tag3", "tag4" ).min( 2 ).build()
+                        "tags(tag1)->tags(tag2)->min(4); tags(tag3,tag4)->min(2); halt();",
+                        filter().tags( "tag1" ).tags( "tag2" ).min( 4 )
+                                .newRule().tags( "tag3", "tag4" ).min( 2 ).build()
                 },
                 {
-                        "tags(tag1,tag2,tag3,tag4)->min(2); tags(tag3,tag4); all()",
-                        filter()
-                                .tags( "tag1", "tag2", "tag3", "tag4" ).min( 2 ).newRule()
-                                .tags( "tag3", "tag4" ).newRule()
-                                .all()
+                        "tags(tag1,tag2,tag3,tag4)->min(2); tags(tag3,tag4);",
+                        filter().tags( "tag1", "tag2", "tag3", "tag4" ).min( 2 )
+                                .newRule().tags( "tag3", "tag4" )
+                                .newRule().all() // implicit
                                 .build()
                 }
         };

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/FilteringPolicyLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/FilteringPolicyLoaderTest.java
@@ -47,25 +47,31 @@ public class FilteringPolicyLoaderTest
                         "asia_west",
 
                         "tags(asia_west) -> min(2);" +
-                        "tags(asia) -> min(2);" +
-                        "all()",
+                        "tags(asia) -> min(2);",
 
                         filter().tags( "asia_west" ).min( 2 ).newRule()
                                 .tags( "asia" ).min( 2 ).newRule()
-                                .all()
+                                .all() // implicit
                                 .build()
                 },
                 {
                         "asia_east",
 
                         "tags(asia_east) -> min(2);" +
-                        "tags(asia) -> min(2);" +
-                        "all()",
+                        "tags(asia) -> min(2);",
 
                         filter().tags( "asia_east" ).min( 2 ).newRule()
                                 .tags( "asia" ).min( 2 ).newRule()
-                                .all()
+                                .all() // implicit
                                 .build()
+                },
+                {
+                        "asia_only",
+
+                        "tags(asia);" +
+                        "halt();",
+
+                        filter().tags( "asia" ).build()
                 },
         };
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
@@ -111,7 +111,7 @@ public class ServerPoliciesLoadBalancingIT
         Map<String,IntFunction<String>> instanceReplicaParams = new HashMap<>();
         instanceReplicaParams.put( CausalClusteringSettings.server_tags.name(), ( id ) -> "replica" + id + ",replica" );
 
-        String defaultPolicy = "tags(core) -> min(3); tags(replica1,replica2) -> min(2); all()";
+        String defaultPolicy = "tags(core) -> min(3); tags(replica1,replica2) -> min(2);";
 
         Map<String,String> coreParams = stringMap(
                 CausalClusteringSettings.cluster_allow_reads_on_followers.name(), "true",
@@ -157,7 +157,7 @@ public class ServerPoliciesLoadBalancingIT
         String defaultPolicySpec = "tags(replica0,replica1)";
         String policyOneTwoSpec = "tags(replica1,replica2)";
         String policyZeroTwoSpec = "tags(replica0,replica2)";
-        String policyAllReplicasSpec = "tags(replica)";
+        String policyAllReplicasSpec = "tags(replica); halt()";
         String allPolicySpec = "all()";
 
         Map<String,String> coreParams = stringMap(


### PR DESCRIPTION
The implicit fallback rule at the end of any policy will now
be all() servers unless it is explicitly prohibited using halt().

The rationale is that this is the common case.