### PR TITLE
Cluster formation decision depends on initial_hosts contents

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
@@ -164,4 +164,7 @@ public class ClusterSettings
             "any arbitrary half failing is expensive. Therefore you may wish to set this parameter to a value less " +
             "than the cluster size." )
     public static final Setting<Integer> max_acceptors = setting( "ha.max_acceptors", INTEGER, "21", min( 1 ) );
+
+    @Internal
+    public static final Setting<Boolean> strict_initial_hosts = setting( "ha.strict_initial_hosts", BOOLEAN, "false");
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -61,6 +61,7 @@ import org.neo4j.cluster.statemachine.StateMachineRules;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.cluster.com.message.Message.internal;
@@ -83,25 +84,26 @@ public class MultiPaxosServerFactory
     }
 
     @Override
-    public ProtocolServer newProtocolServer( InstanceId me, int maxAcceptors,
+    public ProtocolServer newProtocolServer( InstanceId me,
                                              TimeoutStrategy timeoutStrategy, MessageSource input,
                                              MessageSender output, AcceptorInstanceStore acceptorInstanceStore,
                                              ElectionCredentialsProvider electionCredentialsProvider,
                                              Executor stateMachineExecutor,
                                              ObjectInputStreamFactory objectInputStreamFactory,
-                                             ObjectOutputStreamFactory objectOutputStreamFactory )
+                                             ObjectOutputStreamFactory objectOutputStreamFactory,
+                                             Config config )
     {
         DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
 
         // Create state machines
         Timeouts timeouts = new Timeouts( timeoutStrategy );
 
-        final MultiPaxosContext context = new MultiPaxosContext( me, maxAcceptors,
-                Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( ClusterConfiguration.COORDINATOR ) ),
+        final MultiPaxosContext context = new MultiPaxosContext( me,
+                Iterables.iterable( new ElectionRole( ClusterConfiguration.COORDINATOR ) ),
                 new ClusterConfiguration( initialConfig.getName(), logging,
                         initialConfig.getMemberURIs() ),
                 executor, logging, objectInputStreamFactory, objectOutputStreamFactory, acceptorInstanceStore, timeouts,
-                electionCredentialsProvider
+                electionCredentialsProvider, config
         );
 
         SnapshotContext snapshotContext = new SnapshotContext( context.getClusterContext(),

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/NetworkedServerFactory.java
@@ -121,10 +121,9 @@ public class NetworkedServerFactory
                         new NamedThreadFactory( "State machine", namedThreadFactoryMonitor ) ) );
 
         final ProtocolServer protocolServer = protocolServerFactory.newProtocolServer(
-                config.get( ClusterSettings.server_id ), config.get( ClusterSettings.max_acceptors ),
-                timeoutStrategy, receiver, sender,
+                config.get( ClusterSettings.server_id ), timeoutStrategy, receiver, sender,
                 acceptorInstanceStore, electionCredentialsProvider, stateMachineExecutor, objectInputStreamFactory,
-                objectOutputStreamFactory );
+                objectOutputStreamFactory, config );
         receiver.addNetworkChannelsListener( new NetworkReceiver.NetworkChannelsListener()
         {
             private StateTransitionLogger logger;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServerFactory.java
@@ -28,6 +28,7 @@ import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceStore;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
+import org.neo4j.kernel.configuration.Config;
 
 /**
  * Factory for instantiating ProtocolServers.
@@ -36,10 +37,11 @@ import org.neo4j.cluster.timeout.TimeoutStrategy;
  */
 public interface ProtocolServerFactory
 {
-    ProtocolServer newProtocolServer( InstanceId me, int maxAcceptors, TimeoutStrategy timeouts, MessageSource input, MessageSender output,
+    ProtocolServer newProtocolServer( InstanceId me, TimeoutStrategy timeouts, MessageSource input, MessageSender output,
                                       AcceptorInstanceStore acceptorInstanceStore,
                                       ElectionCredentialsProvider electionCredentialsProvider,
                                       Executor stateMachineExecutor,
                                       ObjectInputStreamFactory objectInputStreamFactory,
-                                      ObjectOutputStreamFactory objectOutputStreamFactory );
+                                      ObjectOutputStreamFactory objectOutputStreamFactory,
+                                      Config config );
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.cluster.client;
 
+import org.jboss.netty.logging.InternalLoggerFactory;
+
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-
-import org.jboss.netty.logging.InternalLoggerFactory;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.ExecutorLifecycleAdapter;
@@ -179,10 +179,9 @@ public class ClusterClientModule
 
         AcceptorInstanceStore acceptorInstanceStore = new InMemoryAcceptorInstanceStore();
 
-        server = protocolServerFactory.newProtocolServer( config.get( ClusterSettings.server_id ),
-                config.get( ClusterSettings.max_acceptors ), timeoutStrategy, receiver, sender,
-                acceptorInstanceStore, electionCredentialsProvider, stateMachineExecutor, objectInputStreamFactory,
-                objectOutputStreamFactory );
+        server = protocolServerFactory.newProtocolServer( config.get( ClusterSettings.server_id ),timeoutStrategy,
+                receiver, sender, acceptorInstanceStore, electionCredentialsProvider, stateMachineExecutor,
+                objectInputStreamFactory, objectOutputStreamFactory, config );
 
         life.add( sender );
         life.add( stateMachineExecutor );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
@@ -83,7 +83,6 @@ public class Message<MESSAGETYPE extends MessageType>
         return timeout;
     }
 
-
     // Standard headers
     public static final String CONVERSATION_ID = "conversation-id";
     public static final String CREATED_BY = "created-by";
@@ -91,6 +90,9 @@ public class Message<MESSAGETYPE extends MessageType>
     public static final String FROM = "from";
     public static final String TO = "to";
     public static final String INSTANCE_ID = "instance-id";
+    // Should be present only in configurationRequest messages. Value is a comma separated list of instance ids.
+    // Added in 3.0.9.
+    public static final String DISCOVERED = "discovered";
 
     private MESSAGETYPE messageType;
     private Object payload;
@@ -136,7 +138,7 @@ public class Message<MESSAGETYPE extends MessageType>
     public String getHeader( String name )
             throws IllegalArgumentException
     {
-        String value = headers.get( name );
+        String value = getHeader( name, null );
         if ( value == null )
         {
             throw new IllegalArgumentException( "No such header:" + name );
@@ -144,8 +146,18 @@ public class Message<MESSAGETYPE extends MessageType>
         return value;
     }
 
-    public <MESSAGETYPE extends MessageType> Message<MESSAGETYPE> copyHeadersTo( Message<MESSAGETYPE> message,
-                                                                                 String... names )
+    public String getHeader( String name, String defaultValue )
+    {
+        String value = headers.get( name );
+        if ( value == null )
+        {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    public <MSGTYPE extends MessageType> Message<MSGTYPE> copyHeadersTo( Message<MSGTYPE> message,
+                                                                         String... names )
     {
         if ( names.length == 0 )
         {

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -122,4 +122,6 @@ public interface ClusterContext
     long getLastElectorVersion();
 
     void setLastElectorVersion( long lastElectorVersion );
+
+    boolean shouldFilterContactingInstances();
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -87,6 +87,12 @@ public interface ClusterContext
 
     List<ClusterMessage.ConfigurationRequestState> getDiscoveredInstances();
 
+    boolean haveWeContactedInstance( ClusterMessage.ConfigurationRequestState configurationRequested );
+
+    void addContactingInstance( ClusterMessage.ConfigurationRequestState instance, String discoveryHeader );
+
+    String generateDiscoveryHeader();
+
     void setBoundAt( URI boundAt );
 
     void joinDenied( ConfigurationResponseState configurationResponseState );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -327,20 +327,29 @@ public enum ClusterState
                                         return start;
                                     }
                                 }
-                                if ( context.haveWeContactedInstance( configurationRequested ) )
+                                if ( context.shouldFilterContactingInstances() )
                                 {
-                                    context.getLog( getClass() ).info( format( "%s had header %s which " +
-                                            "contains us. This means we've contacted them and they are in our " +
-                                            "initial hosts.", configurationRequested, message.getHeader( DISCOVERED, "" ) ) );
-                                    discoveredInstances.add( configurationRequested );
+                                    if ( context.haveWeContactedInstance( configurationRequested ) )
+                                    {
+                                        context.getLog( getClass() ).info( format( "%s had header %s which " +
+                                                "contains us. This means we've contacted them and they are in our " +
+                                                "initial hosts.", configurationRequested, message.getHeader( DISCOVERED, "" ) ) );
+
+                                        discoveredInstances.add( configurationRequested );
+                                    }
+                                    else
+                                    {
+                                        context.getLog( getClass() ).warn(
+                                                format( "joining instance %s was not in %s, i will not consider it " +
+                                                                "for " +
+                                                                "purposes of cluster creation",
+                                                        configurationRequested.getJoiningUri(),
+                                                        context.getJoiningInstances() ) );
+                                    }
                                 }
                                 else
                                 {
-                                    context.getLog( getClass() ).warn(
-                                            format( "joining instance %s was not in %s, i will not consider it for " +
-                                                            "purposes of cluster creation",
-                                                    configurationRequested.getJoiningUri(),
-                                                    context.getJoiningInstances() ) );
+                                    discoveredInstances.add( configurationRequested );
                                 }
                             }
                             break;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -34,6 +34,8 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.statemachine.State;
 import org.neo4j.helpers.collection.Iterables;
 
+import static java.lang.String.format;
+import static org.neo4j.cluster.com.message.Message.DISCOVERED;
 import static org.neo4j.cluster.com.message.Message.internal;
 import static org.neo4j.cluster.com.message.Message.respond;
 import static org.neo4j.cluster.com.message.Message.timeout;
@@ -86,12 +88,18 @@ public enum ClusterState
                             String name = ( String ) args[0];
                             URI[] clusterInstanceUris = ( URI[] ) args[1];
                             context.joining( name, Iterables.<URI,URI>iterable( clusterInstanceUris ) );
+                            context.getLog( getClass() ).info( "Trying to join with DISCOVERY header " + context.generateDiscoveryHeader() );
 
                             for ( URI potentialClusterInstanceUri : clusterInstanceUris )
                             {
+                                /*
+                                 * The DISCOVERY header is empty, since we haven't processed configurationRequests
+                                 * at all yet. However, we still send it out for consistency.
+                                 */
                                 outgoing.offer( to( ClusterMessage.configurationRequest,
                                         potentialClusterInstanceUri,
-                                        new ClusterMessage.ConfigurationRequestState( context.getMyId(), context.boundAt() ) ) );
+                                        new ClusterMessage.ConfigurationRequestState( context.getMyId(), context.boundAt() ) )
+                                        .setHeader( DISCOVERED, context.generateDiscoveryHeader() ) );
                             }
                             context.setTimeout( "discovery",
                                     timeout( ClusterMessage.configurationTimeout, message,
@@ -126,6 +134,7 @@ public enum ClusterState
                                            MessageHolder outgoing ) throws Throwable
                 {
                     List<ClusterMessage.ConfigurationRequestState> discoveredInstances = context.getDiscoveredInstances();
+                    context.getLog( getClass() ).info( format( "Discovered instances are %s", discoveredInstances ) );
                     switch ( message.getMessageType() )
                     {
                         case configurationResponse:
@@ -150,9 +159,8 @@ public enum ClusterState
                             if ( !memberList.containsKey( context.getMyId() ) ||
                                     !memberList.get( context.getMyId() ).equals( context.boundAt() ) )
                             {
-                                context.getLog( ClusterState.class ).info( String.format( "%s joining:%s, " +
-                                        "last delivered:%d", context.getMyId().toString(),
-                                        context.getConfiguration().toString(),
+                                context.getLog( ClusterState.class ).info( format( "%s joining:%s, last delivered:%d",
+                                        context.getMyId().toString(), context.getConfiguration().toString(),
                                         state.getLatestReceivedInstanceId().getId() ) );
 
                                 ClusterMessage.ConfigurationChangeState newState = new ClusterMessage.ConfigurationChangeState();
@@ -200,13 +208,16 @@ public enum ClusterState
                             ClusterMessage.ConfigurationTimeoutState state = message.getPayload();
                             if ( state.getRemainingPings() > 0 )
                             {
+                                context.getLog( getClass() ).info( format( "Trying to join with DISCOVERY header %s",
+                                        context.generateDiscoveryHeader() ) );
                                 // Send out requests again
                                 for ( URI potentialClusterInstanceUri : context.getJoiningInstances() )
                                 {
                                     outgoing.offer( to( ClusterMessage.configurationRequest,
                                             potentialClusterInstanceUri,
                                             new ClusterMessage.ConfigurationRequestState(
-                                                    context.getMyId(), context.boundAt() ) ) );
+                                                    context.getMyId(), context.boundAt() ) )
+                                            .setHeader( DISCOVERED, context.generateDiscoveryHeader() ) );
                                 }
                                 context.setTimeout( "join",
                                         timeout( ClusterMessage.configurationTimeout, message,
@@ -233,11 +244,11 @@ public enum ClusterState
                                      * does not contain us, ever.
                                      */
                                     ClusterMessage.ConfigurationRequestState ourRequestState =
-                                            new ClusterMessage.ConfigurationRequestState(context.getMyId(), context.boundAt());
+                                            new ClusterMessage.ConfigurationRequestState( context.getMyId(), context.boundAt() );
                                     // No one to join with
                                     boolean imAlone =
                                             count(context.getJoiningInstances()) == 1
-                                            && discoveredInstances.contains(ourRequestState)
+                                            && discoveredInstances.contains( ourRequestState )
                                             && discoveredInstances.size() == 1;
                                     // Enough instances discovered (half or more - i don't count myself here)
                                     boolean haveDiscoveredMajority =
@@ -259,14 +270,17 @@ public enum ClusterState
                                     else
                                     {
                                         discoveredInstances.clear();
-
+                                        context.getLog( getClass() ).info( format(
+                                                "Trying to join with DISCOVERY header %s",
+                                                context.generateDiscoveryHeader() ) );
                                         // Someone else is supposed to create the cluster - restart the join discovery
                                         for ( URI potentialClusterInstanceUri : context.getJoiningInstances() )
                                         {
                                             outgoing.offer( to( ClusterMessage.configurationRequest,
                                                     potentialClusterInstanceUri,
                                                     new ClusterMessage.ConfigurationRequestState( context.getMyId(),
-                                                            context.boundAt() ) ) );
+                                                            context.boundAt() ) )
+                                                    .setHeader( DISCOVERED, context.generateDiscoveryHeader() ));
                                         }
                                         context.setTimeout( "discovery",
                                                 timeout( ClusterMessage.configurationTimeout, message,
@@ -289,9 +303,15 @@ public enum ClusterState
                             // We're listening for existing clusters, but if all instances start up at the same time
                             // and look for each other, this allows us to pick that up
                             ClusterMessage.ConfigurationRequestState configurationRequested = message.getPayload();
-                            configurationRequested = new ClusterMessage.ConfigurationRequestState( configurationRequested.getJoiningId(), URI.create(message.getHeader( Message.FROM ) ));
+                            configurationRequested = new ClusterMessage.ConfigurationRequestState(
+                                    configurationRequested.getJoiningId(),
+                                    URI.create( message.getHeader( Message.FROM ) ) );
+                            // Make a note that this instance contacted us.
+                            context.addContactingInstance( configurationRequested, message.getHeader( DISCOVERED, "" ) );
+                            context.getLog( getClass() ).info( format( "Received configuration request %s and " +
+                                    "the header was %s", configurationRequested, message.getHeader( DISCOVERED, "" ) ) );
 
-                            if ( !discoveredInstances.contains( configurationRequested ))
+                            if ( !discoveredInstances.contains( configurationRequested ) )
                             {
                                 for ( ClusterMessage.ConfigurationRequestState discoveredInstance :
                                         discoveredInstances )
@@ -300,25 +320,35 @@ public enum ClusterState
                                     {
                                         // we are done
                                         outgoing.offer( internal( ClusterMessage.joinFailure,
-                                                new IllegalStateException( String.format(
+                                                new IllegalStateException( format(
                                                         "Failed to join cluster because I saw two instances with the " +
-                                                                "same ServerId. " +
-                                                                "One is %s. The other is %s", discoveredInstance,
-                                                        configurationRequested ) ) ) );
+                                                                "same ServerId. One is %s. The other is %s",
+                                                        discoveredInstance, configurationRequested ) ) ) );
                                         return start;
                                     }
                                 }
-                                discoveredInstances.add( configurationRequested );
+                                if ( context.haveWeContactedInstance( configurationRequested ) )
+                                {
+                                    context.getLog( getClass() ).info( format( "%s had header %s which " +
+                                            "contains us. This means we've contacted them and they are in our " +
+                                            "initial hosts.", configurationRequested, message.getHeader( DISCOVERED, "" ) ) );
+                                    discoveredInstances.add( configurationRequested );
+                                }
+                                else
+                                {
+                                    context.getLog( getClass() ).warn(
+                                            format( "joining instance %s was not in %s, i will not consider it for " +
+                                                            "purposes of cluster creation",
+                                                    configurationRequested.getJoiningUri(),
+                                                    context.getJoiningInstances() ) );
+                                }
                             }
                             break;
                         }
 
                         case joinDenied:
                         {
-//                            outgoing.offer( internal( ClusterMessage.joinFailure,
-//                                    new ClusterEntryDeniedException( context.me, context.configuration ) ) );
-//                            return start;
-                            context.joinDenied( (ClusterMessage.ConfigurationResponseState) message.getPayload() );
+                            context.joinDenied( message.getPayload() );
                             return this;
                         }
                     }
@@ -375,7 +405,8 @@ public enum ClusterState
                             {
                                 outgoing.offer( to( ClusterMessage.configurationRequest,
                                         potentialClusterInstanceUri,
-                                        new ClusterMessage.ConfigurationRequestState( context.getMyId(), context.boundAt() ) ) );
+                                        new ClusterMessage.ConfigurationRequestState( context.getMyId(), context.boundAt() ) )
+                                        .setHeader( DISCOVERED, context.generateDiscoveryHeader() ));
                             }
                             context.setTimeout( "discovery",
                                     timeout( ClusterMessage.configurationTimeout, message,
@@ -420,7 +451,8 @@ public enum ClusterState
                         case configurationRequest:
                         {
                             ClusterMessage.ConfigurationRequestState request = message.getPayload();
-                            request = new ClusterMessage.ConfigurationRequestState( request.getJoiningId(), URI.create(message.getHeader( Message.FROM ) ));
+                            request = new ClusterMessage.ConfigurationRequestState( request.getJoiningId(),
+                                    URI.create( message.getHeader( Message.FROM ) ) );
 
                             InstanceId joiningId = request.getJoiningId();
                             URI joiningUri = request.getJoiningUri();
@@ -440,16 +472,20 @@ public enum ClusterState
                             {
                                 if(otherInstanceJoiningWithSameId)
                                 {
-                                    context.getLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because another instance is currently joining with the same id.");
+                                    context.getLog( ClusterState.class ).info( format( "Denying entry to instance %s" +
+                                            " because another instance is currently joining with the same id.",
+                                            joiningId ) );
                                 }
                                 else
                                 {
-                                    context.getLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because that instance is already in the cluster.");
+                                    context.getLog( ClusterState.class ).info( format( "Denying entry to " +
+                                            "instance %s because that instance is already in the cluster.", joiningId ) );
                                 }
                                 outgoing.offer( message.copyHeadersTo( respond( ClusterMessage.joinDenied, message,
                                         new ClusterMessage.ConfigurationResponseState( context.getConfiguration()
                                                 .getRoles(), context.getConfiguration().getMembers(),
-                                                new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId( context.getLastDeliveredInstanceId() ),
+                                                new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId(
+                                                        context.getLastDeliveredInstanceId() ),
                                                 context.getConfiguration().getName() ) ) ) );
                             }
                             else
@@ -459,7 +495,8 @@ public enum ClusterState
                                 outgoing.offer( message.copyHeadersTo( respond( ClusterMessage.configurationResponse, message,
                                         new ClusterMessage.ConfigurationResponseState( context.getConfiguration()
                                                 .getRoles(), context.getConfiguration().getMembers(),
-                                                new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId( context.getLastDeliveredInstanceId() ),
+                                                new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId(
+                                                        context.getLastDeliveredInstanceId() ),
                                                 context.getConfiguration().getName() ) ) ) );
                             }
                             break;
@@ -477,8 +514,8 @@ public enum ClusterState
                             List<URI> nodeList = new ArrayList<URI>( context.getConfiguration().getMemberURIs() );
                             if ( nodeList.size() == 1 )
                             {
-                                context.getLog( ClusterState.class ).info( "Shutting down cluster: " + context
-                                        .getConfiguration().getName() );
+                                context.getLog( ClusterState.class ).info( format( "Shutting down cluster: %s",
+                                        context.getConfiguration().getName() ) );
                                 context.left();
 
                                 return start;
@@ -486,7 +523,7 @@ public enum ClusterState
                             }
                             else
                             {
-                                context.getLog( ClusterState.class ).info( "Leaving:" + nodeList );
+                                context.getLog( ClusterState.class ).info( format( "Leaving:%s", nodeList ) );
 
                                 ClusterMessage.ConfigurationChangeState newState = new ClusterMessage
                                         .ConfigurationChangeState();

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
@@ -35,7 +35,11 @@ import org.neo4j.cluster.statemachine.StateTransitionListener;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * TODO
@@ -60,8 +64,13 @@ public class TestProtocolServer
 
         stateMachineExecutor = new DelayedDirectExecutor( logProvider );
 
-        server = factory.newProtocolServer( instanceId, 10, timeoutStrategy, receiver, sender, acceptorInstanceStore,
-                electionCredentialsProvider, stateMachineExecutor, new ObjectStreamFactory(), new ObjectStreamFactory() );
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+        when( config.get( ClusterSettings.strict_initial_hosts) ).thenReturn( Boolean.FALSE );
+
+        server = factory.newProtocolServer( instanceId, timeoutStrategy, receiver, sender, acceptorInstanceStore,
+                electionCredentialsProvider, stateMachineExecutor, new ObjectStreamFactory(), new ObjectStreamFactory(),
+                config );
 
         server.listeningAt( serverUri );
     }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContextTest.java
@@ -21,11 +21,13 @@ package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
 import org.junit.Test;
 
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
@@ -33,6 +35,7 @@ import org.neo4j.logging.NullLogProvider;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LearnerContextTest
 {
@@ -42,7 +45,14 @@ public class LearnerContextTest
     public void shouldOnlyAllowHigherLastLearnedInstanceId() throws Exception
     {
         // Given
-        MultiPaxosContext mpCtx = new MultiPaxosContext( null, 10, Iterables.<ElectionRole>empty(), mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(), null, null, null, null, null );
+
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext mpCtx = new MultiPaxosContext( null, Iterables.<ElectionRole>empty(),
+                mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(),
+                null, null, null, null, null,
+                config );
         LearnerContext state = mpCtx.getLearnerContext();
 
         // When
@@ -57,7 +67,14 @@ public class LearnerContextTest
     public void shouldTrackLastKnownUpToDateAliveInstance() throws Exception
     {
         // Given
-        MultiPaxosContext mpCtx = new MultiPaxosContext( null, 10, Iterables.<ElectionRole>empty(), mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(), null, null, null, null, null );
+
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext mpCtx = new MultiPaxosContext( null, Iterables.<ElectionRole>empty(),
+                mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(),
+                null, null, null, null, null,
+                config );
         LearnerContext state = mpCtx.getLearnerContext();
 
         // When
@@ -74,7 +91,13 @@ public class LearnerContextTest
     public void settingLastLearnedInstanceToNegativeOneShouldAlwaysWin() throws Exception
     {
         // Given
-        MultiPaxosContext mpCtx = new MultiPaxosContext( null, 10, Iterables.<ElectionRole>empty(), mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(), null, null, null, null, null );
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext mpCtx = new MultiPaxosContext( null, Iterables.<ElectionRole>empty(),
+                mock( ClusterConfiguration.class ), null, NullLogProvider.getInstance(),
+                null, null, null, null,
+                null, config );
         LearnerContext state = mpCtx.getLearnerContext();
 
         // When

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
+import org.junit.Test;
+
 import java.net.URI;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 
-import org.junit.Test;
-
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
@@ -32,26 +33,31 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MultiPaxosContextTest
 {
-
     @Test
     public void shouldNotConsiderInstanceJoiningWithSameIdAndIpAProblem() throws Exception
     {
         // Given
+
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         MultiPaxosContext ctx = new MultiPaxosContext( new InstanceId( 1 ),
-                10, Collections.<ElectionRole>emptyList(),
+                Collections.<ElectionRole>emptyList(),
                 mock( ClusterConfiguration.class ), mock( Executor.class ),
                 NullLogProvider.getInstance(), new ObjectStreamFactory(),
                 new ObjectStreamFactory(), mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         InstanceId joiningId = new InstanceId( 12 );
         String joiningUri = "http://127.0.0.1:900";
@@ -76,11 +82,14 @@ public class MultiPaxosContextTest
         ClusterConfiguration clusterConfig = new ClusterConfiguration( "myCluster", NullLogProvider.getInstance() );
         ElectionCredentialsProvider electionCredentials = mock( ElectionCredentialsProvider.class );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         MultiPaxosContext ctx = new MultiPaxosContext( new InstanceId( 1 ),
-                10, Collections.<ElectionRole>emptyList(),
+                Collections.<ElectionRole>emptyList(),
                 clusterConfig, executor,
                 NullLogProvider.getInstance(), objStream,
-                objStream, acceptorInstances, timeouts, electionCredentials );
+                objStream, acceptorInstances, timeouts, electionCredentials, config );
 
         // When
         MultiPaxosContext snapshot = ctx.snapshot( NullLogProvider.getInstance(), timeouts, executor, acceptorInstances, objStream, objStream,

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
@@ -35,6 +35,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -66,7 +67,8 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ),
+                mock( Config.class ) );
 
           // This means instance 2 was the elector at version 8
         context.setLastElector( elector );
@@ -100,7 +102,8 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ),
+                mock( Config.class ) );
 
           // This means instance 2 was the elector at version 8
         context.setLastElector( elector );
@@ -130,7 +133,8 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ),
+                mock( Config.class ) );
 
         // This means instance 2 was the elector at version 8
         context.setLastElector( elector );
@@ -160,7 +164,8 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ),
+                mock( Config.class ) );
 
         // This means instance 2 was the elector at version 8
         context.setLastElector( elector );
@@ -195,7 +200,7 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext, mock( Config.class ) );
 
         verify( heartbeatContext ).addHeartbeatListener( listenerCaptor.capture() );
 
@@ -234,7 +239,7 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext, mock( Config.class ) );
 
         verify( heartbeatContext ).addHeartbeatListener( listenerCaptor.capture() );
 
