### PR TITLE
Fix safe zone id reuse for properties

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+/**
+ * Used to verify that some source of operation is still open when operation is performed.
+ * E.g. verify that transaction is still open when lazily reading property values from store.
+ */
+public interface AssertOpen
+{
+    /**
+     * Assert that source tied to instance is open.
+     * Should throw exception with reason if source is not open.
+     */
+    void assertOpen();
+
+    AssertOpen ALWAYS_OPEN = AlwaysOpen.INSTANCE;
+
+    enum AlwaysOpen implements AssertOpen
+    {
+        INSTANCE
+        {
+            @Override
+            public void assertOpen()
+            {   // no-op
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/AssertOpen.java
@@ -31,16 +31,8 @@ public interface AssertOpen
      */
     void assertOpen();
 
-    AssertOpen ALWAYS_OPEN = AlwaysOpen.INSTANCE;
-
-    enum AlwaysOpen implements AssertOpen
+    AssertOpen ALWAYS_OPEN = () ->
     {
-        INSTANCE
-        {
-            @Override
-            public void assertOpen()
-            {   // no-op
-            }
-        }
-    }
+        // Always open
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
@@ -68,7 +68,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
     public void visitDeletedNode( long id )
     {
         counts.incrementNodeCount( ANY_LABEL, -1 );
-        try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id ) )
+        try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
         {
             if ( node.next() )
             {
@@ -141,7 +141,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
             }
             // get the relationship counts from *before* this transaction,
             // the relationship changes will compensate for what happens during the transaction
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
             {
                 if ( node.next() )
                 {
@@ -206,7 +206,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
 
     private Cursor<NodeItem> nodeCursor( StorageStatement statement, long nodeId )
     {
-        Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId );
+        Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, () -> {} );
         return txState.augmentSingleNodeCursor( cursor, nodeId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.impl.api.CountsRecordState;
@@ -68,7 +69,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
     public void visitDeletedNode( long id )
     {
         counts.incrementNodeCount( ANY_LABEL, -1 );
-        try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
+        try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, AssertOpen.ALWAYS_OPEN ) )
         {
             if ( node.next() )
             {
@@ -141,7 +142,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
             }
             // get the relationship counts from *before* this transaction,
             // the relationship changes will compensate for what happens during the transaction
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, AssertOpen.ALWAYS_OPEN ) )
             {
                 if ( node.next() )
                 {
@@ -206,7 +207,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
 
     private Cursor<NodeItem> nodeCursor( StorageStatement statement, long nodeId )
     {
-        Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, () -> {} );
+        Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, AssertOpen.ALWAYS_OPEN );
         return txState.augmentSingleNodeCursor( cursor, nodeId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -25,6 +25,7 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ExecutingQuery;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
@@ -61,7 +62,7 @@ import org.neo4j.storageengine.api.StorageStatement;
  * instance again, when it's initialized.</li>
  * </ol>
  */
-public class KernelStatement implements TxStateHolder, Statement
+public class KernelStatement implements TxStateHolder, Statement, AssertOpen
 {
     private final TxStateHolder txStateHolder;
     private final StorageStatement storeStatement;
@@ -164,7 +165,8 @@ public class KernelStatement implements TxStateHolder, Statement
         }
     }
 
-    void assertOpen()
+    @Override
+    public void assertOpen()
     {
         if ( referenceCount == 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -33,11 +33,11 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.LegacyIndexHits;
+import org.neo4j.kernel.api.ProcedureCallOperations;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -359,10 +359,6 @@ public class OperationsFacade
         {
             return node.get().getProperty( propertyKeyId );
         }
-        finally
-        {
-            statement.assertOpen();
-        }
     }
 
     @Override
@@ -465,10 +461,6 @@ public class OperationsFacade
         {
             return relationship.get().getProperty( propertyKeyId );
         }
-        finally
-        {
-            statement.assertOpen();
-        }
     }
 
     @Override
@@ -502,10 +494,6 @@ public class OperationsFacade
             PrimitiveIntCollection propertyKeys = node.get().getPropertyKeys();
             return propertyKeys.iterator();
         }
-        finally
-        {
-            statement.assertOpen();
-        }
     }
 
     @Override
@@ -516,10 +504,6 @@ public class OperationsFacade
         {
             PrimitiveIntCollection propertyKeys = relationship.get().getPropertyKeys();
             return propertyKeys.iterator();
-        }
-        finally
-        {
-            statement.assertOpen();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -147,7 +147,7 @@ public class StateHandlingStatementOperations implements
     @Override
     public Cursor<NodeItem> nodeCursor( KernelStatement statement, long nodeId )
     {
-        Cursor<NodeItem> cursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, statement::assertOpen );
+        Cursor<NodeItem> cursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, statement );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentSingleNodeCursor( cursor, nodeId );
@@ -172,7 +172,7 @@ public class StateHandlingStatementOperations implements
     public Cursor<RelationshipItem> relationshipCursor( KernelStatement statement, long relationshipId )
     {
         Cursor<RelationshipItem> cursor = statement.getStoreStatement().acquireSingleRelationshipCursor(
-                relationshipId, statement::assertOpen );
+                relationshipId, statement );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentSingleRelationshipCursor( cursor, relationshipId );
@@ -183,7 +183,7 @@ public class StateHandlingStatementOperations implements
     @Override
     public Cursor<NodeItem> nodeCursorGetAll( KernelStatement statement )
     {
-        Cursor<NodeItem> cursor = statement.getStoreStatement().nodesGetAllCursor( statement::assertOpen );
+        Cursor<NodeItem> cursor = statement.getStoreStatement().nodesGetAllCursor( statement );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentNodesGetAllCursor( cursor );
@@ -195,7 +195,7 @@ public class StateHandlingStatementOperations implements
     public Cursor<RelationshipItem> relationshipCursorGetAll( KernelStatement statement )
     {
         Cursor<RelationshipItem> cursor =
-                statement.getStoreStatement().relationshipsGetAllCursor( statement::assertOpen );
+                statement.getStoreStatement().relationshipsGetAllCursor( statement );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentRelationshipsGetAllCursor( cursor );
@@ -209,7 +209,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         return storeStatement.acquireIteratorNodeCursor(
-                storeLayer.nodesGetForLabel( storeStatement, labelId ), statement::assertOpen );
+                storeLayer.nodesGetForLabel( storeStatement, labelId ), statement );
     }
 
     @Override
@@ -219,7 +219,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.seek( value ), statement::assertOpen );
+        return storeStatement.acquireIteratorNodeCursor( reader.seek( value ), statement );
     }
 
     @Override
@@ -229,7 +229,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.scan(), statement::assertOpen );
+        return storeStatement.acquireIteratorNodeCursor( reader.scan(), statement );
     }
 
     @Override
@@ -240,7 +240,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement::assertOpen );
+        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement );
     }
 
     @Override
@@ -256,7 +256,7 @@ public class StateHandlingStatementOperations implements
         IndexReader reader = storeStatement.getIndexReader( index );
         return COMPARE_NUMBERS.isEmptyRange( lower, includeLower, upper, includeUpper ) ? Cursors.<NodeItem>empty() :
                storeStatement.acquireIteratorNodeCursor(
-                       reader.rangeSeekByNumberInclusive( lower, upper ), statement::assertOpen );
+                       reader.rangeSeekByNumberInclusive( lower, upper ), statement );
     }
 
     @Override
@@ -271,7 +271,7 @@ public class StateHandlingStatementOperations implements
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
         return storeStatement.acquireIteratorNodeCursor(
-                reader.rangeSeekByString( lower, includeLower, upper, includeUpper ), statement::assertOpen );
+                reader.rangeSeekByString( lower, includeLower, upper, includeUpper ), statement );
     }
 
     @Override
@@ -282,7 +282,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement::assertOpen );
+        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement );
     }
 
     @Override
@@ -294,7 +294,7 @@ public class StateHandlingStatementOperations implements
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getFreshIndexReader( index );
         PrimitiveLongIterator seekResult = PrimitiveLongCollections.resourceIterator( reader.seek( value ), reader );
-        return storeStatement.acquireIteratorNodeCursor( seekResult, statement::assertOpen );
+        return storeStatement.acquireIteratorNodeCursor( seekResult, statement );
     }
 
     // </Cursors>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -147,7 +147,7 @@ public class StateHandlingStatementOperations implements
     @Override
     public Cursor<NodeItem> nodeCursor( KernelStatement statement, long nodeId )
     {
-        Cursor<NodeItem> cursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId );
+        Cursor<NodeItem> cursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, statement::assertOpen );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentSingleNodeCursor( cursor, nodeId );
@@ -172,7 +172,7 @@ public class StateHandlingStatementOperations implements
     public Cursor<RelationshipItem> relationshipCursor( KernelStatement statement, long relationshipId )
     {
         Cursor<RelationshipItem> cursor = statement.getStoreStatement().acquireSingleRelationshipCursor(
-                relationshipId );
+                relationshipId, statement::assertOpen );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentSingleRelationshipCursor( cursor, relationshipId );
@@ -183,7 +183,7 @@ public class StateHandlingStatementOperations implements
     @Override
     public Cursor<NodeItem> nodeCursorGetAll( KernelStatement statement )
     {
-        Cursor<NodeItem> cursor = statement.getStoreStatement().nodesGetAllCursor();
+        Cursor<NodeItem> cursor = statement.getStoreStatement().nodesGetAllCursor( statement::assertOpen );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentNodesGetAllCursor( cursor );
@@ -194,7 +194,8 @@ public class StateHandlingStatementOperations implements
     @Override
     public Cursor<RelationshipItem> relationshipCursorGetAll( KernelStatement statement )
     {
-        Cursor<RelationshipItem> cursor = statement.getStoreStatement().relationshipsGetAllCursor();
+        Cursor<RelationshipItem> cursor =
+                statement.getStoreStatement().relationshipsGetAllCursor( statement::assertOpen );
         if ( statement.hasTxStateWithChanges() )
         {
             return statement.txState().augmentRelationshipsGetAllCursor( cursor );
@@ -208,7 +209,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         return storeStatement.acquireIteratorNodeCursor(
-                storeLayer.nodesGetForLabel( storeStatement, labelId ) );
+                storeLayer.nodesGetForLabel( storeStatement, labelId ), statement::assertOpen );
     }
 
     @Override
@@ -218,7 +219,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.seek( value ) );
+        return storeStatement.acquireIteratorNodeCursor( reader.seek( value ), statement::assertOpen );
     }
 
     @Override
@@ -228,7 +229,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.scan() );
+        return storeStatement.acquireIteratorNodeCursor( reader.scan(), statement::assertOpen );
     }
 
     @Override
@@ -239,7 +240,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ) );
+        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement::assertOpen );
     }
 
     @Override
@@ -255,7 +256,7 @@ public class StateHandlingStatementOperations implements
         IndexReader reader = storeStatement.getIndexReader( index );
         return COMPARE_NUMBERS.isEmptyRange( lower, includeLower, upper, includeUpper ) ? Cursors.<NodeItem>empty() :
                storeStatement.acquireIteratorNodeCursor(
-                       reader.rangeSeekByNumberInclusive( lower, upper ) );
+                       reader.rangeSeekByNumberInclusive( lower, upper ), statement::assertOpen );
     }
 
     @Override
@@ -270,7 +271,7 @@ public class StateHandlingStatementOperations implements
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
         return storeStatement.acquireIteratorNodeCursor(
-                reader.rangeSeekByString( lower, includeLower, upper, includeUpper ) );
+                reader.rangeSeekByString( lower, includeLower, upper, includeUpper ), statement::assertOpen );
     }
 
     @Override
@@ -281,7 +282,7 @@ public class StateHandlingStatementOperations implements
         // TODO Filter this properly
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
-        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ) );
+        return storeStatement.acquireIteratorNodeCursor( reader.rangeSeekByPrefix( prefix ), statement::assertOpen );
     }
 
     @Override
