### PR TITLE
Composite uniqueness constraint enforcement on nodeSetProperty

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
@@ -96,4 +96,9 @@ public class LabelSchemaDescriptor implements SchemaDescriptor
     {
         return "LabelSchemaDescriptor( " + userDescription( SchemaUtil.idTokenNameLookup ) + " )";
     }
+
+    public interface Supplier extends SchemaDescriptor.Supplier
+    {
+        LabelSchemaDescriptor schema();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/OrderedPropertyValues.java
@@ -206,12 +206,4 @@ public class OrderedPropertyValues
         }
         return compare;
     };
-
-    public void validate()
-    {
-        for ( DefinedProperty p : properties )
-        {
-            Validators.INDEX_VALUE_VALIDATOR.validate( p.value() );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/UniquenessConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/UniquenessConstraintDescriptor.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
-public class UniquenessConstraintDescriptor extends ConstraintDescriptor
+public class UniquenessConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaDescriptor.Supplier
 {
     private final LabelSchemaDescriptor schema;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
-import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
 import static java.lang.String.format;
@@ -35,7 +34,7 @@ import static java.lang.String.format;
  * This will be renamed to IndexDescriptor, once the old org.neo4j.kernel.api.schema.IndexDescriptor is completely
  * removed.
  */
-public class NewIndexDescriptor implements SchemaDescriptor.Supplier
+public class NewIndexDescriptor implements LabelSchemaDescriptor.Supplier
 {
     public enum Type { GENERAL, UNIQUE }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -104,7 +104,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         this.entityReadOperations = entityReadOperations;
         this.schemaWriteOperations = schemaWriteOperations;
         this.schemaReadOperations = schemaReadOperations;
-        nodeSchemaMatcher = new NodeSchemaMatcher( entityReadOperations );
+        nodeSchemaMatcher = new NodeSchemaMatcher<>( entityReadOperations );
     }
 
     @Override
@@ -141,10 +141,10 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         {
             NodeItem node = cursor.get();
             Iterator<ConstraintDescriptor> constraints = getConstraintsForProperty( state, property.propertyKeyId() );
-            Iterator<UniquenessConstraintDescriptor> uniqueness =
+            Iterator<UniquenessConstraintDescriptor> uniquenessConstraints =
                     new CastingIterator<>( constraints, UniquenessConstraintDescriptor.class );
 
-            nodeSchemaMatcher.onMatchingSchema( state, uniqueness, node, property.propertyKeyId(),
+            nodeSchemaMatcher.onMatchingSchema( state, uniquenessConstraints, node, property.propertyKeyId(),
                     constraint -> {
                         validateNoExistingNodeWithExactValues( state, constraint,
                                 getAllPropertyValues( state, constraint.schema(), node, property ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -140,7 +140,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         try ( Cursor<NodeItem> cursor = nodeCursorById( state, nodeId ) )
         {
             NodeItem node = cursor.get();
-            Iterator<ConstraintDescriptor> constraints = getConstraintsForProperty( state, property.propertyKeyId() );
+            Iterator<ConstraintDescriptor> constraints = getConstraintsInvolvingProperty( state, property.propertyKeyId() );
             Iterator<UniquenessConstraintDescriptor> uniquenessConstraints =
                     new CastingIterator<>( constraints, UniquenessConstraintDescriptor.class );
 
@@ -155,7 +155,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         return entityWriteOperations.nodeSetProperty( state, nodeId, property );
     }
 
-    private Iterator<ConstraintDescriptor> getConstraintsForProperty( KernelStatement state, int propertyId )
+    private Iterator<ConstraintDescriptor> getConstraintsInvolvingProperty( KernelStatement state, int propertyId )
     {
         Iterator<ConstraintDescriptor> allConstraints = schemaReadOperations.constraintsGetAll( state );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1045,14 +1045,13 @@ public class StateHandlingStatementOperations implements
             if ( existingProperty == NO_SUCH_PROPERTY )
             {
                 state.txState().nodeDoAddProperty( node.id(), property );
-                indexTxStateUpdater.onPropertyChange( state, node, indexTxStateUpdater.add( property ) );
+                indexTxStateUpdater.onPropertyAdd( state, node, property );
                 return Property.noProperty( property.propertyKeyId(), EntityType.NODE, node.id() );
             }
             else
             {
                 state.txState().nodeDoChangeProperty( node.id(), existingProperty, property );
-                indexTxStateUpdater
-                        .onPropertyChange( state, node, indexTxStateUpdater.change( existingProperty, property ) );
+                indexTxStateUpdater.onPropertyChange( state, node, existingProperty, property );
                 return existingProperty;
             }
         }
@@ -1119,7 +1118,7 @@ public class StateHandlingStatementOperations implements
                     autoIndexing.nodes().propertyRemoved( ops, nodeId, propertyKeyId );
                     state.txState().nodeDoRemoveProperty( node.id(), existingProperty );
 
-                    indexTxStateUpdater.onPropertyChange( state, node, indexTxStateUpdater.remove( existingProperty ) );
+                    indexTxStateUpdater.onPropertyRemove( state, node, existingProperty );
                 }
             }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.schema;
+
+import java.util.Iterator;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
+import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
+import org.neo4j.storageengine.api.NodeItem;
+
+/**
+ * This class holds functionality to match LabelSchemaDescriptors to nodes
+ * @param <SUPPLIER> the type to match. Must implement LabelSchemaDescriptor.Supplier
+ */
+public class NodeSchemaMatcher<SUPPLIER extends LabelSchemaDescriptor.Supplier>
+{
+    private final EntityReadOperations readOps;
+
+    public NodeSchemaMatcher( EntityReadOperations readOps )
+    {
+        this.readOps = readOps;
+    }
+
+    /**
+     * Iterate over some schema suppliers, and invoke an action for every supplier that matches the node. To match the
+     * node N the supplier must supply a LabelSchemaDescriptor D, such that N has the label of D, and values for all
+     * the properties of D.
+     *
+     * To avoid unnecessary store lookups, this implementation only gets propertyKeyIds for the node if some
+     * descriptor has a valid label.
+     *
+     * @param state The current statement
+     * @param schemaSuppliers The suppliers to match
+     * @param node The node
+     * @param specialPropertyId This property id will always count as a match for the descriptor, regardless of
+     *                          whether the node has this property or not
+     * @param action The action to take on match
+     * @param <EXCEPTION> The type of exception that can be thrown when taking the action
+     * @throws EXCEPTION This exception is propagated from the action
+     */
+    public <EXCEPTION extends Exception> void onMatchingSchema(
+            KernelStatement state,
+            Iterator<SUPPLIER> schemaSuppliers,
+            NodeItem node,
+            int specialPropertyId,
+            SchemaMatchAction<SUPPLIER, EXCEPTION> action
+    ) throws EXCEPTION
+    {
+        PrimitiveIntSet nodePropertyIds = null;
+        while ( schemaSuppliers.hasNext() )
+        {
+            SUPPLIER schemaSupplier = schemaSuppliers.next();
+            LabelSchemaDescriptor schema = schemaSupplier.schema();
+            if ( node.labels().contains( schema.getLabelId() ) )
+            {
+                if ( nodePropertyIds == null )
+                {
+                    nodePropertyIds = Primitive.intSet();
+                    nodePropertyIds.addAll( readOps.nodeGetPropertyKeys( state, node ).iterator() );
+                }
+
+                if ( nodeHasSchemaProperties( nodePropertyIds, schema.getPropertyIds(), specialPropertyId ) )
+                {
+                    action.act( schemaSupplier );
+                }
+            }
+        }
+    }
+
+    private static boolean nodeHasSchemaProperties(
+            PrimitiveIntSet nodeProperties, int[] indexPropertyIds, int changedPropertyId )
+    {
+        for ( int indexPropertyId : indexPropertyIds )
+        {
+            if ( indexPropertyId != changedPropertyId && !nodeProperties.contains( indexPropertyId ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public interface SchemaMatchAction<SUPPLIER extends SchemaDescriptor.Supplier, EXCEPTION extends Exception>
+    {
+        void act( SUPPLIER schemaSupplier ) throws EXCEPTION;
+    }
+
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
@@ -33,9 +33,9 @@ import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
+import org.neo4j.kernel.impl.api.schema.NodeSchemaMatcher;
 import org.neo4j.storageengine.api.NodeItem;
 
-import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_PROPERTY_KEY;
 import static org.neo4j.kernel.api.properties.DefinedProperty.NO_SUCH_PROPERTY;
 import static org.neo4j.kernel.api.schema_new.SchemaDescriptorPredicates.hasProperty;
 
@@ -43,11 +43,13 @@ public class IndexTxStateUpdater
 {
     private final SchemaReadOperations schemaReadOps;
     private final EntityReadOperations readOps;
+    private final NodeSchemaMatcher<NewIndexDescriptor> nodeIndexMatcher;
 
     public IndexTxStateUpdater( SchemaReadOperations schemaReadOps, EntityReadOperations readOps )
     {
         this.schemaReadOps = schemaReadOps;
         this.readOps = readOps;
+        this.nodeIndexMatcher = new NodeSchemaMatcher<>( readOps );
     }
 
     // LABEL CHANGES
@@ -57,8 +59,8 @@ public class IndexTxStateUpdater
     public void onLabelChange( KernelStatement state, int labelId, NodeItem node, LabelChangeType changeType )
             throws EntityNotFoundException
     {
-        PrimitiveIntSet propertyIds = Primitive.intSet();
-        propertyIds.addAll( readOps.nodeGetPropertyKeys( state, node ).iterator() );
+        PrimitiveIntSet nodePropertyIds = Primitive.intSet();
+        nodePropertyIds.addAll( readOps.nodeGetPropertyKeys( state, node ).iterator() );
 
         Iterator<NewIndexDescriptor> indexes =
                 Iterators.concat(
@@ -68,9 +70,10 @@ public class IndexTxStateUpdater
         while ( indexes.hasNext() )
         {
             NewIndexDescriptor index = indexes.next();
-            OrderedPropertyValues values = valuesIfPropertiesMatch( state, propertyIds, index, node );
-            if ( values != null )
+            int[] indexPropertyIds = index.schema().getPropertyIds();
+            if ( nodeHasIndexProperties( nodePropertyIds, indexPropertyIds ) )
             {
+                OrderedPropertyValues values = getOrderedPropertyValues( state, node, indexPropertyIds );
                 if ( changeType == LabelChangeType.ADDED_LABEL )
                 {
                     state.txState().indexDoUpdateEntry( index.schema(), node.id(), null, values );
@@ -85,75 +88,44 @@ public class IndexTxStateUpdater
 
     // PROPERTY CHANGES
 
-    interface PropertyUpdate
+    public void onPropertyAdd( KernelStatement state, NodeItem node, DefinedProperty after )
+            throws EntityNotFoundException
     {
-        void updateIndexIfApplicable( KernelStatement state, NodeItem node, PrimitiveIntSet nodePropertyIds,
-                NewIndexDescriptor index ) throws EntityNotFoundException;
-
-        int propertyId();
+        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, after.propertyKeyId() );
+        nodeIndexMatcher.onMatchingSchema( state, indexes, node, after.propertyKeyId(),
+                index -> {
+                    OrderedPropertyValues values = getOrderedPropertyValues( state, node, after, index.schema().getPropertyIds() );
+                    if ( values != null )
+                    {
+                        values.validate();
+                        state.txState().indexDoUpdateEntry( index.schema(), node.id(), null, values );
+                    }
+                });
     }
 
-    public PropertyUpdate add( DefinedProperty after )
+    public void onPropertyRemove( KernelStatement state, NodeItem node, DefinedProperty before )
+            throws EntityNotFoundException
     {
-        return new PropertyUpdate()
-        {
-            @Override
-            public void updateIndexIfApplicable( KernelStatement state, NodeItem node,
-                    PrimitiveIntSet nodePropertyIds, NewIndexDescriptor index ) throws EntityNotFoundException
-            {
-                OrderedPropertyValues values = valuesIfPropertiesMatch(
-                        state, nodePropertyIds, index, node, after );
-                if ( values != null )
-                {
-                    values.validate();
-                    state.txState().indexDoUpdateEntry( index.schema(), node.id(), null, values );
-                }
-            }
-
-            @Override
-            public int propertyId()
-            {
-                return after.propertyKeyId();
-            }
-        };
+        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, before.propertyKeyId() );
+        nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
+                index -> {
+                    OrderedPropertyValues values = getOrderedPropertyValues( state, node, before, index.schema().getPropertyIds() );
+                    if ( values != null )
+                    {
+                        state.txState().indexDoUpdateEntry( index.schema(), node.id(), values, null );
+                    }
+                });
     }
 
-    public PropertyUpdate remove( DefinedProperty before )
-    {
-        return new PropertyUpdate()
-        {
-            @Override
-            public void updateIndexIfApplicable( KernelStatement state, NodeItem node,
-                    PrimitiveIntSet nodePropertyIds, NewIndexDescriptor index ) throws EntityNotFoundException
-            {
-                OrderedPropertyValues values = valuesIfPropertiesMatch( state, nodePropertyIds, index, node,
-                        before );
-                if ( values != null )
-                {
-                    state.txState().indexDoUpdateEntry( index.schema(), node.id(), values, null );
-                }
-            }
-
-            @Override
-            public int propertyId()
-            {
-                return before.propertyKeyId();
-            }
-        };
-    }
-
-    public PropertyUpdate change( DefinedProperty before, DefinedProperty after )
+    public void onPropertyChange( KernelStatement state, NodeItem node, DefinedProperty before, DefinedProperty after )
+            throws EntityNotFoundException
     {
         assert before.propertyKeyId() == after.propertyKeyId();
-        return new PropertyUpdate()
-        {
-            @Override
-            public void updateIndexIfApplicable( KernelStatement state, NodeItem node,
-                    PrimitiveIntSet nodePropertyIds, NewIndexDescriptor index ) throws EntityNotFoundException
-            {
-                int[] indexPropertyIds = index.schema().getPropertyIds();
-                if ( nodeHasIndexProperties( nodePropertyIds, indexPropertyIds ) )
-                {
+        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, before.propertyKeyId() );
+        nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
+                index -> {
+                    int[] indexPropertyIds = index.schema().getPropertyIds();
+
                     Object[] valuesBefore = new Object[indexPropertyIds.length];
                     Object[] valuesAfter = new Object[indexPropertyIds.length];
                     for ( int i = 0; i < indexPropertyIds.length; i++ )
@@ -173,54 +145,20 @@ public class IndexTxStateUpdater
                     }
                     state.txState().indexDoUpdateEntry( index.schema(), node.id(),
                             OrderedPropertyValues.ofUndefined( valuesBefore ), OrderedPropertyValues.ofUndefined( valuesAfter ) );
-                }
-            }
-
-            @Override
-            public int propertyId()
-            {
-                return before.propertyKeyId();
-            }
-        };
+                });
     }
 
-    public void onPropertyChange( KernelStatement state, NodeItem node, PropertyUpdate update )
-            throws EntityNotFoundException
-    {
-        PrimitiveIntSet nodePropertyIds = null;
-        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, update.propertyId() );
-        while ( indexes.hasNext() )
-        {
-            NewIndexDescriptor index = indexes.next();
-            LabelSchemaDescriptor schema = index.schema();
-            if ( node.labels().contains( schema.getLabelId() ) )
-            {
-                if ( nodePropertyIds == null )
-                {
-                    nodePropertyIds = Primitive.intSet();
-                    nodePropertyIds.addAll( readOps.nodeGetPropertyKeys( state, node ).iterator() );
-                }
+    // HELPERS
 
-                update.updateIndexIfApplicable( state, node, nodePropertyIds, index );
-            }
-        }
+    private OrderedPropertyValues getOrderedPropertyValues( KernelStatement state, NodeItem node,
+            int[] indexPropertyIds )
+    {
+        return getOrderedPropertyValues( state, node, NO_SUCH_PROPERTY, indexPropertyIds );
     }
 
-    private OrderedPropertyValues valuesIfPropertiesMatch( KernelStatement state, PrimitiveIntSet nodeProperties,
-            NewIndexDescriptor index, NodeItem node ) throws EntityNotFoundException
+    private OrderedPropertyValues getOrderedPropertyValues( KernelStatement state, NodeItem node,
+            DefinedProperty changedProperty, int[] indexPropertyIds )
     {
-        return valuesIfPropertiesMatch( state, nodeProperties, index, node, NO_SUCH_PROPERTY );
-    }
-
-    private OrderedPropertyValues valuesIfPropertiesMatch( KernelStatement state, PrimitiveIntSet nodeProperties,
-            NewIndexDescriptor index, NodeItem node, DefinedProperty changedProperty ) throws EntityNotFoundException
-    {
-        int[] indexPropertyIds = index.schema().getPropertyIds();
-        if ( !nodeHasIndexProperties( nodeProperties, indexPropertyIds, changedProperty.propertyKeyId() ) )
-        {
-            return null;
-        }
-
         DefinedProperty[] values = new DefinedProperty[indexPropertyIds.length];
         for ( int i = 0; i < values.length; i++ )
         {
@@ -235,15 +173,9 @@ public class IndexTxStateUpdater
 
     private static boolean nodeHasIndexProperties( PrimitiveIntSet nodeProperties, int[] indexPropertyIds )
     {
-        return nodeHasIndexProperties( nodeProperties, indexPropertyIds, NO_SUCH_PROPERTY_KEY );
-    }
-
-    private static boolean nodeHasIndexProperties(
-            PrimitiveIntSet nodeProperties, int[] indexPropertyIds, int changedPropertyId )
-    {
         for ( int indexPropertyId : indexPropertyIds )
         {
-            if ( indexPropertyId != changedPropertyId && !nodeProperties.contains( indexPropertyId ) )
+            if ( !nodeProperties.contains( indexPropertyId ) )
             {
                 return false;
             }
@@ -251,6 +183,8 @@ public class IndexTxStateUpdater
         return true;
     }
 
+    // Lifting this method to the schemaReadOps layer could allow more efficient finding of indexes, by introducing
+    // suitable maps in the SchemaCache. This can be done when we have a benchmarking reason.
     private Iterator<NewIndexDescriptor> getIndexesForProperty( KernelStatement state, int propertyId )
     {
         Iterator<NewIndexDescriptor> allIndexes =

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
@@ -95,10 +95,10 @@ public class IndexTxStateUpdater
     public void onPropertyAdd( KernelStatement state, NodeItem node, DefinedProperty after )
             throws EntityNotFoundException
     {
-        Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
         Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, after.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, after.propertyKeyId(),
                 index -> {
+                    Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
                     OrderedPropertyValues values =
                             getOrderedPropertyValues( state, node, after, index.schema().getPropertyIds() );
                     state.txState().indexDoUpdateEntry( index.schema(), node.id(), null, values );
@@ -121,10 +121,10 @@ public class IndexTxStateUpdater
             throws EntityNotFoundException
     {
         assert before.propertyKeyId() == after.propertyKeyId();
-        Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
         Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, before.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
                 index -> {
+                    Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
                     int[] indexPropertyIds = index.schema().getPropertyIds();
 
                     Object[] valuesBefore = new Object[indexPropertyIds.length];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
@@ -95,7 +95,7 @@ public class IndexTxStateUpdater
     public void onPropertyAdd( KernelStatement state, NodeItem node, DefinedProperty after )
             throws EntityNotFoundException
     {
-        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, after.propertyKeyId() );
+        Iterator<NewIndexDescriptor> indexes = getIndexesInvolvingProperty( state, after.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, after.propertyKeyId(),
                 index -> {
                     Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
@@ -108,7 +108,7 @@ public class IndexTxStateUpdater
     public void onPropertyRemove( KernelStatement state, NodeItem node, DefinedProperty before )
             throws EntityNotFoundException
     {
-        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, before.propertyKeyId() );
+        Iterator<NewIndexDescriptor> indexes = getIndexesInvolvingProperty( state, before.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
                 index -> {
                     OrderedPropertyValues values =
@@ -121,7 +121,7 @@ public class IndexTxStateUpdater
             throws EntityNotFoundException
     {
         assert before.propertyKeyId() == after.propertyKeyId();
-        Iterator<NewIndexDescriptor> indexes = getIndexesForProperty( state, before.propertyKeyId() );
+        Iterator<NewIndexDescriptor> indexes = getIndexesInvolvingProperty( state, before.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
                 index -> {
                     Validators.INDEX_VALUE_VALIDATOR.validate( after.value() );
@@ -200,7 +200,7 @@ public class IndexTxStateUpdater
 
     // Lifting this method to the schemaReadOps layer could allow more efficient finding of indexes, by introducing
     // suitable maps in the SchemaCache. This can be done when we have a benchmarking reason.
-    private Iterator<NewIndexDescriptor> getIndexesForProperty( KernelStatement state, int propertyId )
+    private Iterator<NewIndexDescriptor> getIndexesInvolvingProperty( KernelStatement state, int propertyId )
     {
         Iterator<NewIndexDescriptor> allIndexes =
                 Iterators.concat(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.integrationtest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.StatementTokenNameLookup;
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
+import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
+import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
+import org.neo4j.kernel.api.security.SecurityContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.api.CompositeIndexingIT.LABEL_ID;
+import static org.neo4j.kernel.api.properties.Property.property;
+import static org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory.forLabel;
+import static org.neo4j.test.assertion.Assert.assertException;
+
+@RunWith( Parameterized.class )
+public class CompositeUniquenessConstraintValidationIT extends KernelIntegrationTest
+{
+    @Rule
+    public final TestName testName = new TestName();
+
+    @Parameterized.Parameters( name = "Index: {0}" )
+    public static Iterable<Object[]> parameterValues() throws IOException
+    {
+        return Arrays.<Object[]>asList(
+                Iterators.array( "v1", "v2", "v1", "v2" ),
+                Iterators.array( 10, 20, 10, 20 ),
+                Iterators.array( 10L, 20L, 10, 20 ),
+                Iterators.array( 10, 20, 10L, 20L ),
+                Iterators.array( 10, 20, 10.0, 20.0 ),
+                Iterators.array( new int[]{1,2}, "v2", new int[]{1,2}, "v2" ),
+                Iterators.array( 'v', "v2", "v", "v2" )
+        );
+    }
+
+    private static final String prop1 = "key1";
+    private static final String prop2 = "key2";
+    private static final String label = "Label1";
+    private Statement statement;
+
+    private final Object valueA1;
+    private final Object valueA2;
+
+    private final Object valueB1;
+    private final Object valueB2;
+
+    public CompositeUniquenessConstraintValidationIT( Object valueA1, Object valueA2, Object valueB1, Object valueB2 )
+    {
+        this.valueA1 = valueA1;
+        this.valueA2 = valueA2;
+        this.valueB1 = valueB1;
+        this.valueB2 = valueB2;
+    }
+
+    @Test
+    public void shouldEnforceOnSetProperty() throws Exception
+    {
+        // given
+        constrainedNode( label, MapUtil.map( prop1, valueA1, prop2, valueA2 ) );
+
+        // when
+        newTransaction();
+        long node = createLabeledNode( label );
+        assertException( () -> {
+            setProperty( node, prop1, valueB1 ); // still ok
+            setProperty( node, prop2, valueB2 ); // boom!
+
+        }, UniquePropertyValueValidationException.class, "" );
+    }
+
+    @Test
+    public void shouldEnforceOnSetLabel() throws Exception
+    {
+        // given
+        constrainedNode( label, MapUtil.map( prop1, valueA1, prop2, valueA2 ) );
+
+        // when
+        newTransaction();
+        long node = createNode();
+        assertException( () -> {
+            setProperty( node, prop1, valueB1 ); // still ok
+            setProperty( node, prop2, valueB2 ); // and fine
+            addLabel( node, label ); // boom again
+
+        }, UniquePropertyValueValidationException.class, "" );
+    }
+
+    @Test
+    public void shouldEnforceOnSetPropertyInTx() throws Exception
+    {
+        // given
+        createConstraint( label, prop1, prop2 );
+
+        // when
+        newTransaction();
+        long nodeA = createLabeledNode( label );
+        setProperty( nodeA, prop1, valueA1 );
+        setProperty( nodeA, prop2, valueA2 );
+
+        long nodeB = createLabeledNode( label );
+        assertException( () -> {
+            setProperty( nodeB, prop1, valueB1 ); // still ok
+            setProperty( nodeB, prop2, valueB2 ); // boom!
+
+        }, UniquePropertyValueValidationException.class, "" );
+    }
+
+    @Test
+    public void shouldEnforceOnSetLabelInTx() throws Exception
+    {
+        // given
+        createConstraint( label, prop1, prop2 );
+
+        // when
+        newTransaction();
+        long nodeA = createLabeledNode( label );
+        setProperty( nodeA, prop1, valueA1 );
+        setProperty( nodeA, prop2, valueA2 );
+
+        long nodeB = createNode();
+        assertException( () -> {
+            setProperty( nodeB, prop1, valueB1 ); // still ok
+            setProperty( nodeB, prop2, valueB2 ); // and fine
+            addLabel( nodeB, label ); // boom again
+
+        }, UniquePropertyValueValidationException.class, "" );
+    }
+
+    private void newTransaction() throws KernelException
+    {
+        statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+    }
+
+    private long createLabeledNode( String label ) throws KernelException
+    {
+        long node = statement.dataWriteOperations().nodeCreate();
+        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label );
+        statement.dataWriteOperations().nodeAddLabel( node, labelId );
+        return node;
+    }
+
+    private void addLabel( long nodeId, String label ) throws KernelException
+    {
+        addLabel( nodeId, getLabelId( label ) );
+    }
+
+    private void addLabel( long nodeId, int labelId ) throws KernelException
+    {
+        statement.dataWriteOperations().nodeAddLabel( nodeId, labelId );
+    }
+
+    private void setProperty( long nodeId, int propertyId, Object value ) throws KernelException
+    {
+        statement.dataWriteOperations().nodeSetProperty( nodeId, property( propertyId, value ) );
+    }
+
+    private void setProperty( long nodeId, String propertyName, Object value ) throws KernelException
+    {
+        statement.dataWriteOperations().nodeSetProperty( nodeId, property( getPropertyId( propertyName ), value ) );
+    }
+
+    private long createNode() throws KernelException
+    {
+        return statement.dataWriteOperations().nodeCreate();
+    }
+
+    private long constrainedNode( String label, Map<String,Object> properties )
+            throws KernelException
+    {
+        newTransaction();
+        int labelId = getLabelId( label );
+        long nodeId = createNode();
+        addLabel( nodeId, labelId );
+        for ( Map.Entry<String,Object> entry : properties.entrySet() )
+        {
+            int propertyId = getPropertyId( entry.getKey() );
+            setProperty( nodeId, propertyId, entry.getValue() );
+        }
+        commit();
+
+        createConstraint( label, properties.keySet().toArray( new String[0] ) );
+        return nodeId;
+    }
+
+    private void createConstraint( String label, String... propertyNames ) throws KernelException
+    {
+        newTransaction();
+        int labelId = getLabelId( label );
+        int[] propertyIds =
+                Arrays.stream( propertyNames )
+                    .mapToInt( this::getPropertyId )
+                    .toArray();
+
+        commit();
+
+        newTransaction();
+        statement.schemaWriteOperations().uniquePropertyConstraintCreate( forLabel( labelId, propertyIds ) );
+        commit();
+    }
+
+    private int getLabelId( String label ) throws IllegalTokenNameException, TooManyLabelsException
+    {
+        return statement.tokenWriteOperations().labelGetOrCreateForName( label );
+    }
+
+    private int getPropertyId( String propertyName )
+    {
+        try
+        {
+            return statement.tokenWriteOperations().propertyKeyGetOrCreateForName( propertyName );
+        }
+        catch ( IllegalTokenNameException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -48,7 +48,7 @@ import static org.neo4j.kernel.api.schema_new.IndexQuery.exact;
 public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 {
     @Test
-    public void shouldEnforceUniquenessConstraintOnSetProperty() throws Exception
+    public void shouldEnforceOnSetProperty() throws Exception
     {
         // given
         constrainedNode( "Label1", "key1", "value1" );
@@ -162,31 +162,6 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         commit();
     }
 
-    private long createLabeledNode( Statement statement, String label ) throws KernelException
-    {
-        long node = statement.dataWriteOperations().nodeCreate();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label );
-        statement.dataWriteOperations().nodeAddLabel( node, labelId );
-        return node;
-    }
-
-    private long createNode( Statement statement, String key, Object value ) throws KernelException
-    {
-        long node = statement.dataWriteOperations().nodeCreate();
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
-        statement.dataWriteOperations().nodeSetProperty( node, property( propertyKeyId, value ) );
-        return node;
-    }
-
-    private long createLabeledNode( Statement statement, String label, String key, Object value )
-            throws KernelException
-    {
-        long node = createLabeledNode( statement, label );
-        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
-        statement.dataWriteOperations().nodeSetProperty( node, property( propertyKeyId, value ) );
-        return node;
-    }
-
     @Test
     public void shouldAllowRemoveAndAddConflictingDataInOneTransaction_RemoveLabel() throws Exception
     {
@@ -253,11 +228,6 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         {
             assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value2'" ) );
         }
-    }
-
-    private TokenNameLookup tokenLookup( Statement statement )
-    {
-        return new StatementTokenNameLookup( statement.readOperations() );
     }
 
     @Test
@@ -365,6 +335,36 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 
         // then I should find the original node
         assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, 1 ) ), equalTo( ourNode ));
+    }
+
+    private TokenNameLookup tokenLookup( Statement statement )
+    {
+        return new StatementTokenNameLookup( statement.readOperations() );
+    }
+
+    private long createLabeledNode( Statement statement, String label ) throws KernelException
+    {
+        long node = statement.dataWriteOperations().nodeCreate();
+        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label );
+        statement.dataWriteOperations().nodeAddLabel( node, labelId );
+        return node;
+    }
+
+    private long createNode( Statement statement, String key, Object value ) throws KernelException
+    {
+        long node = statement.dataWriteOperations().nodeCreate();
+        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
+        statement.dataWriteOperations().nodeSetProperty( node, property( propertyKeyId, value ) );
+        return node;
+    }
+
+    private long createLabeledNode( Statement statement, String label, String key, Object value )
+            throws KernelException
+    {
+        long node = createLabeledNode( statement, label );
+        int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( key );
+        statement.dataWriteOperations().nodeSetProperty( node, property( propertyKeyId, value ) );
+        return node;
     }
 
     private long constrainedNode( String labelName, String propertyKey, Object propertyValue )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcherTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.schema;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntCollections;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
+import org.neo4j.cursor.Cursor;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
+import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
+import org.neo4j.kernel.impl.api.state.StubCursors;
+import org.neo4j.storageengine.api.NodeItem;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.Iterators.iterator;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory.forLabel;
+
+public class NodeSchemaMatcherTest
+{
+
+    private static final int labelId1 = 10;
+    private static final int labelId2 = 11;
+    private static final int nonExistentLabelId = 12;
+    private static final int propId1 = 20;
+    private static final int propId2 = 21;
+    private static final int unIndexedPropId = 22;
+    private static final int nonExistentPropId = 23;
+    private static final int specialPropId = 24;
+
+    KernelStatement state;
+    NodeItem node;
+
+    NewIndexDescriptor index1 = forLabel( labelId1, propId1 );
+    NewIndexDescriptor index1_2 = forLabel( labelId1, propId1, propId2 );
+    NewIndexDescriptor indexWithMissingProperty = forLabel( labelId1, propId1, nonExistentPropId );
+    NewIndexDescriptor indexWithMissingLabel = forLabel( nonExistentLabelId, propId1, propId2 );
+    NewIndexDescriptor indexOnSpecialProperty = forLabel( labelId1, propId1, specialPropId );
+
+    private NodeSchemaMatcher<NewIndexDescriptor> nodeSchemaMatcher;
+
+    @Before
+    public void setup()
+    {
+        state = mock( KernelStatement.class );
+
+        PrimitiveIntSet labels = Primitive.intSet();
+        labels.add( labelId1 );
+
+        Cursor<NodeItem> nodeItemCursor = StubCursors.asNodeCursor( 0, labels );
+        nodeItemCursor.next();
+        node = nodeItemCursor.get();
+
+        PrimitiveIntSet defaultPropertyIds = PrimitiveIntCollections.asSet( new int[]{ propId1, propId2,
+                unIndexedPropId} );
+        EntityReadOperations readOps = mock( EntityReadOperations.class );
+        when( readOps.nodeGetPropertyKeys( state, node ) ).thenReturn( defaultPropertyIds );
+        when( readOps.nodeGetProperty( state, node, propId1 ) ).thenReturn( "hi1" );
+        when( readOps.nodeGetProperty( state, node, propId2 ) ).thenReturn( "hi2" );
+        when( readOps.nodeGetProperty( state, node, unIndexedPropId ) ).thenReturn( "hi3" );
+
+        nodeSchemaMatcher = new NodeSchemaMatcher<>( readOps );
+    }
+
+    @Test
+    public void shouldMatchOnSingleProperty()
+    {
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, iterator( index1 ), node, unIndexedPropId, matched::add );
+
+        // then
+        assertThat( matched, contains( index1 ) );
+    }
+
+    @Test
+    public void shouldMatchOnTwoProperties()
+    {
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, iterator( index1_2 ), node, unIndexedPropId, matched::add );
+
+        // then
+        assertThat( matched, contains( index1_2 ) );
+    }
+
+    @Test
+    public void shouldNotMatchIfNodeIsMissingProperty()
+    {
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, iterator( indexWithMissingProperty ), node, unIndexedPropId, matched::add );
+
+        // then
+        assertThat( matched, empty() );
+    }
+
+    @Test
+    public void shouldNotMatchIfNodeIsMissingLabel()
+    {
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, iterator( indexWithMissingLabel ), node, unIndexedPropId, matched::add );
+
+        // then
+        assertThat( matched, empty() );
+    }
+
+    @Test
+    public void shouldMatchOnSpecialProperty()
+    {
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, iterator( indexOnSpecialProperty ), node, specialPropId, matched::add );
+
+        // then
+        assertThat( matched, contains( indexOnSpecialProperty ) );
+    }
+
+    @Test
+    public void shouldMatchSeveralTimes()
+    {
+        // given
+        List<NewIndexDescriptor> indexes = Arrays.asList( index1, index1, index1_2, index1_2 );
+
+        // when
+        final List<NewIndexDescriptor> matched = new ArrayList<>();
+        nodeSchemaMatcher.onMatchingSchema(
+                state, indexes.iterator(), node, unIndexedPropId, matched::add );
+
+        // then
+        assertThat( matched, equalTo( indexes ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
@@ -161,10 +161,10 @@ public class IndexTxStateUpdaterTest
     public void shouldNotUpdateIndexesOnChangedIrrelevantProperty() throws EntityNotFoundException
     {
         // WHEN
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.add( property( unIndexedPropId, "whAt" ) ));
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.remove( property( unIndexedPropId, "whAt" ) ));
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.change(
-                property( unIndexedPropId, "whAt" ), property( unIndexedPropId, "whAt2" ) ));
+        indexTxUpdater.onPropertyAdd( state, node, property( unIndexedPropId, "whAt" ) );
+        indexTxUpdater.onPropertyRemove( state, node, property( unIndexedPropId, "whAt" ) );
+        indexTxUpdater.onPropertyChange( state, node,
+                property( unIndexedPropId, "whAt" ), property( unIndexedPropId, "whAt2" ) );
 
         // THEN
         verify( txState, times( 0 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
@@ -174,7 +174,7 @@ public class IndexTxStateUpdaterTest
     public void shouldUpdateIndexesOnAddedProperty() throws EntityNotFoundException
     {
         // WHEN
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.add( property( newPropId, "newHi" ) ));
+        indexTxUpdater.onPropertyAdd( state, node, property( newPropId, "newHi" ) );
 
         // THEN
         verifyIndexUpdate( indexOn2_new.schema(), node.id(), null, values( "newHi" ) );
@@ -186,7 +186,7 @@ public class IndexTxStateUpdaterTest
     public void shouldUpdateIndexesOnRemovedProperty() throws EntityNotFoundException
     {
         // WHEN
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.remove( property( propId2, "hi2" ) ));
+        indexTxUpdater.onPropertyRemove( state, node, property( propId2, "hi2" ) );
 
         // THEN
         verifyIndexUpdate( uniqueOn1_2.schema(), node.id(), values( "hi2" ), null );
@@ -198,8 +198,8 @@ public class IndexTxStateUpdaterTest
     public void shouldUpdateIndexesOnChangesProperty() throws EntityNotFoundException
     {
         // WHEN
-        indexTxUpdater.onPropertyChange( state, node, indexTxUpdater.change(
-                property( propId2, "hi2" ), property( propId2, "new2" ) ));
+        indexTxUpdater.onPropertyChange( state, node,
+                property( propId2, "hi2" ), property( propId2, "new2" ) );
 
         // THEN
         verifyIndexUpdate( uniqueOn1_2.schema(), node.id(), values( "hi2" ), values( "new2" ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
@@ -30,6 +30,7 @@ import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -39,6 +40,7 @@ import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.storageengine.api.NodeItem;
+import org.neo4j.storageengine.api.PropertyItem;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -111,6 +113,10 @@ public class IndexTxStateUpdaterTest
         PrimitiveIntSet defaultPropertyIds = PrimitiveIntCollections.asSet( new int[]{ propId1, propId2, propId3 } );
         EntityReadOperations readOps = mock( EntityReadOperations.class );
         when( readOps.nodeGetPropertyKeys( state, node ) ).thenReturn( defaultPropertyIds );
+        when( readOps.nodeGetProperties( state, node ) ).thenAnswer( p -> StubCursors.asPropertyCursor(
+                Property.property( propId1, "hi1" ),
+                Property.property( propId2, "hi2" ),
+                Property.property( propId3, "hi3" ) ) );
         when( readOps.nodeGetProperty( state, node, propId1 ) ).thenReturn( "hi1" );
         when( readOps.nodeGetProperty( state, node, propId2 ) ).thenReturn( "hi2" );
         when( readOps.nodeGetProperty( state, node, propId3 ) ).thenReturn( "hi3" );


### PR DESCRIPTION
Enforce composite uniqueness constrains on nodeSetProperty. 

This PR introduces the new class `NodeSchemaMatcher` that finds indexes or constraints that are valid for a node. This class is now used to find the relevant uniqueness constraints when setting a property, and the relevant indexes to update in the TxState.

Composite uniqueness constraints were already enforced on nodeAddLabel, but this PR adds some tests to verify this behaviour.