@@ -267,7 +272,7 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext, mock( Config.class ) );
 
         ClusterMessage.ConfigurationRequestState request = mock( ClusterMessage.ConfigurationRequestState.class );
         when ( request.getJoiningId() ).thenReturn( joining );
@@ -297,7 +302,7 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext, mock( Config.class ) );
 
         ClusterMessage.ConfigurationRequestState requestOne = mock( ClusterMessage.ConfigurationRequestState.class );
         when ( requestOne.getJoiningId() ).thenReturn( joiningOne );
@@ -332,7 +337,7 @@ public class ClusterContextImplTest
 
         ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
-                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext, mock( Config.class ) );
 
         ClusterMessage.ConfigurationRequestState requestOne = mock( ClusterMessage.ConfigurationRequestState.class );
         when ( requestOne.getJoiningId() ).thenReturn( joiningOne );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
-import java.net.URI;
-import java.util.concurrent.Executor;
-
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.util.concurrent.Executor;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
@@ -31,12 +31,15 @@ import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterContext;
+import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -247,5 +250,119 @@ public class ClusterContextImplTest
         // Then
         assertEquals( context.getLastElector(), elector );
         assertEquals( context.getLastElectorVersion(), 8 );
+    }
+
+    @Test
+    public void shouldGracefullyHandleEmptyDiscoveryHeader() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId joining = new InstanceId( 2 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+        Timeouts timeouts = mock( Timeouts.class );
+        Executor executor = mock( Executor.class );
+
+        HeartbeatContext heartbeatContext = mock ( HeartbeatContext.class );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
+                timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+
+        ClusterMessage.ConfigurationRequestState request = mock( ClusterMessage.ConfigurationRequestState.class );
+        when ( request.getJoiningId() ).thenReturn( joining );
+
+        // When
+        // Instance 2 contacts us with a request but it is empty
+        context.addContactingInstance( request, "" );
+
+        // Then
+        // The discovery header we generate should still contain that instance
+        assertEquals( "2", context.generateDiscoveryHeader() );
+    }
+
+    @Test
+    public void shouldUpdateDiscoveryHeaderWithContactingInstances() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId joiningOne = new InstanceId( 2 );
+        InstanceId joiningTwo = new InstanceId( 3 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+        Timeouts timeouts = mock( Timeouts.class );
+        Executor executor = mock( Executor.class );
+
+        HeartbeatContext heartbeatContext = mock ( HeartbeatContext.class );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
+                timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+
+        ClusterMessage.ConfigurationRequestState requestOne = mock( ClusterMessage.ConfigurationRequestState.class );
+        when ( requestOne.getJoiningId() ).thenReturn( joiningOne );
+
+        ClusterMessage.ConfigurationRequestState requestTwo = mock( ClusterMessage.ConfigurationRequestState.class );
+        when ( requestTwo.getJoiningId() ).thenReturn( joiningTwo );
+
+        // When
+        // Instance 2 contacts us twice and Instance 3 contacts us once
+        context.addContactingInstance( requestOne, "4, 5" ); // discovery headers are random here
+        context.addContactingInstance( requestOne, "4, 5" );
+        context.addContactingInstance( requestTwo, "2, 5" );
+
+        // Then
+        // The discovery header we generate should still contain one copy of each instance
+        assertEquals( "2,3", context.generateDiscoveryHeader() );
+    }
+
+    @Test
+    public void shouldKeepTrackOfInstancesWeHaveContacted() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId joiningOne = new InstanceId( 2 );
+        InstanceId joiningTwo = new InstanceId( 3 );
+
+        CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
+        Timeouts timeouts = mock( Timeouts.class );
+        Executor executor = mock( Executor.class );
+
+        HeartbeatContext heartbeatContext = mock ( HeartbeatContext.class );
+
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
+                timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
+                ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
+
+        ClusterMessage.ConfigurationRequestState requestOne = mock( ClusterMessage.ConfigurationRequestState.class );
+        when ( requestOne.getJoiningId() ).thenReturn( joiningOne );
+
+        ClusterMessage.ConfigurationRequestState requestTwo = mock( ClusterMessage.ConfigurationRequestState.class );
+        when ( requestTwo.getJoiningId() ).thenReturn( joiningTwo );
+
+        // When
+        // Instance two contacts us but we are not in the header
+        context.addContactingInstance( requestOne, "4, 5" );
+        // Then we haven't contacted instance 2
+        assertFalse(context.haveWeContactedInstance( requestOne ) );
+
+        // When
+        // Instance 2 reports that we have contacted it after all
+        context.addContactingInstance( requestOne, "4, 5, 1" );
+        // Then
+        assertTrue(context.haveWeContactedInstance( requestOne ) );
+
+        // When
+        // Instance 3 says we have contacted it
+        context.addContactingInstance( requestTwo, "2, 5, 1" );
+        // Then
+        assertTrue( context.haveWeContactedInstance( requestTwo ) );
+
+        // When
+        // For some reason we are not in the header of 3 in subsequent responses (a delayed one, for example)
+        context.addContactingInstance( requestTwo, "2, 5" );
+        // Then
+        // The state should still keep the fact we've contacted it already
+        assertTrue( context.haveWeContactedInstance( requestTwo ) );
     }
 }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