@@ -293,7 +294,7 @@ public class StateHandlingStatementOperations implements
         StorageStatement storeStatement = statement.getStoreStatement();
         IndexReader reader = storeStatement.getFreshIndexReader( index );
         PrimitiveLongIterator seekResult = PrimitiveLongCollections.resourceIterator( reader.seek( value ), reader );
-        return storeStatement.acquireIteratorNodeCursor( seekResult );
+        return storeStatement.acquireIteratorNodeCursor( seekResult, statement::assertOpen );
     }
 
     // </Cursors>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -27,6 +27,7 @@ import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.cursor.IntValue;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.cursor.NodeItemHelper;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -71,7 +72,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
     private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
     private final InstanceCache<StorePropertyCursor> allPropertyCursor;
     protected final RecordCursors cursors;
-    private Runnable assertOnPropertyValueFetch;
+    private AssertOpen assertOpen;
 
     public StoreAbstractNodeCursor( NodeRecord nodeRecord,
             final NeoStores neoStores,
@@ -130,9 +131,9 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
         };
     }
 
-    protected void initialize( Runnable assertOnPropertyValueFetch )
+    protected void initialize( AssertOpen assertOpen )
     {
-        this.assertOnPropertyValueFetch = assertOnPropertyValueFetch;
+        this.assertOpen = assertOpen;
     }
 
     @Override
@@ -193,29 +194,28 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
     @Override
     public Cursor<PropertyItem> properties()
     {
-        return allPropertyCursor.get().init( nodeRecord.getNextProp(), shortLivedReadLock(),
-                assertOnPropertyValueFetch );
+        return allPropertyCursor.get().init( nodeRecord.getNextProp(), shortLivedReadLock(), assertOpen );
     }
 
     @Override
     public Cursor<PropertyItem> property( int propertyKeyId )
     {
         return singlePropertyCursor.get().init( nodeRecord.getNextProp(), propertyKeyId, shortLivedReadLock(),
-                assertOnPropertyValueFetch );
+                assertOpen );
     }
 
     @Override
     public Cursor<RelationshipItem> relationships( Direction direction )
     {
         return nodeRelationshipCursor.get().init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
-                direction, assertOnPropertyValueFetch );
+                direction, assertOpen );
     }
 
     @Override
     public Cursor<RelationshipItem> relationships( Direction direction, int... relTypes )
     {
         return nodeRelationshipCursor.get().init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
-                direction, assertOnPropertyValueFetch, relTypes );
+                direction, assertOpen, relTypes );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -71,6 +71,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
     private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
     private final InstanceCache<StorePropertyCursor> allPropertyCursor;
     protected final RecordCursors cursors;
+    private Runnable assertOnPropertyValueFetch;
 
     public StoreAbstractNodeCursor( NodeRecord nodeRecord,
             final NeoStores neoStores,
@@ -127,6 +128,11 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
                 return new StorePropertyCursor( cursors, allPropertyCursor );
             }
         };
+    }
+
+    protected void initialize( Runnable assertOnPropertyValueFetch )
+    {
+        this.assertOnPropertyValueFetch = assertOnPropertyValueFetch;
     }
 
     @Override
@@ -187,27 +193,29 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
     @Override
     public Cursor<PropertyItem> properties()
     {
-        return allPropertyCursor.get().init( nodeRecord.getNextProp(), shortLivedReadLock() );
+        return allPropertyCursor.get().init( nodeRecord.getNextProp(), shortLivedReadLock(),
+                assertOnPropertyValueFetch );
     }
 
     @Override
     public Cursor<PropertyItem> property( int propertyKeyId )
     {
-        return singlePropertyCursor.get().init( nodeRecord.getNextProp(), propertyKeyId, shortLivedReadLock() );
+        return singlePropertyCursor.get().init( nodeRecord.getNextProp(), propertyKeyId, shortLivedReadLock(),
+                assertOnPropertyValueFetch );
     }
 
     @Override
     public Cursor<RelationshipItem> relationships( Direction direction )
     {
-        return nodeRelationshipCursor.get().init(  nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
-                direction, null );
+        return nodeRelationshipCursor.get().init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
+                direction, assertOnPropertyValueFetch );
     }
 
     @Override
     public Cursor<RelationshipItem> relationships( Direction direction, int... relTypes )
     {
         return nodeRelationshipCursor.get().init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
-                direction, relTypes );
+                direction, assertOnPropertyValueFetch, relTypes );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.cursor.EntityItemHelper;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -46,7 +47,7 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
 
     private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
     private final InstanceCache<StorePropertyCursor> allPropertyCursor;
-    private Runnable assertOnPropertyValueFetch;
+    private AssertOpen assertOpen;
 
     public StoreAbstractRelationshipCursor( RelationshipRecord relationshipRecord, RecordCursors cursors,
             LockService lockService )
@@ -73,9 +74,9 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
         };
     }
 
-    protected void initialize( Runnable assertOnPropertyValueFetch )
+    protected void initialize( AssertOpen assertOpen )
     {
-        this.assertOnPropertyValueFetch = assertOnPropertyValueFetch;
+        this.assertOpen = assertOpen;
     }
 
     @Override
@@ -150,14 +151,13 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
     public Cursor<PropertyItem> properties()
     {
         return allPropertyCursor.get()
-                .init( relationshipRecord.getNextProp(), shortLivedReadLock(), assertOnPropertyValueFetch );
+                .init( relationshipRecord.getNextProp(), shortLivedReadLock(), assertOpen );
     }
 
     @Override
     public Cursor<PropertyItem> property( int propertyKeyId )
     {
         return singlePropertyCursor.get()
-                .init( relationshipRecord.getNextProp(), propertyKeyId, shortLivedReadLock(),
-                        assertOnPropertyValueFetch );
+                .init( relationshipRecord.getNextProp(), propertyKeyId, shortLivedReadLock(), assertOpen );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -46,6 +46,7 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
 
     private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
     private final InstanceCache<StorePropertyCursor> allPropertyCursor;
+    private Runnable assertOnPropertyValueFetch;
 
     public StoreAbstractRelationshipCursor( RelationshipRecord relationshipRecord, RecordCursors cursors,
             LockService lockService )
@@ -70,6 +71,11 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
                 return new StorePropertyCursor( cursors, this );
             }
         };
+    }
+
+    protected void initialize( Runnable assertOnPropertyValueFetch )
+    {
+        this.assertOnPropertyValueFetch = assertOnPropertyValueFetch;
     }
 
     @Override
@@ -143,12 +149,15 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
     @Override
     public Cursor<PropertyItem> properties()
     {
-        return allPropertyCursor.get().init( relationshipRecord.getNextProp(), shortLivedReadLock() );
+        return allPropertyCursor.get()
+                .init( relationshipRecord.getNextProp(), shortLivedReadLock(), assertOnPropertyValueFetch );
     }
 
     @Override
     public Cursor<PropertyItem> property( int propertyKeyId )
     {
-        return singlePropertyCursor.get().init( relationshipRecord.getNextProp(), propertyKeyId, shortLivedReadLock() );
+        return singlePropertyCursor.get()
+                .init( relationshipRecord.getNextProp(), propertyKeyId, shortLivedReadLock(),
+                        assertOnPropertyValueFetch );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -50,9 +51,9 @@ public class StoreIteratorNodeCursor extends StoreAbstractNodeCursor
         this.instanceCache = instanceCache;
     }
 
-    public StoreIteratorNodeCursor init( PrimitiveLongIterator iterator, Runnable assertOnPropertyValueFetch )
+    public StoreIteratorNodeCursor init( PrimitiveLongIterator iterator, AssertOpen assertOpen )
     {
-        initialize( assertOnPropertyValueFetch );
+        initialize( assertOpen );
         this.iterator = iterator;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
@@ -50,8 +50,9 @@ public class StoreIteratorNodeCursor extends StoreAbstractNodeCursor
         this.instanceCache = instanceCache;
     }
 
-    public StoreIteratorNodeCursor init( PrimitiveLongIterator iterator )
+    public StoreIteratorNodeCursor init( PrimitiveLongIterator iterator, Runnable assertOnPropertyValueFetch )
     {
+        initialize( assertOnPropertyValueFetch );
         this.iterator = iterator;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -45,9 +46,9 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
         this.instanceCache = instanceCache;
     }
 
-    public StoreIteratorRelationshipCursor init( PrimitiveLongIterator iterator, Runnable assertOnPropertyValueFetch )
+    public StoreIteratorRelationshipCursor init( PrimitiveLongIterator iterator, AssertOpen assertOpen )
     {
-        initialize( assertOnPropertyValueFetch );
+        initialize( assertOpen );
         this.iterator = iterator;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -45,8 +45,9 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
         this.instanceCache = instanceCache;
     }
 
