### PR TITLE
Composite consistency checker

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -238,15 +238,15 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
         catch ( IndexNotApplicableKernelException e )
         {
             throw new RuntimeException( format(
-                    "Cannot continue %s, as index provider does not support exact composite query: %s",
-                    this.getClass().getSimpleName(), Arrays.toString( query ) ), e );
+                    "Consistency checking error: index provider does not support exact query %s",
+                    Arrays.toString( query ) ), e );
         }
 
         indexedNodeIds = LookupFilter.exactIndexMatches( propertyReader, indexedNodeIds, query );
         return indexedNodeIds;
     }
 
-    public static boolean nodeHasSchemaProperties(
+    private static boolean nodeHasSchemaProperties(
             PrimitiveIntObjectMap<PropertyBlock> nodePropertyMap, int[] indexPropertyIds )
     {
         for ( int indexPropertyId : indexPropertyIds )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -27,7 +27,6 @@ import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.collection.primitive.PrimitiveLongPeekingIterator;
 import org.neo4j.consistency.checking.ChainCheck;
 import org.neo4j.consistency.checking.CheckerEngine;
 import org.neo4j.consistency.checking.RecordCheck;
@@ -37,6 +36,7 @@ import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.store.RecordAccess;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema_new.IndexQuery;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.impl.api.LookupFilter;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -44,6 +44,9 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.storageengine.api.schema.IndexReader;
+
+import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_PROPERTY_KEY;
+import static org.neo4j.kernel.impl.api.schema.NodeSchemaMatcher.nodeHasSchemaProperties;
 
 /**
  * Checks nodes and how they're indexed in one go. Reports any found inconsistencies.
@@ -70,137 +73,96 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
         cacheAccess.client().putPropertiesToCache(properties);
         if ( indexes != null )
         {
-            checkIndexToLabels( record, engine, records, properties );
+            matchIndexesToNode( record, engine, records, properties );
         }
         checkProperty( record, engine, properties );
     }
 
-    private void checkIndexToLabels( NodeRecord record,
-            CheckerEngine<NodeRecord, ConsistencyReport.NodeConsistencyReport> engine,
+    /**
+     * Matches indexes to a node. This implementation mirrors NodeSchemaMatcher.onMatchingSchema(...), but as all
+     * accessor methods are different, a shared implementation was hard to achieve.
+     */
+    private void matchIndexesToNode(
+            NodeRecord record,
+            CheckerEngine<NodeRecord,
+            ConsistencyReport.NodeConsistencyReport> engine,
             RecordAccess records,
-            Collection<PropertyRecord> propertyRecs)
+            Collection<PropertyRecord> propertyRecs )
     {
         Set<Long> labels = NodeLabelReader.getListOfLabels( record, records, engine );
         List<PropertyBlock> properties = null;
+        PrimitiveIntSet nodePropertyIds = null;
         for ( IndexRule indexRule : indexes.rules() )
         {
             long labelId = indexRule.schema().getLabelId();
-            if ( !labels.contains( labelId ) )
+            if ( labels.contains( labelId ) )
             {
-                continue;
-            }
-
-            if ( properties == null )
-            {
-                properties = propertyReader.propertyBlocks( propertyRecs );
-            }
-            int propertyId = indexRule.schema().getPropertyId(); // assuming 1 property always
-            PropertyBlock property = propertyWithKey( properties, propertyId );
-
-            if ( property == null )
-            {
-                continue;
-            }
-
-            try ( IndexReader reader = indexes.accessorFor( indexRule ).newReader() )
-            {
-                Object propertyValue = propertyReader.propertyValue( property ).value();
-                long nodeId = record.getId();
-
-                if ( indexRule.canSupportUniqueConstraint() )
+                if ( properties == null )
                 {
-                    verifyNodeCorrectlyIndexedUniquely( nodeId, property.getKeyIndexId(), propertyValue, engine,
-                            indexRule, reader );
+                    properties = propertyReader.propertyBlocks( propertyRecs );
+                    nodePropertyIds = propertyIds( properties );
                 }
-                else
+
+                int[] indexPropertyIds = indexRule.schema().getPropertyIds();
+                if ( nodeHasSchemaProperties( nodePropertyIds, indexPropertyIds, NO_SUCH_PROPERTY_KEY ) )
                 {
-                    verifyNodeCorrectlyIndexed( nodeId, propertyValue, engine, indexRule, reader );
+                    Object[] values = getPropertyValues( properties, indexPropertyIds );
+                    try ( IndexReader reader = indexes.accessorFor( indexRule ).newReader() )
+                    {
+                        long nodeId = record.getId();
+
+                        if ( indexRule.canSupportUniqueConstraint() )
+                        {
+                            verifyNodeCorrectlyIndexedUniquely( nodeId, values, engine, indexRule, reader );
+                        }
+                        else
+                        {
+                            long count = reader.countIndexedNodes( nodeId, values );
+                            reportIncorrectIndexCount( values, engine, indexRule, count );
+                        }
+                    }
                 }
             }
         }
     }
 
-    private void verifyNodeCorrectlyIndexedUniquely( long nodeId, int propertyKeyId, Object propertyValue,
+    private void verifyNodeCorrectlyIndexedUniquely( long nodeId, Object[] propertyValues,
             CheckerEngine<NodeRecord,ConsistencyReport.NodeConsistencyReport> engine, IndexRule indexRule,
             IndexReader reader )
     {
-        PrimitiveLongIterator indexedNodeIds = null;
-        try
-        {
-            indexedNodeIds = reader.query( IndexQuery.exact( propertyKeyId, propertyValue ) );
-        }
-        catch ( IndexNotApplicableKernelException e )
-        {
-            indexedNodeIds = PrimitiveLongCollections.emptyIterator();
-        }
+        IndexQuery[] query = seek( indexRule.schema(), propertyValues );
 
-        // For verifying node indexed uniquely in offline CC, if one match found in the first stage match,
-        // then there is no need to filter the result. The result is a exact match.
-        // If multiple matches found, we need to filter the result to get exact matches.
-        indexedNodeIds = filterIfMultipleValuesFound( indexedNodeIds, propertyKeyId, propertyValue );
+        PrimitiveLongIterator indexedNodeIds = queryIndexOrEmpty( reader, query );
 
-        boolean found = false;
-
+        long count = 0;
         while ( indexedNodeIds.hasNext() )
         {
             long indexedNodeId = indexedNodeIds.next();
 
             if ( nodeId == indexedNodeId )
             {
-                found = true;
+                count++;
             }
             else
             {
-                engine.report().uniqueIndexNotUnique( indexRule, propertyValue, indexedNodeId );
+                engine.report().uniqueIndexNotUnique( indexRule, propertyValues, indexedNodeId );
             }
         }
 
-        if ( !found )
-        {
-            engine.report().notIndexed( indexRule, propertyValue );
-        }
+        reportIncorrectIndexCount( propertyValues, engine, indexRule, count );
     }
 
-    private PrimitiveLongIterator filterIfMultipleValuesFound( PrimitiveLongIterator indexedNodeIds, int propertyKeyId,
-            Object propertyValue )
+    private void reportIncorrectIndexCount( Object[] propertyValues,
+            CheckerEngine<NodeRecord,ConsistencyReport.NodeConsistencyReport> engine, IndexRule indexRule, long count )
     {
-        PrimitiveLongIterator filteredIndexedNodeIds = new PrimitiveLongPeekingIterator( indexedNodeIds );
-        if ( ((PrimitiveLongPeekingIterator) filteredIndexedNodeIds).hasMultipleValues() )
-        {
-            filteredIndexedNodeIds = LookupFilter.exactIndexMatches( propertyReader, filteredIndexedNodeIds,
-                    propertyKeyId, propertyValue );
-        }
-        return filteredIndexedNodeIds;
-    }
-
-    private void verifyNodeCorrectlyIndexed(
-            long nodeId,
-            Object propertyValue,
-            CheckerEngine<NodeRecord, ConsistencyReport.NodeConsistencyReport> engine,
-            IndexRule indexRule,
-            IndexReader reader )
-    {
-        long count = reader.countIndexedNodes( nodeId, propertyValue );
         if ( count == 0 )
         {
-            engine.report().notIndexed( indexRule, propertyValue );
+            engine.report().notIndexed( indexRule, propertyValues );
         }
         else if ( count != 1 )
         {
-            engine.report().indexedMultipleTimes( indexRule, propertyValue, count );
+            engine.report().indexedMultipleTimes( indexRule, propertyValues, count );
         }
-    }
-
-    private PropertyBlock propertyWithKey( List<PropertyBlock> propertyBlocks, int propertyKey )
-    {
-        for ( PropertyBlock propertyBlock : propertyBlocks )
-        {
-            if ( propertyBlock.getKeyIndexId() == propertyKey )
-            {
-                return propertyBlock;
-            }
-        }
-        return null;
     }
 
     private void checkProperty( NodeRecord record,
@@ -234,5 +196,70 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
                 }
             }
         }