@@ -19,11 +19,12 @@
  */
 package org.neo4j.cluster.protocol.cluster;
 
+import org.junit.Test;
+
 import java.util.Collections;
 import java.util.concurrent.Executor;
 
-import org.junit.Test;
-
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
@@ -35,6 +36,7 @@ import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -55,7 +57,10 @@ public class ClusterContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, Iterables.<ElectionRole, ElectionRole
                 >iterable(
                 new ElectionRole( coordinatorRole ) ), mock( ClusterConfiguration.class ),
                 new Executor()
@@ -68,7 +73,8 @@ public class ClusterContextTest
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class )
+                mock( ElectionCredentialsProvider.class ),
+                config
         );
         ClusterContext context = multiPaxosContext.getClusterContext();
         ElectionContext electionContext = multiPaxosContext.getElectionContext();
@@ -102,7 +108,10 @@ public class ClusterContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, Iterables.<ElectionRole, ElectionRole
                 >iterable(
                 new ElectionRole( coordinatorRole ) ), mock( ClusterConfiguration.class ),
                 new Executor()
@@ -115,7 +124,8 @@ public class ClusterContextTest
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class )
+                mock( ElectionCredentialsProvider.class ),
+                config
         );
         ClusterContext context = multiPaxosContext.getClusterContext();
 
