### PR TITLE
Introduce CrashGenCleaner

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.index.internal.gbptree.GBPTree.Monitor;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
+/**
+ * Scans the entire tree and checks all GSPPs, replacing all CRASH gen GSPs with zeros.
+ */
+class CrashGenCleaner
+{
+    private final PagedFile pagedFile;
+    private final TreeNode<?,?> treeNode;
+    private final long lowTreeNodeId;
+    private final long highTreeNodeId;
+    private final long stableGeneration;
+    private final long unstableGeneration;
+    private final Monitor monitor;
+    private final long maxKeyCount;
+
+    public CrashGenCleaner( PagedFile pagedFile, TreeNode<?,?> treeNode, long lowTreeNodeId, long highTreeNodeId,
+            long stableGeneration, long unstableGeneration, Monitor monitor )
+    {
+        this.pagedFile = pagedFile;
+        this.treeNode = treeNode;
+        this.lowTreeNodeId = lowTreeNodeId;
+        this.highTreeNodeId = highTreeNodeId;
+        this.stableGeneration = stableGeneration;
+        this.unstableGeneration = unstableGeneration;
+        this.monitor = monitor;
+        this.maxKeyCount = treeNode.internalMaxKeyCount();
+    }
+
+    // === Methods about the execution and threading ===
+
+    public void clean() throws IOException
+    {
+        assert unstableGeneration > stableGeneration;
+        assert unstableGeneration - stableGeneration > 1;
+
+        long startTime = currentTimeMillis();
+        int threads = Runtime.getRuntime().availableProcessors();
+        ExecutorService executor = Executors.newFixedThreadPool( threads );
+        AtomicLong nextId = new AtomicLong( lowTreeNodeId);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicInteger cleanedPointers = new AtomicInteger();
+        for ( int i = 0; i < threads; i++ )
+        {
+            executor.submit( cleaner( nextId, error, cleanedPointers ) );
+        }
+        executor.shutdown();
+
+        try
+        {
+            long lastProgression = nextId.get();
+            // Have max no-progress-timeout quite high to be able to cope with huge
+            // I/O congestion spikes w/o failing in vain.
+            while ( !executor.awaitTermination( 30, SECONDS ) )
+            {
+                if ( lastProgression == nextId.get() )
+                {
+                    // No progression at all, abort?
+                    error.compareAndSet( null, new IOException( "No progress, so forcing abort" ) );
+                }
+                lastProgression = nextId.get();
+            }
+        }
+        catch ( InterruptedException e )
+        {
+            Thread.currentThread().interrupt();
+        }
+
+        Throwable finalError = error.get();
+        if ( finalError != null )
+        {
+            throw launderedException( IOException.class, finalError );
+        }
+
+        long endTime = currentTimeMillis();
+        monitor.recoveryCompleted( highTreeNodeId - lowTreeNodeId, cleanedPointers.get(), endTime - startTime );
+    }
+
+    private Runnable cleaner( AtomicLong nextId, AtomicReference<Throwable> error, AtomicInteger cleanedPointers )
+    {
+        return () ->
+        {
+            try ( PageCursor cursor = pagedFile.io( 0, PagedFile.PF_SHARED_READ_LOCK );
+                    PageCursor writeCursor = pagedFile.io( 0, PagedFile.PF_SHARED_WRITE_LOCK ) )
+            {
+                while ( nextId.get() < highTreeNodeId )
+                {
+                    // Do a batch of max 1000
+                    int batchCount = 0;
+                    for ( ; batchCount < 1_000; batchCount++ )
+                    {
+                        long id = nextId.getAndIncrement();
+                        if ( id >= highTreeNodeId )
+                        {
+                            break;
+                        }
+
+                        // TODO: we should try to figure out if the disk backing this paged file
+                        // is good at concurrent random reads (i.e. if it's an SSD).
+                        // If it's not it'd likely be beneficial to let other threads wait until
+                        // goTo completes before letting others read. This will have reads be
+                        // 100% sequential.
+                        PageCursorUtil.goTo( cursor, "clean", id );
+
+                        if ( hasCrashedGSPP( treeNode, cursor ) )
+                        {
+                            writeCursor.next( cursor.getCurrentPageId() );
+                            cleanTreeNode( treeNode, writeCursor, cleanedPointers );
+                        }
+                    }
+
+                    // Check error status after a batch, to reduce volatility overhead.
+                    // Is this over thinking things? Perhaps
+                    if ( error.get() != null )
+                    {
+                        break;
+                    }
+                }
+            }
+            catch ( Throwable e )
+            {
+                error.compareAndSet( null, e );
+            }
+        };
+    }
+
+    // === Methods about checking if a tree node has crashed pointers ===
+
+    private boolean hasCrashedGSPP( TreeNode<?,?> treeNode, PageCursor cursor ) throws IOException
+    {
+        boolean isTreeNode;
+        int keyCount;
+        do
+        {
+            isTreeNode = TreeNode.nodeType( cursor ) == TreeNode.NODE_TYPE_TREE_NODE;
+            keyCount = treeNode.keyCount( cursor );
+        }
+        while ( cursor.shouldRetry() );
+
+        if ( !isTreeNode )
+        {
+            return false;
+        }
+
+        boolean hasCrashed;
+        do
+        {
+            hasCrashed =
+                    hasCrashedGSPP( cursor, TreeNode.BYTE_POS_NEWGEN ) ||
+                    hasCrashedGSPP( cursor, TreeNode.BYTE_POS_LEFTSIBLING ) ||
+                    hasCrashedGSPP( cursor, TreeNode.BYTE_POS_RIGHTSIBLING );
+
+            if ( !hasCrashed && TreeNode.isInternal( cursor ) )
+            {
+                for ( int i = 0; i <= keyCount && i <= maxKeyCount && !hasCrashed; i++ )
+                {
+                    hasCrashed |= hasCrashedGSPP( cursor, treeNode.childOffset( i ) );
+                }
+            }
+        }
+        while ( cursor.shouldRetry() );
+        return hasCrashed;
+    }
+
+    private boolean hasCrashedGSPP( PageCursor cursor, int gsppOffset )
+    {
+        return hasCrashedGSP( cursor, gsppOffset ) || hasCrashedGSP( cursor, gsppOffset + GenSafePointer.SIZE );
+    }
+
+    private boolean hasCrashedGSP( PageCursor cursor, int offset )
+    {
+        cursor.setOffset( offset );
+        long generation = GenSafePointer.readGeneration( cursor );
+        return generation > stableGeneration && generation < unstableGeneration;
+    }
+
+    // === Methods about actually cleaning a discovered crashed tree node ===
+
+    private void cleanTreeNode( TreeNode<?,?> treeNode, PageCursor cursor, AtomicInteger cleanedPointers )
+    {
+        cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_NEWGEN, cleanedPointers );
+        cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_LEFTSIBLING, cleanedPointers );
+        cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_RIGHTSIBLING, cleanedPointers );
+
+        if ( TreeNode.isInternal( cursor ) )
+        {
+            int keyCount = treeNode.keyCount( cursor );
+            for ( int i = 0; i <= keyCount && i <= maxKeyCount; i++ )
+            {
+                cleanCrashedGSPP( cursor, treeNode.childOffset( i ), cleanedPointers );
+            }
+        }
+    }
+
+    private void cleanCrashedGSPP( PageCursor cursor, int gsppOffset, AtomicInteger cleanedPointers )
+    {
+        cleanCrashedGSP( cursor, gsppOffset, cleanedPointers );
+        cleanCrashedGSP( cursor, gsppOffset + GenSafePointer.SIZE, cleanedPointers );
+    }
+
+    private void cleanCrashedGSP( PageCursor cursor, int gspOffset, AtomicInteger cleanedPointers )
+    {
+        if ( hasCrashedGSP( cursor, gspOffset ) )
+        {
+            cursor.setOffset( gspOffset );
+            GenSafePointer.clean( cursor );
+            cleanedPointers.incrementAndGet();
+        }
+    }
+}

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
@@ -62,8 +62,6 @@ class CrashGenCleaner
         this.availableProcessors = Runtime.getRuntime().availableProcessors();
         this.batchSize = // Each processor will get roughly 100 batches each
                 min( 1000, max( 10, (highTreeNodeId - lowTreeNodeId) / (100 * availableProcessors) ) );
