### PR TITLE
Make sure composite index queries are handled correctly

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -130,12 +130,12 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     entryConstructor(plannables.map(p => p.propertyPredicate) :+ labelPredicate)
   }
 
-  private def mergeQueryExpressionsToSingleOne(plannables: Seq[IndexPlannableExpression]) =
+  private def mergeQueryExpressionsToSingleOne(plannables: Seq[IndexPlannableExpression]): QueryExpression[Expression] =
     if (plannables.length == 1)
       plannables.head.queryExpression
     else {
       val expressions: Seq[Expression] = plannables.flatMap(_.queryExpression.expressions)
-      CompositeQueryExpression(expressions)
+      CompositeQueryExpression(plannables.map(_.queryExpression))
     }
 
   private def indexPlannableExpression(argumentIds: Set[IdName],
@@ -176,11 +176,8 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
       plannables find (p => p.propertyKeyName.id.contains(propertyKeyId))
     }
 
-    val temporarilyTurnOffCompositeIndexesUntilTheyAreSupportedByTheKernel = true //foundPredicates.length == 1
-
     // Currently we only support using the composite index if ALL properties are specified, but this could be generalized
-    if (foundPredicates.length == indexDescriptor.properties.length &&
-      temporarilyTurnOffCompositeIndexesUntilTheyAreSupportedByTheKernel)
+    if (foundPredicates.length == indexDescriptor.properties.length)
       Some(foundPredicates)
     else
       None

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/OrLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/OrLeafPlanner.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, Ors}
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.SeqCombiner.combine
 import org.neo4j.cypher.internal.ir.v3_2.QueryGraph
 
 case class OrLeafPlanner(inner: Seq[LeafPlanFromExpressions]) extends LeafPlanner {
@@ -69,44 +70,6 @@ case class OrLeafPlanner(inner: Seq[LeafPlanFromExpressions]) extends LeafPlanne
 
       case _ => Seq.empty
     }
-  }
-
-  /**
-    * Combines each element in the inner Seq's with one element of every other inner Seq.
-    *
-    * scala> combine(List(List("A", "B", "C"), List(1,2,3), List("x", "y", "z")))
-      res0: Seq[Seq[Any]] = List(
-          List(A, 1, x),
-          List(A, 1, y),
-          List(A, 1, z),
-          List(A, 2, x),
-          List(A, 2, y),
-          List(A, 2, z),
-          List(A, 3, x),
-          List(A, 3, y),
-          List(A, 3, z),
-          List(B, 1, x),
-          List(B, 1, y),
-          List(B, 1, z),
-          List(B, 2, x),
-          List(B, 2, y),
-          List(B, 2, z),
-          List(B, 3, x),
-          List(B, 3, y),
-          List(B, 3, z),
-          List(C, 1, x),
-          List(C, 1, y),
-          List(C, 1, z),
-          List(C, 2, x),
-          List(C, 2, y),
-          List(C, 2, z),
-          List(C, 3, x),
-          List(C, 3, y),
-          List(C, 3, z))
-    */
-  private def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =
-  xs.foldLeft(Seq(Seq.empty[A])) {
-    (x, y) => for (a <- x; b <- y) yield a :+ b
   }
 
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/IteratorOfIterarorsTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/IteratorOfIterarorsTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.commands
+
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+
+class IteratorOfIterarorsTest extends CypherFunSuite {
+  test("single inner iterator") {
+    val r = new IteratorOfIterarors[Int](Seq(Iterator(1, 2, 3)))
+    r.toList should equal(List(1, 2, 3))
+  }
+
+  test("two inner non-empty iterators") {
+    val r = new IteratorOfIterarors[Int](Seq(Iterator(1, 2, 3), Iterator(4, 5, 6)))
+    r.toList should equal(List(1, 2, 3, 4, 5, 6))
+  }
+
+  test("two empty inner iterators") {
+    val r = new IteratorOfIterarors[Int](Seq(Iterator.empty, Iterator.empty))
+    r.toList should equal(List.empty)
+  }
+
+  test("non-empty iterators with an empty one") {
+    val r = new IteratorOfIterarors[Int](Seq(Iterator(1, 2, 3), Iterator.empty, Iterator(4, 5, 6)))
+    r.toList should equal(List(1, 2, 3, 4, 5, 6))
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipeTest.scala
@@ -196,8 +196,8 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
     val pipe = NodeIndexSeekPipe("n", label,
       propertyKey :+ PropertyKeyToken(PropertyKeyName("prop2") _, PropertyKeyId(11)),
       CompositeQueryExpression(Seq(
-        Literal("hello"),
-        Literal("world")
+        SingleQueryExpression(Literal("hello")),
+        SingleQueryExpression(Literal("world"))
       )))()
     val result = pipe.createResults(queryState)
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LeafPlanningIntegrationTest.scala
@@ -442,6 +442,10 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop", "prop2")
     } getLogicalPlanFor "MATCH (n:Awesome) WHERE n.prop = 42 AND n.prop2 = 'foo' RETURN n"
 
+
+    val seek1: SingleQueryExpression[Expression] = SingleQueryExpression(SignedDecimalIntegerLiteral("42")_)
+    val seek2: SingleQueryExpression[Expression] = SingleQueryExpression(StringLiteral("foo")_)
+
     plan._2 should equal(
       NodeIndexSeek(
         "n",
@@ -449,7 +453,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         Seq(
           PropertyKeyToken(PropertyKeyName("prop") _, PropertyKeyId(0)),
           PropertyKeyToken(PropertyKeyName("prop2") _, PropertyKeyId(1))),
-        CompositeQueryExpression(Seq(SignedDecimalIntegerLiteral("42") _, StringLiteral("foo") _)),
+        CompositeQueryExpression(Seq(seek1, seek2)),
         Set.empty)(solved)
     )
   }