@@ -142,7 +152,10 @@ public class ClusterContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, Iterables.<ElectionRole, ElectionRole
                 >iterable(
                 new ElectionRole( coordinatorRole ) ), mock( ClusterConfiguration.class ),
                 new Executor()
@@ -155,7 +168,7 @@ public class ClusterContextTest
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class )
+                mock( ElectionCredentialsProvider.class ), config
         );
         ClusterContext context = multiPaxosContext.getClusterContext();
         ElectionContext electionContext = multiPaxosContext.getElectionContext();
@@ -189,8 +202,10 @@ public class ClusterContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole
-                >iterable(
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext multiPaxosContext = new MultiPaxosContext( me, Iterables.iterable(
                 new ElectionRole( coordinatorRole ) ), mock( ClusterConfiguration.class ),
                 new Executor()
                 {
@@ -202,7 +217,7 @@ public class ClusterContextTest
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class )
+                mock( ElectionCredentialsProvider.class ), config
         );
         ClusterContext context = multiPaxosContext.getClusterContext();
         ElectionContext electionContext = multiPaxosContext.getElectionContext();

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -19,6 +19,27 @@
  */
 package org.neo4j.cluster.protocol.cluster;
 
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.com.message.Message;
+import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.com.message.TrackingMessageHolder;
+import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationRequestState;
+import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationResponseState;
+import org.neo4j.logging.NullLog;
+import org.neo4j.logging.NullLogProvider;
+
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -26,25 +47,12 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.cluster.com.message.Message.DISCOVERED;
+import static org.neo4j.cluster.com.message.Message.internal;
 import static org.neo4j.cluster.com.message.Message.to;
 import static org.neo4j.cluster.protocol.cluster.ClusterMessage.configurationRequest;
+import static org.neo4j.cluster.protocol.cluster.ClusterMessage.configurationTimeout;
 import static org.neo4j.cluster.protocol.cluster.ClusterMessage.joinDenied;
-
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Test;
-import org.mockito.ArgumentMatcher;
-import org.neo4j.cluster.InstanceId;
-import org.neo4j.cluster.com.message.Message;
-import org.neo4j.cluster.com.message.MessageType;
-import org.neo4j.cluster.com.message.TrackingMessageHolder;
-import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationRequestState;
-import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationResponseState;
-import org.neo4j.logging.NullLog;
-import org.neo4j.logging.NullLogProvider;
 
 public class ClusterStateTest
 {
@@ -134,6 +142,66 @@ public class ClusterStateTest
         // THEN assert that the failure contains the received configuration
         Message<? extends MessageType> response = outgoing.single();
         assertEquals( ClusterMessage.configurationResponse, response.getMessageType() );
+    }
+
+    @Test
+    public void discoveredInstancesShouldBeOnlyOnesWeHaveContactedDirectly() throws Throwable
+    {
+        // GIVEN
+        ClusterContext context = mock( ClusterContext.class );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getUriForId( id( 2 ) ) ).thenReturn( uri( 2 ) );
+
+        List<ConfigurationRequestState> discoveredInstances = new LinkedList<>();
+        when( context.getDiscoveredInstances() ).thenReturn( discoveredInstances );
+
+        MessageHolder outgoing = mock( MessageHolder.class );
+        ConfigurationRequestState configurationRequestFromTwo = configuration( 2 );
+        Message<ClusterMessage> message = to( configurationRequest, uri( 1 ), configurationRequestFromTwo )
+                .setHeader( Message.FROM, uri( 2 ).toString() );
+
+        // WHEN
+        // We receive a configuration request from an instance which we haven't contacted
+        ClusterState.discovery.handle( context, message, outgoing );
+
+        // THEN
+        // It shouldn't be added to the discovered instances
+        assertTrue( discoveredInstances.isEmpty() );
+
+        // WHEN
+        // It subsequently contacts us
+        when( context.haveWeContactedInstance( configurationRequestFromTwo ) ).thenReturn( true );
+        ClusterState.discovery.handle( context, message, outgoing );
+
+        // Then
+        assertTrue( discoveredInstances.contains( configurationRequestFromTwo ) );
+    }
+
+    @Test
+    public void shouldSetDiscoveryHeaderProperly() throws Throwable
+    {
+        // GIVEN
+        ClusterContext context = mock( ClusterContext.class );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getUriForId( id( 2 ) ) ).thenReturn( uri( 2 ) );
+        when( context.getJoiningInstances() ).thenReturn( singletonList( uri( 2 ) ) );
+
+        List<ConfigurationRequestState> discoveredInstances = new LinkedList<>();
+        when( context.getDiscoveredInstances() ).thenReturn( discoveredInstances );
+
+        TrackingMessageHolder outgoing = new TrackingMessageHolder();
+        ClusterMessage.ConfigurationTimeoutState timeoutState = new ClusterMessage.ConfigurationTimeoutState( 3 );
+        Message<ClusterMessage> message = internal( configurationTimeout, timeoutState );
+        String discoveryHeader = "1,2,3";
+        when( context.generateDiscoveryHeader() ).thenReturn( discoveryHeader );
+
+        // WHEN
+        // We receive a configuration request from an instance which we haven't contacted
+        ClusterState.discovery.handle( context, message, outgoing );
+
+        // THEN
+        // It shouldn't be added to the discovered instances
+        assertEquals( discoveryHeader, outgoing.first().getHeader( DISCOVERED ) );
     }
 
     private ConfigurationResponseState configurationResponseState( Map<InstanceId, URI> existingMembers )

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
@@ -41,6 +42,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static junit.framework.Assert.assertNull;
@@ -88,18 +90,21 @@ public class ElectionContextTest
         members.put( new InstanceId( 1 ), URI.create( "server1" ) );
         members.put( new InstanceId( 2 ), URI.create( "server2" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         when( clusterConfiguration.getMembers() ).thenReturn( members );
 
         ClusterContext clusterContext = mock( ClusterContext.class );
         when( clusterContext.getConfiguration() ).thenReturn( clusterConfiguration );
 
-        MultiPaxosContext context = new MultiPaxosContext( new InstanceId( 1 ), 10,
+        MultiPaxosContext context = new MultiPaxosContext( new InstanceId( 1 ),
                 Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
                 clusterConfiguration, mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         context.getHeartbeatContext().getFailed().addAll( failed );
 
@@ -121,18 +126,21 @@ public class ElectionContextTest
         members.put( new InstanceId( 3 ), URI.create( "server3" ) );
         members.put( new InstanceId( 4 ), URI.create( "server4" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         when( clusterConfiguration.getMembers() ).thenReturn( members );
 
         ClusterContext clusterContext = mock( ClusterContext.class );
         when( clusterContext.getConfiguration() ).thenReturn( clusterConfiguration );
 
-        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                 new ElectionRole( "coordinator" ) ), clusterConfiguration,
                 mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         context.getHeartbeatContext().getFailed().addAll( failed );
 
@@ -156,18 +164,21 @@ public class ElectionContextTest
         members.put( new InstanceId( 4 ), URI.create( "server4" ) );
         members.put( new InstanceId( 5 ), URI.create( "server5" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         when( clusterConfiguration.getMembers() ).thenReturn( members );
 
         ClusterContext clusterContext = mock( ClusterContext.class );
         when( clusterContext.getConfiguration() ).thenReturn( clusterConfiguration );
 
-        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                 new ElectionRole( "coordinator" ) ), clusterConfiguration,
                 mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         context.getHeartbeatContext().getFailed().addAll( failed );
 
@@ -189,18 +200,21 @@ public class ElectionContextTest
         members.put( new InstanceId( 2 ), URI.create( "server2" ) );
         members.put( new InstanceId( 3 ), URI.create( "server3" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         when( clusterConfiguration.getMembers() ).thenReturn( members );
 
         ClusterContext clusterContext = mock( ClusterContext.class );
         when( clusterContext.getConfiguration() ).thenReturn( clusterConfiguration );
 
-        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                         new ElectionRole( coordinatorRole ) ), clusterConfiguration,
                         mock( Executor.class ), NullLogProvider.getInstance(),
                         mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         ElectionContext toTest = context.getElectionContext();
 
@@ -223,11 +237,15 @@ public class ElectionContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        ElectionContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        ElectionContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                 new ElectionRole( coordinatorRole ) ),  mock( ClusterConfiguration.class ),
                 mock( Executor.class ),  NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
-                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) ).getElectionContext();
+                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
+                mock( ElectionCredentialsProvider.class ), config ).getElectionContext();
 
         ElectionContext.VoteRequest voteRequestBefore = context.voteRequestForRole( new ElectionRole( coordinatorRole ) );
         context.forgetElection( coordinatorRole );
@@ -243,11 +261,16 @@ public class ElectionContextTest
         HeartbeatContext heartbeatContext = mock(HeartbeatContext.class);
         when( heartbeatContext.getFailed() ).thenReturn( Collections.<InstanceId>emptySet() );
 
-        ElectionContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        ElectionContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                 new ElectionRole( coordinatorRole ) ),  mock( ClusterConfiguration.class ),
                 mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
-                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) ).getElectionContext();
+                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ),
+                config
+        ).getElectionContext();
 
         // When
         ElectionContext.VoteRequest voteRequestBefore = context.voteRequestForRole( new ElectionRole( coordinatorRole ) );