-        System.out.println( "Number of processors: " + availableProcessors + ", number of pages: " +
-                (highTreeNodeId - lowTreeNodeId) + ", batch size: " + batchSize );
         this.stableGeneration = stableGeneration;
         this.unstableGeneration = unstableGeneration;
         this.monitor = monitor;
@@ -231,6 +229,9 @@ class CrashGenCleaner
         cleanCrashedGSP( cursor, gsppOffset + GenSafePointer.SIZE, cleanedPointers );
     }
 
+    /**
+     * NOTE: No shouldRetry is used because cursor is assumed to be a write cursor.
+     */
     private void cleanCrashedGSP( PageCursor cursor, int gspOffset, AtomicInteger cleanedPointers )
     {
         if ( hasCrashedGSP( cursor, gspOffset ) )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -848,7 +848,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
      *
      * @throws IOException on {@link PageCache} error.
      */
-    public void cleanCrashPointers() throws IOException
+    public void finishRecovery() throws IOException
     {
         // For the time being there's an issue where update that come in before a crash
         // may be applied in a different order than when they get recovered.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -848,7 +848,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
      *
      * @throws IOException on {@link PageCache} error.
      */
-    public void completeRecovery() throws IOException
+    public void cleanCrashPointers() throws IOException
     {
         // For the time being there's an issue where update that come in before a crash
         // may be applied in a different order than when they get recovered.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenSafePointer.java
@@ -47,6 +47,9 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
  */
 class GenSafePointer
 {
+    private static final int EMPTY_POINTER = 0;
+    private static final int EMPTY_GENERATION = 0;
+
     static final long MIN_GENERATION = 1L;
     // unsigned int
     static final long MAX_GENERATION = 0xFFFFFFFFL;
@@ -70,13 +73,23 @@ class GenSafePointer
      * @param generation generation to write.
      * @param pointer pointer to write.
      */
-    public static void write( PageCursor cursor, long generation, long pointer )
+    static void write( PageCursor cursor, long generation, long pointer )
     {
         assertGenerationOnWrite( generation );
         assertPointerOnWrite( pointer );
+        writeGSP( cursor, generation, pointer );
+    }
+
+    private static void writeGSP( PageCursor cursor, long generation, long pointer )
+    {
         cursor.putInt( (int) generation );
         put6BLong( cursor, pointer );
         cursor.putShort( checksumOf( generation, pointer ) );
+    }
+
+    static void clean( PageCursor cursor )
+    {
+        writeGSP( cursor, EMPTY_GENERATION, EMPTY_POINTER );
     }
 
     static void assertGenerationOnWrite( long generation )
@@ -140,6 +153,6 @@ class GenSafePointer
 
     public static boolean isEmpty( long generation, long pointer )
     {
-        return generation == 0 && pointer == 0;
+        return generation == EMPTY_GENERATION && pointer == EMPTY_POINTER;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -56,7 +56,7 @@ class TreePrinter<KEY,VALUE>
      * @param cursor {@link PageCursor} placed at root of tree or sub-tree.
      * @param out target to print tree at.
      * @param printPosition whether or not to include positional (slot number) information.
-     * @param printState
+     * @param printState whether or not to also print state pages
      * @throws IOException on page cache access error.
      */
     void printTree( PageCursor cursor, PrintStream out, boolean printValues, boolean printPosition, boolean printState )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -70,19 +69,19 @@ public class CrashGenCleanerTest
     private final int firstChildPos = 0;
     private final int middleChildPos = corruptableTreeNode.internalMaxKeyCount() / 2;
     private final int lastChildPos = corruptableTreeNode.internalMaxKeyCount();
-    private final List<PageCorruption> possibleCorruptionsInInternal = new ArrayList<>( Arrays.asList(
+    private final List<PageCorruption> possibleCorruptionsInInternal = Arrays.asList(
             crashed( leftSibling() ),
             crashed( rightSibling() ),
             crashed( newGen() ),
             crashed( child( firstChildPos ) ),
             crashed( child( middleChildPos ) ),
             crashed( child( lastChildPos ) )
-    ) );
-    private final List<PageCorruption> possibleCorruptionsInLeaf = new ArrayList<>( Arrays.asList(
+    );
+    private final List<PageCorruption> possibleCorruptionsInLeaf = Arrays.asList(
             crashed( leftSibling() ),
             crashed( rightSibling() ),
             crashed( newGen() )
-    ) );
+    );
 
     private class SimpleMonitor implements GBPTree.Monitor
     {

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree;
+
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.test.rule.PageCacheRule.config;
+
+public class CrashGenCleanerTest
+{
+    private FileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    private PageCacheRule pageCacheRule = new PageCacheRule();
+    private TestDirectory testDirectory = TestDirectory.testDirectory( this.getClass(), fileSystemRule.get() );
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( fileSystemRule ).around( testDirectory ).around( pageCacheRule );
+
+    private static final String FILE_NAME = "index";
+    private static final int PAGE_SIZE = 256;
+
+    private PagedFile pagedFile;
+    private final Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();
+    private final CorruptableTreeNode corruptableTreeNode = new CorruptableTreeNode( PAGE_SIZE, layout );
+    private final int oldStableGen = 9;
+    private final int stableGen = 10;
+    private final int unstableGen = 12;
+    private final int crashGen = 11;
+
+    private class SimpleMonitor implements GBPTree.Monitor
+    {
+        boolean recoveryCompleted;
+        private long numberOfPagesVisited;
+        private long numberOfCleanedCrashPointers;
+
+        @Override
+        public void recoveryCompleted( long numberOfPagesVisited, long numberOfCleanedCrashPointers,
+                long durationMillis )
+        {
+            recoveryCompleted = true;
+            this.numberOfPagesVisited = numberOfPagesVisited;
+            this.numberOfCleanedCrashPointers = numberOfCleanedCrashPointers;
+        }
+    }
+
+    @Before
+    public void setupPagedFile() throws IOException
+    {
+        PageCache pageCache = pageCacheRule
+                .getPageCache( fileSystemRule.get(), config().withPageSize( PAGE_SIZE ).withAccessChecks( true ) );
+        pagedFile = pageCache
+                .map( testDirectory.file( FILE_NAME ), PAGE_SIZE, CREATE, DELETE_ON_CLOSE );
+    }
+
+    @After
+    public void teardownPagedFile() throws IOException
+    {
+        pagedFile.close();
+    }
+
+    @Test
+    public void shouldCleanOneCrashPerPage() throws Exception
+    {
+        // GIVEN
+        initializeFile( pagedFile, with(
+                /* left sibling */
+                leafWith( crashed( leftSibling() ) ),
+                internalWith( crashed( leftSibling() ) ),
+
+                /* right sibling */
+                leafWith( crashed( rightSibling() ) ),
+                internalWith( crashed( rightSibling() ) ),
+
+                /* new gen */
+                leafWith( crashed( newGen() ) ),
+                internalWith( crashed( newGen() ) ),
+
+                /* child */
+                internalWith( crashed( child( 0 ) ) ),
+                internalWith( crashed( child( corruptableTreeNode.internalMaxKeyCount() ) ) )
+        ) );
+
+        // WHEN
+        SimpleMonitor monitor = new SimpleMonitor();
+        crashGenCleaner( pagedFile, 0, 8, monitor ).clean();
+
+        // THEN
+        assertPagesVisisted( monitor, 8 );
+        assertCleanedCrashPointers( monitor, 8 );
+    }
+
+    @Test
+    public void shouldCleanMultipleCrashPerPage() throws Exception
+    {
+        // GIVEN
+        initializeFile( pagedFile, with(
+                /* left sibling */
+                leafWith(
+                        crashed( leftSibling() ),
+                        crashed( rightSibling() ) ),
+                internalWith(
+                        crashed( leftSibling() ),
+                        crashed( rightSibling() ),
+                        crashed( child( 0 ) ),
+                        crashed( child( corruptableTreeNode.internalMaxKeyCount() ) ) )
+        ) );
+
+        // WHEN
+        SimpleMonitor monitor = new SimpleMonitor();
+        crashGenCleaner( pagedFile, 0, 2, monitor ).clean();
+
+        // THEN
+        assertPagesVisisted( monitor, 2 );
+        assertCleanedCrashPointers( monitor, 6 );
+    }
+
+    private void assertCleanedCrashPointers( SimpleMonitor monitor,
+            int expectedNumberOfCleanedCrashPointers )
+    {
+        assertEquals( "Expected number of cleaned crash pointers to be " +
+                        expectedNumberOfCleanedCrashPointers + " but was " + monitor.numberOfCleanedCrashPointers,
+                expectedNumberOfCleanedCrashPointers, monitor.numberOfCleanedCrashPointers );
+    }
+
+    private void assertPagesVisisted( SimpleMonitor monitor, int expectedNumberOfPagesVisited )
+    {
+        assertEquals( "Expected number of visited pages to be " + expectedNumberOfPagesVisited +
+                        " but was " + monitor.numberOfPagesVisited,
+                expectedNumberOfPagesVisited, monitor.numberOfPagesVisited );
+    }
+
+    private CrashGenCleaner crashGenCleaner( PagedFile pagedFile, int lowTreeNodeId, int highTreeNodeId,
+            SimpleMonitor monitor )
+    {
+        return new CrashGenCleaner( pagedFile, corruptableTreeNode, lowTreeNodeId, highTreeNodeId,
+                stableGen, unstableGen, monitor );
+    }
+
+    private void initializeFile( PagedFile pagedFile, Page... pages ) throws IOException
+    {
+        try ( PageCursor cursor = pagedFile.io( 0, PagedFile.PF_SHARED_WRITE_LOCK ) )
+        {
+            for ( Page page : pages )
+            {
+                cursor.next();
+                page.write( cursor, corruptableTreeNode, stableGen, unstableGen, crashGen );
+            }
+        }
+    }
+
+    /* Page */
+    private Page[] with( Page... pages )
+    {
+        return pages;
+    }
+
+    private Page leafWith( PageCorruption... pageCorruptions )
+    {
+        return new Page( PageType.LEAF, pageCorruptions );
+    }
+
+    private Page internalWith( PageCorruption... pageCorruptions )
+    {
+        return new Page( PageType.INTERNAL, pageCorruptions );
+    }
+
+    private class Page
+    {
+        private final PageType type;
+        private final PageCorruption[] pageCorruptions;
+
+        private Page( PageType type, PageCorruption... pageCorruptions )
+        {
+            this.type = type;
+            this.pageCorruptions = pageCorruptions;
+        }
+
+        private void write( PageCursor cursor, CorruptableTreeNode node, int stableGen, int unstableGen, int crashGen )
+                throws IOException
+        {
+            type.write( cursor, node, oldStableGen, stableGen );
+            Arrays.stream( pageCorruptions )
+                    .forEach( pc -> pc.corrupt( cursor, node, stableGen, unstableGen, crashGen ) );
+        }
+    }
+
+    enum PageType
+    {
+        LEAF
+                {
+                    @Override
+                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGen,
+                            int unstableGen )
+                    {
+                        corruptableTreeNode.initializeLeaf( cursor, stableGen, unstableGen );
+                    }
+                },
+        INTERNAL
+                {
+                    @Override
+                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGen,
+                            int unstableGen )
+                    {
+                        corruptableTreeNode.initializeInternal( cursor, stableGen, unstableGen );
+                        int maxKeyCount = corruptableTreeNode.internalMaxKeyCount();
+                        long base = IdSpace.MIN_TREE_NODE_ID;
+                        for ( int i = 0; i <= maxKeyCount; i++ )
+                        {
+                            long child = base + i;
+                            corruptableTreeNode.setChildAt( cursor, child, i, stableGen, unstableGen );
+                        }
+                        corruptableTreeNode.setKeyCount( cursor, maxKeyCount );
+                    }
+                };
+
+        abstract void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode,
+                int stableGen, int unstableGen );
+    }
+
+    /* GSPPType */
+    private GSPPType leftSibling()
+    {
+        return SimpleGSPPType.LEFT_SIBLING;
+    }
+
+    private GSPPType rightSibling()
+    {
+        return SimpleGSPPType.RIGHT_SIBLING;
+    }
+
+    private GSPPType newGen()
+    {
+        return SimpleGSPPType.NEW_GEN;
+    }
+
+    private GSPPType child( int pos )
+    {
+        return childGSPPType( pos );
+    }
+
+    interface GSPPType
+    {
+        int offset( TreeNode node );
+    }
+
+    enum SimpleGSPPType implements GSPPType
+    {
+        LEFT_SIBLING
+                {
+                    @Override
+                    public int offset( TreeNode node )
+                    {
+                        return TreeNode.BYTE_POS_LEFTSIBLING;
+                    }
+                },
+        RIGHT_SIBLING
+                {
+                    @Override
+                    public int offset( TreeNode node )
+                    {
+                        return TreeNode.BYTE_POS_RIGHTSIBLING;
+                    }
+                },
+        NEW_GEN
+                {
+                    @Override
+                    public int offset( TreeNode node )
+                    {
+                        return TreeNode.BYTE_POS_NEWGEN;
+                    }
+                }
+    }
+
+    private GSPPType childGSPPType( int pos )
+    {
+        return node -> node.childOffset( pos );
+    }
+
+    /* PageCorruption */
+    private PageCorruption crashed( GSPPType gsppType )
+    {
+        return ( pageCursor, node, stableGen, unstableGen, crashGen ) ->
+                node.crashGSPP( pageCursor, gsppType.offset( node ), crashGen );
+    }
+
+    private interface PageCorruption
+    {
+        void corrupt( PageCursor pageCursor, CorruptableTreeNode node, int stableGen,
+                int unstableGen, int crashGen );
+    }
+
+    class CorruptableTreeNode extends TreeNode<MutableLong,MutableLong>
+    {
+        CorruptableTreeNode( int pageSize, Layout<MutableLong,MutableLong> layout )
+        {
+            super( pageSize, layout );
+        }
+
+        void crashGSPP( PageCursor pageCursor, int offset, int crashGen )
+        {
+            pageCursor.setOffset( offset );
+            GenSafePointerPair.write( pageCursor, 42, stableGen, crashGen );
+        }
+    }
+}

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
@@ -116,6 +116,41 @@ public class CrashGenCleanerTest
     }
 
     @Test
+    public void shouldNotCrashOnEmptyFile() throws Exception
+    {
+        // GIVEN
+        Page[] pages = with();
+        initializeFile( pagedFile, pages );
+
+        // WHEN
+        SimpleMonitor monitor = new SimpleMonitor();
+        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+
+        // THEN
+        assertPagesVisisted( monitor, pages.length );
+        assertCleanedCrashPointers( monitor, 0 );
+    }
+
+    @Test
+    public void shouldNotReportErrorsOnCleanPages() throws Exception
+    {
+        // GIVEN
+        Page[] pages = with(
+                leafWith(),
+                internalWith()
+        );
+        initializeFile( pagedFile, pages );
+
+        // WHEN
+        SimpleMonitor monitor = new SimpleMonitor();
+        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+
+        // THEN
+        assertPagesVisisted( monitor, 2 );
+        assertCleanedCrashPointers( monitor, 0 );
+    }
+
+    @Test
     public void shouldCleanOneCrashPerPage() throws Exception
     {
         // GIVEN

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
@@ -36,6 +36,7 @@ import org.neo4j.cursor.RawCursor;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.RandomRule.Seed;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
@@ -122,14 +123,13 @@ public class GBPTreeRecoveryTest
     public void shouldRecoverFromAnythingReplayExactFromCheckpoint() throws Exception
     {
         doShouldRecoverFromAnything( true );
-
     }
 
+    @Seed( 1488879322788L )
     @Test
     public void shouldRecoverFromAnythingReplayFromBeforeLastCheckpoint() throws Exception
     {
         doShouldRecoverFromAnything( false );
-
     }
 
     private void doShouldRecoverFromAnything( boolean replayRecoveryExactlyFromCheckpoint ) throws Exception
@@ -200,6 +200,7 @@ public class GBPTreeRecoveryTest
                 GBPTree<MutableLong,MutableLong> index = createIndex( pageCache, file ) )
         {
             recover( recoveryActions, index );
+            index.completeRecovery();
 
             // THEN
             // we should end up with a consistent index containing all the stuff load says

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
@@ -100,7 +100,7 @@ public class GBPTreeRecoveryTest
         {
             // this is the mimic:ed recovery
             index.prepareForRecovery();
-            index.cleanCrashPointers();
+            index.finishRecovery();
 
             try ( Writer<MutableLong,MutableLong> writer = index.writer() )
             {
@@ -231,7 +231,7 @@ public class GBPTreeRecoveryTest
                 GBPTree<MutableLong,MutableLong> index = createIndex( pageCache, file ) )
         {
             recover( recoveryActions, index );
-            index.cleanCrashPointers();
+            index.finishRecovery();
 
             // THEN
             // we should end up with a consistent index containing all the stuff load says

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryTest.java
@@ -100,7 +100,7 @@ public class GBPTreeRecoveryTest
         {
             // this is the mimic:ed recovery
             index.prepareForRecovery();
-            index.completeRecovery();
+            index.cleanCrashPointers();
 
             try ( Writer<MutableLong,MutableLong> writer = index.writer() )
             {
@@ -231,7 +231,7 @@ public class GBPTreeRecoveryTest
                 GBPTree<MutableLong,MutableLong> index = createIndex( pageCache, file ) )
         {
             recover( recoveryActions, index );
-            index.completeRecovery();
+            index.cleanCrashPointers();
 
             // THEN
             // we should end up with a consistent index containing all the stuff load says

--- a/community/io/src/test/java/org/neo4j/adversaries/RandomAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/RandomAdversary.java
@@ -40,7 +40,7 @@ public class RandomAdversary extends AbstractAdversary
         assert 0 <= errorRate && errorRate < 1.0 :
                 "Expected error rate in [0.0; 1.0[ but was " + errorRate;
         assert mischiefRate + errorRate + failureRate < 1.0 :
-                "Expected error rate + failure rate in [0.0; 1.0[ but was " +
+                "Expected mischief rate + error rate + failure rate in [0.0; 1.0[ but was " +
                         (mischiefRate + errorRate + failureRate);
 
         this.mischiefRate = mischiefRate;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.labelscan;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -61,6 +62,10 @@ public interface LabelScanStore extends Lifecycle
         }
 
         default void rebuilt( long roughNodeCount )
+        {   // empty
+        }
+
+        default void recoveryCompleted( Map<String,Object> data )
         {   // empty
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.kernel.api.labelscan;
 
+import java.util.Map;
+
 import org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor;
 import org.neo4j.logging.Log;
+
+import static java.lang.String.format;
 
 /**
  * Logs about important events about {@link LabelScanStore} {@link Monitor}.
@@ -80,5 +84,14 @@ public class LoggingMonitor implements Monitor
     {
         log.info( "Scan store rebuilt (roughly " + roughNodeCount + " nodes)" );
         delegate.rebuilt( roughNodeCount );
+    }
+
+    @Override
+    public void recoveryCompleted( Map<String,Object> data )
+    {
+        StringBuilder builder = new StringBuilder( "Scan store recovery completed:" );
+        data.forEach( (key,value) -> builder.append( format( " %s: %s", key, value ) ) );
+        log.info( builder.toString() );
+        delegate.recoveryCompleted( data );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -391,7 +391,7 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         if ( recoveryStarted )
         {
-            index.cleanCrashPointers();
+            index.finishRecovery();
             recoveryStarted = false;
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -218,6 +218,7 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         try
         {
+            maybeCompleteRecovery();
             index.checkpoint( limiter );
         }
         catch ( IOException e )
@@ -381,12 +382,18 @@ public class NativeLabelScanStore implements LabelScanStore
             needsRebuild = false;
         }
 
+        maybeCompleteRecovery();
+
+        started = true;
+    }
+
+    private void maybeCompleteRecovery() throws IOException
+    {
         if ( recoveryStarted )
         {
             index.completeRecovery();
+            recoveryStarted = false;
         }
-
-        started = true;
     }
 
     private NativeLabelScanWriter writer() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -42,9 +42,11 @@ import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
 
+import static org.neo4j.helpers.Format.duration;
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
 import static org.neo4j.helpers.collection.Iterators.iterator;
+import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 
@@ -319,7 +321,23 @@ public class NativeLabelScanStore implements LabelScanStore
 
     private void instantiateTree() throws IOException
     {
-        index = new GBPTree<>( pageCache, storeFile, new LabelScanLayout(), pageSize, GBPTree.NO_MONITOR, NO_HEADER );
+        index = new GBPTree<>( pageCache, storeFile, new LabelScanLayout(), pageSize, treeMonitor(), NO_HEADER );
+    }
+
+    private GBPTree.Monitor treeMonitor()
+    {
+        return new GBPTree.Monitor()
+        {
+            @Override
+            public void recoveryCompleted( long numberOfPagesVisited, long numberOfCleanedCrashPointers,
+                    long durationMillis )
+            {
+                monitor.recoveryCompleted( map(
+                        "Number of pages visited", numberOfPagesVisited,
+                        "Number of cleaned crashed pointers", numberOfCleanedCrashPointers,
+                        "Time spent", duration( durationMillis ) ) );
+            }
+        };
     }
 
     @Override
@@ -362,6 +380,12 @@ public class NativeLabelScanStore implements LabelScanStore
             monitor.rebuilt( numberOfNodes );
             needsRebuild = false;
         }
+
+        if ( recoveryStarted )
+        {
+            index.completeRecovery();
+        }
+
         started = true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -391,7 +391,7 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         if ( recoveryStarted )
         {
-            index.completeRecovery();
+            index.cleanCrashPointers();
             recoveryStarted = false;
         }
     }


### PR DESCRIPTION
For the time being there's an issue where update that come in before a crash
may be applied in a different order than when they get recovered.
This may have structural changes be different during recovery than what they were
during normal application. The result of this is that there may be CRASH pointers left
hanging in the tree. A problem with CRASH pointers is that they can only be recognized
while doing recovery, where they are recognized from their generation being STABLE < gen < UNSTABLE,
i.e. recovery creates this gap to be able to distinguish crashed from fixed pointers.
After recovery is completed and the next checkpoint/close happens that gap is closed
and any remaining CRASH pointers cannot be recognized as such anymore.

The temporary solution right now is to scan through all tree nodes, as performant as possible,
and zero out all CRASH pointers.

NOTE: Github display commits in wrong order, real order is
```
1cbaaba Introduce CrashGenCleaner
18d3c9c Add test for CrashGenCleaner
c11b59b Add randomized CrashGenCleaner test
e75e181 Different key contention in GBPTreeRecoveryTest
4999ae7 Fix complete recovery being triggered to late because of intermediate force
```