@@ -459,6 +463,10 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop", "prop2")
     } getLogicalPlanFor "MATCH (n:Awesome) WHERE n.prop2 = 'foo' AND n.prop = 42 RETURN n"
 
+    val seek1: SingleQueryExpression[Expression] = SingleQueryExpression(SignedDecimalIntegerLiteral("42")_)
+    val seek2: SingleQueryExpression[Expression] = SingleQueryExpression(StringLiteral("foo")_)
+
+
     plan._2 should equal(
       NodeIndexSeek(
         "n",
@@ -466,7 +474,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         Seq(
           PropertyKeyToken(PropertyKeyName("prop") _, PropertyKeyId(0)),
           PropertyKeyToken(PropertyKeyName("prop2") _, PropertyKeyId(1))),
-        CompositeQueryExpression(Seq(SignedDecimalIntegerLiteral("42") _, StringLiteral("foo") _)),
+        CompositeQueryExpression(Seq(seek1, seek2)),
         Set.empty)(solved)
     )
   }
@@ -476,6 +484,9 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop", "prop2")
     } getLogicalPlanFor "MATCH (n:Awesome) WHERE n.prop2 = 'foo' AND exists(n.name) AND n.prop = 42 RETURN n"
 
+    val seek1: SingleQueryExpression[Expression] = SingleQueryExpression(SignedDecimalIntegerLiteral("42")_)
+    val seek2: SingleQueryExpression[Expression] = SingleQueryExpression(StringLiteral("foo")_)
+
     plan._2 should equal(
       Selection(Seq(FunctionInvocation(FunctionName("exists") _, Property(varFor("n"), PropertyKeyName("name") _) _) _),
         NodeIndexSeek(
@@ -484,7 +495,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
           Seq(
             PropertyKeyToken(PropertyKeyName("prop") _, PropertyKeyId(0)),
             PropertyKeyToken(PropertyKeyName("prop2") _, PropertyKeyId(1))),
-          CompositeQueryExpression(Seq(SignedDecimalIntegerLiteral("42") _, StringLiteral("foo") _)),
+          CompositeQueryExpression(Seq(seek1, seek2)),
           Set.empty)(solved)
       )(solved)
     )

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexLeafPlannerTest.scala
@@ -286,8 +286,12 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       resultPlans should beLike {
         case Seq(
           AssertSameNode(`idName`,
-            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _)), CompositeQueryExpression(Seq(`val1`, `val2`)), _),
-            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), _, SingleQueryExpression(`val3`), _))) => ()
+            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _)),
+              CompositeQueryExpression(Seq(
+                SingleQueryExpression(`val1`),
+                SingleQueryExpression(`val2`))), _),
+            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), _,
+              SingleQueryExpression(`val3`), _))) => ()
       }
     }
   }
@@ -316,8 +320,14 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       resultPlans should beLike {
         case Seq(
           AssertSameNode(`idName`,
-            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _)), CompositeQueryExpression(Seq(`val1`, `val2`)), _),
-            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop2", _), PropertyKeyToken("prop3", _)), CompositeQueryExpression(Seq(`val2`, `val3`)), _))) => ()
+            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _)),
+              CompositeQueryExpression(Seq(
+                SingleQueryExpression(`val1`),
+                SingleQueryExpression(`val2`))), _),
+            NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop2", _), PropertyKeyToken("prop3", _)),
+              CompositeQueryExpression(Seq(
+                SingleQueryExpression(`val2`),
+                SingleQueryExpression(`val3`))), _))) => ()
       }
     }
   }