@@ -267,6 +290,9 @@ public class ElectionContextTest
         InstanceId failingInstance = new InstanceId( 2 );
         InstanceId otherInstance = new InstanceId( 3 );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         List<InstanceId> clusterMemberIds = new LinkedList<InstanceId>();
         clusterMemberIds.add( failingInstance );
@@ -274,7 +300,7 @@ public class ElectionContextTest
         clusterMemberIds.add( me );
         when( clusterConfiguration.getMemberIds() ).thenReturn( clusterMemberIds );
 
-        MultiPaxosContext context = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( me, Iterables.<ElectionRole, ElectionRole>iterable(
                 new ElectionRole( role1 ), new ElectionRole( role2 ) ), clusterConfiguration,
                 new Executor()
                 {
@@ -285,7 +311,8 @@ public class ElectionContextTest
                     }
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
-                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
+                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ),
+                config );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         ElectionContext electionContext = context.getElectionContext();
@@ -315,6 +342,9 @@ public class ElectionContextTest
         InstanceId failingInstance = new InstanceId( 2 );
         InstanceId forQuorum = new InstanceId( 3 );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         List<InstanceId> clusterMemberIds = new LinkedList<InstanceId>();
         clusterMemberIds.add( failingInstance );
@@ -322,7 +352,7 @@ public class ElectionContextTest
         clusterMemberIds.add( forQuorum );
         when( clusterConfiguration.getMemberIds() ).thenReturn( clusterMemberIds );
 
