### PR TITLE
Add page cache hit metric into query profile report

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
@@ -41,6 +41,7 @@ class ExecutionPlanConverter
             ExecutionPlanDescription.ProfilerStatistics profile = plan.getProfilerStatistics();
             out.put( "dbHits", profile.getDbHits() );
             out.put( "pageCacheHits", profile.getPageCacheHits() );
+            out.put( "pageCacheMisses", profile.getPageCacheMisses() );
             out.put( "rows", profile.getRows() );
         }
         return out;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverter.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.bolt.v1.runtime;
 
-import org.neo4j.graphdb.ExecutionPlanDescription;
-
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import org.neo4j.graphdb.ExecutionPlanDescription;
 
 /** Takes execution plans and converts them to the subset of types used in the Neo4j type system */
 class ExecutionPlanConverter
@@ -40,6 +40,7 @@ class ExecutionPlanConverter
         {
             ExecutionPlanDescription.ProfilerStatistics profile = plan.getProfilerStatistics();
             out.put( "dbHits", profile.getDbHits() );
+            out.put( "pageCacheHits", profile.getPageCacheHits() );
             out.put( "rows", profile.getRows() );
         }
         return out;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/CypherAdapterStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/CypherAdapterStreamTest.java
@@ -21,16 +21,6 @@ package org.neo4j.bolt.v1.runtime;
 
 import org.junit.Test;
 
-import org.neo4j.bolt.v1.runtime.spi.Record;
-import org.neo4j.bolt.v1.runtime.spi.BoltResult;
-import org.neo4j.graphdb.ExecutionPlanDescription;
-import org.neo4j.graphdb.InputPosition;
-import org.neo4j.graphdb.Notification;
-import org.neo4j.graphdb.QueryStatistics;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.impl.notification.NotificationCode;
-import org.neo4j.kernel.impl.query.TransactionalContext;
-
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +29,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.neo4j.bolt.v1.runtime.spi.BoltResult;
+import org.neo4j.bolt.v1.runtime.spi.Record;
+import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.InputPosition;
+import org.neo4j.graphdb.Notification;
+import org.neo4j.graphdb.QueryStatistics;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.impl.notification.NotificationCode;
+import org.neo4j.kernel.impl.query.TransactionalContext;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -139,8 +139,8 @@ public class CypherAdapterStreamTest
         when( result.getQueryStatistics() ).thenReturn( queryStatistics );
         when( result.getNotifications() ).thenReturn( Collections.emptyList() );
         when( result.getExecutionPlanDescription() ).thenReturn(
-                plan( "Join", map( "arg1", 1 ), 2, 1, singletonList( "id1" ),
-                        plan( "Scan", map( "arg2", 1 ), 2, 1, singletonList( "id2" ) ) ) );
+                plan( "Join", map( "arg1", 1 ), 2, 4, 1, singletonList( "id1" ),
+                        plan( "Scan", map( "arg2", 1 ), 2, 4, 1, singletonList( "id2" ) ) ) );
 
         TransactionalContext tc = mock( TransactionalContext.class );
         CypherAdapterStream stream = new CypherAdapterStream( result, Clock.systemUTC() );
@@ -149,7 +149,9 @@ public class CypherAdapterStreamTest
         Map<String,Object> meta = metadataOf( stream );
 
         // Then
-        assertThat( meta.get( "profile" ).toString(), equalTo( "{args={arg1=1}, children=[{args={arg2=1}, children=[], dbHits=2, identifiers=[id2], operatorType=Scan, rows=1}], dbHits=2, identifiers=[id1], operatorType=Join, rows=1}" ));
+        assertThat( meta.get( "profile" ).toString(), equalTo( "{args={arg1=1}, children=[{args={arg2=1}, " +
+                "children=[], dbHits=2, identifiers=[id2], operatorType=Scan, rows=1, pageCacheHits=4}], dbHits=2, " +
+                "identifiers=[id1], operatorType=Join, rows=1, pageCacheHits=4}" ));
     }
 
     @Test
@@ -200,7 +202,9 @@ public class CypherAdapterStreamTest
         return meta;
     }
 
