### PR TITLE
Log stacktrace of bolt protocol violations

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
@@ -102,7 +102,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
         }
         catch ( BoltProtocolBreachFatality e )
         {
-            log.error( "Bolt protocol breach in session '" + machine.key() + "'" );
+            log.error( "Bolt protocol breach in session '" + machine.key() + "'", e );
         }
         catch ( Throwable t )
         {


### PR DESCRIPTION
Previously error logging of `BoltProtocolBreachFatality` did not include the stacktrace. This made is hard to investigate driver problems and incorrect messages. This commit adds stacktrace logging.