-        MultiPaxosContext context = new MultiPaxosContext( me, 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( me, Iterables.iterable(
                 new ElectionRole( role1 ) ), clusterConfiguration,
                 new Executor()
                 {
@@ -333,7 +363,8 @@ public class ElectionContextTest
                     }
                 }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
-                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
+                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ),
+                config );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         ClusterContext clusterContext = context.getClusterContext();
@@ -370,6 +401,9 @@ public class ElectionContextTest
         InstanceId leavingInstance = new InstanceId( 2 );
         InstanceId forQuorum = new InstanceId( 3 );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         List<InstanceId> clusterMemberIds = new LinkedList<InstanceId>();
         clusterMemberIds.add( leavingInstance );
@@ -378,7 +412,7 @@ public class ElectionContextTest
         when( clusterConfiguration.getMemberIds() ).thenReturn( clusterMemberIds );
 
         MultiPaxosContext context = new MultiPaxosContext( me,
-                10, Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( role1 ) ), clusterConfiguration,
+                Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( role1 ) ), clusterConfiguration,
                 new Executor()
                 {
                     @Override
@@ -388,7 +422,8 @@ public class ElectionContextTest
                     }
                 },
                 NullLogProvider.getInstance(), mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
-                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
+                mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ),
+                config );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         ClusterContext clusterContext = context.getClusterContext();
@@ -419,18 +454,21 @@ public class ElectionContextTest
         members.put( new InstanceId( 2 ), URI.create( "server2" ) );
         members.put( new InstanceId( 3 ), URI.create( "server3" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         ClusterConfiguration clusterConfiguration = mock( ClusterConfiguration.class );
         when( clusterConfiguration.getMembers() ).thenReturn( members );
 
         ClusterContext clusterContext = mock( ClusterContext.class );
         when( clusterContext.getConfiguration() ).thenReturn( clusterConfiguration );
 
-        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.iterable(
                         new ElectionRole( "coordinator" ) ), clusterConfiguration,
                         mock( Executor.class ), NullLogProvider.getInstance(),
                         mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class) );