@@ -343,7 +353,12 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       // then
       resultPlans should beLike {
         case Seq(
-          NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _), Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _), PropertyKeyToken("prop3", _)), CompositeQueryExpression(Seq(`val1`, `val2`, `val3`)), _)
+          NodeUniqueIndexSeek(`idName`, LabelToken("Awesome", _),
+            Seq(PropertyKeyToken("prop1", _), PropertyKeyToken("prop2", _), PropertyKeyToken("prop3", _)),
+            CompositeQueryExpression(Seq(
+              SingleQueryExpression(`val1`),
+              SingleQueryExpression(`val2`),
+              SingleQueryExpression(`val3`))), _)
         ) => ()
       }
     }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
@@ -108,7 +108,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       resultPlans should beLike {
         case Seq(NodeIndexSeek(`idName`, LabelToken("Awesome", _),
         Seq(PropertyKeyToken("prop", _), PropertyKeyToken("prop2", _)),
-        CompositeQueryExpression(Seq(`lit42`, `lit6`)), _)) => ()
+        CompositeQueryExpression(Seq(SingleQueryExpression(`lit42`), SingleQueryExpression(`lit6`))), _)) => ()
       }
     }
   }
@@ -143,7 +143,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       resultPlans should beLike {
         case Seq(NodeIndexSeek(`idName`, LabelToken("Awesome", _),
         Seq(PropertyKeyToken("prop", _), PropertyKeyToken("prop2", _)),
-        CompositeQueryExpression(Seq(`lit42`, `lit6`)), _)) => ()
+        CompositeQueryExpression(Seq(SingleQueryExpression(`lit42`), SingleQueryExpression(`lit6`))), _)) => ()
       }
     }
   }
@@ -210,9 +210,10 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
   }
 
   test("does not plan an index seek when the RHS expression does not have its dependencies in scope") {
-    new given { // MATCH a, x WHERE a.prop IN [x]
-       val x = varFor("x")
-      qg = queryGraph(In(property, ListLiteral(Seq(x))_)_, hasLabels)
+    new given {
+      // MATCH a, x WHERE a.prop IN [x]
+      val x = varFor("x")
+      qg = queryGraph(In(property, ListLiteral(Seq(x)) _) _, hasLabels)
 
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/IndexSeekLeafPlannerTest.scala
@@ -179,7 +179,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
         case Seq(NodeIndexSeek(`idName`, LabelToken("Awesome", _),
         props@Seq(_*),
         CompositeQueryExpression(vals@Seq(_*)), _))
-          if assertPropsAndValuesMatch(propertyNames, values, props, vals) => ()
+          if assertPropsAndValuesMatch(propertyNames, values, props, vals.flatMap(_.expressions)) => ()
       }
     }
   }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/SeqCombiner.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/SeqCombiner.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v3_2.helpers
+
+object SeqCombiner {
+  /**
+    * Combines each element in the inner Seq's with one element of every other inner Seq.
+    *
+    * scala> combine(List(List("A", "B", "C"), List(1,2,3), List("x", "y", "z")))
+      res0: Seq[Seq[Any]] = List(
+          List(A, 1, x),
+          List(A, 1, y),
+          List(A, 1, z),
+          List(A, 2, x),
+          List(A, 2, y),
+          List(A, 2, z),
+          List(A, 3, x),
+          List(A, 3, y),
+          List(A, 3, z),
+          List(B, 1, x),
+          List(B, 1, y),
+          List(B, 1, z),
+          List(B, 2, x),
+          List(B, 2, y),
+          List(B, 2, z),
+          List(B, 3, x),
+          List(B, 3, y),
+          List(B, 3, z),
+          List(C, 1, x),
+          List(C, 1, y),
+          List(C, 1, z),
+          List(C, 2, x),
+          List(C, 2, y),
+          List(C, 2, z),
+          List(C, 3, x),
+          List(C, 3, y),
+          List(C, 3, z))
+    */
+  def combine[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] =
+    xs.foldLeft(Seq(Seq.empty[A])) {
+      (x, y) => for (a <- x; b <- y) yield a :+ b
+    }
+
+}

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -199,9 +199,6 @@ object LogicalPlanConverter {
           case e: RangeQueryExpression[_] =>
             throw new CantCompileQueryException(s"To be done")
 
-          case e: CompositeRangeQueryExpression[_] =>
-            throw new CantCompileQueryException(s"To be done")
-
           case e => throw new CantCompileQueryException(s"$e is not a valid QueryExpression")
         }
 


### PR DESCRIPTION
Before this change, a query like `WHERE n.a IN [1,2,3] and n.b IN ['a','b','c']'` would search
the index for the values [1,2,3] and ['a','b','c'] instead of doing a separate seek for each pair of values.