-    public StoreIteratorRelationshipCursor init( PrimitiveLongIterator iterator )
+    public StoreIteratorRelationshipCursor init( PrimitiveLongIterator iterator, Runnable assertOnPropertyValueFetch )
     {
+        initialize( assertOnPropertyValueFetch );
         this.iterator = iterator;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.store;
 
 import java.util.function.Consumer;
 
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -67,16 +68,16 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
             long firstRelId,
             long fromNodeId,
             Direction direction,
-            Runnable assertOnPropertyValueFetch )
+            AssertOpen assertOpen )
     {
-        return init( isDense, firstRelId, fromNodeId, direction, assertOnPropertyValueFetch, null );
+        return init( isDense, firstRelId, fromNodeId, direction, assertOpen, null );
     }
 
     public final StoreNodeRelationshipCursor init( boolean isDense,
             long firstRelId,
             long fromNodeId,
             Direction direction,
-            Runnable assertOnPropertyValueFetch,
+            AssertOpen assertOpen,
             int... relTypes )
     {
         this.isDense = isDense;
@@ -85,7 +86,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         this.direction = direction;
         this.relTypes = relTypes;
         this.end = false;
-        initialize( assertOnPropertyValueFetch );
+        initialize( assertOpen );
         if ( isDense && relationshipId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
             cursors.relationshipGroup().next( firstRelId, groupRecord, FORCE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -66,15 +66,17 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
     public StoreNodeRelationshipCursor init( boolean isDense,
             long firstRelId,
             long fromNodeId,
-            Direction direction )
+            Direction direction,
+            Runnable assertOnPropertyValueFetch )
     {
-        return init( isDense, firstRelId, fromNodeId, direction, null );
+        return init( isDense, firstRelId, fromNodeId, direction, assertOnPropertyValueFetch, null );
     }
 
-    public StoreNodeRelationshipCursor init( boolean isDense,
+    public final StoreNodeRelationshipCursor init( boolean isDense,
             long firstRelId,
             long fromNodeId,
             Direction direction,
+            Runnable assertOnPropertyValueFetch,
             int... relTypes )
     {
         this.isDense = isDense;
@@ -83,7 +85,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         this.direction = direction;
         this.relTypes = relTypes;
         this.end = false;
-
+        initialize( assertOnPropertyValueFetch );
         if ( isDense && relationshipId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
             cursors.relationshipGroup().next( firstRelId, groupRecord, FORCE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -41,6 +41,7 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     private final RecordCursor<PropertyRecord> recordCursor;
 
     private Lock lock;
+    private Runnable assertOnValueFetch;
 
     public StorePropertyCursor( RecordCursors cursors, Consumer<StorePropertyCursor> instanceCache )
     {
@@ -49,11 +50,12 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
         this.recordCursor = cursors.property();
     }
 
-    public StorePropertyCursor init( long firstPropertyId, Lock readLock )
+    public StorePropertyCursor init( long firstPropertyId, Lock readLock, Runnable assertOnValueFetch )
     {
         recordCursor.placeAt( firstPropertyId, FORCE );
         payload.clear();
         lock = readLock;
+        this.assertOnValueFetch = assertOnValueFetch;
         return this;
     }
 
@@ -99,7 +101,9 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     @Override
     public Object value()
     {
-        return payload.value();
+        Object value = payload.value();
+        assertOnValueFetch.run();
+        return value;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api.store;
 import java.util.function.Consumer;
 
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -41,7 +42,7 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     private final RecordCursor<PropertyRecord> recordCursor;
 
     private Lock lock;
-    private Runnable assertOnValueFetch;
+    private AssertOpen assertOpen;
 
     public StorePropertyCursor( RecordCursors cursors, Consumer<StorePropertyCursor> instanceCache )
     {
@@ -50,12 +51,12 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
         this.recordCursor = cursors.property();
     }
 
-    public StorePropertyCursor init( long firstPropertyId, Lock readLock, Runnable assertOnValueFetch )
+    public StorePropertyCursor init( long firstPropertyId, Lock readLock, AssertOpen assertOpen )
     {
         recordCursor.placeAt( firstPropertyId, FORCE );
         payload.clear();
         lock = readLock;
-        this.assertOnValueFetch = assertOnValueFetch;
+        this.assertOpen = assertOpen;
         return this;
     }
 
@@ -102,7 +103,7 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     public Object value()
     {
         Object value = payload.value();
-        assertOnValueFetch.run();
+        assertOpen.assertOpen();
         return value;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.store;
 
 import java.util.function.Consumer;
 
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
@@ -48,9 +49,9 @@ public class StoreSingleNodeCursor extends StoreAbstractNodeCursor
         this.instanceCache = instanceCache;
     }
 
-    public StoreSingleNodeCursor init( long nodeId, Runnable assertOnPropertyValueFetch )
+    public StoreSingleNodeCursor init( long nodeId, AssertOpen assertOpen )
     {
-        initialize( assertOnPropertyValueFetch );
+        initialize( assertOpen );
         this.nodeId = nodeId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -48,8 +48,9 @@ public class StoreSingleNodeCursor extends StoreAbstractNodeCursor
         this.instanceCache = instanceCache;
     }
 
-    public StoreSingleNodeCursor init( long nodeId )
+    public StoreSingleNodeCursor init( long nodeId, Runnable assertOnPropertyValueFetch )
     {
+        initialize( assertOnPropertyValueFetch );
         this.nodeId = nodeId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.store;
 
 import java.util.function.Consumer;
 
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -38,9 +39,9 @@ public class StoreSinglePropertyCursor extends StorePropertyCursor
     }
 
     public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock,
-            Runnable assertOnValueFetch )
+            AssertOpen assertOpen )
     {
-        super.init( firstPropertyId, lock, assertOnValueFetch );
+        super.init( firstPropertyId, lock, assertOpen );
         this.propertyKeyId = propertyKeyId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -37,9 +37,10 @@ public class StoreSinglePropertyCursor extends StorePropertyCursor
         super( cursors, (Consumer) instanceCache );
     }
 
-    public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock )
+    public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock,
+            Runnable assertOnValueFetch )
     {
-        super.init( firstPropertyId, lock );
+        super.init( firstPropertyId, lock, assertOnValueFetch );
         this.propertyKeyId = propertyKeyId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -42,8 +42,9 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
         this.instanceCache = instanceCache;
     }
 
-    public StoreSingleRelationshipCursor init( long relId )
+    public StoreSingleRelationshipCursor init( long relId, Runnable assertOnPropertyValueFetch )
     {
+        initialize( assertOnPropertyValueFetch );
         this.relationshipId = relId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -42,9 +43,9 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
         this.instanceCache = instanceCache;
     }
 
-    public StoreSingleRelationshipCursor init( long relId, Runnable assertOnPropertyValueFetch )
+    public StoreSingleRelationshipCursor init( long relId, AssertOpen assertOpen )
     {
-        initialize( assertOnPropertyValueFetch );
+        initialize( assertOpen );
         this.relationshipId = relId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
@@ -123,43 +123,46 @@ public class StoreStatement implements StorageStatement
     }
 
     @Override
-    public Cursor<NodeItem> acquireSingleNodeCursor( long nodeId )
+    public Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, Runnable assertOnPropertyValueFetch )
     {
         neoStores.assertOpen();
-        return singleNodeCursor.get().init( nodeId );
+        return singleNodeCursor.get().init( nodeId, assertOnPropertyValueFetch );
     }
 
     @Override
-    public Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIdIterator )
+    public Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIdIterator,
+            Runnable assertOnPropertyValueFetch )
     {
         neoStores.assertOpen();
-        return iteratorNodeCursor.get().init( nodeIdIterator );
+        return iteratorNodeCursor.get().init( nodeIdIterator, assertOnPropertyValueFetch );
     }
 
     @Override
-    public Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relId )
+    public Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relId, Runnable assertOnPropertyValueFetch )
     {
         neoStores.assertOpen();
-        return singleRelationshipCursor.get().init( relId );
+        return singleRelationshipCursor.get().init( relId, assertOnPropertyValueFetch );
     }
 
     @Override
-    public Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator iterator )
+    public Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator iterator,
+            Runnable assertOnPropertyValueFetch )
     {
         neoStores.assertOpen();
-        return iteratorRelationshipCursor.get().init( iterator );
+        return iteratorRelationshipCursor.get().init( iterator, assertOnPropertyValueFetch );
     }
 
     @Override
-    public Cursor<NodeItem> nodesGetAllCursor()
+    public Cursor<NodeItem> nodesGetAllCursor( Runnable assertOnPropertyValueFetch )
     {
-        return acquireIteratorNodeCursor( new AllStoreIdIterator( nodeStore ) );
+        return acquireIteratorNodeCursor( new AllStoreIdIterator( nodeStore ), assertOnPropertyValueFetch );
     }
 
     @Override
-    public Cursor<RelationshipItem> relationshipsGetAllCursor()
+    public Cursor<RelationshipItem> relationshipsGetAllCursor( Runnable assertOnPropertyValueFetch )
     {
-        return acquireIteratorRelationshipCursor( new AllStoreIdIterator( relationshipStore ) );
+        return acquireIteratorRelationshipCursor( new AllStoreIdIterator( relationshipStore ),
+                assertOnPropertyValueFetch );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.IndexReaderFactory;
@@ -123,46 +124,43 @@ public class StoreStatement implements StorageStatement
     }
 
     @Override
-    public Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, Runnable assertOnPropertyValueFetch )
+    public Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, AssertOpen assertOpen )
     {
         neoStores.assertOpen();
-        return singleNodeCursor.get().init( nodeId, assertOnPropertyValueFetch );
+        return singleNodeCursor.get().init( nodeId, assertOpen );
     }
 
     @Override
-    public Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIdIterator,
-            Runnable assertOnPropertyValueFetch )
+    public Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIdIterator, AssertOpen assertOpen )
     {
         neoStores.assertOpen();
-        return iteratorNodeCursor.get().init( nodeIdIterator, assertOnPropertyValueFetch );
+        return iteratorNodeCursor.get().init( nodeIdIterator, assertOpen );
     }
 
     @Override
-    public Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relId, Runnable assertOnPropertyValueFetch )
+    public Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relId, AssertOpen assertOpen )
     {
         neoStores.assertOpen();
-        return singleRelationshipCursor.get().init( relId, assertOnPropertyValueFetch );
+        return singleRelationshipCursor.get().init( relId, assertOpen );
     }
 
     @Override
-    public Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator iterator,
-            Runnable assertOnPropertyValueFetch )
+    public Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator iterator, AssertOpen assertOpen )
     {
         neoStores.assertOpen();
-        return iteratorRelationshipCursor.get().init( iterator, assertOnPropertyValueFetch );
+        return iteratorRelationshipCursor.get().init( iterator, assertOpen );
     }
 
     @Override
-    public Cursor<NodeItem> nodesGetAllCursor( Runnable assertOnPropertyValueFetch )
+    public Cursor<NodeItem> nodesGetAllCursor( AssertOpen assertOpen )
     {
-        return acquireIteratorNodeCursor( new AllStoreIdIterator( nodeStore ), assertOnPropertyValueFetch );
+        return acquireIteratorNodeCursor( new AllStoreIdIterator( nodeStore ), assertOpen );
     }
 
     @Override
-    public Cursor<RelationshipItem> relationshipsGetAllCursor( Runnable assertOnPropertyValueFetch )
+    public Cursor<RelationshipItem> relationshipsGetAllCursor( AssertOpen assertOpen )
     {
-        return acquireIteratorRelationshipCursor( new AllStoreIdIterator( relationshipStore ),
-                assertOnPropertyValueFetch );
+        return acquireIteratorRelationshipCursor( new AllStoreIdIterator( relationshipStore ), assertOpen );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
@@ -203,7 +204,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         {
             for ( Long nodeId : state.addedAndRemovedNodes().getRemoved() )
             {
-                try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeId, () -> {} ) )
+                try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeId, AssertOpen.ALWAYS_OPEN ) )
                 {
                     if ( node.next() )
                     {
@@ -232,7 +233,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             {
                 Relationship relationshipProxy = relationship( relId );
                 try ( Cursor<RelationshipItem> relationship =
-                              storeStatement.acquireSingleRelationshipCursor( relId, () -> {} ) )
+                              storeStatement.acquireSingleRelationshipCursor( relId, AssertOpen.ALWAYS_OPEN ) )
                 {
                     if ( relationship.next() )
                     {
@@ -360,7 +361,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             return null;
         }
 
-        try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeState.getId(), () -> {} ) )
+        try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeState.getId(), AssertOpen.ALWAYS_OPEN ) )
         {
             if ( !node.next() )
             {
@@ -387,7 +388,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         }
 
         try ( Cursor<RelationshipItem> relationship = storeStatement.acquireSingleRelationshipCursor(
-                relState.getId(), () -> {} ) )
+                relState.getId(), AssertOpen.ALWAYS_OPEN ) )
         {
             if ( !relationship.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
@@ -41,8 +40,6 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.security.AccessMode;
-import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.core.NodeProxy;
 import org.neo4j.kernel.impl.core.RelationshipProxy;
@@ -206,7 +203,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         {
             for ( Long nodeId : state.addedAndRemovedNodes().getRemoved() )
             {
-                try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeId ) )
+                try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeId, () -> {} ) )
                 {
                     if ( node.next() )
                     {
@@ -234,7 +231,8 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             for ( Long relId : state.addedAndRemovedRelationships().getRemoved() )
             {
                 Relationship relationshipProxy = relationship( relId );
-                try ( Cursor<RelationshipItem> relationship = storeStatement.acquireSingleRelationshipCursor( relId ) )
+                try ( Cursor<RelationshipItem> relationship =
+                              storeStatement.acquireSingleRelationshipCursor( relId, () -> {} ) )
                 {
                     if ( relationship.next() )
                     {
@@ -362,7 +360,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             return null;
         }
 
-        try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeState.getId() ) )
+        try ( Cursor<NodeItem> node = storeStatement.acquireSingleNodeCursor( nodeState.getId(), () -> {} ) )
         {
             if ( !node.next() )
             {
@@ -389,7 +387,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         }
 
         try ( Cursor<RelationshipItem> relationship = storeStatement.acquireSingleRelationshipCursor(
-                relState.getId() ) )
+                relState.getId(), () -> {} ) )
         {
             if ( !relationship.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.neo4j.helpers.collection.Iterables;
@@ -690,7 +689,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
         final List<Object> scratch = new ArrayList<>();
         return ( ENTITY entity, RECORD record ) ->
         {
-            cursor.init( record.getNextProp(), LockService.NO_LOCK );
+            cursor.init( record.getNextProp(), LockService.NO_LOCK, () -> {} );
             scratch.clear();
             while ( cursor.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -48,6 +48,7 @@ import org.neo4j.io.pagecache.FileHandle;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.store.StorePropertyCursor;
@@ -689,7 +690,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
         final List<Object> scratch = new ArrayList<>();
         return ( ENTITY entity, RECORD record ) ->
         {
-            cursor.init( record.getNextProp(), LockService.NO_LOCK, () -> {} );
+            cursor.init( record.getNextProp(), LockService.NO_LOCK, AssertOpen.ALWAYS_OPEN );
             scratch.clear();
             while ( cursor.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.neo4j.graphdb.Node;

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -69,7 +69,7 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeId id of node to get cursor for.
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch.
      * @return a {@link Cursor} over {@link NodeItem} for the given {@code nodeId}.
      */
     Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, AssertOpen assertOpen );
@@ -80,7 +80,7 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeIds ids of nodes to get cursor for.
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch
      * @return a {@link Cursor} over {@link NodeItem} for the given node ids.
      */
     Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIds, AssertOpen assertOpen );
@@ -92,7 +92,7 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipId id of relationship to get cursor for.
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given {@code relationshipId}.
      */
     Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relationshipId,
@@ -105,7 +105,7 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipIds ids of relationships to get cursor for.
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given relationship ids.
      */
     Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator relationshipIds,
@@ -116,7 +116,7 @@ public interface StorageStatement extends AutoCloseable
      * No node is selected when this method returns, a call to {@link Cursor#next()} will have to be made
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch
      * @return {@link Cursor} over all stored nodes.
      */
     Cursor<NodeItem> nodesGetAllCursor( AssertOpen assertOpen );
@@ -127,7 +127,7 @@ public interface StorageStatement extends AutoCloseable
      * will have to be made to place the cursor over the first item and then more calls to move the cursor
      * through the selection.
      *
-     * @param assertOpen to check if source transaction is still open on each property value fetch
+     * @param assertOpen tied to resource(s) expected to still be open on each property value fetch
      * @return a {@link Cursor} over all stored relationships.
      */
     Cursor<RelationshipItem> relationshipsGetAllCursor( AssertOpen assertOpen );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -21,6 +21,7 @@ package org.neo4j.storageengine.api;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
@@ -68,10 +69,10 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeId id of node to get cursor for.
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return a {@link Cursor} over {@link NodeItem} for the given {@code nodeId}.
      */
-    Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, Runnable assertOnPropertyValueFetch );
+    Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, AssertOpen assertOpen );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link NodeItem} for selected nodes.
@@ -79,10 +80,10 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeIds ids of nodes to get cursor for.
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return a {@link Cursor} over {@link NodeItem} for the given node ids.
      */
-    Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIds, Runnable assertOnPropertyValueFetch );
+    Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIds, AssertOpen assertOpen );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -91,11 +92,11 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipId id of relationship to get cursor for.
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given {@code relationshipId}.
      */
     Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relationshipId,
-            Runnable assertOnPropertyValueFetch );
+            AssertOpen assertOpen );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -104,21 +105,21 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipIds ids of relationships to get cursor for.
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given relationship ids.
      */
     Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator relationshipIds,