+                mock( ElectionCredentialsProvider.class), config );
 
         context.getHeartbeatContext().getFailed().addAll( failed );
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
@@ -43,6 +44,7 @@ import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -86,15 +88,18 @@ public class HeartbeatContextTest
 
         context = mock( ClusterContext.class );
 
+        Config configuration = mock( Config.class );
+        when( configuration.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         when( context.getConfiguration() ).thenReturn( config );
         when( context.getMyId() ).thenReturn( instanceIds[0] );
 
-        MultiPaxosContext context = new MultiPaxosContext( instanceIds[0], 10, Iterables.<ElectionRole, ElectionRole>iterable(
+        MultiPaxosContext context = new MultiPaxosContext( instanceIds[0], Iterables.iterable(
                         new ElectionRole( "coordinator" ) ), config,
                         Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
                         Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
                         Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
-                        mock( ElectionCredentialsProvider.class) );
+                        mock( ElectionCredentialsProvider.class ), configuration );
 
         toTest = context.getHeartbeatContext();
     }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.cluster.protocol.heartbeat;
 
-import java.net.URI;
-import java.util.concurrent.Executor;
-
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import java.net.URI;
+import java.util.concurrent.Executor;
+
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.DelayedDirectExecutor;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.StateMachines;
@@ -45,6 +46,7 @@ import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.statemachine.StateMachine;
 import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.NullLogProvider;
 
@@ -56,7 +58,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.Iterables.asSet;
 import static org.neo4j.helpers.collection.Iterables.iterable;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
@@ -74,12 +75,15 @@ public class HeartbeatStateTest
         configuration.joined( instanceId, URI.create( "cluster://1" ) );
         configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
-        MultiPaxosContext context = new MultiPaxosContext( instanceId, 10, iterable(
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext context = new MultiPaxosContext( instanceId, iterable(
                 new ElectionRole( "coordinator" ) ), configuration,
                 Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
                 Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
                 Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class ) );
+                mock( ElectionCredentialsProvider.class ), config );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
@@ -105,12 +109,15 @@ public class HeartbeatStateTest
         configuration.joined( myId, URI.create( "cluster://1" ) );
         configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
-        MultiPaxosContext context = new MultiPaxosContext( myId, 10, iterable(
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
+        MultiPaxosContext context = new MultiPaxosContext( myId, iterable(
                 new ElectionRole( "coordinator" ) ), configuration,
                 Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
                 Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
                 Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class ) );
+                mock( ElectionCredentialsProvider.class ), config );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
@@ -137,8 +144,11 @@ public class HeartbeatStateTest
         InstanceId otherInstance = new InstanceId( 2 );
         configuration.joined( otherInstance, URI.create( "cluster://2" ) );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         MultiPaxosContext context = new MultiPaxosContext(
-                instanceId, 10,
+                instanceId,
                 iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 Mockito.mock( Executor.class ),
@@ -147,7 +157,8 @@ public class HeartbeatStateTest
                 Mockito.mock( ObjectOutputStreamFactory.class ),
                 Mockito.mock( AcceptorInstanceStore.class ),
                 Mockito.mock( Timeouts.class ),
-                mock( ElectionCredentialsProvider.class ) );
+                mock( ElectionCredentialsProvider.class ),
+                config );
 
         int lastDeliveredInstanceId = 100;
         context.getLearnerContext().setLastDeliveredInstanceId( lastDeliveredInstanceId );
