### PR TITLE
Added Data Center-Local Catchup Strategy for Multi-DC Deployments.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -239,7 +239,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
         long lastQueuedTxId = applier.lastQueuedTxId();
         pullRequestMonitor.txPullRequest( lastQueuedTxId );
         TxPullRequest txPullRequest = new TxPullRequest( lastQueuedTxId, localStoreId );
-        log.debug( "Pull transactions where tx id > %d [batch #%d]", lastQueuedTxId, batchCount );
+        log.debug( "Pull transactions from %s where tx id > %d [batch #%d]", upstream, lastQueuedTxId, batchCount );
 
         TxStreamFinishedResponse response;
         try
@@ -275,7 +275,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
             case SUCCESS_END_OF_BATCH:
                 return true;
             case SUCCESS_END_OF_STREAM:
-                log.debug( "Successfully pulled transactions from %d", lastQueuedTxId  );
+                log.debug( "Successfully pulled transactions from tx id %d", lastQueuedTxId  );
                 upToDateFuture.complete( true );
                 return false;
             case E_TRANSACTION_PRUNED:

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectWithinDataCenter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ConnectWithinDataCenter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.readreplica;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.discovery.ReadReplicaInfo;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.helpers.Service;
+
+@Service.Implementation(UpstreamDatabaseSelectionStrategy.class)
+public class ConnectWithinDataCenter extends UpstreamDatabaseSelectionStrategy
+{
+    private Random random = new Random();;
+
+    public ConnectWithinDataCenter()
+    {
+        super( "connect-within-data-center" );
+    }
+
+    @Override
+    public Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException
+    {
+        Map<MemberId, ReadReplicaInfo> replicas = topologyService.readReplicas().replicaMembers();
+
+        List<String> tags = config.get( CausalClusteringSettings.server_tags );
+        if ( tags.isEmpty() )
+        {
+            return Optional.empty();
+        }
+
+        String myTag = tags.get( 0 );
+
+        List<Map.Entry<MemberId, ReadReplicaInfo>> choices = replicas.entrySet().stream()
+                .filter( entry -> entry.getValue().tags().contains( myTag ) && !entry.getKey().equals( myself ) )
+                .collect( Collectors.toList() );
+
+        if ( choices.isEmpty() )
+        {
+            return Optional.empty();
+        }
+        else
+        {
+            return Optional.of( choices.get( random.nextInt( choices.size() ) ).getKey() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -248,10 +248,12 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         ConnectToRandomCoreServer defaultStrategy = new ConnectToRandomCoreServer();
         defaultStrategy.setTopologyService( topologyService );
+        defaultStrategy.setConfig( config );
+        defaultStrategy.setMyself( myself );
 
         UpstreamDatabaseStrategySelector upstreamDatabaseStrategySelector =
                 new UpstreamDatabaseStrategySelector( defaultStrategy,
-                        new UpstreamDatabaseStrategiesLoader( topologyService, config ), myself );
+                        new UpstreamDatabaseStrategiesLoader( topologyService, config, myself, logProvider ), myself, logProvider );
 
         CatchupPollingProcess catchupProcess =
                 new CatchupPollingProcess( logProvider, localDatabase, servicesToStopOnStoreCopy, catchUpClient,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseSelectionStrategy.java
@@ -24,10 +24,13 @@ import java.util.Optional;
 import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
+import org.neo4j.kernel.configuration.Config;
 
 public abstract class UpstreamDatabaseSelectionStrategy extends Service
 {
-    TopologyService topologyService;
+    protected TopologyService topologyService;
+    protected Config config;
+    protected MemberId myself;
 
     public UpstreamDatabaseSelectionStrategy( String key, String... altKeys )
     {
@@ -40,5 +43,37 @@ public abstract class UpstreamDatabaseSelectionStrategy extends Service
         this.topologyService = topologyService;
     }
 
+    void setConfig( Config config )
+    {
+        this.config = config;
+    }
+
+    void setMyself(MemberId myself) { this.myself = myself;}
+
     public abstract Optional<MemberId> upstreamDatabase() throws UpstreamDatabaseSelectionException;
+
+    @Override
+    public String toString()
+    {
+        return nicelyCommaSeparatedList( getKeys() );
+    }
+
+    private static String nicelyCommaSeparatedList( Iterable<String> keys )
+    {
+        StringBuilder sb = new StringBuilder();
+        for ( String key : keys )
+        {
+            sb.append( key );
+            sb.append( "," );
+            sb.append( " " );
+        }
+
+        int trimThese = sb.lastIndexOf( ", " );
+        if ( trimThese > 1 )
+        {
+            sb.replace( trimThese, sb.length(), "" );
+        }
+
+        return sb.toString();
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelector.java
@@ -24,6 +24,9 @@ import java.util.LinkedHashSet;
 import java.util.NoSuchElementException;
 
 import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.empty;
 
@@ -31,16 +34,20 @@ public class UpstreamDatabaseStrategySelector
 {
     private LinkedHashSet<UpstreamDatabaseSelectionStrategy> strategies = new LinkedHashSet<>();
     private MemberId myself;
+    private Log log;
 
     UpstreamDatabaseStrategySelector( UpstreamDatabaseSelectionStrategy defaultStrategy )
     {
-        this( defaultStrategy, empty(), null );
+        this( defaultStrategy, empty(), null, NullLogProvider.getInstance() );
     }
 
     UpstreamDatabaseStrategySelector( UpstreamDatabaseSelectionStrategy defaultStrategy,
-            Iterable<UpstreamDatabaseSelectionStrategy> otherStrategies, MemberId myself )
+                                      Iterable<UpstreamDatabaseSelectionStrategy> otherStrategies, MemberId myself,
+                                      LogProvider logProvider )
     {
         this.myself = myself;
+        this.log = logProvider.getLog( getClass() );
+
         if ( otherStrategies != null )
         {
             for ( UpstreamDatabaseSelectionStrategy otherStrategy : otherStrategies )
@@ -56,6 +63,7 @@ public class UpstreamDatabaseStrategySelector
         MemberId result = null;
         for ( UpstreamDatabaseSelectionStrategy strategy : strategies )
         {
+            log.debug( "Trying selection strategy [%s]", strategy.toString() );
             try
             {
                 if ( strategy.upstreamDatabase().isPresent() )
@@ -76,6 +84,7 @@ public class UpstreamDatabaseStrategySelector
                     "Could not find an upstream database with which to connect." );
         }
 
+        log.debug( "Selected upstream database [%s]", result );
         return result;
     }
 }

--- a/enterprise/causal-clustering/src/main/resources/META-INF/services/org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionStrategy
+++ b/enterprise/causal-clustering/src/main/resources/META-INF/services/org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionStrategy
@@ -1,1 +1,2 @@
 org.neo4j.causalclustering.readreplica.ConnectToRandomCoreServer
+org.neo4j.causalclustering.readreplica.ConnectWithinDataCenter

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategiesLoaderTest.java
@@ -22,9 +22,12 @@ package org.neo4j.causalclustering.readreplica;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.UUID;
 
 import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -33,6 +36,9 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class UpstreamDatabaseStrategiesLoaderTest
 {
+
+    private MemberId myself = new MemberId( UUID.randomUUID() );
+
     @Test
     public void shouldReturnConfiguredClassesOnly() throws Exception
     {
@@ -40,8 +46,9 @@ public class UpstreamDatabaseStrategiesLoaderTest
         Config config = Config.defaults();
         config.augment( stringMap( "causal_clustering.upstream_selection_strategy", "dummy" ) );
 
-        UpstreamDatabaseStrategiesLoader
-                strategies = new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config );
+        UpstreamDatabaseStrategiesLoader strategies =
+                new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config,
+                        myself, NullLogProvider.getInstance() );
 
         // when
         Set<UpstreamDatabaseSelectionStrategy> upstreamDatabaseSelectionStrategies = asSet( strategies.iterator() );
@@ -61,8 +68,9 @@ public class UpstreamDatabaseStrategiesLoaderTest
                 stringMap( "causal_clustering.upstream_selection_strategy", "yet-another-dummy,dummy,another-dummy" ) );
 
         // when
-        UpstreamDatabaseStrategiesLoader
-                strategies = new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config );
+        UpstreamDatabaseStrategiesLoader strategies =
+                new UpstreamDatabaseStrategiesLoader( mock( TopologyService.class ), config,
+                        myself, NullLogProvider.getInstance() );
 
         // then
         assertEquals( UpstreamDatabaseStrategySelectorTest.YetAnotherDummyUpstreamDatabaseSelectionStrategy.class,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UpstreamDatabaseStrategySelectorTest.java
@@ -32,6 +32,7 @@ import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.Service;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -59,7 +60,7 @@ public class UpstreamDatabaseStrategySelectorTest
         when( goodOne.upstreamDatabase() ).thenReturn( Optional.of( theMemberId ) );
 
         UpstreamDatabaseStrategySelector selector =
-                new UpstreamDatabaseStrategySelector( badOne, iterable( goodOne, anotherBadOne ), null );
+                new UpstreamDatabaseStrategySelector( badOne, iterable( goodOne, anotherBadOne ), null, NullLogProvider.getInstance() );
 
         // when
         MemberId result = selector.bestUpstreamDatabase();
@@ -104,7 +105,7 @@ public class UpstreamDatabaseStrategySelectorTest
         when( mockStrategy.upstreamDatabase() ).thenReturn( Optional.of( new MemberId( UUID.randomUUID() ) ) );
 
         UpstreamDatabaseStrategySelector selector =
-                new UpstreamDatabaseStrategySelector( shouldNotUse, iterable( mockStrategy ), null );
+                new UpstreamDatabaseStrategySelector( shouldNotUse, iterable( mockStrategy ), null, NullLogProvider.getInstance() );
 
         // when
         selector.bestUpstreamDatabase();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.neo4j.backup.OnlineBackupSettings;
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.causalclustering.discovery.ReadReplica;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionException;
+import org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionStrategy;
+import org.neo4j.function.ThrowingSupplier;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.Service;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.neo4j.causalclustering.helpers.DataCreator.createLabelledNodesWithProperty;
+import static org.neo4j.causalclustering.scenarios.ReadReplicaToReadReplicaCatchupIT.SpecificReplicaStrategy.upstreamFactory;
+import static org.neo4j.causalclustering.scenarios.ReadReplicaToReadReplicaCatchupIT.checkDataHasReplicatedToReadReplicas;
+import static org.neo4j.com.storecopy.StoreUtil.TEMP_COPY_DIRECTORY_NAME;
+import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.test.assertion.Assert.assertEventually;
+
+public class ReadReplicaHierarchicalCatchupIT
+{
+    private Map<Integer,String> serverTags = new HashMap<>();
+
+    @Before
+    public void setup()
+    {
+        serverTags.put( 0, "NORTH" );
+        serverTags.put( 1, "NORTH" );
+        serverTags.put( 2, "NORTH" );
+
+        serverTags.put( 3, "EAST" );
+        serverTags.put( 5, "EAST" );
+
+        serverTags.put( 4, "WEST" );
+        serverTags.put( 6, "WEST" );
+    }
+
+    @Rule
+    public ClusterRule clusterRule =
+            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+                    .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
+                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+
+    @Test
+    public void shouldCatchupThroughHierarchy() throws Throwable
+    {
+        clusterRule = clusterRule
+                .withInstanceReadReplicaParam( CausalClusteringSettings.server_tags, id -> serverTags.get( id ) )
+                .withInstanceCoreParam( CausalClusteringSettings.server_tags, id -> serverTags.get( id ) );
+
+        // given
+        Cluster cluster = clusterRule.startCluster();
+        int numberOfNodesToCreate = 100;
+
+        cluster.coreTx( ( db, tx ) ->
+        {
+            db.schema().constraintFor( label( "Foo" ) ).assertPropertyIsUnique( "foobar" ).create();
+            tx.success();
+        } );
+
+        // 0, 1, 2 are core instances
+        createLabelledNodesWithProperty( cluster, numberOfNodesToCreate, label( "Foo" ),
+                () -> Pair.of( "foobar", String.format( "baz_bat%s", UUID.randomUUID() ) ) );
+
+        // 3, 4 are other DCs
+        ReadReplica east3 = cluster.addReadReplicaWithId( 3 );
+        east3.start();
+        ReadReplica west4 = cluster.addReadReplicaWithId( 4 );
+        west4.start();
+
+        checkDataHasReplicatedToReadReplicas( cluster, numberOfNodesToCreate );
+
+        for ( CoreClusterMember coreClusterMember : cluster.coreMembers() )
+        {
+            coreClusterMember.stopCatchupServer();
+        }
+
+        // 5, 6 are other DCs
+        ReadReplica east5 = cluster.addReadReplicaWithId( 5 );
+        east5.setUpstreamDatabaseSelectionStrategy( "connect-within-data-center" );
+        east5.start();
+        ReadReplica west6 = cluster.addReadReplicaWithId( 6 );
+        west6.setUpstreamDatabaseSelectionStrategy( "connect-within-data-center" );
+        west6.start();
+
+        checkDataHasReplicatedToReadReplicas( cluster, numberOfNodesToCreate );
+
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
@@ -81,9 +81,6 @@ public class ReadReplicaToReadReplicaCatchupIT
 
         ReadReplica firstReadReplica = cluster.addReadReplicaWithIdAndMonitors( 101, new Monitors() );
 
-        File labelScanStore = LabelScanStoreProvider
-                .getStoreDirectory( new File( firstReadReplica.storeDir(), TEMP_COPY_DIRECTORY_NAME ) );
-
         firstReadReplica.start();
 
         checkDataHasReplicatedToReadReplicas( cluster, numberOfNodesToCreate );
@@ -124,8 +121,6 @@ public class ReadReplicaToReadReplicaCatchupIT
 
         ReadReplica firstReadReplica =
                 cluster.addReadReplicaWithIdAndMonitors( firstReadReplicaLocalMemberId, new Monitors() );
-        File labelScanStore = LabelScanStoreProvider
-                .getStoreDirectory( new File( firstReadReplica.storeDir(), TEMP_COPY_DIRECTORY_NAME ) );
 
         firstReadReplica.start();
 
@@ -155,7 +150,7 @@ public class ReadReplicaToReadReplicaCatchupIT
         checkDataHasReplicatedToReadReplicas( cluster, numberOfNodes * 2 );
     }
 
-    private void checkDataHasReplicatedToReadReplicas( Cluster cluster, long numberOfNodes ) throws Exception
+    static void checkDataHasReplicatedToReadReplicas( Cluster cluster, long numberOfNodes ) throws Exception
     {
         for ( final ReadReplica server : cluster.readReplicas() )
         {

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsBuilder.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsBuilder.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.metrics.MetricsSettings;
 import org.neo4j.metrics.output.EventReporter;
+import org.neo4j.metrics.source.causalclustering.CatchUpMetrics;
 import org.neo4j.metrics.source.causalclustering.CoreMetrics;
 import org.neo4j.metrics.source.causalclustering.ReadReplicaMetrics;
 import org.neo4j.metrics.source.cluster.ClusterMetrics;
@@ -197,11 +198,13 @@ public class Neo4jMetricsBuilder
             if ( mode == OperationalMode.core )
             {
                 life.add( new CoreMetrics( dependencies.monitors(), registry, dependencies.raft() ) );
+                life.add( new CatchUpMetrics( dependencies.monitors(), registry ) );
                 result = true;
             }
             else if ( mode == OperationalMode.read_replica )
             {
                 life.add( new ReadReplicaMetrics( dependencies.monitors(), registry ) );
+                life.add( new CatchUpMetrics( dependencies.monitors(), registry ) );
                 result = true;
             }
             else

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CatchUpMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CatchUpMetrics.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.source.causalclustering;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import org.neo4j.causalclustering.core.consensus.CoreMetaData;
+import org.neo4j.kernel.impl.annotations.Documented;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@Documented(".CatchUp Metrics")
+public class CatchUpMetrics extends LifecycleAdapter
+{
+    private static final String CAUSAL_CLUSTERING_PREFIX = "neo4j.causal_clustering.catchup";
+
+    @Documented("TX pull requests received from read replicas")
+    public static final String TX_PULL_REQUESTS_RECEIVED = name( CAUSAL_CLUSTERING_PREFIX, "tx_pull_requests_received" );
+
+    private Monitors monitors;
+    private MetricRegistry registry;
+    private final TxPullRequestsMetric txPullRequestsMetric = new TxPullRequestsMetric();
+
+    public CatchUpMetrics( Monitors monitors, MetricRegistry registry )
+    {
+        this.monitors = monitors;
+        this.registry = registry;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        monitors.addMonitorListener( txPullRequestsMetric );
+        registry.register( TX_PULL_REQUESTS_RECEIVED, (Gauge<Long>) txPullRequestsMetric::txPullRequestsReceived );
+    }
+
+    @Override
+    public void stop() throws IOException
+    {
+        registry.remove( TX_PULL_REQUESTS_RECEIVED );
+        monitors.removeMonitorListener( txPullRequestsMetric );
+    }
+}

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CoreMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/CoreMetrics.java
@@ -45,8 +45,6 @@ public class CoreMetrics extends LifecycleAdapter
     public static final String TERM = name( CAUSAL_CLUSTERING_PREFIX, "term" );
     @Documented("Leader was not found while attempting to commit a transaction")
     public static final String LEADER_NOT_FOUND = name( CAUSAL_CLUSTERING_PREFIX, "leader_not_found" );
-    @Documented("TX pull requests received from read replicas")
-    public static final String TX_PULL_REQUESTS_RECEIVED = name( CAUSAL_CLUSTERING_PREFIX, "tx_pull_requests_received" );
     @Documented("Transaction retries")
     public static final String TX_RETRIES = name( CAUSAL_CLUSTERING_PREFIX, "tx_retries" );
     @Documented("Is this server the leader?")
@@ -90,7 +88,6 @@ public class CoreMetrics extends LifecycleAdapter
         registry.register( APPEND_INDEX, (Gauge<Long>) raftLogAppendIndexMetric::appendIndex );
         registry.register( TERM, (Gauge<Long>) raftTermMetric::term );
         registry.register( LEADER_NOT_FOUND, (Gauge<Long>) leaderNotFoundMetric::leaderNotFoundExceptions );
-        registry.register( TX_PULL_REQUESTS_RECEIVED, (Gauge<Long>) txPullRequestsMetric::txPullRequestsReceived );
         registry.register( TX_RETRIES, (Gauge<Long>) txRetryMetric::transactionsRetries );
         registry.register( IS_LEADER, new LeaderGauge() );
         registry.register( DROPPED_MESSAGES, (Gauge<Long>) messageQueueMetric::droppedMessages );
@@ -104,7 +101,6 @@ public class CoreMetrics extends LifecycleAdapter
         registry.remove( APPEND_INDEX );
         registry.remove( TERM );
         registry.remove( LEADER_NOT_FOUND );
-        registry.remove( TX_PULL_REQUESTS_RECEIVED );
         registry.remove( TX_RETRIES );
         registry.remove( IS_LEADER );
         registry.remove( DROPPED_MESSAGES );

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.metrics.source.causalclustering.CatchUpMetrics;
 import org.neo4j.metrics.source.causalclustering.CoreMetrics;
 import org.neo4j.test.causalclustering.ClusterRule;
 
@@ -133,7 +134,7 @@ public class CoreEdgeMetricsIT
             for ( final File homeDir : cluster.coreMembers().stream().map( CoreClusterMember::homeDir ).collect( Collectors.toList()) )
             {
                 File metricsDir = new File( homeDir, "metrics" );
-                total += readLongValue( metricsCsv( metricsDir, CoreMetrics.TX_PULL_REQUESTS_RECEIVED ) );
+                total += readLongValue( metricsCsv( metricsDir, CatchUpMetrics.TX_PULL_REQUESTS_RECEIVED ) );
             }
             return total;
         }, greaterThan( 0L ), TIMEOUT, TimeUnit.SECONDS );


### PR DESCRIPTION
Adding a Data Center-Local upstream strategy.
A sensible out of the box plugin for allowing read replicas to catch up from named others within their locality.
Log the loaded strategies and their order of precedence.
Does not catchup from self.