-            Runnable assertOnPropertyValueFetch );
+            AssertOpen assertOpen );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link NodeItem} for selected nodes.
      * No node is selected when this method returns, a call to {@link Cursor#next()} will have to be made
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return {@link Cursor} over all stored nodes.
      */
-    Cursor<NodeItem> nodesGetAllCursor( Runnable assertOnPropertyValueFetch );
+    Cursor<NodeItem> nodesGetAllCursor( AssertOpen assertOpen );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -126,10 +127,10 @@ public interface StorageStatement extends AutoCloseable
      * will have to be made to place the cursor over the first item and then more calls to move the cursor
      * through the selection.
      *
-     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
+     * @param assertOpen to check if source transaction is still open on each property value fetch
      * @return a {@link Cursor} over all stored relationships.
      */
-    Cursor<RelationshipItem> relationshipsGetAllCursor( Runnable assertOnPropertyValueFetch );
+    Cursor<RelationshipItem> relationshipsGetAllCursor( AssertOpen assertOpen );
 
     /**
      * @return {@link LabelScanReader} capable of reading nodes for specific label ids.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -68,9 +68,10 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeId id of node to get cursor for.
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return a {@link Cursor} over {@link NodeItem} for the given {@code nodeId}.
      */
-    Cursor<NodeItem> acquireSingleNodeCursor( long nodeId );
+    Cursor<NodeItem> acquireSingleNodeCursor( long nodeId, Runnable assertOnPropertyValueFetch );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link NodeItem} for selected nodes.
@@ -78,9 +79,10 @@ public interface StorageStatement extends AutoCloseable
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
      * @param nodeIds ids of nodes to get cursor for.
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return a {@link Cursor} over {@link NodeItem} for the given node ids.
      */
-    Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIds );
+    Cursor<NodeItem> acquireIteratorNodeCursor( PrimitiveLongIterator nodeIds, Runnable assertOnPropertyValueFetch );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -89,9 +91,11 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipId id of relationship to get cursor for.
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given {@code relationshipId}.
      */
-    Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relationshipId );
+    Cursor<RelationshipItem> acquireSingleRelationshipCursor( long relationshipId,
+            Runnable assertOnPropertyValueFetch );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -100,18 +104,21 @@ public interface StorageStatement extends AutoCloseable
      * through the selection.
      *
      * @param relationshipIds ids of relationships to get cursor for.
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return a {@link Cursor} over {@link RelationshipItem} for the given relationship ids.
      */