-    private static ExecutionPlanDescription plan( final String name, final Map<String, Object> args, final long dbHits, final long rows, final List<String> identifiers, final ExecutionPlanDescription ... children )
+    private static ExecutionPlanDescription plan( final String name, final Map<String, Object> args, final long dbHits,
+            final long pageCacheHits, final long rows, final List<String> identifiers,
+            final ExecutionPlanDescription... children )
     {
         return plan( name, args, identifiers, new ExecutionPlanDescription.ProfilerStatistics()
         {
@@ -214,6 +218,12 @@ public class CypherAdapterStreamTest
             public long getDbHits()
             {
                 return dbHits;
+            }
+
+            @Override
+            public long getPageCacheHits()
+            {
+                return pageCacheHits;
             }
         }, children );
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.helpers.collection.MapUtil;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExecutionPlanConverterTest
+{
+
+    @Test
+    public void profileStatisticConversion() throws Exception
+    {
+        Map<String,Object> convertedMap = ExecutionPlanConverter.convert(
+                new TestExecutionPlanDescription( "description", getProfilerStatistics(), getIdentifiers(),
+                        getArguments() ) );
+        assertEquals( convertedMap.get( "operatorType" ), "description" );
+        assertEquals( convertedMap.get( "args" ), getArguments() );
+        assertEquals( convertedMap.get( "identifiers" ), getIdentifiers() );
+        assertEquals( convertedMap.get( "children" ), Collections.emptyList() );
+        assertEquals( convertedMap.get( "rows" ), 1L );
+        assertEquals( convertedMap.get( "dbHits" ), 2L );
+        assertEquals( convertedMap.get( "pageCacheHits" ), 3L );
+        assertEquals( convertedMap.size(), 7 );
+    }
+
+    private Map<String,Object> getArguments()
+    {
+        return MapUtil.map( "argKey", "argValue" );
+    }
+
+    private Set<String> getIdentifiers()
+    {
+        return Iterators.asSet("identifier1", "identifier2");
+    }
+
+    private TestProfilerStatistics getProfilerStatistics()
+    {
+        return new TestProfilerStatistics( 1, 2, 3 );
+    }
+
+    private class TestExecutionPlanDescription implements ExecutionPlanDescription
+    {
+
+        private final String name;
+        private final ProfilerStatistics profilerStatistics;
+        private final Set<String> identifiers;
+        private final Map<String,Object> arguments;
+
+        public TestExecutionPlanDescription( String name, ProfilerStatistics profilerStatistics,
+                Set<String> identifiers, Map<String,Object> arguments )
+        {
+            this.name = name;
+            this.profilerStatistics = profilerStatistics;
+            this.identifiers = identifiers;
+            this.arguments = arguments;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public List<ExecutionPlanDescription> getChildren()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Map<String,Object> getArguments()
+        {
+            return arguments;
+        }
+
+        @Override
+        public Set<String> getIdentifiers()
+        {
+            return identifiers;
+        }
+
+        @Override
+        public boolean hasProfilerStatistics()
+        {
+            return profilerStatistics != null;
+        }
+
+        @Override
+        public ProfilerStatistics getProfilerStatistics()
+        {
+            return profilerStatistics;
+        }
+    }
+
+    private class TestProfilerStatistics implements ExecutionPlanDescription.ProfilerStatistics
+    {
+
+        private final long rows;
+        private final long dbHits;
+        private final long pageCacheHits;
+
+        private TestProfilerStatistics( long rows, long dbHits, long pageCacheHits )
+        {
+            this.rows = rows;
+            this.dbHits = dbHits;
+            this.pageCacheHits = pageCacheHits;
+        }
+
+        @Override
+        public long getRows()
+        {
+            return rows;
+        }
+
+        @Override
+        public long getDbHits()
+        {
+            return dbHits;
+        }
+
+        @Override
+        public long getPageCacheHits()
+        {
+            return pageCacheHits;
+        }
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
@@ -75,8 +75,8 @@ public class ExecutionPlanConverterTest
         private final Set<String> identifiers;
         private final Map<String,Object> arguments;
 
-        public TestExecutionPlanDescription( String name, ProfilerStatistics profilerStatistics,
-                Set<String> identifiers, Map<String,Object> arguments )
+        TestExecutionPlanDescription( String name, ProfilerStatistics profilerStatistics, Set<String> identifiers,
+                Map<String,Object> arguments )
         {
             this.name = name;
             this.profilerStatistics = profilerStatistics;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ExecutionPlanConverterTest.java
@@ -48,7 +48,8 @@ public class ExecutionPlanConverterTest
         assertEquals( convertedMap.get( "rows" ), 1L );
         assertEquals( convertedMap.get( "dbHits" ), 2L );
         assertEquals( convertedMap.get( "pageCacheHits" ), 3L );
-        assertEquals( convertedMap.size(), 7 );
+        assertEquals( convertedMap.get( "pageCacheMisses" ), 2L );
+        assertEquals( convertedMap.size(), 8 );
     }
 
     private Map<String,Object> getArguments()
@@ -63,7 +64,7 @@ public class ExecutionPlanConverterTest
 
     private TestProfilerStatistics getProfilerStatistics()
     {
-        return new TestProfilerStatistics( 1, 2, 3 );
+        return new TestProfilerStatistics( 1, 2, 3, 2 );
     }
 
     private class TestExecutionPlanDescription implements ExecutionPlanDescription
@@ -126,12 +127,14 @@ public class ExecutionPlanConverterTest
         private final long rows;
         private final long dbHits;
         private final long pageCacheHits;
+        private final long pageCacheMisses;
 
-        private TestProfilerStatistics( long rows, long dbHits, long pageCacheHits )
+        private TestProfilerStatistics( long rows, long dbHits, long pageCacheHits, long pageCacheMisses )
         {
             this.rows = rows;
             this.dbHits = dbHits;
             this.pageCacheHits = pageCacheHits;
+            this.pageCacheMisses = pageCacheMisses;
         }
 
         @Override
@@ -150,6 +153,12 @@ public class ExecutionPlanConverterTest
         public long getPageCacheHits()
         {
             return pageCacheHits;
+        }
+
+        @Override
+        public long getPageCacheMisses()
+        {
+            return pageCacheMisses;
         }
     }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/InternalPlanDescription.scala
@@ -77,6 +77,7 @@ object InternalPlanDescription {
     case class Rows(value: Long) extends Argument
     case class DbHits(value: Long) extends Argument
     case class PageCacheHits(value: Long) extends Argument
+    case class PageCacheMisses(value: Long) extends Argument
     case class ColumnsLeft(value: Seq[String]) extends Argument
     case class Expression(value: ast.Expression) extends Argument
     case class Expressions(expressions: Map[String, ast.Expression]) extends Argument
@@ -209,6 +210,7 @@ final case class CompactedPlanDescription(similar: Seq[InternalPlanDescription])
   override val arguments: Seq[Argument] = {
     var dbHits: Option[Long] = None
     var pageCacheHits: Option[Long] = None
+    var pageCacheMisses: Option[Long] = None
     var time: Option[Long] = None
     var rows: Option[Long] = None
 
@@ -217,12 +219,13 @@ final case class CompactedPlanDescription(similar: Seq[InternalPlanDescription])
         val args = plan.arguments.filter {
           case DbHits(v) => dbHits = Some(dbHits.map(_ + v).getOrElse(v)); false
           case PageCacheHits(v) => pageCacheHits = Some(pageCacheHits.map(_ + v).getOrElse(v)); false
+          case PageCacheMisses(v) => pageCacheMisses = Some(pageCacheMisses.map(_ + v).getOrElse(v)); false
           case Time(v) => time = Some(time.map(_ + v).getOrElse(v)); false
           case Rows(v) => rows = Some(rows.map(o => Math.max(o, v)).getOrElse(v)); false
           case _ => true
         }
         acc ++ args
-    }.toIndexedSeq ++ dbHits.map(DbHits.apply) ++ pageCacheHits.map(PageCacheHits.apply) ++ time.map(Time.apply) ++ rows.map(Rows.apply)
+    }.toIndexedSeq ++ dbHits.map(DbHits.apply) ++ pageCacheHits.map(PageCacheHits.apply) ++ pageCacheMisses.map(PageCacheMisses.apply) ++ time.map(Time.apply) ++ rows.map(Rows.apply)
   }
 
   override def find(name: String): Seq[InternalPlanDescription] = similar.last.find(name)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planDescription
 
-import org.neo4j.cypher.internal.frontend.v3_2.helpers.UnNamedNameGenerator._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.UnNamedNameGenerator._
 
 
 object PlanDescriptionArgumentSerializer {
@@ -46,6 +46,7 @@ object PlanDescriptionArgumentSerializer {
       case KeyNames(keys) => keys.map(removeGeneratedNames).mkString(SEPARATOR)
       case KeyExpressions(expressions) => expressions.mkString(SEPARATOR)
       case DbHits(value) => Long.box(value)
+      case PageCacheHits(value) => Long.box(value)
       case _: EntityByIdRhs => arg.toString
       case Rows(value) => Long.box(value)
       case Time(value) => Long.box(value)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -47,6 +47,7 @@ object PlanDescriptionArgumentSerializer {
       case KeyExpressions(expressions) => expressions.mkString(SEPARATOR)
       case DbHits(value) => Long.box(value)
       case PageCacheHits(value) => Long.box(value)
+      case PageCacheMisses(value) => Long.box(value)
       case _: EntityByIdRhs => arg.toString
       case Rows(value) => Long.box(value)
       case Time(value) => Long.box(value)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/renderAsTreeTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/renderAsTreeTable.scala
@@ -29,11 +29,12 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
   private val ESTIMATED_ROWS = "Estimated Rows"
   private val ROWS = "Rows"
   private val HITS = "DB Hits"
+  private val PAGE_CACHE_HITS = "Page Cache Hits"
   private val TIME = "Time (ms)"
   val VARIABLES = "Variables"
   val MAX_VARIABLE_COLUMN_WIDTH = 100
   private val OTHER = "Other"
-  private val HEADERS = Seq(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, TIME, VARIABLES, OTHER)
+  private val HEADERS = Seq(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, PAGE_CACHE_HITS, TIME, VARIABLES, OTHER)
   private val newLine = System.lineSeparator()
 
   def apply(plan: InternalPlanDescription): String = {
@@ -130,6 +131,7 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
     case EstimatedRows(count) => mapping(ESTIMATED_ROWS, Right(format(count)))
     case Rows(count) => mapping(ROWS, Right(count.toString))
     case DbHits(count) => mapping(HITS, Right(count.toString))
+    case PageCacheHits(count) => mapping(PAGE_CACHE_HITS, Right(count.toString))
     case Time(nanos) => mapping(TIME, Right("%.3f".format(nanos/1000000.0)))
     case _ => None
   }.toMap + (
@@ -148,6 +150,7 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
     description.arguments.collect { case x
       if !x.isInstanceOf[Rows] &&
         !x.isInstanceOf[DbHits] &&
+        !x.isInstanceOf[PageCacheHits] &&
         !x.isInstanceOf[EstimatedRows] &&
         !x.isInstanceOf[Planner] &&
         !x.isInstanceOf[PlannerImpl] &&

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/renderAsTreeTable.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/renderAsTreeTable.scala
@@ -30,11 +30,12 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
   private val ROWS = "Rows"
   private val HITS = "DB Hits"
   private val PAGE_CACHE_HITS = "Page Cache Hits"
+  private val PAGE_CACHE_MISSES = "Page Cache Misses"
   private val TIME = "Time (ms)"
   val VARIABLES = "Variables"
   val MAX_VARIABLE_COLUMN_WIDTH = 100
   private val OTHER = "Other"
-  private val HEADERS = Seq(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, PAGE_CACHE_HITS, TIME, VARIABLES, OTHER)
+  private val HEADERS = Seq(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, PAGE_CACHE_HITS, PAGE_CACHE_MISSES, TIME, VARIABLES, OTHER)
   private val newLine = System.lineSeparator()
 
   def apply(plan: InternalPlanDescription): String = {
@@ -132,6 +133,7 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
     case Rows(count) => mapping(ROWS, Right(count.toString))
     case DbHits(count) => mapping(HITS, Right(count.toString))
     case PageCacheHits(count) => mapping(PAGE_CACHE_HITS, Right(count.toString))
+    case PageCacheMisses(count) => mapping(PAGE_CACHE_MISSES, Right(count.toString))
     case Time(nanos) => mapping(TIME, Right("%.3f".format(nanos/1000000.0)))
     case _ => None
   }.toMap + (
@@ -151,6 +153,7 @@ object renderAsTreeTable extends (InternalPlanDescription => String) {
       if !x.isInstanceOf[Rows] &&
         !x.isInstanceOf[DbHits] &&
         !x.isInstanceOf[PageCacheHits] &&
+        !x.isInstanceOf[PageCacheMisses] &&
         !x.isInstanceOf[EstimatedRows] &&
         !x.isInstanceOf[Planner] &&
         !x.isInstanceOf[PlannerImpl] &&

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{Expander, K
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -210,6 +211,8 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   override def detachDeleteNode(node: Node): Int = manyDbHits(inner.detachDeleteNode(node))
 
   override def assertSchemaWritesAllowed(): Unit = inner.assertSchemaWritesAllowed()
+
+  override def pageCursorTracer(): PageCursorTracer = inner.pageCursorTracer()
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{Expander, K
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -212,7 +211,7 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   override def assertSchemaWritesAllowed(): Unit = inner.assertSchemaWritesAllowed()
 
-  override def pageCursorTracer(): PageCursorTracer = inner.pageCursorTracer()
+  override def kernelStatisticProvider(): KernelStatisticProvider = inner.kernelStatisticProvider()
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/KernelStatisticProvider.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/KernelStatisticProvider.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.spi
+
+/**
+  * Expose various query execution kernel statistics
+  */
+trait KernelStatisticProvider {
+  /**
+    * @return observed page cache hits that was caused by particular query execution
+    */
+  def getPageCacheHits: Long
+
+  /**
+    * @return observer page cache misses that was caused by particular query execution
+    */
+  def getPageCacheMisses: Long
+}
+
+object EmptyKernelStatisticProvider extends KernelStatisticProvider {
+  override def getPageCacheHits: Long = 0
+
+  override def getPageCacheMisses: Long = 0
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v3_2.{IndexDescriptor, InternalQueryStatistics}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -180,7 +179,7 @@ trait QueryContext extends TokenContext {
 
   def assertSchemaWritesAllowed(): Unit
 
-  def pageCursorTracer() : PageCursorTracer
+  def kernelStatisticProvider() : KernelStatisticProvider
 }
 
 trait Operations[T <: PropertyContainer] {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v3_2.{IndexDescriptor, InternalQueryStatistics}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -179,6 +180,7 @@ trait QueryContext extends TokenContext {
 
   def assertSchemaWritesAllowed(): Unit
 
+  def pageCursorTracer() : PageCursorTracer
 }
 
 trait Operations[T <: PropertyContainer] {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/builders/EntityProducerFactoryTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/builders/EntityProducerFactoryTest.scala
@@ -25,12 +25,11 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_2.commands._
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.QueryStateHelper
-import org.neo4j.cypher.internal.compiler.v3_2.spi.{PlanContext, QueryContext, QueryContextAdaptation}
+import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionContext, IndexDescriptor}
 import org.neo4j.cypher.internal.frontend.v3_2.IndexHintException
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.Node
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 class EntityProducerFactoryTest extends CypherFunSuite {
   var planContext: PlanContext = null
@@ -87,8 +86,8 @@ class EntityProducerFactoryTest extends CypherFunSuite {
         Iterator.empty
       }
 
-      override def pageCursorTracer(): PageCursorTracer = {
-        PageCursorTracer.NULL
+      override def kernelStatisticProvider(): KernelStatisticProvider = {
+        EmptyKernelStatisticProvider
       }
     }
     val state = QueryStateHelper.emptyWith(query = queryContext)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/builders/EntityProducerFactoryTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/builders/EntityProducerFactoryTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionContext, IndexDescripto
 import org.neo4j.cypher.internal.frontend.v3_2.IndexHintException
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.Node
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 class EntityProducerFactoryTest extends CypherFunSuite {
   var planContext: PlanContext = null
@@ -84,6 +85,10 @@ class EntityProducerFactoryTest extends CypherFunSuite {
       override def indexSeek(index: IndexDescriptor, values: Seq[Any]): Iterator[Node] = {
         seenValues = values
         Iterator.empty
+      }
+
+      override def pageCursorTracer(): PageCursorTracer = {
+        PageCursorTracer.NULL
       }
     }
     val state = QueryStateHelper.emptyWith(query = queryContext)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.cypher.internal.frontend.v3_2.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 class ProcedureCallPipeTest
   extends CypherFunSuite
@@ -130,5 +131,8 @@ class ProcedureCallPipeTest
       result(args)
     }
 
+    override def pageCursorTracer(): PageCursorTracer =  {
+      PageCursorTracer.NULL
+    }
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.cypher.internal.frontend.v3_2.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 class ProcedureCallPipeTest
   extends CypherFunSuite
@@ -131,8 +130,8 @@ class ProcedureCallPipeTest
       result(args)
     }
 
-    override def pageCursorTracer(): PageCursorTracer =  {
-      PageCursorTracer.NULL
+    override def kernelStatisticProvider(): KernelStatisticProvider =  {
+      EmptyKernelStatisticProvider
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderTreeTableTest.scala
@@ -156,47 +156,53 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
     val leaf1 = PlanDescriptionImpl(new Id, "LEAF1", NoChildren, Seq(
       Rows(42),
       DbHits(33),
+      PageCacheHits(1),
       EstimatedRows(1)), Set())
     val leaf2 = PlanDescriptionImpl(new Id, "LEAF2", NoChildren, Seq(
       Rows(9),
       DbHits(2),
+      PageCacheHits(2),
       EstimatedRows(1)), Set())
     val leaf3 = PlanDescriptionImpl(new Id, "LEAF3", NoChildren, Seq(
       Rows(9),
       DbHits(2),
+      PageCacheHits(3),
       EstimatedRows(1)), Set())
     val pass = PlanDescriptionImpl(new Id, "PASS", SingleChild(leaf2), Seq(
       Rows(4),
       DbHits(0),
+      PageCacheHits(4),
       EstimatedRows(4)), Set())
     val inner = PlanDescriptionImpl(new Id, "INNER", TwoChildren(leaf1, pass), Seq(
       Rows(7),
       DbHits(42),
+      PageCacheHits(5),
       EstimatedRows(6)), Set())
     val plan = PlanDescriptionImpl(new Id, "ROOT", TwoChildren(leaf3, inner), Seq(
       Rows(3),
       DbHits(0),
+      PageCacheHits(7),
       EstimatedRows(1)), Set())
     val parent = PlanDescriptionImpl(new Id, "PARENT", SingleChild(plan), Seq(), Set())
 
     renderAsTreeTable(parent) should equal(
-      """+------------+----------------+------+---------+
-        || Operator   | Estimated Rows | Rows | DB Hits |
-        |+------------+----------------+------+---------+
-        || +PARENT    |                |      |         |
-        || |          +----------------+------+---------+
-        || +ROOT      |              1 |    3 |       0 |
-        || |\         +----------------+------+---------+
-        || | +INNER   |              6 |    7 |      42 |
-        || | |\       +----------------+------+---------+
-        || | | +PASS  |              4 |    4 |       0 |
-        || | | |      +----------------+------+---------+
-        || | | +LEAF2 |              1 |    9 |       2 |
-        || | |        +----------------+------+---------+
-        || | +LEAF1   |              1 |   42 |      33 |
-        || |          +----------------+------+---------+
-        || +LEAF3     |              1 |    9 |       2 |
-        |+------------+----------------+------+---------+
+      """+------------+----------------+------+---------+-----------------+
+        || Operator   | Estimated Rows | Rows | DB Hits | Page Cache Hits |
+        |+------------+----------------+------+---------+-----------------+
+        || +PARENT    |                |      |         |                 |
+        || |          +----------------+------+---------+-----------------+
+        || +ROOT      |              1 |    3 |       0 |               7 |
+        || |\         +----------------+------+---------+-----------------+
+        || | +INNER   |              6 |    7 |      42 |               5 |
+        || | |\       +----------------+------+---------+-----------------+
+        || | | +PASS  |              4 |    4 |       0 |               4 |
+        || | | |      +----------------+------+---------+-----------------+
+        || | | +LEAF2 |              1 |    9 |       2 |               2 |
+        || | |        +----------------+------+---------+-----------------+
+        || | +LEAF1   |              1 |   42 |      33 |               1 |
+        || |          +----------------+------+---------+-----------------+
+        || +LEAF3     |              1 |    9 |       2 |               3 |
+        |+------------+----------------+------+---------+-----------------+
         |""".stripMargin)
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderTreeTableTest.scala
@@ -157,52 +157,58 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
       Rows(42),
       DbHits(33),
       PageCacheHits(1),
+      PageCacheMisses(2),
       EstimatedRows(1)), Set())
     val leaf2 = PlanDescriptionImpl(new Id, "LEAF2", NoChildren, Seq(
       Rows(9),
       DbHits(2),
       PageCacheHits(2),
+      PageCacheMisses(3),
       EstimatedRows(1)), Set())
     val leaf3 = PlanDescriptionImpl(new Id, "LEAF3", NoChildren, Seq(
       Rows(9),
       DbHits(2),
       PageCacheHits(3),
+      PageCacheMisses(4),
       EstimatedRows(1)), Set())
     val pass = PlanDescriptionImpl(new Id, "PASS", SingleChild(leaf2), Seq(
       Rows(4),
       DbHits(0),
       PageCacheHits(4),
+      PageCacheMisses(1),
       EstimatedRows(4)), Set())
     val inner = PlanDescriptionImpl(new Id, "INNER", TwoChildren(leaf1, pass), Seq(
       Rows(7),
       DbHits(42),
       PageCacheHits(5),
+      PageCacheMisses(2),
       EstimatedRows(6)), Set())
     val plan = PlanDescriptionImpl(new Id, "ROOT", TwoChildren(leaf3, inner), Seq(
       Rows(3),
       DbHits(0),
       PageCacheHits(7),
+      PageCacheMisses(10),
       EstimatedRows(1)), Set())
     val parent = PlanDescriptionImpl(new Id, "PARENT", SingleChild(plan), Seq(), Set())
 
     renderAsTreeTable(parent) should equal(
-      """+------------+----------------+------+---------+-----------------+
-        || Operator   | Estimated Rows | Rows | DB Hits | Page Cache Hits |
-        |+------------+----------------+------+---------+-----------------+
-        || +PARENT    |                |      |         |                 |
-        || |          +----------------+------+---------+-----------------+
-        || +ROOT      |              1 |    3 |       0 |               7 |
-        || |\         +----------------+------+---------+-----------------+
-        || | +INNER   |              6 |    7 |      42 |               5 |
-        || | |\       +----------------+------+---------+-----------------+
-        || | | +PASS  |              4 |    4 |       0 |               4 |
-        || | | |      +----------------+------+---------+-----------------+
-        || | | +LEAF2 |              1 |    9 |       2 |               2 |
-        || | |        +----------------+------+---------+-----------------+
-        || | +LEAF1   |              1 |   42 |      33 |               1 |
-        || |          +----------------+------+---------+-----------------+
-        || +LEAF3     |              1 |    9 |       2 |               3 |
-        |+------------+----------------+------+---------+-----------------+
+      """+------------+----------------+------+---------+-----------------+-------------------+
+        || Operator   | Estimated Rows | Rows | DB Hits | Page Cache Hits | Page Cache Misses |
+        |+------------+----------------+------+---------+-----------------+-------------------+
+        || +PARENT    |                |      |         |                 |                   |
+        || |          +----------------+------+---------+-----------------+-------------------+
+        || +ROOT      |              1 |    3 |       0 |               7 |                10 |
+        || |\         +----------------+------+---------+-----------------+-------------------+
+        || | +INNER   |              6 |    7 |      42 |               5 |                 2 |
+        || | |\       +----------------+------+---------+-----------------+-------------------+
+        || | | +PASS  |              4 |    4 |       0 |               4 |                 1 |
+        || | | |      +----------------+------+---------+-----------------+-------------------+
+        || | | +LEAF2 |              1 |    9 |       2 |               2 |                 3 |
+        || | |        +----------------+------+---------+-----------------+-------------------+
+        || | +LEAF1   |              1 |   42 |      33 |               1 |                 2 |
+        || |          +----------------+------+---------+-----------------+-------------------+
+        || +LEAF3     |              1 |    9 |       2 |               3 |                 4 |
+        |+------------+----------------+------+---------+-----------------+-------------------+
         |""".stripMargin)
   }
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/Description.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/Description.java
@@ -121,6 +121,12 @@ class Description implements ExecutionPlanDescription
             }
 
             @Override
+            public long getPageCacheMisses()
+            {
+                return statistics.getPageCacheMisses();
+            }
+
+            @Override
             public String toString()
             {
                 return statistics.toString();

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/Description.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/Description.java
@@ -115,6 +115,12 @@ class Description implements ExecutionPlanDescription
             }
 
             @Override
+            public long getPageCacheHits()
+            {
+                return statistics.getPageCacheHits();
+            }
+
+            @Override
             public String toString()
             {
                 return statistics.toString();

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
@@ -41,4 +41,12 @@ public interface ProfilerStatistics
     {
         return 0;
     }
+
+    /**
+     * @return number of page cache misses caused by executing the associated execution step
+     */
+    default long getPageCacheMisses()
+    {
+        return 0;
+    }
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/ProfilerStatistics.java
@@ -33,4 +33,12 @@ public interface ProfilerStatistics
      * @return number of database hits (potential disk accesses) caused by executing the associated execution step
      */
     long getDbHits();
+
+    /**
+     * @return number of page cache hits caused by executing the associated execution step
+     */
+    default long getPageCacheHits()
+    {
+        return 0;
+    }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityPlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityPlanDescription.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_2
 
-import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
-import org.neo4j.cypher.internal.compiler.v3_2.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.compiler.v3_2.RuntimeName
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, PageCacheHits, Rows}
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.frontend.v3_2.PlannerName
 import org.neo4j.cypher.internal.javacompat.{PlanDescription, ProfilerStatistics}
 import org.neo4j.cypher.{CypherVersion, InternalException}
@@ -70,6 +70,8 @@ case class CompatibilityPlanDescription(inner: InternalPlanDescription, version:
       def getDbHits: Long = extract { case DbHits(count) => count }
 
       def getRows: Long = extract { case Rows(count) => count }
+
+      def getPageCacheHits: Long = extract { case PageCacheHits(count) => count }
 
       private def extract(f: PartialFunction[Argument, Long]): Long =
         inner.arguments.collectFirst(f).getOrElse(throw new InternalException("Don't have profiler stats"))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityPlanDescription.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityPlanDescription.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_2
 
 import org.neo4j.cypher.internal.compiler.v3_2.RuntimeName
-import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, PageCacheHits, Rows}
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, PageCacheHits, PageCacheMisses, Rows}
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.frontend.v3_2.PlannerName
 import org.neo4j.cypher.internal.javacompat.{PlanDescription, ProfilerStatistics}
@@ -72,6 +72,8 @@ case class CompatibilityPlanDescription(inner: InternalPlanDescription, version:
       def getRows: Long = extract { case Rows(count) => count }
 
       def getPageCacheHits: Long = extract { case PageCacheHits(count) => count }
+
+      def getPageCacheMisses: Long = extract { case PageCacheMisses(count) => count }
 
       private def extract(f: PartialFunction[Argument, Long]): Long =
         inner.arguments.collectFirst(f).getOrElse(throw new InternalException("Don't have profiler stats"))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{QualifiedName, _}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.spi.v3_2.ExceptionTranslationSupport
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -234,6 +235,8 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
     translateException(inner.detachDeleteNode(node))
 
   override def assertSchemaWritesAllowed(): Unit = translateException(inner.assertSchemaWritesAllowed())
+
+  override def pageCursorTracer(): PageCursorTracer = translateException(inner.pageCursorTracer())
 
   class ExceptionTranslatingOperations[T <: PropertyContainer](inner: Operations[T])
     extends DelegatingOperations[T](inner) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
@@ -28,7 +28,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{QualifiedName, _}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.spi.v3_2.ExceptionTranslationSupport
 import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 
 import scala.collection.Iterator
 
@@ -236,7 +235,7 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
 
   override def assertSchemaWritesAllowed(): Unit = translateException(inner.assertSchemaWritesAllowed())
 
-  override def pageCursorTracer(): PageCursorTracer = translateException(inner.pageCursorTracer())
+  override def kernelStatisticProvider(): KernelStatisticProvider = translateException(inner.kernelStatisticProvider())
 
   class ExceptionTranslatingOperations[T <: PropertyContainer](inner: Operations[T])
     extends DelegatingOperations[T](inner) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ProfileKernelStatisticProvider.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ProfileKernelStatisticProvider.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_2
+
+import org.neo4j.cypher.internal.compiler.v3_2.spi.KernelStatisticProvider
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
+
+class ProfileKernelStatisticProvider(pageCursorTracer: PageCursorTracer) extends KernelStatisticProvider {
+
+  override def getPageCacheHits: Long = {
+    pageCursorTracer.hits()
+  }
+
+  override def getPageCacheMisses: Long = {
+    pageCursorTracer.faults()
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -56,7 +56,6 @@ import org.neo4j.kernel.api.proc.{QualifiedName => KernelQualifiedName}
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory
 import org.neo4j.kernel.api.schema_new.{IndexQuery, SchemaDescriptorFactory}
-import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.locking.ResourceTypes
 
@@ -741,7 +740,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     transactionalContext.statement.schemaWriteOperations()
 
   override def kernelStatisticProvider(): KernelStatisticProvider = {
-    new ProfileKernelStatisticProvider(transactionalContext.statement.asInstanceOf[KernelStatement].getPageCursorTracer)
+    new ProfileKernelStatisticProvider(transactionalContext.statement.executionStatisticsOperations().getPageCursorTracer)
   }
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -25,6 +25,7 @@ import java.util.function.Predicate
 import org.neo4j.collection.RawIterator
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.collection.primitive.base.Empty.EMPTY_PRIMITIVE_LONG_COLLECTION
+import org.neo4j.cypher.internal.compatibility.v3_2.ProfileKernelStatisticProvider
 import org.neo4j.cypher.internal.compiler.v3_2.MinMaxOrdering.{BY_NUMBER, BY_STRING, BY_VALUE}
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.DirectionConverter.toGraphDb
@@ -45,7 +46,6 @@ import org.neo4j.graphdb.RelationshipType._
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.security.URLAccessValidationError
 import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription, Uniqueness}
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.exceptions.ProcedureException
@@ -740,8 +740,8 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def assertSchemaWritesAllowed(): Unit =
     transactionalContext.statement.schemaWriteOperations()
 
-  override def pageCursorTracer(): PageCursorTracer = {
-    transactionalContext.statement.asInstanceOf[KernelStatement].getPageCursorTracer
+  override def kernelStatisticProvider(): KernelStatisticProvider = {
+    new ProfileKernelStatisticProvider(transactionalContext.statement.asInstanceOf[KernelStatement].getPageCursorTracer)
   }
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -45,6 +45,7 @@ import org.neo4j.graphdb.RelationshipType._
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.security.URLAccessValidationError
 import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription, Uniqueness}
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.exceptions.ProcedureException
@@ -55,6 +56,7 @@ import org.neo4j.kernel.api.proc.{QualifiedName => KernelQualifiedName}
 import org.neo4j.kernel.api.schema.NodePropertyDescriptor
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory
 import org.neo4j.kernel.api.schema_new.{IndexQuery, SchemaDescriptorFactory}
+import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.locking.ResourceTypes
 
@@ -737,6 +739,10 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
   override def assertSchemaWritesAllowed(): Unit =
     transactionalContext.statement.schemaWriteOperations()
+
+  override def pageCursorTracer(): PageCursorTracer = {
+    transactionalContext.statement.asInstanceOf[KernelStatement].getPageCursorTracer
+  }
 }
 
 object TransactionBoundQueryContext {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContextTest.scala
@@ -177,14 +177,12 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val transactionalContext = TransactionalContextWrapper(createTransactionContext(graph, tx))
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
 
-    val tracer = context.pageCursorTracer()
-    tracer.hits() should equal(0)
-    tracer.pins() should equal(0)
+    val tracer = context.kernelStatisticProvider()
+    tracer.getPageCacheHits should equal(0)
 
     graph.getNodeById(2)
     graph.getNodeById(1)
-    tracer.hits() should equal(2)
-    tracer.pins() should equal(2)
+    tracer.getPageCacheHits should equal(2)
 
     tx.close()
   }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
@@ -94,5 +94,13 @@ public interface ExecutionPlanDescription
          * @return number of database hits (potential disk accesses) caused by executing the associated execution step
          */
         long getDbHits();
+
+        /**
+         * @return number of page cache hits caused by executing the associated execution step
+         */
+        default long getPageCacheHits()
+        {
+            return 0;
+        }
     }
 }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/ExecutionPlanDescription.java
@@ -102,5 +102,13 @@ public interface ExecutionPlanDescription
         {
             return 0;
         }
+
+        /**
+         * @return number of page cache misses caused by executing the associated execution step
+         */
+        default long getPageCacheMisses()
+        {
+            return 0;
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutionStatisticsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ExecutionStatisticsOperations.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
+
+/**
+ * Defines methods that expose various statistical information from kernel
+ */
+public interface ExecutionStatisticsOperations
+{
+    /**
+     * @return provide current page cursor tracer that expose current transaction page cache statistic
+     */
+    PageCursorTracer getPageCursorTracer();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Statement.java
@@ -68,4 +68,6 @@ public interface Statement extends Resource
      * @return interface exposing all procedure call operations.
      */
     ProcedureCallOperations procedureCallOperations();
+
+    ExecutionStatisticsOperations executionStatisticsOperations();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -26,7 +26,7 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.DataWriteOperations;
-import org.neo4j.kernel.api.query.ExecutingQuery;
+import org.neo4j.kernel.api.ExecutionStatisticsOperations;
 import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
@@ -102,6 +103,12 @@ public class KernelStatement implements TxStateHolder, Statement
 
     @Override
     public ProcedureCallOperations procedureCallOperations()
+    {
+        return facade;
+    }
+
+    @Override
+    public ExecutionStatisticsOperations executionStatisticsOperations()
     {
         return facade;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -32,17 +32,17 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ExecutionStatisticsOperations;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.LegacyIndexHits;
-import org.neo4j.kernel.api.TokenWriteOperations;
-import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.StatementConstants;
+import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.KernelException;
@@ -56,6 +56,7 @@ import org.neo4j.kernel.api.exceptions.legacyindex.AutoIndexingKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
@@ -74,12 +75,12 @@ import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.query.ExecutingQuery;
+import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.IndexQuery;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaBoundary;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
-import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
@@ -114,12 +115,11 @@ import org.neo4j.storageengine.api.schema.PopulationProgress;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
 import static java.lang.String.format;
-import static org.neo4j.collection.primitive.PrimitiveIntCollections.asSet;
 import static org.neo4j.collection.primitive.PrimitiveIntCollections.deduplicate;
 
 public class OperationsFacade
         implements ReadOperations, DataWriteOperations, TokenWriteOperations, SchemaWriteOperations,
-        QueryRegistryOperations, ProcedureCallOperations
+        QueryRegistryOperations, ProcedureCallOperations, ExecutionStatisticsOperations
 {
     private final KernelTransaction tx;
     private final KernelStatement statement;
@@ -1570,6 +1570,12 @@ public class OperationsFacade
             ctx.put( Context.THREAD, Thread.currentThread() );
             return procedures.createAggregationFunction( ctx, name  );
         }
+    }
+
+    @Override
+    public PageCursorTracer getPageCursorTracer()
+    {
+        return statement.getPageCursorTracer();
     }
     // </Procedures>
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubStatement.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ExecutionStatisticsOperations;
 import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
@@ -75,6 +76,12 @@ public class StubStatement implements Statement
 
     @Override
     public ProcedureCallOperations procedureCallOperations()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public ExecutionStatisticsOperations executionStatisticsOperations()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/pom.xml
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/pom.xml
@@ -162,7 +162,13 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
-     </dependency>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-cypher</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- other -->
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/java/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/profiling/ProfilingTracer.java
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/java/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/profiling/ProfilingTracer.java
@@ -35,6 +35,7 @@ public class ProfilingTracer implements QueryExecutionTracer
         long dbHits();
         long rows();
         long pageCacheHits();
+        long pageCacheMisses();
     }
 
     public interface Clock
@@ -115,9 +116,10 @@ public class ProfilingTracer implements QueryExecutionTracer
         {
             long executionTime = clock.nanoTime() - start;
             long pageCacheHits = pageCursorTracer.hits();
+            long pageCacheFaults = pageCursorTracer.faults();
             if ( data != null )
             {
-                data.update( executionTime, hitCount, rowCount, pageCacheHits );
+                data.update( executionTime, hitCount, rowCount, pageCacheHits, pageCacheFaults );
             }
         }
 
@@ -140,13 +142,15 @@ public class ProfilingTracer implements QueryExecutionTracer
         private long hits;
         private long rows;
         private long pageCacheHits;
+        private long pageCacheMisses;
 
-        public void update( long time, long hits, long rows, long pageCacheHits )
+        public void update( long time, long hits, long rows, long pageCacheHits, long pageCacheMisses )
         {
             this.time += time;
             this.hits += hits;
             this.rows += rows;
             this.pageCacheHits += pageCacheHits;
+            this.pageCacheMisses += pageCacheMisses;
         }
 
         @Override
@@ -171,6 +175,12 @@ public class ProfilingTracer implements QueryExecutionTracer
         public long pageCacheHits()
         {
             return pageCacheHits;
+        }
+
+        @Override
+        public long pageCacheMisses()
+        {
+            return pageCacheMisses;
         }
     }
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
@@ -94,7 +94,7 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
 
   private def createTracer(mode: ExecutionMode, queryContext: QueryContext): DescriptionProvider = mode match {
     case ProfileMode =>
-      val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
+      val tracer = new ProfilingTracer(queryContext.kernelStatisticProvider())
       (description: InternalPlanDescription) =>
         (new Provider[InternalPlanDescription] {
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
@@ -104,6 +104,7 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
               plan.
                 addArgument(Arguments.DbHits(data.dbHits())).
                 addArgument(Arguments.PageCacheHits(data.pageCacheHits())).
+                addArgument(Arguments.PageCacheMisses(data.pageCacheMisses())).
                 addArgument(Arguments.Rows(data.rows())).
                 addArgument(Arguments.Time(data.time()))
           }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
@@ -73,7 +73,7 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
           ExplainExecutionResult(compiled.columns.toList,
             compiled.planDescription, READ_ONLY, context.notificationLogger.notifications)
         } else
-          compiled.executionResultBuilder(queryContext, executionMode, createTracer(executionMode), params, taskCloser)
+          compiled.executionResultBuilder(queryContext, executionMode, createTracer(executionMode, queryContext), params, taskCloser)
       } catch {
         case (t: Throwable) =>
           taskCloser.close(success = false)
@@ -92,9 +92,9 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
     override def plannedIndexUsage: Seq[IndexUsage] = compiled.plannedIndexUsage
   }
 
-  private def createTracer(mode: ExecutionMode): DescriptionProvider = mode match {
+  private def createTracer(mode: ExecutionMode, queryContext: QueryContext): DescriptionProvider = mode match {
     case ProfileMode =>
-      val tracer = new ProfilingTracer()
+      val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
       (description: InternalPlanDescription) =>
         (new Provider[InternalPlanDescription] {
 
@@ -103,6 +103,7 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
               val data = tracer.get(plan.id)
               plan.
                 addArgument(Arguments.DbHits(data.dbHits())).
+                addArgument(Arguments.PageCacheHits(data.pageCacheHits())).
                 addArgument(Arguments.Rows(data.rows())).
                 addArgument(Arguments.Time(data.time()))
           }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
@@ -45,6 +45,7 @@ object ExecutionPlanBuilder {
               plan.
                 addArgument(Arguments.DbHits(data.dbHits())).
                 addArgument(Arguments.PageCacheHits(data.pageCacheHits())).
+                addArgument(Arguments.PageCacheMisses(data.pageCacheMisses())).
                 addArgument(Arguments.Rows(data.rows())).
                 addArgument(Arguments.Time(data.time()))
           }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
@@ -33,9 +33,9 @@ object ExecutionPlanBuilder {
   type DescriptionProvider =
     (InternalPlanDescription => (Provider[InternalPlanDescription], Option[QueryExecutionTracer]))
 
-  def tracer(mode: ExecutionMode): DescriptionProvider = mode match {
+  def tracer(mode: ExecutionMode, queryContext: QueryContext): DescriptionProvider = mode match {
     case ProfileMode =>
-      val tracer = new ProfilingTracer()
+      val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
       (description: InternalPlanDescription) =>
         (new Provider[InternalPlanDescription] {
 
@@ -44,6 +44,7 @@ object ExecutionPlanBuilder {
               val data = tracer.get(plan.id)
               plan.
                 addArgument(Arguments.DbHits(data.dbHits())).
+                addArgument(Arguments.PageCacheHits(data.pageCacheHits())).
                 addArgument(Arguments.Rows(data.rows())).
                 addArgument(Arguments.Time(data.time()))
           }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/ExecutionPlanBuilder.scala
@@ -35,7 +35,7 @@ object ExecutionPlanBuilder {
 
   def tracer(mode: ExecutionMode, queryContext: QueryContext): DescriptionProvider = mode match {
     case ProfileMode =>
-      val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
+      val tracer = new ProfilingTracer(queryContext.kernelStatisticProvider())
       (description: InternalPlanDescription) =>
         (new Provider[InternalPlanDescription] {
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/profiling/ProfilingTracerTest.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/profiling/ProfilingTracerTest.scala
@@ -19,9 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.profiling
 
+import org.neo4j.cypher.internal.compatibility.v3_2.ProfileKernelStatisticProvider
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
+import org.neo4j.cypher.internal.compiler.v3_2.spi.EmptyKernelStatisticProvider
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
-import org.neo4j.io.pagecache.tracing.cursor.{DefaultPageCursorTracer, PageCursorTracer}
+import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer
 
 class ProfilingTracerTest extends CypherFunSuite {
 
@@ -38,7 +40,7 @@ class ProfilingTracerTest extends CypherFunSuite {
     // given
     val clock = new Clock
     val operatorId = new Id
-    val tracer = new ProfilingTracer(clock, PageCursorTracer.NULL)
+    val tracer = new ProfilingTracer(clock, EmptyKernelStatisticProvider)
     val event = tracer.executeOperator(operatorId)
 
     // when
@@ -53,7 +55,7 @@ class ProfilingTracerTest extends CypherFunSuite {
     // given
     val clock = new Clock
     val operatorId = new Id
-    val tracer = new ProfilingTracer(clock, PageCursorTracer.NULL)
+    val tracer = new ProfilingTracer(clock, EmptyKernelStatisticProvider)
 
     // when
     val event1 = tracer.executeOperator(operatorId)
@@ -71,7 +73,7 @@ class ProfilingTracerTest extends CypherFunSuite {
   test("shouldReportDbHitsOfQueryExecution") {
     // given
     val operatorId = new Id
-    val tracer = new ProfilingTracer(PageCursorTracer.NULL)
+    val tracer = new ProfilingTracer(EmptyKernelStatisticProvider)
     val event = tracer.executeOperator(operatorId)
 
     // when
@@ -88,7 +90,7 @@ class ProfilingTracerTest extends CypherFunSuite {
   test("shouldReportRowsOfQueryExecution") {
     // given
     val operatorId = new Id
-    val tracer = new ProfilingTracer(PageCursorTracer.NULL)
+    val tracer = new ProfilingTracer(EmptyKernelStatisticProvider)
     val event = tracer.executeOperator(operatorId)
 
     // when
@@ -106,7 +108,7 @@ class ProfilingTracerTest extends CypherFunSuite {
   test("report page cache hits as part of profiling statistics") {
     val operatorId = new Id
     val cursorTracer = new DefaultPageCursorTracer
-    var tracer = new ProfilingTracer(cursorTracer)
+    var tracer = new ProfilingTracer(new ProfileKernelStatisticProvider(cursorTracer))
     val event = tracer.executeOperator(operatorId)
 
     1 to 100 foreach { _ => {
@@ -125,7 +127,7 @@ class ProfilingTracerTest extends CypherFunSuite {
   test("report page cache misses as part of profiling statistics") {
     val operatorId = new Id
     val cursorTracer = new DefaultPageCursorTracer
-    var tracer = new ProfilingTracer(cursorTracer)
+    var tracer = new ProfilingTracer(new ProfileKernelStatisticProvider(cursorTracer))
     val event = tracer.executeOperator(operatorId)
 
     1 to 17 foreach { _ => {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
@@ -1677,7 +1677,7 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
   }
 
   private def compileAndExecute(plan: LogicalPlan, params: Map[String, AnyRef] = Map.empty, taskCloser: TaskCloser = new TaskCloser) = {
-    compile(plan).executionResultBuilder(queryContext, NormalMode, tracer(NormalMode), params, taskCloser)
+    compile(plan).executionResultBuilder(queryContext, NormalMode, tracer(NormalMode, queryContext), params, taskCloser)
   }
 
   /*

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CodeGenSugar.scala
@@ -75,7 +75,7 @@ trait CodeGenSugar extends MockitoSugar {
       val transactionalContext = TransactionalContextWrapper(contextFactory.newContext(ClientConnectionInfo.EMBEDDED_CONNECTION, tx,
         "no query text exists for this test", Collections.emptyMap()))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(mock[IndexSearchMonitor])
-      val result = plan.executionResultBuilder(queryContext, mode, tracer(mode), Map.empty, new TaskCloser)
+      val result = plan.executionResultBuilder(queryContext, mode, tracer(mode, queryContext), Map.empty, new TaskCloser)
       tx.success()
       result.size
       result

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
@@ -80,7 +80,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     }
 
     // when
-    val tracer = new ProfilingTracer()
+    val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
     newInstance(compiled, queryContext = queryContext, provider = provider, queryExecutionTracer = tracer).size
 
     // then

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.collection.primitive.PrimitiveLongIterator
+import org.neo4j.cypher.internal.compatibility.v3_2.ProfileKernelStatisticProvider
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.Variable
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions.CodeGenType
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.profiling.ProfilingTracer
@@ -61,7 +62,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     val queryContext = mock[QueryContext]
     val transactionalContext = mock[TransactionalContextWrapper]
     when(queryContext.transactionalContext).thenReturn(transactionalContext.asInstanceOf[QueryTransactionalContext])
-    when(queryContext.pageCursorTracer()).thenReturn(new DefaultPageCursorTracer)
+    when(queryContext.kernelStatisticProvider()).thenReturn(new ProfileKernelStatisticProvider(new DefaultPageCursorTracer))
     when(transactionalContext.readOperations).thenReturn(readOps)
     when(entityAccessor.newNodeProxyById(anyLong())).thenReturn(mock[NodeProxy])
     when(queryContext.entityAccessor).thenReturn(entityAccessor.asInstanceOf[queryContext.EntityAccessor])
@@ -82,7 +83,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     }
 
     // when
-    val tracer = new ProfilingTracer(queryContext.pageCursorTracer())
+    val tracer = new ProfilingTracer(queryContext.kernelStatisticProvider())
     newInstance(compiled, queryContext = queryContext, provider = provider, queryExecutionTracer = tracer).size
 
     // then

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
@@ -37,6 +37,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, CardinalityEstimation, IdName, PlannerQuery}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer
 import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.security.AnonymousContext
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy}
@@ -60,6 +61,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
     val queryContext = mock[QueryContext]
     val transactionalContext = mock[TransactionalContextWrapper]
     when(queryContext.transactionalContext).thenReturn(transactionalContext.asInstanceOf[QueryTransactionalContext])
+    when(queryContext.pageCursorTracer()).thenReturn(new DefaultPageCursorTracer)
     when(transactionalContext.readOperations).thenReturn(readOps)
     when(entityAccessor.newNodeProxyById(anyLong())).thenReturn(mock[NodeProxy])
     when(queryContext.entityAccessor).thenReturn(entityAccessor.asInstanceOf[queryContext.EntityAccessor])


### PR DESCRIPTION
Using newly introduced page cache hit metric it should be much more easier
to see how particular query use data that are already in page cache.
Each page cache `hit` indicate that data from cache was used and there was no page fault
when particular price of data request was served.
Now when hit metric added into query execution profile statistic we have possibility to
investigate how particular query utilize page cache.