### PR TITLE
Ability to auto-select label index based on existing store

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -36,6 +36,7 @@ import org.neo4j.consistency.statistics.Statistics;
 import org.neo4j.consistency.statistics.VerboseStatistics;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -69,6 +70,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
+
 import static org.neo4j.helpers.Service.load;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
@@ -212,7 +214,9 @@ public class ConsistencyCheckService
             throws ConsistencyCheckIncompleteException
     {
         Log log = logProvider.getLog( getClass() );
-        config = config.with( stringMap( GraphDatabaseSettings.read_only.name(), TRUE ) );
+        config = config.with( stringMap(
+                GraphDatabaseSettings.read_only.name(), TRUE,
+                GraphDatabaseSettings.label_index.name(), LabelIndex.AUTO.name() ) );
         StoreFactory factory = new StoreFactory( storeDir, config,
                 new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem, logProvider );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -508,8 +508,20 @@ public class GraphDatabaseSettings implements LoadableConfig
 
     public enum LabelIndex
     {
+        /**
+         * Native label index. Generally the best option.
+         */
         NATIVE,
-        LUCENE;
+
+        /**
+         * Label index backed by Lucene.
+         */
+        LUCENE,
+
+        /**
+         * Selects which ever label index is present in a store, or the default (NATIVE) if no label index present.
+         */
+        AUTO;
     }
 
     @Description( "Backend to use for label --> nodes index" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -136,4 +136,10 @@ public interface LabelScanStore extends Lifecycle
      * @return whether or not this index is read-only.
      */
     boolean isReadOnly();
+
+    /**
+     * @return whether or not there's an existing store present for this label scan store.
+     * @throws IOException on I/O error checking the presence of a store.
+     */
+    boolean hasStore() throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/LabelScanStoreProvider.java
@@ -92,4 +92,9 @@ public class LabelScanStoreProvider extends LifecycleAdapter
     {
         labelScanStore.drop();
     }
+
+    public boolean hasStore() throws IOException
+    {
+        return labelScanStore.hasStore();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -278,7 +278,7 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         monitor.init();
 
-        boolean storeExists = storeExists();
+        boolean storeExists = hasStore();
         try
         {
             needsRebuild = !storeExists;
@@ -299,7 +299,8 @@ public class NativeLabelScanStore implements LabelScanStore
         }
     }
 
-    private boolean storeExists() throws IOException
+    @Override
+    public boolean hasStore() throws IOException
     {
         try
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/dependency/NamedLabelScanStoreSelectionStrategyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/dependency/NamedLabelScanStoreSelectionStrategyTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.extension.dependency;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.helpers.collection.Iterables.iterable;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class NamedLabelScanStoreSelectionStrategyTest
+{
+    @Test
+    public void shouldSelectSpecificallyConfiguredProviderWhenSingle() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.NATIVE );
+        LabelScanStoreProvider single = provider( LabelIndex.NATIVE, store( false ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, single );
+
+        // THEN
+        assertSame( single, selected );
+    }
+
+    @Test
+    public void shouldSelectSpecificallyConfiguredProviderAmongMultiple() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.LUCENE );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( false ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( false ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, nativeProvider, luceneProvider );
+
+        // THEN
+        assertSame( luceneProvider, selected );
+    }
+
+    @Test
+    public void shouldFailOnMissingSpecificallyConfiguredProvider() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.LUCENE );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( false ) );
+
+        // WHEN
+        try
+        {
+            select( strategy, nativeProvider );
+            fail( "Should've failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN good
+        }
+    }
+
+    @Test
+    public void shouldAutoSelectSingleProviderWithPresentStore() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( true ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, nativeProvider );
+
+        // THEN
+        assertSame( nativeProvider, selected );
+    }
+
+    @Test
+    public void shouldAutoSelectSingleProviderWithPresentStoreAmongMultipleProviders() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( false ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( true ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, nativeProvider, luceneProvider );
+
+        // THEN
+        assertSame( luceneProvider, selected );
+    }
+
+    @Test
+    public void shouldAutoSelectDefaultProviderIfNoProviderWithPresentStore() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( false ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( false ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, nativeProvider, luceneProvider );
+
+        // THEN
+        assertEquals( GraphDatabaseSettings.label_index.getDefaultValue(), selected.getName() );
+    }
+
+    @Test
+    public void shouldFailAutoSelectIfMultipleProvidersWithPresentStore() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( true ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( true ) );
+
+        // WHEN
+        try
+        {
+            select( strategy, nativeProvider, luceneProvider );
+            fail( "Should've failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN good
+        }
+    }
+
+    @Test
+    public void shouldFailAutoSelectIfNoProviderWithPresentStoreAndSomeReportedIOException() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( false ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( null ) );
+
+        // WHEN
+        try
+        {
+            select( strategy, nativeProvider, luceneProvider );
+            fail( "Should've failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN good
+            assertTrue( e.getCause() instanceof IOException );
+        }
+    }
+
+    @Test
+    public void shouldAutoSelectProviderWithPresentStoreEvenIfSomeOtherReportedIOException() throws Exception
+    {
+        // GIVEN
+        NamedLabelScanStoreSelectionStrategy strategy = strategy( LabelIndex.AUTO );
+        LabelScanStoreProvider nativeProvider = provider( LabelIndex.NATIVE, store( true ) );
+        LabelScanStoreProvider luceneProvider = provider( LabelIndex.LUCENE, store( null ) );
+
+        // WHEN
+        LabelScanStoreProvider selected = select( strategy, nativeProvider, luceneProvider );
+
+        // THEN
+        assertSame( nativeProvider, selected );
+    }
+
+    private NamedLabelScanStoreSelectionStrategy strategy( LabelIndex index )
+    {
+        return new NamedLabelScanStoreSelectionStrategy( Config.defaults().augment( stringMap(
+                GraphDatabaseSettings.label_index.name(), index.name() ) ) );
+    }
+
+    private LabelScanStoreProvider provider( LabelIndex index, LabelScanStore store )
+    {
+        return new LabelScanStoreProvider( index.name(), store );
+    }
+
+    private LabelScanStore store( Boolean present ) throws IOException
+    {
+        LabelScanStore store = mock( LabelScanStore.class );
+        if ( present == null )
+        {
+            when( store.hasStore() ).thenThrow( IOException.class );
+        }
+        else
+        {
+            when( store.hasStore() ).thenReturn( present );
+        }
+        return store;
+    }
+
+    private LabelScanStoreProvider select( NamedLabelScanStoreSelectionStrategy strategy,
+            LabelScanStoreProvider... among )
+    {
+        return strategy.select( LabelScanStoreProvider.class, iterable( among ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1533,6 +1533,12 @@ public class BatchInsertTest
         {
             return false;
         }
+
+        @Override
+        public boolean hasStore()
+        {
+            return false;
+        }
     }
 
     interface NoDependencies

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
@@ -98,7 +98,7 @@ public class LuceneLabelScanStore implements LabelScanStore
         monitor.init();
         try
         {
-            if ( !luceneIndex.exists() )
+            if ( !hasStore() )
             {
                 monitor.noIndex();
 
@@ -188,5 +188,11 @@ public class LuceneLabelScanStore implements LabelScanStore
     public boolean isReadOnly()
     {
         return luceneIndex.isReadOnly();
+    }
+
+    @Override
+    public boolean hasStore() throws IOException
+    {
+        return luceneIndex.exists();
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -98,6 +99,7 @@ public class CopiedStoreRecovery extends LifecycleAdapter
                 .setKernelExtensions( kernelExtensions )
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore )
+                .setConfig( GraphDatabaseSettings.label_index, LabelIndex.AUTO.name() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.neo4j.com.Response;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -343,7 +344,7 @@ public class StoreCopyClient
                 .setKernelExtensions( kernelExtensions )
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore.getAbsoluteFile() )
-                .setConfig( GraphDatabaseSettings.label_index, config.get( GraphDatabaseSettings.label_index ) )
+                .setConfig( GraphDatabaseSettings.label_index, LabelIndex.AUTO.name() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )


### PR DESCRIPTION
Introducing LabelIndex.AUTO which is intended to be used for tooling
where it's convenient to not have a say in which label index to use,
but let database select which ever label index is present already.

This was driven by a backup scenario where the backup client would
select a different label index than the source. This would work
conceptually (because it would have been rebuilt), but proved to be
troublesome by means of page cache actions for moving files after
temporary store had been started and stopped. In this case the
original label index store would have been deleted and making the
following move action invalid.

Letting the backup client internally use AUTO label index selection
solves this. It's still of course possible to configure another
label index when restoring from this backup, which is separate from
this problem of doing the backup.

In this vein, even consistency checker uses AUTO.