### PR TITLE
Fix RPM version numbering

### DIFF
--- a/new-packaging/bin/build-rpm-package
+++ b/new-packaging/bin/build-rpm-package
@@ -35,7 +35,7 @@ if [ -z ${version_label} ]; then
   rpm_release="1"
 else
   # Pre-release version
-  rpm_release="0.1.${version_label}"
+  rpm_release="0.${version_label}.1"
 fi
 
 echo "RPM version: ${rpm_version}"


### PR DESCRIPTION
comparisons were broken with the previous scheme due to label going
before the package version (the 1)

will need to rebuild published pre-release RPMs with this change