@@ -181,9 +192,11 @@ public class HeartbeatStateTest
         TimeoutStrategy timeoutStrategy = mock( TimeoutStrategy.class );
         Timeouts timeouts = new Timeouts( timeoutStrategy );
 
+        Config config = mock( Config.class );
+        when( config.get( ClusterSettings.max_acceptors ) ).thenReturn( 10 );
+
         MultiPaxosContext context = new MultiPaxosContext(
                 instanceId,
-                10,
                 iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 mock( Executor.class ),
@@ -192,7 +205,8 @@ public class HeartbeatStateTest
                 mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ),
                 timeouts,
-                mock( ElectionCredentialsProvider.class ) );
+                mock( ElectionCredentialsProvider.class ),
+                config );
 
         StateMachines stateMachines = new StateMachines(
                 internalLog,


### PR DESCRIPTION
This change makes it so only instances listed in initial_hosts are
 considered for purposes of forming a cluster. This allows mismatching
 initial_hosts contents to be manipulated to make it harder for
 instances to start a cluster, for example slave_only instances to
 depend on the presence of a master but the master to be allowed to
 form the cluster regardless of the presence of other instances.
The functionality is achieved with the introduction of a
 (backwards compatible) discovery header in the configurationRequest
 messages which keeps track of which instance has contacted which
 during the initial discovery round. Since sending of these messages
 depends only on the initial_hosts content, this effectively allows
 for filtering of configurationRequests based on initial_host content.