-    Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator relationshipIds );
+    Cursor<RelationshipItem> acquireIteratorRelationshipCursor( PrimitiveLongIterator relationshipIds,
+            Runnable assertOnPropertyValueFetch );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link NodeItem} for selected nodes.
      * No node is selected when this method returns, a call to {@link Cursor#next()} will have to be made
      * to place the cursor over the first item and then more calls to move the cursor through the selection.
      *
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return {@link Cursor} over all stored nodes.
      */
-    Cursor<NodeItem> nodesGetAllCursor();
+    Cursor<NodeItem> nodesGetAllCursor( Runnable assertOnPropertyValueFetch );
 
     /**
      * Acquires {@link Cursor} capable of {@link Cursor#get() serving} {@link RelationshipItem} for selected
@@ -119,9 +126,10 @@ public interface StorageStatement extends AutoCloseable
      * will have to be made to place the cursor over the first item and then more calls to move the cursor
      * through the selection.
      *
+     * @param assertOnPropertyValueFetch assertion to be invoked on each property value fetch
      * @return a {@link Cursor} over all stored relationships.
      */
-    Cursor<RelationshipItem> relationshipsGetAllCursor();
+    Cursor<RelationshipItem> relationshipsGetAllCursor( Runnable assertOnPropertyValueFetch );
 
     /**
      * @return {@link LabelScanReader} capable of reading nodes for specific label ids.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
@@ -57,7 +57,7 @@ abstract class BatchRelationshipIterable<T> implements Iterable<T>
         {
             NodeStore nodeStore = neoStores.getNodeStore();
             NodeRecord nodeRecord = nodeStore.getRecord( nodeId, nodeStore.newRecord(), NORMAL );
-            relationshipCursor.init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeId, Direction.BOTH );
+            relationshipCursor.init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeId, Direction.BOTH, () -> {} );
         }
         catch ( InvalidRecordException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
@@ -33,10 +33,11 @@ import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-import org.neo4j.storageengine.api.Direction;
 
+import static org.neo4j.kernel.api.AssertOpen.ALWAYS_OPEN;
 import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
+import static org.neo4j.storageengine.api.Direction.BOTH;
 
 abstract class BatchRelationshipIterable<T> implements Iterable<T>
 {
@@ -57,7 +58,7 @@ abstract class BatchRelationshipIterable<T> implements Iterable<T>
         {
             NodeStore nodeStore = neoStores.getNodeStore();
             NodeRecord nodeRecord = nodeStore.getRecord( nodeId, nodeStore.newRecord(), NORMAL );
-            relationshipCursor.init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeId, Direction.BOTH, () -> {} );
+            relationshipCursor.init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeId, BOTH, ALWAYS_OPEN );
         }
         catch ( InvalidRecordException e )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -51,6 +51,8 @@ import org.neo4j.storageengine.api.schema.IndexReader;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -116,7 +118,8 @@ public class IndexQueryTransactionStateTest
         long nodeId = 2L;
         when( indexReader.seek( value ) ).then( answerAsPrimitiveLongIteratorFrom( asList( 1L, nodeId, 3L ) ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn( asNodeCursor( nodeId ) );
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( nodeId ) );
 
         txContext.nodeDelete( state, nodeId );
 
@@ -134,7 +137,8 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn( asNodeCursor( nodeId ) );
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( nodeId ) );
 
         txContext.nodeDelete( state, nodeId );
 
@@ -186,7 +190,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, noNodeProperty( nodeId, propertyKeyId ),
                 stringProperty( propertyKeyId, value ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         Cursors.<LabelItem>empty() ) );
@@ -210,7 +214,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, noNodeProperty( nodeId, propertyKeyId ),
                 stringProperty( propertyKeyId, value ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         Cursors.<LabelItem>empty() ) );
@@ -232,7 +236,7 @@ public class IndexQueryTransactionStateTest
 
         long nodeId = 1L;
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor() ) );
@@ -254,7 +258,7 @@ public class IndexQueryTransactionStateTest
 
         long nodeId = 2L;
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor() ) );
@@ -275,7 +279,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).then( answerAsPrimitiveLongIteratorFrom( asList( nodeId, 2L, 3L ) ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );
@@ -296,7 +300,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );
@@ -320,7 +324,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, Property.noNodeProperty( nodeId, propertyKeyId ),
                 Property.intProperty( propertyKeyId, 10 ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor(),
                         asLabelCursor( labelId ) ) );
@@ -341,7 +345,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( nodeId ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -28,6 +28,7 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
@@ -118,7 +119,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 2L;
         when( indexReader.seek( value ) ).then( answerAsPrimitiveLongIteratorFrom( asList( 1L, nodeId, 3L ) ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) )
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( nodeId ) );
 
         txContext.nodeDelete( state, nodeId );
@@ -137,7 +138,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) )
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( nodeId ) );
 
         txContext.nodeDelete( state, nodeId );
@@ -190,7 +191,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, noNodeProperty( nodeId, propertyKeyId ),
                 stringProperty( propertyKeyId, value ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         Cursors.<LabelItem>empty() ) );
@@ -214,7 +215,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, noNodeProperty( nodeId, propertyKeyId ),
                 stringProperty( propertyKeyId, value ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         Cursors.<LabelItem>empty() ) );
@@ -236,7 +237,7 @@ public class IndexQueryTransactionStateTest
 
         long nodeId = 1L;
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor() ) );
@@ -258,7 +259,7 @@ public class IndexQueryTransactionStateTest
 
         long nodeId = 2L;
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor() ) );
@@ -279,7 +280,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).then( answerAsPrimitiveLongIteratorFrom( asList( nodeId, 2L, 3L ) ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );
@@ -300,7 +301,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );
@@ -324,7 +325,7 @@ public class IndexQueryTransactionStateTest
         state.txState().nodeDoReplaceProperty( nodeId, Property.noNodeProperty( nodeId, propertyKeyId ),
                 Property.intProperty( propertyKeyId, 10 ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor(),
                         asLabelCursor( labelId ) ) );
@@ -345,7 +346,7 @@ public class IndexQueryTransactionStateTest
         long nodeId = 1L;
         when( indexReader.seek( value ) ).thenReturn( asPrimitiveResourceIterator( nodeId ) );
 
-        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( Runnable.class ) ) ).thenReturn(
+        when( statement.acquireSingleNodeCursor( eq( nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( nodeId,
                         asPropertyCursor( stringProperty( propertyKeyId, value ) ),
                         asLabelCursor( labelId ) ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.txstate.TransactionState;
@@ -246,7 +247,7 @@ public class LabelTransactionStateTest
     public void should_return_true_when_adding_new_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1337 ) );
 
         // WHEN
@@ -260,7 +261,7 @@ public class LabelTransactionStateTest
     public void should_return_false_when_adding_existing_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1337, asPropertyCursor(),
                 asLabelCursor( 12 ) ) );
 
@@ -275,7 +276,7 @@ public class LabelTransactionStateTest
     public void should_return_true_when_removing_existing_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1337, asPropertyCursor(), asLabelCursor( 12 ) ) );
 
         // WHEN
@@ -289,7 +290,7 @@ public class LabelTransactionStateTest
     public void should_return_true_when_removing_non_existant_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1337 ) );
 
         // WHEN
@@ -333,7 +334,7 @@ public class LabelTransactionStateTest
         Map<Integer,Collection<Long>> allLabels = new HashMap<>();
         for ( Labels nodeLabels : labels )
         {
-            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( Runnable.class ) ) )
+            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( AssertOpen.class ) ) )
                     .thenReturn( StubCursors.asNodeCursor(
                             nodeLabels.nodeId, asPropertyCursor(), asLabelCursor( nodeLabels.labelIds ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -46,6 +46,8 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -244,7 +246,8 @@ public class LabelTransactionStateTest
     public void should_return_true_when_adding_new_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337 ) );
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1337 ) );
 
         // WHEN
         boolean added = txContext.nodeAddLabel( state, 1337, 12 );
@@ -257,7 +260,8 @@ public class LabelTransactionStateTest
     public void should_return_false_when_adding_existing_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, asPropertyCursor(),
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1337, asPropertyCursor(),
                 asLabelCursor( 12 ) ) );
 
         // WHEN
@@ -271,8 +275,8 @@ public class LabelTransactionStateTest
     public void should_return_true_when_removing_existing_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, asPropertyCursor(),
-                asLabelCursor( 12 ) ) );
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1337, asPropertyCursor(), asLabelCursor( 12 ) ) );
 
         // WHEN
         boolean added = txContext.nodeRemoveLabel( state, 1337, 12 );
@@ -285,7 +289,8 @@ public class LabelTransactionStateTest
     public void should_return_true_when_removing_non_existant_label() throws Exception
     {
         // GIVEN
-        when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337 ) );
+        when( storeStatement.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1337 ) );
 
         // WHEN
         boolean removed = txContext.nodeRemoveLabel( state, 1337, 12 );
@@ -328,8 +333,9 @@ public class LabelTransactionStateTest
         Map<Integer,Collection<Long>> allLabels = new HashMap<>();
         for ( Labels nodeLabels : labels )
         {
-            when( storeStatement.acquireSingleNodeCursor( nodeLabels.nodeId ) ).thenReturn( StubCursors.asNodeCursor(
-                    nodeLabels.nodeId, asPropertyCursor(), asLabelCursor( nodeLabels.labelIds ) ) );
+            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( Runnable.class ) ) )
+                    .thenReturn( StubCursors.asNodeCursor(
+                            nodeLabels.nodeId, asPropertyCursor(), asLabelCursor( nodeLabels.labelIds ) ) );
 
             for ( int label : nodeLabels.labelIds )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -47,6 +47,8 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -264,7 +266,7 @@ public class SchemaTransactionStateTest
         Map<Integer, Collection<Long>> allLabels = new HashMap<>();
         for ( Labels nodeLabels : labels )
         {
-            when( storeStatement.acquireSingleNodeCursor( nodeLabels.nodeId ) ).thenReturn(
+            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( Runnable.class ) ) ).thenReturn(
                     StubCursors.asNodeCursor( nodeLabels.nodeId,
                             Cursors.<PropertyItem>empty(), StubCursors.asLabelCursor( nodeLabels.labelIds ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.txstate.TransactionState;
@@ -266,7 +267,7 @@ public class SchemaTransactionStateTest
         Map<Integer, Collection<Long>> allLabels = new HashMap<>();
         for ( Labels nodeLabels : labels )
         {
-            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( Runnable.class ) ) ).thenReturn(
+            when( storeStatement.acquireSingleNodeCursor( eq( nodeLabels.nodeId ), any( AssertOpen.class ) ) ).thenReturn(
                     StubCursors.asNodeCursor( nodeLabels.nodeId,
                             Cursors.<PropertyItem>empty(), StubCursors.asLabelCursor( nodeLabels.labelIds ) ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -32,6 +32,7 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -98,7 +99,7 @@ public class StateHandlingStatementOperationsTest
         when( state.txState() ).thenReturn( new TxState() );
         StoreStatement storeStatement = mock( StoreStatement.class );
         when( state.getStoreStatement() ).thenReturn( storeStatement );
-        when( storeStatement.acquireSingleNodeCursor( anyLong(), any( Runnable.class ) ) ).
+        when( storeStatement.acquireSingleNodeCursor( anyLong(), any( AssertOpen.class ) ) ).
                 thenReturn( asNodeCursor( 0 ) );
 
         StateHandlingStatementOperations ctx = newTxStateOps( inner );
@@ -110,7 +111,7 @@ public class StateHandlingStatementOperationsTest
         ctx.nodeRemoveLabel( state, 0, 0 );
 
         // one for add and one for remove
-        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( eq( 0L ), any( Runnable.class ) );
+        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( eq( 0L ), any( AssertOpen.class ) );
         verifyNoMoreInteractions( storeStatement );
     }
 
@@ -338,7 +339,7 @@ public class StateHandlingStatementOperationsTest
         when( indexReader.rangeSeekByNumberInclusive( lower, upper ) ).thenReturn(
                 PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( 43L, 44L, 46L ), null )
         );
-        when( storageStatement.acquireSingleNodeCursor( anyLong(), any( Runnable.class ) ) ).thenAnswer(
+        when( storageStatement.acquireSingleNodeCursor( anyLong(), any( AssertOpen.class ) ) ).thenAnswer(
                 new Answer<Cursor<NodeItem>>()
                 {
                     @Override
@@ -442,7 +443,7 @@ public class StateHandlingStatementOperationsTest
         KernelStatement kernelStatement = mock( KernelStatement.class );
         StoreStatement storeStatement = mock( StoreStatement.class );
         Cursor<NodeItem> ourNode = nodeCursorWithProperty( propertyKeyId, value );
-        when( storeStatement.acquireSingleNodeCursor( nodeId ) ).thenReturn( ourNode );
+        when( storeStatement.acquireSingleNodeCursor( nodeId, kernelStatement ) ).thenReturn( ourNode );
         when( kernelStatement.getStoreStatement() ).thenReturn( storeStatement );
         InternalAutoIndexing autoIndexing = mock( InternalAutoIndexing.class );
         AutoIndexOperations autoIndexOps = mock( AutoIndexOperations.class );
@@ -471,7 +472,8 @@ public class StateHandlingStatementOperationsTest
         KernelStatement kernelStatement = mock( KernelStatement.class );
         StoreStatement storeStatement = mock( StoreStatement.class );
         Cursor<RelationshipItem> ourRelationship = relationshipCursorWithProperty( propertyKeyId, value );
-        when( storeStatement.acquireSingleRelationshipCursor( relationshipId ) ).thenReturn( ourRelationship );
+        when( storeStatement.acquireSingleRelationshipCursor( relationshipId, kernelStatement ) )
+                .thenReturn( ourRelationship );
         when( kernelStatement.getStoreStatement() ).thenReturn( storeStatement );
         InternalAutoIndexing autoIndexing = mock( InternalAutoIndexing.class );
         AutoIndexOperations autoIndexOps = mock( AutoIndexOperations.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -98,7 +98,7 @@ public class StateHandlingStatementOperationsTest
         when( state.txState() ).thenReturn( new TxState() );
         StoreStatement storeStatement = mock( StoreStatement.class );
         when( state.getStoreStatement() ).thenReturn( storeStatement );
-        when( storeStatement.acquireSingleNodeCursor( anyLong() ) ).
+        when( storeStatement.acquireSingleNodeCursor( anyLong(), any( Runnable.class ) ) ).
                 thenReturn( asNodeCursor( 0 ) );
 
         StateHandlingStatementOperations ctx = newTxStateOps( inner );
@@ -110,7 +110,7 @@ public class StateHandlingStatementOperationsTest
         ctx.nodeRemoveLabel( state, 0, 0 );
 
         // one for add and one for remove
-        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( 0 );
+        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( eq( 0L ), any( Runnable.class ) );
         verifyNoMoreInteractions( storeStatement );
     }
 
@@ -338,7 +338,7 @@ public class StateHandlingStatementOperationsTest
         when( indexReader.rangeSeekByNumberInclusive( lower, upper ) ).thenReturn(
                 PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( 43L, 44L, 46L ), null )
         );
-        when( storageStatement.acquireSingleNodeCursor( anyLong() ) ).thenAnswer(
+        when( storageStatement.acquireSingleNodeCursor( anyLong(), any( Runnable.class ) ) ).thenAnswer(
                 new Answer<Cursor<NodeItem>>()
                 {
                     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateOperationsAutoIndexingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateOperationsAutoIndexingTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.legacyindex.AutoIndexing;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -72,7 +73,7 @@ public class StateOperationsAutoIndexingTest
     public void shouldSignalNodeRemovedToAutoIndex() throws Exception
     {
         // Given
-        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( mock( NodeItem.class ) ) );
 
         // When
@@ -86,7 +87,7 @@ public class StateOperationsAutoIndexingTest
     public void shouldSignalRelationshipRemovedToAutoIndex() throws Exception
     {
         // Given
-        when( storeStmt.acquireSingleRelationshipCursor( eq(1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleRelationshipCursor( eq(1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( mock( RelationshipItem.class ) ) );
 
         // When
@@ -105,7 +106,7 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( property.propertyKeyId() )).thenReturn( Cursors.empty() );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( node ) );
 
         // When
@@ -123,7 +124,7 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( property.propertyKeyId() )).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( rel ) );
 
         // When
@@ -146,7 +147,7 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( property.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( node ) );
 
         // When
@@ -168,7 +169,7 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( property.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
-        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( rel ) );
 
         // When
@@ -190,7 +191,7 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( existingProperty.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( node ) );
 
         // When
@@ -211,7 +212,7 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( existingProperty.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
-        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( AssertOpen.class ) ) )
                 .thenReturn( Cursors.cursor( rel ) );
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateOperationsAutoIndexingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateOperationsAutoIndexingTest.java
@@ -72,7 +72,8 @@ public class StateOperationsAutoIndexingTest
     public void shouldSignalNodeRemovedToAutoIndex() throws Exception
     {
         // Given
-        when( storeStmt.acquireSingleNodeCursor( 1337 ) ).thenReturn( Cursors.cursor( mock( NodeItem.class )) );
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( mock( NodeItem.class ) ) );
 
         // When
         context.nodeDelete( stmt, 1337 );
@@ -85,7 +86,8 @@ public class StateOperationsAutoIndexingTest
     public void shouldSignalRelationshipRemovedToAutoIndex() throws Exception
     {
         // Given
-        when( storeStmt.acquireSingleRelationshipCursor( 1337 ) ).thenReturn( Cursors.cursor( mock( RelationshipItem.class )) );
+        when( storeStmt.acquireSingleRelationshipCursor( eq(1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( mock( RelationshipItem.class ) ) );
 
         // When
         context.relationshipDelete( stmt, 1337 );
@@ -103,7 +105,8 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( property.propertyKeyId() )).thenReturn( Cursors.empty() );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( 1337 ) ).thenReturn( Cursors.cursor( node ) );
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( node ) );
 
         // When
         context.nodeSetProperty( stmt, 1337, property );
@@ -120,7 +123,8 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( property.propertyKeyId() )).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleRelationshipCursor( 1337 ) ).thenReturn( Cursors.cursor( rel ) );
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( rel ) );
 
         // When
         context.relationshipSetProperty( stmt, 1337, property );
@@ -142,7 +146,8 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( property.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( 1337 ) ).thenReturn( Cursors.cursor( node ) );
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( node ) );
 
         // When
         context.nodeSetProperty( stmt, 1337, property );
@@ -163,7 +168,8 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( property.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
-        when( storeStmt.acquireSingleRelationshipCursor( 1337 ) ).thenReturn( Cursors.cursor( rel ) );
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( rel ) );
 
         // When
         context.relationshipSetProperty( stmt, 1337, property );
@@ -184,7 +190,8 @@ public class StateOperationsAutoIndexingTest
         NodeItem node = mock( NodeItem.class );
         when( node.property( existingProperty.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
         when( node.labels() ).thenReturn( Cursors.empty() );
-        when( storeStmt.acquireSingleNodeCursor( 1337 ) ).thenReturn( Cursors.cursor( node ) );
+        when( storeStmt.acquireSingleNodeCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( node ) );
 
         // When
         context.nodeRemoveProperty( stmt, 1337, existingProperty.propertyKeyId() );
@@ -204,7 +211,8 @@ public class StateOperationsAutoIndexingTest
 
         RelationshipItem rel = mock( RelationshipItem.class );
         when( rel.property( existingProperty.propertyKeyId() )).thenReturn( Cursors.cursor( existingProperty ) );
-        when( storeStmt.acquireSingleRelationshipCursor( 1337 ) ).thenReturn( Cursors.cursor( rel ) );
+        when( storeStmt.acquireSingleRelationshipCursor( eq( 1337L ), any( Runnable.class ) ) )
+                .thenReturn( Cursors.cursor( rel ) );
 
         // When
         context.relationshipRemoveProperty( stmt, 1337, existingProperty.propertyKeyId() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
@@ -63,7 +63,7 @@ public class DiskLayerLabelTest extends DiskLayerTest
         }
 
         // THEN
-        Cursor<NodeItem> node = disk.newStatement().acquireSingleNodeCursor( nodeId );
+        Cursor<NodeItem> node = disk.newStatement().acquireSingleNodeCursor( nodeId, () -> {} );
         node.next();
         PrimitiveIntIterator readLabels = node.get().getLabels();
         assertEquals( new HashSet<>( asList( labelId1, labelId2 ) ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerLabelTest.java
@@ -31,6 +31,7 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -63,7 +64,7 @@ public class DiskLayerLabelTest extends DiskLayerTest
         }
 
         // THEN
-        Cursor<NodeItem> node = disk.newStatement().acquireSingleNodeCursor( nodeId, () -> {} );
+        Cursor<NodeItem> node = disk.newStatement().acquireSingleNodeCursor( nodeId, AssertOpen.ALWAYS_OPEN );
         node.next();
         PrimitiveIntIterator readLabels = node.get().getLabels();
         assertEquals( new HashSet<>( asList( labelId1, labelId2 ) ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
@@ -31,6 +31,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.AssertOpen.ALWAYS_OPEN;
 
 /**
  * Test reading committed node and relationships from disk.
@@ -89,7 +90,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
     {
         try ( StorageStatement statement = disk.newStatement() )
         {
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, ALWAYS_OPEN ) )
             {
                 return node.next();
             }
@@ -100,7 +101,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
     {
         try ( StorageStatement statement = disk.newStatement() )
         {
-            try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( id, () -> {} ) )
+            try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( id, ALWAYS_OPEN ) )
             {
                 return relationship.next();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
@@ -89,7 +89,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
     {
         try ( StorageStatement statement = disk.newStatement() )
         {
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id, () -> {} ) )
             {
                 return node.next();
             }
@@ -100,7 +100,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
     {
         try ( StorageStatement statement = disk.newStatement() )
         {
-            try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( id ) )
+            try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( id, () -> {} ) )
             {
                 return relationship.next();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.lang.reflect.Array;
 
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.storageengine.api.NodeItem;
@@ -95,7 +96,7 @@ public class DiskLayerPropertyTest extends DiskLayerTest
             long nodeId = createLabeledNode( db, singletonMap( "prop", value ), label1 ).getId();
 
             // when
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, AssertOpen.ALWAYS_OPEN ) )
             {
                 node.next();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
@@ -95,7 +95,7 @@ public class DiskLayerPropertyTest extends DiskLayerTest
             long nodeId = createLabeledNode( db, singletonMap( "prop", value ), label1 ).getId();
 
             // when
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
             {
                 node.next();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
@@ -24,6 +24,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.DynamicArrayStore;
 import org.neo4j.kernel.impl.store.DynamicStringStore;
@@ -64,7 +65,7 @@ public class StoreIteratorRelationshipCursorTest
         try ( StoreIteratorRelationshipCursor cursor = createRelationshipCursor( relationshipRecord,
                 relationshipStore ) )
         {
-            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), () -> {} );
+            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }
@@ -82,7 +83,7 @@ public class StoreIteratorRelationshipCursorTest
         try ( StoreIteratorRelationshipCursor cursor = createRelationshipCursor( relationshipRecord,
                 relationshipStore ) )
         {
-            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), () -> {} );
+            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursorTest.java
@@ -64,7 +64,7 @@ public class StoreIteratorRelationshipCursorTest
         try ( StoreIteratorRelationshipCursor cursor = createRelationshipCursor( relationshipRecord,
                 relationshipStore ) )
         {
-            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ) );
+            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), () -> {} );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }
@@ -82,7 +82,7 @@ public class StoreIteratorRelationshipCursorTest
         try ( StoreIteratorRelationshipCursor cursor = createRelationshipCursor( relationshipRecord,
                 relationshipStore ) )
         {
-            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ) );
+            cursor.init( PrimitiveLongCollections.iterator( RELATIONSHIP_ID ), () -> {} );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.store.NeoStores;
@@ -118,13 +119,13 @@ public class StoreNodeRelationshipCursorTest
 
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1L, FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, 1L, FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
 
-            cursor.init( dense, 2, FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, 2, FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
 
-            cursor.init( dense, 3, FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, 3, FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
         }
     }
@@ -136,7 +137,7 @@ public class StoreNodeRelationshipCursorTest
         long expectedNodeId = 1;
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
             while ( cursor.next() )
             {
                 assertEquals( "Should load next relationship in a sequence", expectedNodeId++, cursor.get().id() );
@@ -154,7 +155,7 @@ public class StoreNodeRelationshipCursorTest
         int relationshipIndex = 0;
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
             while ( cursor.next() )
             {
                 assertEquals( "Should load next relationship in a sequence",
@@ -173,7 +174,7 @@ public class StoreNodeRelationshipCursorTest
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
             // WHEN
-            cursor.init( dense, NO_NEXT_RELATIONSHIP.intValue(), FIRST_OWNING_NODE, direction, () -> {} );
+            cursor.init( dense, NO_NEXT_RELATIONSHIP.intValue(), FIRST_OWNING_NODE, direction, AssertOpen.ALWAYS_OPEN );
 
             // THEN
             assertFalse( cursor.next() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -118,13 +118,13 @@ public class StoreNodeRelationshipCursorTest
 
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1L, FIRST_OWNING_NODE, direction );
+            cursor.init( dense, 1L, FIRST_OWNING_NODE, direction, () -> {} );
             assertTrue( cursor.next() );
 
-            cursor.init( dense, 2, FIRST_OWNING_NODE, direction );
+            cursor.init( dense, 2, FIRST_OWNING_NODE, direction, () -> {} );
             assertTrue( cursor.next() );
 
-            cursor.init( dense, 3, FIRST_OWNING_NODE, direction );
+            cursor.init( dense, 3, FIRST_OWNING_NODE, direction, () -> {} );
             assertTrue( cursor.next() );
         }
     }
@@ -136,7 +136,7 @@ public class StoreNodeRelationshipCursorTest
         long expectedNodeId = 1;
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1, FIRST_OWNING_NODE, direction );
+            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, () -> {} );
             while ( cursor.next() )
             {
                 assertEquals( "Should load next relationship in a sequence", expectedNodeId++, cursor.get().id() );
@@ -154,7 +154,7 @@ public class StoreNodeRelationshipCursorTest
         int relationshipIndex = 0;
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
-            cursor.init( dense, 1, FIRST_OWNING_NODE, direction );
+            cursor.init( dense, 1, FIRST_OWNING_NODE, direction, () -> {} );
             while ( cursor.next() )
             {
                 assertEquals( "Should load next relationship in a sequence",
@@ -173,7 +173,7 @@ public class StoreNodeRelationshipCursorTest
         try ( StoreNodeRelationshipCursor cursor = getNodeRelationshipCursor() )
         {
             // WHEN
-            cursor.init( dense, NO_NEXT_RELATIONSHIP.intValue(), FIRST_OWNING_NODE, direction );
+            cursor.init( dense, NO_NEXT_RELATIONSHIP.intValue(), FIRST_OWNING_NODE, direction, () -> {} );
 
             // THEN
             assertFalse( cursor.next() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -250,7 +251,7 @@ public class StorePropertyCursorTest
         {
             // given
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore, cache );
-            storePropertyCursor.init( 0, NO_LOCK );
+            storePropertyCursor.init( 0, NO_LOCK, () -> {} );
 
             // when
             storePropertyCursor.close();
@@ -329,7 +330,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -337,6 +338,27 @@ public class StorePropertyCursorTest
                 assertEquals( keyId, item.propertyKeyId() );
                 assertEqualValues( expectedValue, item );
                 assertFalse( cursor.next() );
+            }
+        }
+
+        @Test
+        public void shouldCallAssertWhenFetchingAValue() throws Throwable
+        {
+            // given
+            int keyId = 11;
+            Object expectedValue = actualValue( this.expectedValue );
+
+            long recordId = createSinglePropertyValue( propertyStore, keyId, expectedValue ).getId();
+
+            StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
+            MutableBoolean called = new MutableBoolean();
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, called::setTrue ) )
+            {
+                // then
+                assertFalse( called.booleanValue() );
+                cursor.next();
+                cursor.get().value();
+                assertTrue( called.booleanValue() );
             }
         }
     }
@@ -392,7 +414,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -424,7 +446,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
             {
                 PropertyItem item;
 
@@ -470,7 +492,7 @@ public class StorePropertyCursorTest
 
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
             {
                 assertTrue( cursor.next() );
                 PropertyItem item = cursor.get();
@@ -480,7 +502,7 @@ public class StorePropertyCursorTest
             }
 
             // when using it
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -504,7 +526,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( propertyValues ), valuesFromCursor );
@@ -520,7 +542,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
 
                 assertTrue( cursor.next() );
                 assertEquals( "1", cursor.value() );
@@ -546,7 +568,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", 3, 5L, '7', "9 and 10" ), valuesFromCursor );
@@ -565,7 +587,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", "2", 6L, '7', '8', "9 and 10" ), valuesFromCursor );
@@ -585,7 +607,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( Collections.emptyList(), valuesFromCursor );
@@ -604,7 +626,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK );
+                cursor.init( chainStartId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( values ), valuesFromCursor );
@@ -670,7 +692,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK );
+                cursor.init( chainStartId, NO_LOCK, () -> {} );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 for ( int i = 0; i < valuesFromCursor.size(); i++ )
@@ -708,7 +730,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK );
+                cursor.init( recordId, NO_LOCK, () -> {} );
                 assertTrue( cursor.next() );
                 assertEquals( expectedValue, cursor.value() );
                 assertFalse( cursor.next() );
@@ -719,7 +741,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK );
+                cursor.init( recordId, NO_LOCK, () -> {} );
                 assertTrue( cursor.next() );
                 assertArrayEquals( expectedValue, (byte[]) cursor.value() );
                 assertFalse( cursor.next() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -39,6 +38,7 @@ import java.util.function.Consumer;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.store.DynamicArrayStore;
 import org.neo4j.kernel.impl.store.DynamicRecordAllocator;
 import org.neo4j.kernel.impl.store.DynamicStringStore;
@@ -251,7 +251,7 @@ public class StorePropertyCursorTest
         {
             // given
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore, cache );
-            storePropertyCursor.init( 0, NO_LOCK, () -> {} );
+            storePropertyCursor.init( 0, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
             // when
             storePropertyCursor.close();
@@ -330,7 +330,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -351,14 +351,14 @@ public class StorePropertyCursorTest
             long recordId = createSinglePropertyValue( propertyStore, keyId, expectedValue ).getId();
 
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
-            MutableBoolean called = new MutableBoolean();
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, called::setTrue ) )
+            AssertOpen assertOpen = mock( AssertOpen.class );
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, assertOpen ) )
             {
                 // then
-                assertFalse( called.booleanValue() );
+                verify( assertOpen, times( 0 ) ).assertOpen();
                 cursor.next();
                 cursor.get().value();
-                assertTrue( called.booleanValue() );
+                verify( assertOpen, times( 1 ) ).assertOpen();
             }
         }
     }
@@ -414,7 +414,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -446,7 +446,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN ) )
             {
                 PropertyItem item;
 
@@ -492,7 +492,7 @@ public class StorePropertyCursorTest
 
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN ) )
             {
                 assertTrue( cursor.next() );
                 PropertyItem item = cursor.get();
@@ -502,7 +502,7 @@ public class StorePropertyCursorTest
             }
 
             // when using it
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, () -> {} ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -526,7 +526,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
+                cursor.init( firstPropertyId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( propertyValues ), valuesFromCursor );
@@ -542,7 +542,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
+                cursor.init( firstPropertyId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 assertTrue( cursor.next() );
                 assertEquals( "1", cursor.value() );
@@ -568,7 +568,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
+                cursor.init( firstPropertyId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", 3, 5L, '7', "9 and 10" ), valuesFromCursor );
@@ -587,7 +587,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
+                cursor.init( firstPropertyId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", "2", 6L, '7', '8', "9 and 10" ), valuesFromCursor );
@@ -607,7 +607,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK, () -> {} );
+                cursor.init( firstPropertyId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( Collections.emptyList(), valuesFromCursor );
@@ -626,7 +626,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK, () -> {} );
+                cursor.init( chainStartId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( values ), valuesFromCursor );
@@ -692,7 +692,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK, () -> {} );
+                cursor.init( chainStartId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 for ( int i = 0; i < valuesFromCursor.size(); i++ )
@@ -730,7 +730,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK, () -> {} );
+                cursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
                 assertTrue( cursor.next() );
                 assertEquals( expectedValue, cursor.value() );
                 assertFalse( cursor.next() );
@@ -741,7 +741,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK, () -> {} );
+                cursor.init( recordId, NO_LOCK, AssertOpen.ALWAYS_OPEN );
                 assertTrue( cursor.next() );
                 assertArrayEquals( expectedValue, (byte[]) cursor.value() );
                 assertFalse( cursor.next() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursorTest.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
@@ -623,7 +624,7 @@ public class StoreSingleNodeCursorTest
                 mock( StoreStatement.class ), mock( Consumer.class ), new RecordCursors( resolveNeoStores() ),
                 NO_LOCK_SERVICE );
 
-        cursor.init( nodeId, () -> {} );
+        cursor.init( nodeId, AssertOpen.ALWAYS_OPEN );
         assertTrue( cursor.next() );
 
         return cursor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursorTest.java
@@ -623,7 +623,7 @@ public class StoreSingleNodeCursorTest
                 mock( StoreStatement.class ), mock( Consumer.class ), new RecordCursors( resolveNeoStores() ),
                 NO_LOCK_SERVICE );
 
-        cursor.init( nodeId );
+        cursor.init( nodeId, () -> {} );
         assertTrue( cursor.next() );
 
         return cursor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
@@ -80,7 +80,7 @@ public class StoreSingleRelationshipCursorTest
 
         try ( StoreSingleRelationshipCursor cursor = createRelationshipCursor() )
         {
-            cursor.init( RELATIONSHIP_ID );
+            cursor.init( RELATIONSHIP_ID, () -> {} );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }
@@ -95,7 +95,7 @@ public class StoreSingleRelationshipCursorTest
 
         try ( StoreSingleRelationshipCursor cursor = createRelationshipCursor() )
         {
-            cursor.init( RELATIONSHIP_ID );
+            cursor.init( RELATIONSHIP_ID, () -> {} );
             assertFalse( cursor.next() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
@@ -80,7 +81,7 @@ public class StoreSingleRelationshipCursorTest
 
         try ( StoreSingleRelationshipCursor cursor = createRelationshipCursor() )
         {
-            cursor.init( RELATIONSHIP_ID, () -> {} );
+            cursor.init( RELATIONSHIP_ID, AssertOpen.ALWAYS_OPEN );
             assertTrue( cursor.next() );
             assertEquals( RELATIONSHIP_ID, cursor.get().id() );
         }
@@ -95,7 +96,7 @@ public class StoreSingleRelationshipCursorTest
 
         try ( StoreSingleRelationshipCursor cursor = createRelationshipCursor() )
         {
-            cursor.init( RELATIONSHIP_ID, () -> {} );
+            cursor.init( RELATIONSHIP_ID, AssertOpen.ALWAYS_OPEN );
             assertFalse( cursor.next() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -99,10 +100,10 @@ public class TxStateTransactionDataViewTest
         state.nodeDoDelete( 1L );
         state.nodeDoDelete( 2L );
 
-        when( storeStatement.acquireSingleNodeCursor( eq( 2L ), any( Runnable.class ) ) ).
+        when( storeStatement.acquireSingleNodeCursor( eq( 2L ), any( AssertOpen.class ) ) ).
                 thenReturn( asNodeCursor( 2L, asPropertyCursor( stringProperty( 1, "p" ) ), asLabelCursor( 15 ) ) );
 
-        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( AssertOpen.class ) ) ).
                 thenReturn( asNodeCursor( 1L, asPropertyCursor(), asLabelCursor() ) );
 
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "key" );
@@ -133,9 +134,9 @@ public class TxStateTransactionDataViewTest
         state.relationshipDoDelete( 1L, 1, 1L, 2L );
         state.relationshipDoDelete( 2L, 1, 1L, 1L );
 
-        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( AssertOpen.class ) ) ).
                 thenReturn( asRelationshipCursor( 1L, 1, 1L, 2L, asPropertyCursor() ) );
-        when( storeStatement.acquireSingleRelationshipCursor( eq( 2L ), any( Runnable.class ) ) ).
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 2L ), any( AssertOpen.class ) ) ).
                 thenReturn( asRelationshipCursor( 2L, 1, 1L, 1L,
                         asPropertyCursor( Property.stringProperty( 1, "p" ) ) ) );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "key" );
@@ -155,7 +156,7 @@ public class TxStateTransactionDataViewTest
         state.nodeDoDelete( nodeId );
         Node node = mock( Node.class );
         when( node.getId() ).thenReturn( 1L );
-        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1 ) );
 //        when( ops.nodeGetLabels( storeStatement, 1L ) ).thenReturn( PrimitiveIntCollections.emptyIterator() );
 
@@ -171,7 +172,7 @@ public class TxStateTransactionDataViewTest
 
         Relationship rel = mock( Relationship.class );
         when( rel.getId() ).thenReturn( 1L );
-        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( AssertOpen.class ) ) )
                 .thenReturn( asRelationshipCursor( 1L, 1, 1L, 2L, asPropertyCursor() ) );
 
         // When & Then
@@ -185,7 +186,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevProp = stringProperty( 1, "prevValue" );
         state.nodeDoReplaceProperty( 1L, prevProp, stringProperty( 1, "newValue" ) );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( 1L, asPropertyCursor( prevProp ), asLabelCursor() ) );
 
         // When
@@ -206,7 +207,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevProp = stringProperty( 1, "prevValue" );
         state.nodeDoRemoveProperty( 1L, prevProp );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( AssertOpen.class ) ) ).thenReturn(
                 asNodeCursor( 1L, asPropertyCursor( prevProp ), asLabelCursor() ) );
 
         // When
@@ -226,7 +227,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevValue = stringProperty( 1, "prevValue" );
         state.relationshipDoRemoveProperty( 1L, prevValue );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( AssertOpen.class ) ) ).thenReturn(
                 StubCursors.asRelationshipCursor( 1, 0, 0, 0, asPropertyCursor(
                         prevValue ) ) );
 
@@ -248,7 +249,7 @@ public class TxStateTransactionDataViewTest
         state.relationshipDoReplaceProperty( 1L, prevProp, stringProperty( 1, "newValue" ) );
 
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( AssertOpen.class ) ) ).thenReturn(
                 StubCursors.asRelationshipCursor( 1, 0, 0, 0, asPropertyCursor(
                         prevProp ) ) );
 
@@ -269,7 +270,7 @@ public class TxStateTransactionDataViewTest
         // Given
         state.nodeDoAddLabel( 2, 1L );
         when( ops.labelGetName( 2 ) ).thenReturn( "theLabel" );
-        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) )
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( AssertOpen.class ) ) )
                 .thenReturn( asNodeCursor( 1 ) );
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -52,6 +52,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterables.single;
@@ -97,10 +99,10 @@ public class TxStateTransactionDataViewTest
         state.nodeDoDelete( 1L );
         state.nodeDoDelete( 2L );
 
-        when( storeStatement.acquireSingleNodeCursor( 2L ) ).
+        when( storeStatement.acquireSingleNodeCursor( eq( 2L ), any( Runnable.class ) ) ).
                 thenReturn( asNodeCursor( 2L, asPropertyCursor( stringProperty( 1, "p" ) ), asLabelCursor( 15 ) ) );
 
-        when( storeStatement.acquireSingleNodeCursor( 1L ) ).
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).
                 thenReturn( asNodeCursor( 1L, asPropertyCursor(), asLabelCursor() ) );
 
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "key" );
@@ -131,9 +133,9 @@ public class TxStateTransactionDataViewTest
         state.relationshipDoDelete( 1L, 1, 1L, 2L );
         state.relationshipDoDelete( 2L, 1, 1L, 1L );
 
-        when( storeStatement.acquireSingleRelationshipCursor( 1L ) ).
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).
                 thenReturn( asRelationshipCursor( 1L, 1, 1L, 2L, asPropertyCursor() ) );
-        when( storeStatement.acquireSingleRelationshipCursor( 2L ) ).
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 2L ), any( Runnable.class ) ) ).
                 thenReturn( asRelationshipCursor( 2L, 1, 1L, 1L,
                         asPropertyCursor( Property.stringProperty( 1, "p" ) ) ) );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "key" );
@@ -148,10 +150,13 @@ public class TxStateTransactionDataViewTest
     public void correctlySaysNodeIsDeleted() throws Exception
     {
         // Given
-        state.nodeDoDelete( 1L );
+        long nodeId = 1L;
+        long propertyId = 42L;
+        state.nodeDoDelete( nodeId );
         Node node = mock( Node.class );
         when( node.getId() ).thenReturn( 1L );
-        when( storeStatement.acquireSingleNodeCursor( 1 ) ).thenReturn( asNodeCursor( 1 ) );
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1 ) );
 //        when( ops.nodeGetLabels( storeStatement, 1L ) ).thenReturn( PrimitiveIntCollections.emptyIterator() );
 
         // When & Then
@@ -166,8 +171,8 @@ public class TxStateTransactionDataViewTest
 
         Relationship rel = mock( Relationship.class );
         when( rel.getId() ).thenReturn( 1L );
-        when( storeStatement.acquireSingleRelationshipCursor( 1L ) ).thenReturn( asRelationshipCursor( 1L, 1, 1L, 2L,
-                asPropertyCursor() ) );
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) )
+                .thenReturn( asRelationshipCursor( 1L, 1, 1L, 2L, asPropertyCursor() ) );
 
         // When & Then
         assertThat( snapshot().isDeleted( rel ), equalTo( true ) );
@@ -180,7 +185,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevProp = stringProperty( 1, "prevValue" );
         state.nodeDoReplaceProperty( 1L, prevProp, stringProperty( 1, "newValue" ) );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleNodeCursor( 1L ) ).thenReturn(
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( 1L, asPropertyCursor( prevProp ), asLabelCursor() ) );
 
         // When
@@ -201,7 +206,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevProp = stringProperty( 1, "prevValue" );
         state.nodeDoRemoveProperty( 1L, prevProp );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleNodeCursor( 1L ) ).thenReturn(
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
                 asNodeCursor( 1L, asPropertyCursor( prevProp ), asLabelCursor() ) );
 
         // When
@@ -221,7 +226,7 @@ public class TxStateTransactionDataViewTest
         DefinedProperty prevValue = stringProperty( 1, "prevValue" );
         state.relationshipDoRemoveProperty( 1L, prevValue );
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleRelationshipCursor( 1 ) ).thenReturn(
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
                 StubCursors.asRelationshipCursor( 1, 0, 0, 0, asPropertyCursor(
                         prevValue ) ) );
 
@@ -243,7 +248,7 @@ public class TxStateTransactionDataViewTest
         state.relationshipDoReplaceProperty( 1L, prevProp, stringProperty( 1, "newValue" ) );
 
         when( ops.propertyKeyGetName( 1 ) ).thenReturn( "theKey" );
-        when( storeStatement.acquireSingleRelationshipCursor( 1 ) ).thenReturn(
+        when( storeStatement.acquireSingleRelationshipCursor( eq( 1L ), any( Runnable.class ) ) ).thenReturn(
                 StubCursors.asRelationshipCursor( 1, 0, 0, 0, asPropertyCursor(
                         prevProp ) ) );
 
@@ -264,7 +269,8 @@ public class TxStateTransactionDataViewTest
         // Given
         state.nodeDoAddLabel( 2, 1L );
         when( ops.labelGetName( 2 ) ).thenReturn( "theLabel" );
-        when( storeStatement.acquireSingleNodeCursor( 1 ) ).thenReturn( asNodeCursor( 1 ) );
+        when( storeStatement.acquireSingleNodeCursor( eq( 1L ), any( Runnable.class ) ) )
+                .thenReturn( asNodeCursor( 1 ) );
 
         // When
         Iterable<LabelEntry> labelEntries = snapshot().assignedLabels();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -100,6 +100,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.counts_store_rotation_timeout;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.api.AssertOpen.ALWAYS_OPEN;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.store.RecordStore.getRecord;
 import static org.neo4j.kernel.impl.store.format.standard.MetaDataRecordFormat.FIELD_NOT_PRESENT;
@@ -292,7 +293,7 @@ public class NeoStoresTest
         DefinedProperty property = Property.property( key, value );
         Property oldProperty = Property.noNodeProperty( nodeId, key );
         try ( StorageStatement statement = storeLayer.newStatement();
-                Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
+              Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, ALWAYS_OPEN ) )
         {
             if ( cursor.next() )
             {
@@ -313,7 +314,8 @@ public class NeoStoresTest
         DefinedProperty property = Property.property( key, value );
         Property oldProperty = Property.noRelationshipProperty( relationshipId, key );
         try ( StorageStatement statement = storeLayer.newStatement();
-                Cursor<RelationshipItem> cursor = statement.acquireSingleRelationshipCursor( relationshipId, () -> {} ) )
+                Cursor<RelationshipItem> cursor = statement.acquireSingleRelationshipCursor( relationshipId,
+                        ALWAYS_OPEN ) )
         {
             if ( cursor.next() )
             {
@@ -947,7 +949,7 @@ public class NeoStoresTest
     {
         int count = 0;
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, statement ) )
         {
             nodeCursor.next();
 
@@ -1029,7 +1031,7 @@ public class NeoStoresTest
         count = 0;
 
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, statement ) )
         {
             nodeCursor.next();
 
@@ -1064,7 +1066,7 @@ public class NeoStoresTest
     {
         try ( StorageStatement statement = storeLayer.newStatement() )
         {
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, ALWAYS_OPEN ) )
             {
                 return node.next();
             }
@@ -1327,7 +1329,7 @@ public class NeoStoresTest
     {
 
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, statement ) )
         {
             nodeCursor.next();
             PrimitiveLongIterator rels = nodeCursor.get().getRelationships( Direction.BOTH );
@@ -1435,7 +1437,8 @@ public class NeoStoresTest
         {
             for ( long relId : relIds )
             {
-                try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( relId, () -> {} ) )
+                try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( relId,
+                        ALWAYS_OPEN ) )
                 {
                     assertFalse( relationship.next() );
                 }
@@ -1446,7 +1449,7 @@ public class NeoStoresTest
     private void deleteRelationships( long nodeId ) throws Exception
     {
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, () -> {} ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, statement ) )
         {
             nodeCursor.next();
             PrimitiveLongIterator relationships = nodeCursor.get().getRelationships( Direction.BOTH );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -292,7 +292,7 @@ public class NeoStoresTest
         DefinedProperty property = Property.property( key, value );
         Property oldProperty = Property.noNodeProperty( nodeId, key );
         try ( StorageStatement statement = storeLayer.newStatement();
-                Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId ) )
+                Cursor<NodeItem> cursor = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
         {
             if ( cursor.next() )
             {
@@ -313,7 +313,7 @@ public class NeoStoresTest
         DefinedProperty property = Property.property( key, value );
         Property oldProperty = Property.noRelationshipProperty( relationshipId, key );
         try ( StorageStatement statement = storeLayer.newStatement();
-                Cursor<RelationshipItem> cursor = statement.acquireSingleRelationshipCursor( relationshipId ) )
+                Cursor<RelationshipItem> cursor = statement.acquireSingleRelationshipCursor( relationshipId, () -> {} ) )
         {
             if ( cursor.next() )
             {
@@ -947,7 +947,7 @@ public class NeoStoresTest
     {
         int count = 0;
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
         {
             nodeCursor.next();
 
@@ -1029,7 +1029,7 @@ public class NeoStoresTest
         count = 0;
 
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
         {
             nodeCursor.next();
 
@@ -1064,7 +1064,7 @@ public class NeoStoresTest
     {
         try ( StorageStatement statement = storeLayer.newStatement() )
         {
-            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId ) )
+            try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( nodeId, () -> {} ) )
             {
                 return node.next();
             }
@@ -1327,7 +1327,7 @@ public class NeoStoresTest
     {
 
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( node, () -> {} ) )
         {
             nodeCursor.next();
             PrimitiveLongIterator rels = nodeCursor.get().getRelationships( Direction.BOTH );
@@ -1435,7 +1435,7 @@ public class NeoStoresTest
         {
             for ( long relId : relIds )
             {
-                try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( relId ) )
+                try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( relId, () -> {} ) )
                 {
                     assertFalse( relationship.next() );
                 }
@@ -1446,7 +1446,7 @@ public class NeoStoresTest
     private void deleteRelationships( long nodeId ) throws Exception
     {
         try ( KernelStatement statement = (KernelStatement) tx.acquireStatement();
-              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId ) )
+              Cursor<NodeItem> nodeCursor = statement.getStoreStatement().acquireSingleNodeCursor( nodeId, () -> {} ) )
         {
             nodeCursor.next();
             PrimitiveLongIterator relationships = nodeCursor.get().getRelationships( Direction.BOTH );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
@@ -339,7 +339,6 @@ public class TerminationOfSlavesDuringPullUpdatesTest
         return node ? db.getNodeById( id ) : db.getRelationshipById( id );
     }
 
-
     private static class PropertyKeyActions implements ReadContestantActions
     {
         final char keyPrefixA;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
@@ -78,43 +78,51 @@ public class TerminationOfSlavesDuringPullUpdatesTest
     public static Iterable<Object> data()
     {
         return Arrays.<Object>asList( new Object[][]
-                {
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
-                                ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
-                                "NodeStringProperty[allProps]"},
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
-                                ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
-                                "NodeStringProperty[singleProp]"},
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
-                                ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
-                                "NodeStringProperty[varArgsProp]"},
+        {
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
+                        "NodeStringProperty[allProps]"},
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
+                        "NodeStringProperty[singleProp]"},
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
+                        "NodeStringProperty[varArgsProp]"},
 
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
-                                "RelationshipStringProperty[allProps]"},
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
-                                "RelationshipStringProperty[singleProp]"},
-                        {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
-                                "RelationshipStringProperty[varArgsProp]"},
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
+                        "RelationshipStringProperty[allProps]"},
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
+                        "RelationshipStringProperty[singleProp]"},
+                {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
+                        "RelationshipStringProperty[varArgsProp]"},
 
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
-                                "NodeArrayProperty[allProps]"},
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
-                                "NodeArrayProperty[singleProp]"},
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
-                                "NodeArrayProperty[varArgsProp]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
+                        "NodeArrayProperty[allProps]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
+                        "NodeArrayProperty[singleProp]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
+                        "NodeArrayProperty[varArgsProp]"},
 
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
-                                "RelationshipArrayProperty[allProps]"},
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
-                                "RelationshipArrayProperty[singleProp]"},
-                        {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false, ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
-                                "RelationshipArrayProperty[varArgsProp]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getAllProperties().get( key ) ),
+                        "RelationshipArrayProperty[allProps]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperty( key, null ) ),
+                        "RelationshipArrayProperty[singleProp]"},
+                {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false,
+                        ( db, entityId, key, node ) -> getEntity( db, entityId, node ).getProperties( key ).get( key ) ),
+                        "RelationshipArrayProperty[varArgsProp]"},
 
-                        {new PropertyKeyActions( 'a', 'b', true ), "NodePropertyKeys"},
+                {new PropertyKeyActions( 'a', 'b', true ), "NodePropertyKeys"},
 
-                        {new PropertyKeyActions( 'a', 'b', false ), "RelationshipPropertyKeys"},
-                }
-        );
+                {new PropertyKeyActions( 'a', 'b', false ), "RelationshipPropertyKeys"},
+        } );
     }
 
     @Test

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -149,7 +150,7 @@ class PropertyExistenceEnforcer extends TxStateVisitor.Delegator
 
     private Cursor<NodeItem> nodeCursor( long id )
     {
-        Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id, () -> {} );
+        Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id, AssertOpen.ALWAYS_OPEN );
         return txState.augmentSingleNodeCursor( cursor, id );
     }
 
@@ -213,7 +214,7 @@ class PropertyExistenceEnforcer extends TxStateVisitor.Delegator
 
     private Cursor<RelationshipItem> relationshipCursor( long id )
     {
-        Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id, () -> {} );
+        Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id, AssertOpen.ALWAYS_OPEN );
         return txState.augmentSingleRelationshipCursor( cursor, id );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -149,7 +149,7 @@ class PropertyExistenceEnforcer extends TxStateVisitor.Delegator
 
     private Cursor<NodeItem> nodeCursor( long id )
     {
-        Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id );
+        Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id, () -> {} );
         return txState.augmentSingleNodeCursor( cursor, id );
     }
 
@@ -213,7 +213,7 @@ class PropertyExistenceEnforcer extends TxStateVisitor.Delegator
 
     private Cursor<RelationshipItem> relationshipCursor( long id )
     {
-        Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id );
+        Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id, () -> {} );
         return txState.augmentSingleRelationshipCursor( cursor, id );
     }
 }


### PR DESCRIPTION
Make sure termination of transactions is checked during lazy
property evaluation by pushing down the statement is open assertion
to cursor level.

During slave pull updates the `TransactionBatchCommitter` will mark transactions falling outside of safe zone for termination. 

Consider this scenario:
```
try ( Transaction tx = db.beginTx )
{
    Object property = db.getNodeById( id ).getProperty( propKey );
    // Act on information from property
    tx.success();
}
```
Until we do `tx.success` we don't know if our transaction has been terminated or not and we could potentially act on inconsistent data (from the dynamic store).

The current workaround for this is to assert that statement is still open before returning. We do this for 
`nodeGetProperty( long nodeId, int propertyKeyId )`
`relationshipGetProperty( long nodeId, int propertyKeyId )`
`nodeGetPropertyKeys( long nodeId )`
`relationshipGetPropertyKeys( long nodeId )`
but not for any other `getProperty/Properties`.
The updated `TerminationOfSlavesDuringPullUpdatesTest` shows that this is a problem and this PR tries to solve it by pushing down the assert open check to the cursor level.