+    }
+
+    private Object[] getPropertyValues( List<PropertyBlock> properties, int[] indexPropertyIds )
+    {
+        Object[] values = new Object[indexPropertyIds.length];
+        for ( int i = 0; i < indexPropertyIds.length; i++ )
+        {
+            PropertyBlock propertyBlock = propertyWithKey( properties, indexPropertyIds[i] );
+            if ( propertyBlock == null )
+            {
+                throw new IllegalStateException( "We should have checked that the index and node match before coming " +
+                        "here, so this should not happen" );
+            }
+            values[i] = propertyReader.propertyValue( propertyBlock ).value();
+        }
+        return values;
+    }
+
+    private PropertyBlock propertyWithKey( List<PropertyBlock> propertyBlocks, int propertyKey )
+    {
+        for ( PropertyBlock propertyBlock : propertyBlocks )
+        {
+            if ( propertyBlock.getKeyIndexId() == propertyKey )
+            {
+                return propertyBlock;
+            }
+        }
+        return null;
+    }
+
+    private PrimitiveIntSet propertyIds( List<PropertyBlock> propertyBlocks )
+    {
+        PrimitiveIntSet propertyIds = Primitive.intSet();
+        for ( PropertyBlock propertyBlock : propertyBlocks )
+        {
+            propertyIds.add( propertyBlock.getKeyIndexId() );
+        }
+        return propertyIds;
+    }
+
+    private IndexQuery[] seek( LabelSchemaDescriptor schema, Object[] propertyValues )
+    {
+        assert schema.getPropertyIds().length == propertyValues.length;
+        IndexQuery[] query = new IndexQuery[propertyValues.length];
+        for ( int i = 0; i < query.length; i++ )
+        {
+            query[i] = IndexQuery.exact( schema.getPropertyIds()[i], propertyValues[i] );
+        }
+        return query;
+    }
+
+    private PrimitiveLongIterator queryIndexOrEmpty( IndexReader reader, IndexQuery[] query )
+    {
+        PrimitiveLongIterator indexedNodeIds;
+        try
+        {
+            indexedNodeIds = reader.query( query );
+        }
+        catch ( IndexNotApplicableKernelException e )
+        {
+            indexedNodeIds = PrimitiveLongCollections.emptyIterator();
+        }
+
+        indexedNodeIds = LookupFilter.exactIndexMatches( propertyReader, indexedNodeIds, query );
+        return indexedNodeIds;
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.consistency.checking.full;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -26,7 +27,6 @@ import java.util.Set;
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.consistency.checking.ChainCheck;
 import org.neo4j.consistency.checking.CheckerEngine;
@@ -46,7 +46,7 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
-import static org.neo4j.kernel.impl.api.schema.NodeSchemaMatcher.nodeHasSchemaProperties;
+import static java.lang.String.format;
 
 /**
  * Checks nodes and how they're indexed in one go. Reports any found inconsistencies.
@@ -237,7 +237,9 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
         }
         catch ( IndexNotApplicableKernelException e )
         {
-            indexedNodeIds = PrimitiveLongCollections.emptyIterator();
+            throw new RuntimeException( format(
+                    "Cannot continue %s, as index provider does not support exact composite query: %s",
+                    this.getClass().getSimpleName(), Arrays.toString( query ) ), e );
         }
 
         indexedNodeIds = LookupFilter.exactIndexMatches( propertyReader, indexedNodeIds, query );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexAccessors.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/index/IndexAccessors.java
@@ -79,12 +79,11 @@ public class IndexAccessors implements Closeable
         }
     }
 
-    public IndexAccessor accessorFor(IndexRule indexRule)
+    public IndexAccessor accessorFor( IndexRule indexRule )
     {
         return accessors.get( indexRule.getId() );
     }
 
-    // TODO: return pair of rules and accessor
     public Iterable<IndexRule> rules()
     {
         return indexRules;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -184,13 +184,13 @@ public interface ConsistencyReport
         void dynamicRecordChainCycle( DynamicRecord nextRecord );
 
         @Documented( "This node was not found in the expected index." )
-        void notIndexed( IndexRule index, Object propertyValue );
+        void notIndexed( IndexRule index, Object[] propertyValues );
 
         @Documented( "This node was found in the expected index, although multiple times" )
-        void indexedMultipleTimes( IndexRule index, Object propertyValue, long count );
+        void indexedMultipleTimes( IndexRule index, Object[] propertyValues, long count );
 
         @Documented( "There is another node in the unique index with the same property value." )
-        void uniqueIndexNotUnique( IndexRule index, Object propertyValue, long duplicateNodeId );
+        void uniqueIndexNotUnique( IndexRule index, Object[] propertyValues, long duplicateNodeId );
 
         @Documented( "The referenced relationship group record is not in use." )
         void relationshipGroupNotInUse( RelationshipGroupRecord group );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -189,7 +189,7 @@ public interface ConsistencyReport
         @Documented( "This node was found in the expected index, although multiple times" )
         void indexedMultipleTimes( IndexRule index, Object[] propertyValues, long count );
 
-        @Documented( "There is another node in the unique index with the same property values." )
+        @Documented( "There is another node in the unique index with the same property value(s)." )
         void uniqueIndexNotUnique( IndexRule index, Object[] propertyValues, long duplicateNodeId );
 
         @Documented( "The referenced relationship group record is not in use." )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -189,7 +189,7 @@ public interface ConsistencyReport
         @Documented( "This node was found in the expected index, although multiple times" )
         void indexedMultipleTimes( IndexRule index, Object[] propertyValues, long count );
 
-        @Documented( "There is another node in the unique index with the same property value." )
+        @Documented( "There is another node in the unique index with the same property values." )
         void uniqueIndexNotUnique( IndexRule index, Object[] propertyValues, long duplicateNodeId );
 
         @Documented( "The referenced relationship group record is not in use." )

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -152,7 +152,6 @@ public class FullCheckIntegrationTest
     private static final Object VALUE1 = "value1";
     private static final Object VALUE2 = "value2";
 
-
     private int label1, label2, label3, label4, draconian;
     private int key1, key2, mandatory;
     private int C, T, M;
@@ -1761,6 +1760,24 @@ public class FullCheckIntegrationTest
     }
 
     @Test
+    public void shouldReportDuplicatedCompositeUniquenessConstraintRules() throws Exception
+    {
+        // Given
+        int labelId = createLabel();
+        int propertyKeyId1 = createPropertyKey( "p1" );
+        int propertyKeyId2 = createPropertyKey( "p2" );
+        createUniquenessConstraintRule( labelId, propertyKeyId1, propertyKeyId2 );
+        createUniquenessConstraintRule( labelId, propertyKeyId1, propertyKeyId2 );
+
+        // When
+        ConsistencySummaryStatistics stats = check();
+
+        // Then
+        on( stats ).verify( RecordType.SCHEMA, 2 ) // pair of duplicated indexes & pair of duplicated constraints
+                .andThatsAllFolks();
+    }
+
+    @Test
     public void shouldReportDuplicatedNodePropertyExistenceConstraintRules() throws Exception
     {
         // Given
@@ -1811,9 +1828,9 @@ public class FullCheckIntegrationTest
     public void shouldReportInvalidLabelIdInUniquenessConstraintRule() throws Exception
     {
         // Given
-        int labelId = fixture.idGenerator().label();
+        int badLabelId = fixture.idGenerator().label();
         int propertyKeyId = createPropertyKey();
-        createUniquenessConstraintRule( labelId, propertyKeyId );
+        createUniquenessConstraintRule( badLabelId, propertyKeyId );
 
         // When
         ConsistencySummaryStatistics stats = check();
@@ -1827,9 +1844,9 @@ public class FullCheckIntegrationTest
     public void shouldReportInvalidLabelIdInNodePropertyExistenceConstraintRule() throws Exception
     {
         // Given
-        int labelId = fixture.idGenerator().label();
+        int badLabelId = fixture.idGenerator().label();
         int propertyKeyId = createPropertyKey();
-        createNodePropertyExistenceConstraint( labelId, propertyKeyId );
+        createNodePropertyExistenceConstraint( badLabelId, propertyKeyId );
 
         // When
         ConsistencySummaryStatistics stats = check();
@@ -1907,8 +1924,8 @@ public class FullCheckIntegrationTest
     {
         // Given
         int labelId = createLabel();
-        int propertyKeyId = fixture.idGenerator().propertyKey();
-        createNodePropertyExistenceConstraint( labelId, propertyKeyId );
+        int badPropertyKeyId = fixture.idGenerator().propertyKey();
+        createNodePropertyExistenceConstraint( labelId, badPropertyKeyId );
 
         // When
         ConsistencySummaryStatistics stats = check();
@@ -1921,9 +1938,9 @@ public class FullCheckIntegrationTest
     public void shouldReportInvalidRelTypeIdInRelationshipPropertyExistenceConstraintRule() throws Exception
     {
         // Given
-        int relTypeId = fixture.idGenerator().relationshipType();
+        int badRelTypeId = fixture.idGenerator().relationshipType();
         int propertyKeyId = createPropertyKey();
-        createRelationshipPropertyExistenceConstraint( relTypeId, propertyKeyId );
+        createRelationshipPropertyExistenceConstraint( badRelTypeId, propertyKeyId );
 
         // When
         ConsistencySummaryStatistics stats = check();

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -1084,38 +1084,6 @@ public class FullCheckIntegrationTest
                    .andThatsAllFolks();
     }
 
-    public static Collection<DynamicRecord> serializeRule( SchemaRule rule, DynamicRecord... records )
-    {
-        return serializeRule( rule, asList( records ) );
-    }
-
-    public static Collection<DynamicRecord> serializeRule( SchemaRule rule, Collection<DynamicRecord> records )
-    {
-        byte[] data = rule.serialize();
-        DynamicRecordAllocator dynamicRecordAllocator =
-                new ReusableRecordsCompositeAllocator( records, schemaAllocator );
-        Collection<DynamicRecord> result = new ArrayList<>();
-        AbstractDynamicStore.allocateRecordsFromBytes( result, data, dynamicRecordAllocator );
-        return result;
-    }
-
-    private static DynamicRecordAllocator schemaAllocator = new DynamicRecordAllocator()
-    {
-        private int next = 10000; // we start high to not conflict with real ids
-
-        @Override
-        public int getRecordDataSize()
-        {
-            return SchemaStore.BLOCK_SIZE;
-        }
-
-        @Override
-        public DynamicRecord nextRecord()
-        {
-            return new DynamicRecord( next++ );
-        }
-    };
-
     @Test
     public void shouldReportArrayPropertyInconsistencies() throws Exception
     {
@@ -1542,14 +1510,14 @@ public class FullCheckIntegrationTest
                    .andThatsAllFolks();
     }
 
-    protected RelationshipRecord withNext( RelationshipRecord relationship, long next )
+    private RelationshipRecord withNext( RelationshipRecord relationship, long next )
     {
         relationship.setFirstNextRel( next );
         relationship.setSecondNextRel( next );
         return relationship;
     }
 
-    protected RelationshipRecord withPrev( RelationshipRecord relationship, long prev )
+    private RelationshipRecord withPrev( RelationshipRecord relationship, long prev )
     {
         relationship.setFirstInFirstChain( false );
         relationship.setFirstInSecondChain( false );
@@ -2317,4 +2285,31 @@ public class FullCheckIntegrationTest
             assertEquals( "Total number of inconsistencies: " + stats, total, stats.getTotalInconsistencyCount() );
         }
     }
+
+    private static Collection<DynamicRecord> serializeRule( SchemaRule rule, DynamicRecord... records )
+    {
+        byte[] data = rule.serialize();
+        DynamicRecordAllocator dynamicRecordAllocator =
+                new ReusableRecordsCompositeAllocator( asList( records ), schemaAllocator );
+        Collection<DynamicRecord> result = new ArrayList<>();
+        AbstractDynamicStore.allocateRecordsFromBytes( result, data, dynamicRecordAllocator );
+        return result;
+    }
+
+    private static DynamicRecordAllocator schemaAllocator = new DynamicRecordAllocator()
+    {
+        private int next = 10000; // we start high to not conflict with real ids
+
+        @Override
+        public int getRecordDataSize()
+        {
+            return SchemaStore.BLOCK_SIZE;
+        }
+
+        @Override
+        public DynamicRecord nextRecord()
+        {
+            return new DynamicRecord( next++ );
+        }
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -27,6 +27,8 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema_new.IndexQuery;
 import org.neo4j.kernel.impl.api.operations.EntityOperations;
 import org.neo4j.storageengine.api.NodeItem;
@@ -61,12 +63,13 @@ public class LookupFilter
         {
             LongPredicate combinedPredicate = nodeId ->
             {
-                try {
+                try
+                {
                     for ( IndexQuery predicate : numericPredicates )
                     {
                         int propertyKeyId = predicate.propertyKeyId();
-                        Object value = accessor.getProperty( nodeId, propertyKeyId );
-                        if ( !predicate.test( value ) )
+                        Property property = accessor.getProperty( nodeId, propertyKeyId );
+                        if ( property.isDefined() && !predicate.test( ((DefinedProperty)property).value() ) )
                         {
                             return false;
                         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -75,7 +75,9 @@ public class LookupFilter
                 }
                 catch ( EntityNotFoundException ignored )
                 {
-                    return false;
+                    return false; // The node has been deleted but was still reported from the index. CC will catch
+                                  // this through other mechanism (NodeInUseWithCorrectLabelsCheck), so we can
+                                  // silently ignore here
                 }
             };
             return PrimitiveLongCollections.filter( indexedNodeIds, combinedPredicate );
@@ -119,7 +121,8 @@ public class LookupFilter
                 }
                 catch ( EntityNotFoundException ignored )
                 {
-                    return false;
+                    return false; // The node has been deleted but was still reported from the index. We hope that this
+                                  // is some transient problem and just ignore this index entry.
                 }
             };
             return PrimitiveLongCollections.filter( indexedNodeIds, combinedPredicate );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -68,8 +68,8 @@ public class LookupFilter
                     for ( IndexQuery predicate : numericPredicates )
                     {
                         int propertyKeyId = predicate.propertyKeyId();
-                        Property property = accessor.getProperty( nodeId, propertyKeyId );
-                        if ( property.isDefined() && !predicate.test( ((DefinedProperty)property).value() ) )
+                        Object value = accessor.getProperty( nodeId, propertyKeyId ).value( null );
+                        if ( !predicate.test( value ) )
                         {
                             return false;
                         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
@@ -89,7 +89,7 @@ public class NodeSchemaMatcher
         }
     }
 
-    private static boolean nodeHasSchemaProperties(
+    public static boolean nodeHasSchemaProperties(
             PrimitiveIntSet nodeProperties, int[] indexPropertyIds, int changedPropertyId )
     {
         for ( int indexPropertyId : indexPropertyIds )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
@@ -23,9 +23,9 @@ import java.util.Iterator;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
+import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaSupplier;
-import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.storageengine.api.NodeItem;
@@ -43,7 +43,7 @@ public class NodeSchemaMatcher
     }
 
     /**
-     * Iterate over some schema suppliers, and invoke an action for every supplier that matches the node. To match the
+     * Iterate over some schema suppliers, and invoke a callback for every supplier that matches the node. To match the
      * node N the supplier must supply a LabelSchemaDescriptor D, such that N has the label of D, and values for all
      * the properties of D.
      *
@@ -55,7 +55,7 @@ public class NodeSchemaMatcher
      * @param node The node
      * @param specialPropertyId This property id will always count as a match for the descriptor, regardless of
      *                          whether the node has this property or not
-     * @param action The action to take on match
+     * @param callback The action to take on match
      * @param <SUPPLIER> the type to match. Must implement LabelSchemaDescriptor.Supplier
      * @param <EXCEPTION> The type of exception that can be thrown when taking the action
      * @throws EXCEPTION This exception is propagated from the action
@@ -65,7 +65,7 @@ public class NodeSchemaMatcher
             Iterator<SUPPLIER> schemaSuppliers,
             NodeItem node,
             int specialPropertyId,
-            SchemaMatchAction<SUPPLIER, EXCEPTION> action
+            ThrowingConsumer<SUPPLIER, EXCEPTION> callback
     ) throws EXCEPTION
     {
         PrimitiveIntSet nodePropertyIds = null;
@@ -83,7 +83,7 @@ public class NodeSchemaMatcher
 
                 if ( nodeHasSchemaProperties( nodePropertyIds, schema.getPropertyIds(), specialPropertyId ) )
                 {
-                    action.act( schemaSupplier );
+                    callback.accept( schemaSupplier );
                 }
             }
         }
@@ -101,10 +101,4 @@ public class NodeSchemaMatcher
         }
         return true;
     }
-
-    public interface SchemaMatchAction<SUPPLIER extends SchemaDescriptor.Supplier, EXCEPTION extends Exception>
-    {
-        void act( SUPPLIER schemaSupplier ) throws EXCEPTION;
-    }
-
 }


### PR DESCRIPTION
Adds checks of composite indexes and uniqueness constraints to the consistency checker. This in essence means duplicating existing tests but applied on composite alternative schema objects.

Looks huge, but this is because it sits on #8984. Only commits https://github.com/neo4j/neo4j/pull/8993/commits/127392591c21f0b8558d63ed5ec10cb2f9c67194, https://github.com/neo4j/neo4j/pull/8993/commits/50512cffd7fa618fd8cacb96eda9404ac48d0d6b and https://github.com/neo4j/neo4j/pull/8993/commits/50a03bbd6f5f847a45e0a1c17ec89c2f1deb9168 are relevant. 