### PR TITLE
Cleanup, use gen instead of generation in index module

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
@@ -42,7 +42,7 @@ class FreelistNode
     private static final int PAGE_ID_SIZE = GenSafePointer.POINTER_SIZE;
     private static final int BYTE_POS_NEXT = TreeNode.BYTE_POS_NODE_TYPE + Byte.BYTES;
     private static final int HEADER_LENGTH = BYTE_POS_NEXT + PAGE_ID_SIZE;
-    private static final int ENTRY_SIZE = GenSafePointer.GENERATION_SIZE + PAGE_ID_SIZE;
+    private static final int ENTRY_SIZE = GenSafePointer.GEN_SIZE + PAGE_ID_SIZE;
     static final long NO_PAGE_ID = TreeNode.NO_NODE_FLAG;
 
     private final int maxEntries;
@@ -57,16 +57,16 @@ class FreelistNode
         cursor.putByte( TreeNode.BYTE_POS_NODE_TYPE, TreeNode.NODE_TYPE_FREE_LIST_NODE );
     }
 
-    void write( PageCursor cursor, long unstableGeneration, long pageId, int pos )
+    void write( PageCursor cursor, long unstableGen, long pageId, int pos )
     {
         if ( pageId == NO_PAGE_ID )
         {
             throw new IllegalArgumentException( "Tried to write pageId " + pageId + " which means null" );
         }
         assertPos( pos );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenSafePointer.assertGenOnWrite( unstableGen );
         cursor.setOffset( entryOffset( pos ) );
-        cursor.putInt( (int) unstableGeneration );
+        cursor.putInt( (int) unstableGen );
         put6BLong( cursor, pageId );
     }
 
@@ -82,12 +82,12 @@ class FreelistNode
         }
     }
 
-    long read( PageCursor cursor, long stableGeneration, int pos )
+    long read( PageCursor cursor, long stableGen, int pos )
     {
         assertPos( pos );
         cursor.setOffset( entryOffset( pos ) );
-        long generation = getUnsignedInt( cursor );
-        return generation <= stableGeneration ? get6BLong( cursor ) : NO_PAGE_ID;
+        long gen = getUnsignedInt( cursor );
+        return gen <= stableGen ? get6BLong( cursor ) : NO_PAGE_ID;
     }
 
     private static int entryOffset( int pos )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Gen.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Gen.java
@@ -27,45 +27,45 @@ package org.neo4j.index.internal.gbptree;
  *       msb <-------> lsb
  * </pre>
  */
-class Generation
+class Gen
 {
-    private static final long UNSTABLE_GENERATION_MASK = 0xFFFFFFFFL;
-    private static final int STABLE_GENERATION_SHIFT = Integer.SIZE;
+    private static final long UNSTABLE_GEN_MASK = 0xFFFFFFFFL;
+    private static final int STABLE_GEN_SHIFT = Integer.SIZE;
 
     /**
      * Takes one stable and one unstable generation (both unsigned ints) and crams them into one {@code long}.
      *
-     * @param stableGeneration stable generation.
-     * @param unstableGeneration unstable generation.
+     * @param stableGen stable generation.
+     * @param unstableGen unstable generation.
      * @return the two generation numbers as one {@code long}.
      */
-    public static long generation( long stableGeneration, long unstableGeneration )
+    public static long gen( long stableGen, long unstableGen )
     {
-        GenSafePointer.assertGenerationOnWrite( stableGeneration );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenSafePointer.assertGenOnWrite( stableGen );
+        GenSafePointer.assertGenOnWrite( unstableGen );
 
-        return (stableGeneration << STABLE_GENERATION_SHIFT) | unstableGeneration;
+        return (stableGen << STABLE_GEN_SHIFT) | unstableGen;
     }
 
     /**
      * Extracts and returns unstable generation from generation {@code long}.
      *
-     * @param generation generation variable containing both stable and unstable generations.
+     * @param gen generation variable containing both stable and unstable generations.
      * @return unstable generation from generation.
      */
-    public static long unstableGeneration( long generation )
+    public static long unstableGen( long gen )
     {
-        return generation & UNSTABLE_GENERATION_MASK;
+        return gen & UNSTABLE_GEN_MASK;
     }
 
     /**
      * Extracts and returns stable generation from generation {@code long}.
      *
-     * @param generation generation variable containing both stable and unstable generations.
+     * @param gen generation variable containing both stable and unstable generations.
      * @return stable generation from generation.
      */
-    public static long stableGeneration( long generation )
+    public static long stableGen( long gen )
     {
-        return generation >>> STABLE_GENERATION_SHIFT;
+        return gen >>> STABLE_GEN_SHIFT;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdProvider.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/IdProvider.java
@@ -33,21 +33,21 @@ interface IdProvider
      * Acquires a page id, guaranteed to currently not be used. The bytes on the page at this id
      * are all guaranteed to be zero at the point of returning from this method.
      *
-     * @param stableGeneration current stable generation.
-     * @param unstableGeneration current unstable generation.
+     * @param stableGen current stable generation.
+     * @param unstableGen current unstable generation.
      * @return page id guaranteed to current not be used and whose bytes are all zeros.
      * @throws IOException on {@link PageCursor} error.
      */
-    long acquireNewId( long stableGeneration, long unstableGeneration ) throws IOException;
+    long acquireNewId( long stableGen, long unstableGen ) throws IOException;
 
     /**
      * Releases a page id which has previously been used, but isn't anymore, effectively allowing
      * it to be reused and returned from {@link #acquireNewId(long, long)}.
      *
-     * @param stableGeneration current stable generation.
-     * @param unstableGeneration current unstable generation.
+     * @param stableGen current stable generation.
+     * @param unstableGen current unstable generation.
      * @param id page id to release.
      * @throws IOException on {@link PageCursor} error.
      */
-    void releaseId( long stableGeneration, long unstableGeneration, long id ) throws IOException;
+    void releaseId( long stableGen, long unstableGen, long id ) throws IOException;
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Root.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Root.java
@@ -37,12 +37,12 @@ class Root
     /**
      * Generation of current {@link #rootId}.
      */
-    private final long rootGeneration;
+    private final long rootGen;
 
-    Root( long rootId, long rootGeneration )
+    Root( long rootId, long rootGen )
     {
         this.rootId = rootId;
-        this.rootGeneration = rootGeneration;
+        this.rootGen = rootGen;
     }
 
     /**
@@ -56,7 +56,7 @@ class Root
     long goTo( PageCursor cursor ) throws IOException
     {
         PageCursorUtil.goTo( cursor, "root", rootId );
-        return rootGeneration;
+        return rootGen;
     }
 
     long id()
@@ -64,8 +64,8 @@ class Root
         return rootId;
     }
 
-    long generation()
+    long gen()
     {
-        return rootGeneration;
+        return rootGen;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -119,25 +119,25 @@ class TreeNode<KEY,VALUE>
         return cursor.getByte( BYTE_POS_NODE_TYPE );
     }
 
-    private void initialize( PageCursor cursor, byte type, long stableGeneration, long unstableGeneration )
+    private void initialize( PageCursor cursor, byte type, long stableGen, long unstableGen )
     {
         cursor.putByte( BYTE_POS_NODE_TYPE, NODE_TYPE_TREE_NODE );
         cursor.putByte( BYTE_POS_TYPE, type );
-        setGen( cursor, unstableGeneration );
+        setGen( cursor, unstableGen );
         setKeyCount( cursor, 0 );
-        setRightSibling( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
-        setLeftSibling( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
-        setNewGen( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
+        setRightSibling( cursor, NO_NODE_FLAG, stableGen, unstableGen );
+        setLeftSibling( cursor, NO_NODE_FLAG, stableGen, unstableGen );
+        setNewGen( cursor, NO_NODE_FLAG, stableGen, unstableGen );
     }
 
-    void initializeLeaf( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    void initializeLeaf( PageCursor cursor, long stableGen, long unstableGen )
     {
-        initialize( cursor, LEAF_FLAG, stableGeneration, unstableGeneration );
+        initialize( cursor, LEAF_FLAG, stableGen, unstableGen );
     }
 
-    void initializeInternal( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    void initializeInternal( PageCursor cursor, long stableGen, long unstableGen )
     {
-        initialize( cursor, INTERNAL_FLAG, stableGeneration, unstableGeneration );
+        initialize( cursor, INTERNAL_FLAG, stableGen, unstableGen );
     }
 
     // HEADER METHODS
@@ -154,7 +154,7 @@ class TreeNode<KEY,VALUE>
 
     long gen( PageCursor cursor )
     {
-        return cursor.getInt( BYTE_POS_GEN ) & GenSafePointer.GENERATION_MASK;
+        return cursor.getInt( BYTE_POS_GEN ) & GenSafePointer.GEN_MASK;
     }
 
     int keyCount( PageCursor cursor )
@@ -162,28 +162,28 @@ class TreeNode<KEY,VALUE>
         return cursor.getInt( BYTE_POS_KEYCOUNT );
     }
 
-    long rightSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    long rightSibling( PageCursor cursor, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_RIGHTSIBLING );
-        return read( cursor, stableGeneration, unstableGeneration, NO_LOGICAL_POS );
+        return read( cursor, stableGen, unstableGen, NO_LOGICAL_POS );
     }
 
-    long leftSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    long leftSibling( PageCursor cursor, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_LEFTSIBLING );
-        return read( cursor, stableGeneration, unstableGeneration, NO_LOGICAL_POS );
+        return read( cursor, stableGen, unstableGen, NO_LOGICAL_POS );
     }
 
-    long newGen( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    long newGen( PageCursor cursor, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_NEWGEN );
-        return read( cursor, stableGeneration, unstableGeneration, NO_LOGICAL_POS );
+        return read( cursor, stableGen, unstableGen, NO_LOGICAL_POS );
     }
 
-    void setGen( PageCursor cursor, long generation )
+    void setGen( PageCursor cursor, long gen )
     {
-        GenSafePointer.assertGenerationOnWrite( generation );
-        cursor.putInt( BYTE_POS_GEN, (int) generation );
+        GenSafePointer.assertGenOnWrite( gen );
+        cursor.putInt( BYTE_POS_GEN, (int) gen );
     }
 
     void setKeyCount( PageCursor cursor, int count )
@@ -191,24 +191,24 @@ class TreeNode<KEY,VALUE>
         cursor.putInt( BYTE_POS_KEYCOUNT, count );
     }
 
-    void setRightSibling( PageCursor cursor, long rightSiblingId, long stableGeneration, long unstableGeneration )
+    void setRightSibling( PageCursor cursor, long rightSiblingId, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_RIGHTSIBLING );
-        long result = GenSafePointerPair.write( cursor, rightSiblingId, stableGeneration, unstableGeneration );
+        long result = GenSafePointerPair.write( cursor, rightSiblingId, stableGen, unstableGen );
         GenSafePointerPair.assertSuccess( result );
     }
 
-    void setLeftSibling( PageCursor cursor, long leftSiblingId, long stableGeneration, long unstableGeneration )
+    void setLeftSibling( PageCursor cursor, long leftSiblingId, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_LEFTSIBLING );
-        long result = GenSafePointerPair.write( cursor, leftSiblingId, stableGeneration, unstableGeneration );
+        long result = GenSafePointerPair.write( cursor, leftSiblingId, stableGen, unstableGen );
         GenSafePointerPair.assertSuccess( result );
     }
 
-    void setNewGen( PageCursor cursor, long newGenId, long stableGeneration, long unstableGeneration )
+    void setNewGen( PageCursor cursor, long newGenId, long stableGen, long unstableGen )
     {
         cursor.setOffset( BYTE_POS_NEWGEN );
-        long result = GenSafePointerPair.write( cursor, newGenId, stableGeneration, unstableGeneration );
+        long result = GenSafePointerPair.write( cursor, newGenId, stableGen, unstableGen );
         GenSafePointerPair.assertSuccess( result );
     }
 
@@ -223,7 +223,7 @@ class TreeNode<KEY,VALUE>
         int gspOffset = GenSafePointerPair.resultIsFromSlotA( readResult ) ?
                 gsppOffset : gsppOffset + GenSafePointer.SIZE;
         cursor.setOffset( gspOffset );
-        return GenSafePointer.readGeneration( cursor );
+        return GenSafePointer.readGen( cursor );
     }
 
     // BODY METHODS
@@ -286,17 +286,17 @@ class TreeNode<KEY,VALUE>
         layout.writeValue( cursor, value );
     }
 
-    long childAt( PageCursor cursor, int pos, long stableGeneration, long unstableGeneration )
+    long childAt( PageCursor cursor, int pos, long stableGen, long unstableGen )
     {
         cursor.setOffset( childOffset( pos ) );
-        return read( cursor, stableGeneration, unstableGeneration, pos );
+        return read( cursor, stableGen, unstableGen, pos );
     }
 
     void insertChildAt( PageCursor cursor, long child, int pos, int keyCount,
-            long stableGeneration, long unstableGeneration )
+            long stableGen, long unstableGen )
     {
         insertChildSlotsAt( cursor, pos, 1, keyCount );
-        setChildAt( cursor, child, pos, stableGeneration, unstableGeneration );
+        setChildAt( cursor, child, pos, stableGen, unstableGen );
     }
 
     void removeChildAt( PageCursor cursor, int pos, int keyCount )
@@ -304,15 +304,15 @@ class TreeNode<KEY,VALUE>
         removeSlotAt( cursor, pos, keyCount + 1, childOffset( 0 ), childSize() );
     }
 
-    void setChildAt( PageCursor cursor, long child, int pos, long stableGeneration, long unstableGeneration )
+    void setChildAt( PageCursor cursor, long child, int pos, long stableGen, long unstableGen )
     {
         cursor.setOffset( childOffset( pos ) );
-        writeChild( cursor, child, stableGeneration, unstableGeneration );
+        writeChild( cursor, child, stableGen, unstableGen );
     }
 
-    void writeChild( PageCursor cursor, long child, long stableGeneration, long unstableGeneration)
+    void writeChild( PageCursor cursor, long child, long stableGen, long unstableGen)
     {
-        GenSafePointerPair.write( cursor, child, stableGeneration, unstableGeneration );
+        GenSafePointerPair.write( cursor, child, stableGen, unstableGen );
     }
 
     /**

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -37,15 +37,15 @@ class TreePrinter<KEY,VALUE>
 {
     private final TreeNode<KEY,VALUE> node;
     private final Layout<KEY,VALUE> layout;
-    private final long stableGeneration;
-    private final long unstableGeneration;
+    private final long stableGen;
+    private final long unstableGen;
 
-    TreePrinter( TreeNode<KEY,VALUE> node, Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration )
+    TreePrinter( TreeNode<KEY,VALUE> node, Layout<KEY,VALUE> layout, long stableGen, long unstableGen )
     {
         this.node = node;
         this.layout = layout;
-        this.stableGeneration = stableGeneration;
-        this.unstableGeneration = unstableGeneration;
+        this.stableGen = stableGen;
+        this.unstableGen = unstableGen;
     }
 
     /**
@@ -109,15 +109,15 @@ class TreePrinter<KEY,VALUE>
         if ( printHeader )
         {
             //[TYPE][GEN][KEYCOUNT] ([RIGHTSIBLING][LEFTSIBLING][NEWGEN]))
-            long generation = -1;
+            long gen = -1;
             do
             {
-                generation = node.gen( cursor );
+                gen = node.gen( cursor );
 
             } while ( cursor.shouldRetry() );
             String treeNodeType = isLeaf ? "leaf" : "internal";
             out.print( format( "{%d,%s,gen=%d,keyCount=%d}",
-                    cursor.getCurrentPageId(), treeNodeType, generation, keyCount ) );
+                    cursor.getCurrentPageId(), treeNodeType, gen, keyCount ) );
         }
         else
         {
@@ -137,7 +137,7 @@ class TreePrinter<KEY,VALUE>
                 }
                 else
                 {
-                    child = pointer( node.childAt( cursor, i, stableGeneration, unstableGeneration ) );
+                    child = pointer( node.childAt( cursor, i, stableGen, unstableGen ) );
                 }
             }
             while ( cursor.shouldRetry() );
@@ -166,7 +166,7 @@ class TreePrinter<KEY,VALUE>
             long child;
             do
             {
-                child = pointer( node.childAt( cursor, keyCount, stableGeneration, unstableGeneration ) );
+                child = pointer( node.childAt( cursor, keyCount, stableGen, unstableGen ) );
             }
             while ( cursor.shouldRetry() );
 
@@ -188,7 +188,7 @@ class TreePrinter<KEY,VALUE>
             isInternal = TreeNode.isInternal( cursor );
             if ( isInternal )
             {
-                leftmostSibling = node.childAt( cursor, 0, stableGeneration, unstableGeneration );
+                leftmostSibling = node.childAt( cursor, 0, stableGen, unstableGen );
             }
         }
         while ( cursor.shouldRetry() );
@@ -211,7 +211,7 @@ class TreePrinter<KEY,VALUE>
 
             do
             {
-                rightSibling = node.rightSibling( cursor, stableGeneration, unstableGeneration );
+                rightSibling = node.rightSibling( cursor, stableGen, unstableGen );
             }
             while ( cursor.shouldRetry() );
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -45,12 +45,12 @@ class TreeState
     /**
      * Stable generation of the tree.
      */
-    private final long stableGeneration;
+    private final long stableGen;
 
     /**
      * Unstable generation of the tree.
      */
-    private final long unstableGeneration;
+    private final long unstableGen;
 
     /**
      * Page id which is the root of the tree.
@@ -95,13 +95,13 @@ class TreeState
      */
     private boolean valid;
 
-    TreeState( long pageId, long stableGeneration, long unstableGeneration, long rootId, long rootGen, long lastId,
+    TreeState( long pageId, long stableGen, long unstableGen, long rootId, long rootGen, long lastId,
             long freeListWritePageId, long freeListReadPageId, int freeListWritePos, int freeListReadPos,
             boolean valid )
     {
         this.pageId = pageId;
-        this.stableGeneration = stableGeneration;
-        this.unstableGeneration = unstableGeneration;
+        this.stableGen = stableGen;
+        this.unstableGen = unstableGen;
         this.rootId = rootId;
         this.rootGen = rootGen;
         this.lastId = lastId;
@@ -117,14 +117,14 @@ class TreeState
         return pageId;
     }
 
-    long stableGeneration()
+    long stableGen()
     {
-        return stableGeneration;
+        return stableGen;
     }
 
-    long unstableGeneration()
+    long unstableGen()
     {
-        return unstableGeneration;
+        return unstableGen;
     }
 
     long rootId()
@@ -172,8 +172,8 @@ class TreeState
      * are written after each other, the second one acting as checksum for the first, see {@link #valid} field.
      *
      * @param cursor {@link PageCursor} to write into, at its current offset.
-     * @param stableGeneration stable generation.
-     * @param unstableGeneration unstable generation.
+     * @param stableGen stable generation.
+     * @param unstableGen unstable generation.
      * @param rootId root id.
      * @param rootGen root generation.
      * @param lastId last id.
@@ -182,16 +182,16 @@ class TreeState
      * @param freeListWritePos offset into free-list write page id to write released ids into.
      * @param freeListReadPos offset into free-list read page id to read released ids from.
      */
-    static void write( PageCursor cursor, long stableGeneration, long unstableGeneration, long rootId, long rootGen,
+    static void write( PageCursor cursor, long stableGen, long unstableGen, long rootId, long rootGen,
             long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
             int freeListReadPos )
     {
-        GenSafePointer.assertGenerationOnWrite( stableGeneration );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenSafePointer.assertGenOnWrite( stableGen );
+        GenSafePointer.assertGenOnWrite( unstableGen );
 
-        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        writeStateOnce( cursor, stableGen, unstableGen, rootId, rootGen, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos ); // Write state
-        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        writeStateOnce( cursor, stableGen, unstableGen, rootId, rootGen, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos ); // Write checksum
     }
 
@@ -223,15 +223,15 @@ class TreeState
 
     private boolean isEmpty()
     {
-        return stableGeneration == 0L && unstableGeneration == 0L && rootId == 0L && lastId == 0L &&
+        return stableGen == 0L && unstableGen == 0L && rootId == 0L && lastId == 0L &&
                 freeListWritePageId == 0L && freeListReadPageId == 0L && freeListWritePos == 0 && freeListReadPos == 0;
     }
 
     private static TreeState readStateOnce( PageCursor cursor )
     {
         long pageId = cursor.getCurrentPageId();
-        long stableGeneration = cursor.getInt() & GenSafePointer.GENERATION_MASK;
-        long unstableGeneration = cursor.getInt() & GenSafePointer.GENERATION_MASK;
+        long stableGen = cursor.getInt() & GenSafePointer.GEN_MASK;
+        long unstableGen = cursor.getInt() & GenSafePointer.GEN_MASK;
         long rootId = cursor.getLong();
         long rootGen = cursor.getLong();
         long lastId = cursor.getLong();
@@ -239,16 +239,16 @@ class TreeState
         long freeListReadPageId = cursor.getLong();
         int freeListWritePos = cursor.getInt();
         int freeListReadPos = cursor.getInt();
-        return new TreeState( pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        return new TreeState( pageId, stableGen, unstableGen, rootId, rootGen, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, true );
     }
 
-    private static void writeStateOnce( PageCursor cursor, long stableGeneration, long unstableGeneration, long rootId,
+    private static void writeStateOnce( PageCursor cursor, long stableGen, long unstableGen, long rootId,
             long rootGen, long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
             int freeListReadPos )
     {
-        cursor.putInt( (int) stableGeneration );
-        cursor.putInt( (int) unstableGeneration );
+        cursor.putInt( (int) stableGen );
+        cursor.putInt( (int) unstableGen );
         cursor.putLong( rootId );
         cursor.putLong( rootGen );
         cursor.putLong( lastId );
@@ -261,10 +261,10 @@ class TreeState
     @Override
     public String toString()
     {
-        return String.format( "pageId=%d, stableGeneration=%d, unstableGeneration=%d, rootId=%d, rootGen=%d, " +
+        return String.format( "pageId=%d, stableGen=%d, unstableGen=%d, rootId=%d, rootGen=%d, " +
                 "lastId=%d, freeListWritePageId=%d, freeListReadPageId=%d, freeListWritePos=%d, freeListReadPos=%d, " +
                 "valid=%b",
-                pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+                pageId, stableGen, unstableGen, rootId, rootGen, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, valid );
     }
 
@@ -277,8 +277,8 @@ class TreeState
         { return false; }
         TreeState treeState = (TreeState) o;
         return pageId == treeState.pageId &&
-                stableGeneration == treeState.stableGeneration &&
-                unstableGeneration == treeState.unstableGeneration &&
+                stableGen == treeState.stableGen &&
+                unstableGen == treeState.unstableGen &&
                 rootId == treeState.rootId &&
                 rootGen == treeState.rootGen &&
                 lastId == treeState.lastId &&
@@ -292,7 +292,7 @@ class TreeState
     @Override
     public int hashCode()
     {
-        return Objects.hash( pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        return Objects.hash( pageId, stableGen, unstableGen, rootId, rootGen, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, valid );
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeStatePair.java
@@ -30,7 +30,7 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.checkOutOfBounds;
 
 /**
  * Pair of {@link TreeState}, ability to make decision about which of the two to read and write respectively,
- * depending on the {@link TreeState#isValid() validity} and {@link TreeState#stableGeneration()} of each.
+ * depending on the {@link TreeState#isValid() validity} and {@link TreeState#stableGen()} of each.
  */
 class TreeStatePair
 {
@@ -82,7 +82,7 @@ class TreeStatePair
 
     /**
      * @param states the two states to compare.
-     * @return newest (w/ regards to {@link TreeState#stableGeneration()}) {@link TreeState#isValid() valid}
+     * @return newest (w/ regards to {@link TreeState#stableGen()}) {@link TreeState#isValid() valid}
      * {@link TreeState} of the two.
      * @throws IllegalStateException if none were valid.
      */
@@ -95,7 +95,7 @@ class TreeStatePair
 
     /**
      * @param states the two states to compare.
-     * @return oldest (w/ regards to {@link TreeState#stableGeneration()}) {@link TreeState#isValid() invalid}
+     * @return oldest (w/ regards to {@link TreeState#stableGen()}) {@link TreeState#isValid() invalid}
      * {@link TreeState} of the two. If both are invalid then the {@link Pair#getLeft() first one} is returned.
      */
     static TreeState selectOldestOrInvalid( Pair<TreeState,TreeState> states )
@@ -120,15 +120,15 @@ class TreeStatePair
 
             // compare unstable generations of A/B and include sanity check for stable generations
             // such that there cannot be a state S compared to other state O where
-            // S.unstableGeneration > O.unstableGeneration AND S.stableGeneration < O.stableGeneration
+            // S.unstableGen > O.unstableGen AND S.stableGen < O.stableGen
 
-            if ( stateA.stableGeneration() >= stateB.stableGeneration() &&
-                    stateA.unstableGeneration() > stateB.unstableGeneration() )
+            if ( stateA.stableGen() >= stateB.stableGen() &&
+                    stateA.unstableGen() > stateB.unstableGen() )
             {
                 return Optional.of( stateA );
             }
-            else if ( stateA.stableGeneration() <= stateB.stableGeneration() &&
-                    stateA.unstableGeneration() < stateB.unstableGeneration() )
+            else if ( stateA.stableGen() <= stateB.stableGen() &&
+                    stateA.unstableGen() < stateB.unstableGen() )
             {
                 return Optional.of( stateB );
             }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
@@ -82,16 +82,16 @@ public class FreelistNodeTest
     public void shouldReadAndWriteFreeListEntries() throws Exception
     {
         // GIVEN
-        long generationA = 34;
+        long genA = 34;
         long pointerA = 56;
-        long generationB = 78;
+        long genB = 78;
         long pointerB = 90;
 
         // WHEN
-        freelist.write( cursor, generationA, pointerA, 0 );
-        freelist.write( cursor, generationB, pointerB, 1 );
-        long readPointerA = freelist.read( cursor, generationA + 1, 0 );
-        long readPointerB = freelist.read( cursor, generationB + 1, 1 );
+        freelist.write( cursor, genA, pointerA, 0 );
+        freelist.write( cursor, genB, pointerB, 1 );
+        long readPointerA = freelist.read( cursor, genA + 1, 0 );
+        long readPointerB = freelist.read( cursor, genB + 1, 1 );
 
         // THEN
         assertEquals( pointerA, readPointerA );
@@ -129,12 +129,12 @@ public class FreelistNodeTest
     }
 
     @Test
-    public void shouldFailOnWritingTooBigGeneration() throws Exception
+    public void shouldFailOnWritingTooBigGen() throws Exception
     {
         // WHEN
         try
         {
-            freelist.write( cursor, GenSafePointer.MAX_GENERATION + 1, 1, 0 );
+            freelist.write( cursor, GenSafePointer.MAX_GEN + 1, 1, 0 );
             fail( "Should've failed" );
         }
         catch ( IllegalArgumentException e )
@@ -147,14 +147,14 @@ public class FreelistNodeTest
     public void shouldReturnNoPageOnUnstableEntry() throws Exception
     {
         // GIVEN
-        long stableGeneration = 10;
-        long unstableGeneration = stableGeneration + 1;
+        long stableGen = 10;
+        long unstableGen = stableGen + 1;
         long pageId = 20;
         int pos = 2;
-        freelist.write( cursor, unstableGeneration, pageId, pos );
+        freelist.write( cursor, unstableGen, pageId, pos );
 
         // WHEN
-        long read = freelist.read( cursor, stableGeneration, pos );
+        long read = freelist.read( cursor, stableGen, pos );
 
         // THEN
         assertEquals( FreelistNode.NO_PAGE_ID, read );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerPairAdditionalTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerPairAdditionalTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.fail;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointer.MIN_GENERATION;
+import static org.neo4j.index.internal.gbptree.GenSafePointer.MIN_GEN;
 import static org.neo4j.index.internal.gbptree.GenSafePointerPair.MAX_GEN_OFFSET_MASK;
 import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
 import static org.neo4j.index.internal.gbptree.GenSafePointerPair.write;
@@ -38,20 +38,20 @@ public class GenSafePointerPairAdditionalTest
         int pageSize = (int) kibiBytes( 8 );
         PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( pageSize );
         cursor.next( 0 );
-        long firstGeneration = MIN_GENERATION;
-        long secondGeneration = firstGeneration + 1;
-        long thirdGeneration = secondGeneration + 1;
+        long firstGen = MIN_GEN;
+        long secondGen = firstGen + 1;
+        long thirdGen = secondGen + 1;
         int offset = 0;
         cursor.setOffset( offset );
-        write( cursor, 10, firstGeneration, secondGeneration );
+        write( cursor, 10, firstGen, secondGen );
         cursor.setOffset( offset );
-        write( cursor, 11, secondGeneration, thirdGeneration );
+        write( cursor, 11, secondGen, thirdGen );
 
         try
         {
             // WHEN
             cursor.setOffset( offset );
-            read( cursor, secondGeneration, thirdGeneration, (int) (MAX_GEN_OFFSET_MASK + 1) );
+            read( cursor, secondGen, thirdGen, (int) (MAX_GEN_OFFSET_MASK + 1) );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerPairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerPairTest.java
@@ -52,11 +52,11 @@ import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointerStateNa
 public class GenSafePointerPairTest
 {
     private static final int PAGE_SIZE = 128;
-    private static final int OLD_STABLE_GENERATION = 1;
-    private static final int STABLE_GENERATION = 2;
-    private static final int OLD_CRASH_GENERATION = 3;
-    private static final int CRASH_GENERATION = 4;
-    private static final int UNSTABLE_GENERATION = 5;
+    private static final int OLD_STABLE_GEN = 1;
+    private static final int STABLE_GEN = 2;
+    private static final int OLD_CRASH_GEN = 3;
+    private static final int CRASH_GEN = 4;
+    private static final int UNSTABLE_GEN = 5;
     private static final long EMPTY_POINTER = 0L;
 
     private static final long POINTER_A = 5;
@@ -138,7 +138,7 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long result = GenSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, pos );
+        long result = GenSafePointerPair.read( cursor, STABLE_GEN, UNSTABLE_GEN, pos );
 
         // THEN
         expectedReadOutcome.verifyRead( cursor, result, stateA, stateB, preStatePointerA, preStatePointerB, pos );
@@ -155,7 +155,7 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long result = GenSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, NO_LOGICAL_POS );
+        long result = GenSafePointerPair.read( cursor, STABLE_GEN, UNSTABLE_GEN, NO_LOGICAL_POS );
 
         // THEN
         expectedReadOutcome.verifyRead( cursor, result, stateA, stateB, preStatePointerA, preStatePointerB,
@@ -173,7 +173,7 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long written = GenSafePointerPair.write( cursor, WRITTEN_POINTER, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long written = GenSafePointerPair.write( cursor, WRITTEN_POINTER, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         expectedWriteOutcome.verifyWrite( cursor, written, stateA, stateB, preStatePointerA, preStatePointerB );
@@ -248,10 +248,10 @@ public class GenSafePointerPairTest
 
     private static long readSlot( PageCursor cursor )
     {
-        long generation = GenSafePointer.readGeneration( cursor );
+        long gen = GenSafePointer.readGen( cursor );
         long pointer = GenSafePointer.readPointer( cursor );
         short checksum = GenSafePointer.readChecksum( cursor );
-        assertEquals( GenSafePointer.checksumOf( generation, pointer ), checksum );
+        assertEquals( GenSafePointer.checksumOf( gen, pointer ), checksum );
         return pointer;
     }
 
@@ -292,10 +292,10 @@ public class GenSafePointerPairTest
             {
                 cursor.setOffset( slotA ? SLOT_A_OFFSET : SLOT_B_OFFSET );
 
-                long generation = GenSafePointer.readGeneration( cursor );
+                long gen = GenSafePointer.readGen( cursor );
                 long pointer = GenSafePointer.readPointer( cursor );
                 short checksum = GenSafePointer.readChecksum( cursor );
-                assertNotEquals( GenSafePointer.checksumOf( generation, pointer ), checksum );
+                assertNotEquals( GenSafePointer.checksumOf( gen, pointer ), checksum );
             }
         },
         OLD_CRASH( GenSafePointerPair.CRASH )
@@ -303,7 +303,7 @@ public class GenSafePointerPairTest
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, OLD_CRASH_GENERATION, pointer );
+                GenSafePointer.write( cursor, OLD_CRASH_GEN, pointer );
                 return pointer;
             }
         },
@@ -312,7 +312,7 @@ public class GenSafePointerPairTest
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, CRASH_GENERATION, pointer );
+                GenSafePointer.write( cursor, CRASH_GEN, pointer );
                 return pointer;
             }
         },
@@ -321,7 +321,7 @@ public class GenSafePointerPairTest
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, OLD_STABLE_GENERATION, pointer );
+                GenSafePointer.write( cursor, OLD_STABLE_GEN, pointer );
                 return pointer;
             }
         },
@@ -330,7 +330,7 @@ public class GenSafePointerPairTest
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, STABLE_GENERATION, pointer );
+                GenSafePointer.write( cursor, STABLE_GEN, pointer );
                 return pointer;
             }
         },
@@ -339,7 +339,7 @@ public class GenSafePointerPairTest
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, UNSTABLE_GENERATION, pointer );
+                GenSafePointer.write( cursor, UNSTABLE_GEN, pointer );
                 return pointer;
             }
         };

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenSafePointerTest.java
@@ -69,7 +69,7 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldDetectInvalidChecksumOnReadDueToChangedGeneration() throws Exception
+    public void shouldDetectInvalidChecksumOnReadDueToChangedGen() throws Exception
     {
         // GIVEN
         int offset = 0;
@@ -77,7 +77,7 @@ public class GenSafePointerTest
         write( cursor, offset, initial );
 
         // WHEN
-        cursor.putInt( offset, (int) (initial.generation + 5) );
+        cursor.putInt( offset, (int) (initial.gen + 5) );
 
         // THEN
         boolean matches = read( cursor, offset, read );
@@ -102,11 +102,11 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldWriteAndReadGspCloseToGenerationMax() throws Exception
+    public void shouldWriteAndReadGspCloseToGenMax() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION;
-        GSP expected = gsp( generation, 12345 );
+        long gen = GenSafePointer.MAX_GEN;
+        GSP expected = gsp( gen, 12345 );
         write( cursor, 0, expected );
 
         // WHEN
@@ -116,7 +116,7 @@ public class GenSafePointerTest
         // THEN
         assertTrue( matches );
         assertEquals( expected, read );
-        assertEquals( generation, read.generation );
+        assertEquals( gen, read.gen );
     }
 
     @Test
@@ -138,12 +138,12 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldWriteAndReadGspCloseToGenerationAndPointerMax() throws Exception
+    public void shouldWriteAndReadGspCloseToGenAndPointerMax() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION;
+        long gen = GenSafePointer.MAX_GEN;
         long pointer = GenSafePointer.MAX_POINTER;
-        GSP expected = gsp( generation, pointer );
+        GSP expected = gsp( gen, pointer );
         write( cursor, 0, expected );
 
         // WHEN
@@ -153,7 +153,7 @@ public class GenSafePointerTest
         // THEN
         assertTrue( matches );
         assertEquals( expected, read );
-        assertEquals( generation, read.generation );
+        assertEquals( gen, read.gen );
         assertEquals( pointer, read.pointer );
     }
 
@@ -161,9 +161,9 @@ public class GenSafePointerTest
     public void shouldThrowIfPointerToLarge() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION;
+        long gen = GenSafePointer.MIN_GEN;
         long pointer = GenSafePointer.MAX_POINTER + 1;
-        GSP broken = gsp( generation, pointer );
+        GSP broken = gsp( gen, pointer );
 
         // WHEN
         try
@@ -182,9 +182,9 @@ public class GenSafePointerTest
     public void shouldThrowIfPointerToSmall() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION;
+        long gen = GenSafePointer.MIN_GEN;
         long pointer = GenSafePointer.MIN_POINTER - 1;
-        GSP broken = gsp( generation, pointer );
+        GSP broken = gsp( gen, pointer );
 
         // WHEN
         try
@@ -200,12 +200,12 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldThrowIfGenerationToLarge() throws Exception
+    public void shouldThrowIfGenToLarge() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
+        long gen = GenSafePointer.MAX_GEN + 1;
         long pointer = GenSafePointer.MIN_POINTER;
-        GSP broken = gsp( generation, pointer );
+        GSP broken = gsp( gen, pointer );
 
         // WHEN
         try
@@ -221,12 +221,12 @@ public class GenSafePointerTest
     }
 
     @Test
-    public void shouldThrowIfGenerationToSmall() throws Exception
+    public void shouldThrowIfGenToSmall() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION - 1;
+        long gen = GenSafePointer.MIN_GEN - 1;
         long pointer = GenSafePointer.MIN_POINTER;
-        GSP broken = gsp( generation, pointer );
+        GSP broken = gsp( gen, pointer );
 
         // WHEN
         try
@@ -253,7 +253,7 @@ public class GenSafePointerTest
         short reference = 0;
         for ( int i = 0; i < count; i++ )
         {
-            gsp.generation = random.nextLong( GenSafePointer.MAX_GENERATION );
+            gsp.gen = random.nextLong( GenSafePointer.MAX_GEN );
             gsp.pointer = random.nextLong( GenSafePointer.MAX_POINTER );
             short checksum = checksumOf( gsp );
             if ( i == 0 )
@@ -271,10 +271,10 @@ public class GenSafePointerTest
         assertTrue( (double) collisions / count < 0.0001 );
     }
 
-    private GSP gsp( long generation, long pointer )
+    private GSP gsp( long gen, long pointer )
     {
         GSP gsp = new GSP();
-        gsp.generation = generation;
+        gsp.gen = gen;
         gsp.pointer = pointer;
         return gsp;
     }
@@ -282,20 +282,20 @@ public class GenSafePointerTest
     private boolean read( PageCursor cursor, int offset, GSP into )
     {
         cursor.setOffset( offset );
-        into.generation = GenSafePointer.readGeneration( cursor );
+        into.gen = GenSafePointer.readGen( cursor );
         into.pointer = GenSafePointer.readPointer( cursor );
-        return GenSafePointer.verifyChecksum( cursor, into.generation, into.pointer );
+        return GenSafePointer.verifyChecksum( cursor, into.gen, into.pointer );
     }
 
     private void write( PageCursor cursor, int offset, GSP gsp )
     {
         cursor.setOffset( offset );
-        GenSafePointer.write( cursor, gsp.generation, gsp.pointer );
+        GenSafePointer.write( cursor, gsp.gen, gsp.pointer );
     }
 
     private static short checksumOf( GSP gsp )
     {
-        return GenSafePointer.checksumOf( gsp.generation, gsp.pointer );
+        return GenSafePointer.checksumOf( gsp.gen, gsp.pointer );
     }
 
     /**
@@ -306,7 +306,7 @@ public class GenSafePointerTest
      */
     private static class GSP
     {
-        long generation; // unsigned int
+        long gen; // unsigned int
         long pointer;
 
         @Override
@@ -314,7 +314,7 @@ public class GenSafePointerTest
         {
             final int prime = 31;
             int result = 1;
-            result = prime * result + (int) (generation ^ (generation >>> 32));
+            result = prime * result + (int) (gen ^ (gen >>> 32));
             result = prime * result + (int) (pointer ^ (pointer >>> 32));
             return result;
         }
@@ -334,7 +334,7 @@ public class GenSafePointerTest
                 return false;
             }
             GSP other = (GSP) obj;
-            if ( generation != other.generation )
+            if ( gen != other.gen )
             {
                 return false;
             }
@@ -348,7 +348,7 @@ public class GenSafePointerTest
         @Override
         public String toString()
         {
-            return "[gen:" + generation + ",p:" + pointer + "]";
+            return "[gen:" + gen + ",p:" + pointer + "]";
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenTest.java
@@ -23,26 +23,26 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class GenerationTest
+public class GenTest
 {
     @Test
-    public void shouldSetLowGenerations() throws Exception
+    public void shouldSetLowGen() throws Exception
     {
-        shouldComposeAndDecomposeGeneration( GenSafePointer.MIN_GENERATION, GenSafePointer.MIN_GENERATION + 1 );
+        shouldComposeAndDecomposeGen( GenSafePointer.MIN_GEN, GenSafePointer.MIN_GEN + 1 );
     }
 
     @Test
-    public void shouldSetHighGenerations() throws Exception
+    public void shouldSetHighGen() throws Exception
     {
-        shouldComposeAndDecomposeGeneration( GenSafePointer.MAX_GENERATION - 1, GenSafePointer.MAX_GENERATION );
+        shouldComposeAndDecomposeGen( GenSafePointer.MAX_GEN - 1, GenSafePointer.MAX_GEN );
     }
 
-    private void shouldComposeAndDecomposeGeneration( long stable, long unstable )
+    private void shouldComposeAndDecomposeGen( long stable, long unstable )
     {
         // WHEN
-        long generation = Generation.generation( stable, unstable );
-        long readStable = Generation.stableGeneration( generation );
-        long readUnstable = Generation.unstableGeneration( generation );
+        long gen = Gen.gen( stable, unstable );
+        long readStable = Gen.stableGen( gen );
+        long readUnstable = Gen.unstableGen( gen );
 
         // THEN
         assertEquals( stable, readStable );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
@@ -74,7 +74,7 @@ public class InternalTreeLogicTest
     private final StructurePropagation<MutableLong> structurePropagation = new StructurePropagation<>(
             layout.newKey(), layout.newKey(), layout.newKey() );
 
-    private static long stableGen = GenSafePointer.MIN_GENERATION;
+    private static long stableGen = GenSafePointer.MIN_GEN;
     private static long unstableGen = stableGen + 1;
 
     @Parameterized.Parameters( name = "{0}" )
@@ -83,17 +83,17 @@ public class InternalTreeLogicTest
         List<Object[]> parameters = new ArrayList<>();
         // Initial state has same generation as update state
         parameters.add( new Object[]{
-                "NoCheckpoint", GenerationManager.NO_OP_GEN, false} );
+                "NoCheckpoint", GenManager.NO_OP_GEN, false} );
         // Update state in next generation
         parameters.add( new Object[]{
-                "Checkpoint", GenerationManager.DEFAULT, true} );
+                "Checkpoint", GenManager.DEFAULT, true} );
         return parameters;
     }
 
     @Parameterized.Parameter( 0 )
     public String name;
     @Parameterized.Parameter( 1 )
-    public GenerationManager generationManager;
+    public GenManager genManager;
     @Parameterized.Parameter( 2 )
     public boolean isCheckpointing;
 
@@ -125,7 +125,7 @@ public class InternalTreeLogicTest
         assertThat( keyCount(), is( 0 ) );
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( key, value );
 
         // then
@@ -140,7 +140,7 @@ public class InternalTreeLogicTest
     {
         // given
         initialize();
-        generationManager.checkpoint();
+        genManager.checkpoint();
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // when
@@ -159,7 +159,7 @@ public class InternalTreeLogicTest
     {
         // given
         initialize();
-        generationManager.checkpoint();
+        genManager.checkpoint();
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // when
@@ -177,7 +177,7 @@ public class InternalTreeLogicTest
     {
         // given
         initialize();
-        generationManager.checkpoint();
+        genManager.checkpoint();
         for ( int i = 0; i < maxKeyCount; i++ )
         {
             // when
@@ -202,7 +202,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long middle = maxKeyCount;
         insert( middle, middle );
 
@@ -224,7 +224,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( key, key );
 
         // then
@@ -244,7 +244,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( 0L, 0L );
 
         // then
@@ -265,7 +265,7 @@ public class InternalTreeLogicTest
         }
 
         // First split
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( someLargeNumber - i, i );
         i++;
 
@@ -306,7 +306,7 @@ public class InternalTreeLogicTest
         insert( key, value );
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( key, readValue );
 
         // then
@@ -325,7 +325,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( 0, readValue );
 
         // then
@@ -349,7 +349,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( middle, readValue );
 
         // then
@@ -373,7 +373,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( maxKeyCount - 1, readValue );
 
         // then
@@ -396,7 +396,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         goTo( readCursor, structurePropagation.midChild );
         assertThat( keyAt( 0 ), is( 0L ) );
         remove( 0, readValue );
@@ -427,7 +427,7 @@ public class InternalTreeLogicTest
         assertThat( keyAt( 0 ), is( keyToRemove ) );
 
         // and we remove it
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( keyToRemove, readValue );
 
         // then we should still find it in internal
@@ -453,7 +453,7 @@ public class InternalTreeLogicTest
         }
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         assertNull( remove( maxKeyCount, readValue ) );
 
         // then
@@ -487,7 +487,7 @@ public class InternalTreeLogicTest
         assertThat( keyAt( 0 ), is( keyToRemove ) );
 
         // and we remove it
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( keyToRemove, readValue ); // Possibly create new gen of right child
         goTo( readCursor, rootId );
         currentRightChild = childAt( readCursor, 1, stableGen, unstableGen );
@@ -581,7 +581,7 @@ public class InternalTreeLogicTest
 
         // when
         // ... after checkpoint
-        generationManager.checkpoint();
+        genManager.checkpoint();
 
         // ... removing keys from right child until rebalance is triggered
         int index = 0;
@@ -640,7 +640,7 @@ public class InternalTreeLogicTest
         assertSiblings( oldLeftChild, oldMiddleChild, oldRightChild );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long middleKey = keyAt( 0 ) + 1; // Should be located in middle leaf
         remove( middleKey, insertValue );
         allKeys.remove( middleKey );
@@ -706,7 +706,7 @@ public class InternalTreeLogicTest
         assertSiblings( oldLeftChild, oldMiddleChild, oldRightChild );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long keyInLeftChild = keyAt( 0 ) - 1; // Should be located in left leaf
         remove( keyInLeftChild, insertValue );
         allKeys.remove( keyInLeftChild );
@@ -789,7 +789,7 @@ public class InternalTreeLogicTest
         long keyInOldRight = keyAt( 0 );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( keyInOldRight, readValue );
         allKeysInOldLeftAndOldRight.remove( keyInOldRight );
 
@@ -827,7 +827,7 @@ public class InternalTreeLogicTest
 
         // WHEN
         // removing all keys but one
-        generationManager.checkpoint();
+        genManager.checkpoint();
         for ( int j = 0; j < allKeys.size() - 1; j++ )
         {
             remove( allKeys.get( j ), readValue );
@@ -852,7 +852,7 @@ public class InternalTreeLogicTest
             insert( random.nextLong(), random.nextLong() );
             if ( i == numberOfEntries / 2 )
             {
-                generationManager.checkpoint();
+                genManager.checkpoint();
             }
         }
 
@@ -875,7 +875,7 @@ public class InternalTreeLogicTest
         insert( key, firstValue );
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long secondValue = random.nextLong();
         insert( key, secondValue, ValueMergers.overwrite() );
 
@@ -899,7 +899,7 @@ public class InternalTreeLogicTest
         assertThat( actual, is( firstValue ) );
 
         // when
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long secondValue = random.nextLong();
         insert( key, secondValue, ValueMergers.keepExisting() );
 
@@ -920,7 +920,7 @@ public class InternalTreeLogicTest
         insert( key, baseValue );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         int toAdd = 5;
         insert( key, toAdd, ADDER );
 
@@ -945,7 +945,7 @@ public class InternalTreeLogicTest
         }
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long key = 1;
         int toAdd = 5;
         insert( key, toAdd, ADDER );
@@ -971,7 +971,7 @@ public class InternalTreeLogicTest
         }
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long key = structurePropagation.rightKey.longValue();
         int toAdd = 5;
         insert( key, toAdd, ADDER );
@@ -1004,7 +1004,7 @@ public class InternalTreeLogicTest
         }
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long key = firstSplitPrimKey + 1;
         int toAdd = 5;
         insert( key, toAdd, ADDER );
@@ -1033,7 +1033,7 @@ public class InternalTreeLogicTest
         long oldGenId = cursor.getCurrentPageId();
 
         // WHEN root -[newGen]-> newGen root
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( 1L, 1L );
         long newGenId = cursor.getCurrentPageId();
 
@@ -1062,7 +1062,7 @@ public class InternalTreeLogicTest
         long oldGenId = cursor.getCurrentPageId();
 
         // WHEN root -[newGen]-> newGen root
-        generationManager.checkpoint();
+        genManager.checkpoint();
         remove( key, readValue );
         long newGenId = cursor.getCurrentPageId();
 
@@ -1103,7 +1103,7 @@ public class InternalTreeLogicTest
         assertSiblings( leftChild, middleChild, rightChild );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long middleKey = i / 2; // Should be located in middle leaf
         long newValue = middleKey * 100;
         insert( middleKey, newValue );
@@ -1163,7 +1163,7 @@ public class InternalTreeLogicTest
         assertSiblings( leftChild, middleChild, rightChild );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long middleKey = i / 2; // Should be located in middle leaf
         remove( middleKey, insertValue );
 
@@ -1221,7 +1221,7 @@ public class InternalTreeLogicTest
         //                  /      |                \
         //                 v       v                 v
         //               left <-> right(newGen) <--> farRight
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( i, i );
         assertEquals( 1, numberOfRootNewGens );
         goTo( readCursor, rootId );
@@ -1264,7 +1264,7 @@ public class InternalTreeLogicTest
         long firstKeyInLeaf = keyAt( 0 );
 
         // WHEN
-        generationManager.checkpoint();
+        genManager.checkpoint();
         long targetLastId = id.lastId() + 3; /*one for newGen in leaf, one for split leaf, one for newGen in internal*/
         for ( int i = 0; id.lastId() < targetLastId; i++ )
         {
@@ -1297,13 +1297,13 @@ public class InternalTreeLogicTest
         assumeTrue( isCheckpointing );
         initialize();
         long originalNodeId = rootId;
-        generationManager.checkpoint();
+        genManager.checkpoint();
         insert( 1L, 10L ); // TX1 will create heir
         assertEquals( 1, numberOfRootNewGens );
 
         // WHEN
         // recovery happens
-        generationManager.recovery();
+        genManager.recovery();
         // start up on stable root
         goTo( cursor, originalNodeId );
         treeLogic.initialize( cursor );
@@ -1592,13 +1592,13 @@ public class InternalTreeLogicTest
         return result;
     }
 
-    private interface GenerationManager
+    private interface GenManager
     {
         void checkpoint();
 
         void recovery();
 
-        GenerationManager NO_OP_GEN = new GenerationManager()
+        GenManager NO_OP_GEN = new GenManager()
         {
             @Override
             public void checkpoint()
@@ -1613,7 +1613,7 @@ public class InternalTreeLogicTest
             }
         };
 
-        GenerationManager DEFAULT = new GenerationManager()
+        GenManager DEFAULT = new GenManager()
         {
             @Override
             public void checkpoint()

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeySearchTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/KeySearchTest.java
@@ -35,8 +35,8 @@ import static org.neo4j.index.internal.gbptree.KeySearch.search;
 
 public class KeySearchTest
 {
-    private static final int STABLE_GENERATION = 1;
-    private static final int UNSTABLE_GENERATION = 2;
+    private static final int STABLE_GEN = 1;
+    private static final int UNSTABLE_GEN = 2;
 
     private static final int KEY_COUNT = 10;
     private static final int PAGE_SIZE = 512;
@@ -55,7 +55,7 @@ public class KeySearchTest
     public void searchEmptyLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         int keyCount = node.keyCount( cursor );
 
         // then
@@ -67,7 +67,7 @@ public class KeySearchTest
     public void searchEmptyInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         int keyCount = node.keyCount( cursor );
 
         // then
@@ -79,7 +79,7 @@ public class KeySearchTest
     public void searchNoHitLessThanWithOneKeyInLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( 1L );
 
         // then
@@ -91,7 +91,7 @@ public class KeySearchTest
     public void searchNoHitLessThanWithOneKeyInInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( 1L );
 
         // then
@@ -104,7 +104,7 @@ public class KeySearchTest
     {
         // given
         long key = 1L;
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( key );
 
         // then
@@ -117,7 +117,7 @@ public class KeySearchTest
     {
         // given
         long key = 1L;
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( key );
 
         // then
@@ -129,7 +129,7 @@ public class KeySearchTest
     public void searchNoHitGreaterThanWithOneKeyInLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( 1L );
 
         // then
@@ -141,7 +141,7 @@ public class KeySearchTest
     public void searchNoHitGreaterThanWithOneKeyInInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         appendKey( 1L );
 
         // then
@@ -153,7 +153,7 @@ public class KeySearchTest
     public void searchNoHitGreaterThanWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -168,7 +168,7 @@ public class KeySearchTest
     public void searchNoHitGreaterThanWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -183,7 +183,7 @@ public class KeySearchTest
     public void searchHitOnLastWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -198,7 +198,7 @@ public class KeySearchTest
     public void searchHitOnLastWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -213,7 +213,7 @@ public class KeySearchTest
     public void searchHitOnFirstWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -228,7 +228,7 @@ public class KeySearchTest
     public void searchHitOnFirstWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -243,7 +243,7 @@ public class KeySearchTest
     public void searchNoHitLessThanWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i + 1 );
@@ -258,7 +258,7 @@ public class KeySearchTest
     public void searchNoHitLessThanWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i + 1 );
@@ -273,7 +273,7 @@ public class KeySearchTest
     public void searchHitOnMiddleWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -289,7 +289,7 @@ public class KeySearchTest
     public void searchHitOnMiddleWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i );
@@ -305,7 +305,7 @@ public class KeySearchTest
     public void searchNoHitInMiddleWithFullLeaf() throws Exception
     {
         // given
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i * 2 );
@@ -321,7 +321,7 @@ public class KeySearchTest
     public void searchNoHitInMiddleWithFullInternal() throws Exception
     {
         // given
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             appendKey( i * 2 );
@@ -339,7 +339,7 @@ public class KeySearchTest
         // given
         long first = 1L;
         long second = 2L;
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             long key = i < KEY_COUNT / 2 ? first : second;
@@ -357,7 +357,7 @@ public class KeySearchTest
         // given
         long first = 1L;
         long second = 2L;
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             long key = i < KEY_COUNT / 2 ? first : second;
@@ -376,7 +376,7 @@ public class KeySearchTest
         long first = 1L;
         long second = 2L;
         int middle = KEY_COUNT / 2;
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             long key = i < middle ? first : second;
@@ -395,7 +395,7 @@ public class KeySearchTest
         long first = 1L;
         long second = 2L;
         int middle = KEY_COUNT / 2;
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
         for ( int i = 0; i < KEY_COUNT; i++ )
         {
             long key = i < middle ? first : second;
@@ -449,7 +449,7 @@ public class KeySearchTest
     public void shouldSearchAndFindOnRandomData() throws Exception
     {
         // GIVEN a leaf node with random, although sorted (as of course it must be to binary-search), data
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         int internalMaxKeyCount = node.internalMaxKeyCount();
         int half = internalMaxKeyCount / 2;
         int keyCount = random.nextInt( half ) + half;
@@ -524,7 +524,7 @@ public class KeySearchTest
     private void fullLeafWithUniqueKeys()
     {
         // [2,4,8,16,32,64,128,512,1024,2048]
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong key = layout.newKey();
         for ( int i = 0; i < KEY_COUNT; i++ )
         {

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
@@ -33,9 +33,9 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
 public class PointerCheckingTest
 {
     private final PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
-    private final long firstGeneration = 1;
-    private final long secondGeneration = 2;
-    private final long thirdGeneration = 3;
+    private final long firstGen = 1;
+    private final long secondGen = 2;
+    private final long thirdGen = 3;
 
     @Test
     public void checkChildShouldThrowOnNoNode() throws Exception
@@ -74,14 +74,14 @@ public class PointerCheckingTest
     public void checkChildShouldThrowOnWriteFailure() throws Exception
     {
         // GIVEN
-        write( cursor, 123, 0, firstGeneration );
+        write( cursor, 123, 0, firstGen );
         cursor.rewind();
-        write( cursor, 456, firstGeneration, secondGeneration );
+        write( cursor, 456, firstGen, secondGen );
         cursor.rewind();
 
         // WHEN
         // This write will see first and second written pointers and think they belong to CRASHed generation
-        long result = write( cursor, 789, 0, thirdGeneration );
+        long result = write( cursor, 789, 0, thirdGen );
         try
         {
             PointerChecking.checkPointer( result, false );
@@ -97,11 +97,11 @@ public class PointerCheckingTest
     public void checkChildShouldPassOnReadSuccess() throws Exception
     {
         // GIVEN
-        PointerChecking.checkPointer( write( cursor, 123, 0, firstGeneration ), false );
+        PointerChecking.checkPointer( write( cursor, 123, 0, firstGen ), false );
         cursor.rewind();
 
         // WHEN
-        long result = read( cursor, 0, firstGeneration, 456 );
+        long result = read( cursor, 0, firstGen, 456 );
 
         // THEN
         PointerChecking.checkPointer( result, false );
@@ -111,7 +111,7 @@ public class PointerCheckingTest
     public void checkChildShouldPassOnWriteSuccess() throws Exception
     {
         // WHEN
-        long result = write( cursor, 123, 0, firstGeneration );
+        long result = write( cursor, 123, 0, firstGen );
 
         // THEN
         PointerChecking.checkPointer( result, false );
@@ -121,11 +121,11 @@ public class PointerCheckingTest
     public void checkSiblingShouldPassOnReadSuccessForNoNodePointer() throws Exception
     {
         // GIVEN
-        write( cursor, TreeNode.NO_NODE_FLAG, firstGeneration, secondGeneration );
+        write( cursor, TreeNode.NO_NODE_FLAG, firstGen, secondGen );
         cursor.rewind();
 
         // WHEN
-        long result = read( cursor, firstGeneration, secondGeneration, NO_LOGICAL_POS );
+        long result = read( cursor, firstGen, secondGen, NO_LOGICAL_POS );
 
         // THEN
         PointerChecking.checkPointer( result, true );
@@ -136,11 +136,11 @@ public class PointerCheckingTest
     {
         // GIVEN
         long pointer = 101;
-        write( cursor, pointer, firstGeneration, secondGeneration );
+        write( cursor, pointer, firstGen, secondGen );
         cursor.rewind();
 
         // WHEN
-        long result = read( cursor, firstGeneration, secondGeneration, NO_LOGICAL_POS );
+        long result = read( cursor, firstGen, secondGen, NO_LOGICAL_POS );
 
         // THEN
         PointerChecking.checkPointer( result, true );
@@ -150,7 +150,7 @@ public class PointerCheckingTest
     public void checkSiblingShouldThrowOnReadFailure() throws Exception
     {
         // WHEN
-        long result = read( cursor, firstGeneration, secondGeneration, NO_LOGICAL_POS );
+        long result = read( cursor, firstGen, secondGen, NO_LOGICAL_POS );
 
         // WHEN
         try
@@ -168,17 +168,17 @@ public class PointerCheckingTest
     public void checkSiblingShouldThrowOnReadIllegalPointer() throws Exception
     {
         // GIVEN
-        long generation = IdSpace.STATE_PAGE_A;
-        long pointer = this.secondGeneration;
+        long gen = IdSpace.STATE_PAGE_A;
+        long pointer = this.secondGen;
 
         // Can not use GenSafePointer.write because it will fail on pointer assertion.
         cursor.putInt( (int) pointer );
-        put6BLong( cursor, generation );
-        cursor.putShort( GenSafePointer.checksumOf( generation, pointer ) );
+        put6BLong( cursor, gen );
+        cursor.putShort( GenSafePointer.checksumOf( gen, pointer ) );
         cursor.rewind();
 
         // WHEN
-        long result = read( cursor, firstGeneration, pointer, NO_LOGICAL_POS );
+        long result = read( cursor, firstGen, pointer, NO_LOGICAL_POS );
 
         // WHEN
         try

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -49,12 +49,12 @@ import static org.neo4j.index.internal.gbptree.ValueMergers.overwrite;
 public class SeekCursorTest
 {
     private static final int PAGE_SIZE = 256;
-    private static final LongSupplier generationSupplier = new LongSupplier()
+    private static final LongSupplier genSupplier = new LongSupplier()
     {
         @Override
         public long getAsLong()
         {
-            return Generation.generation( stableGen, unstableGen );
+            return Gen.gen( stableGen, unstableGen );
         }
     };
     private static final Supplier<Root> failingRootCatchup = () ->
@@ -79,7 +79,7 @@ public class SeekCursorTest
     private final MutableLong from = layout.newKey();
     private final MutableLong to = layout.newKey();
 
-    private static long stableGen = GenSafePointer.MIN_GENERATION;
+    private static long stableGen = GenSafePointer.MIN_GEN;
     private static long unstableGen = stableGen + 1;
 
     private long rootId;
@@ -1834,7 +1834,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldCatchupRootWhenRootNodeHasTooNewGeneration() throws Exception
+    public void shouldCatchupRootWhenRootNodeHasTooNewGen() throws Exception
     {
         // given
         long id = cursor.getCurrentPageId();
@@ -1848,7 +1848,7 @@ public class SeekCursorTest
 
         // when
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen, unstableGen, generationSupplier, rootCatchup, gen - 1 ) )
+                stableGen, unstableGen, genSupplier, rootCatchup, gen - 1 ) )
         {
             // do nothing
         }
@@ -1858,7 +1858,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldCatchupRootWhenNodeHasTooNewGenerationWhileTraversingDownTree() throws Exception
+    public void shouldCatchupRootWhenNodeHasTooNewGenWhileTraversingDownTree() throws Exception
     {
         // given
         long gen = node.gen( cursor );
@@ -1904,7 +1904,7 @@ public class SeekCursorTest
         from.setValue( 1L );
         to.setValue( 2L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen, unstableGen, generationSupplier, rootCatchup, unstableGen ) )
+                stableGen, unstableGen, genSupplier, rootCatchup, unstableGen ) )
         {
             // do nothing
         }
@@ -1914,7 +1914,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldCatchupRootWhenNodeHasTooNewGenerationWhileTraversingLeaves() throws Exception
+    public void shouldCatchupRootWhenNodeHasTooNewGenWhileTraversingLeaves() throws Exception
     {
         // given
         MutableBoolean triggered = new MutableBoolean( false );
@@ -1959,7 +1959,7 @@ public class SeekCursorTest
         from.setValue( 1L );
         to.setValue( 20L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen - 1, unstableGen - 1, generationSupplier, rootCatchup, unstableGen ) )
+                stableGen - 1, unstableGen - 1, genSupplier, rootCatchup, unstableGen ) )
         {
             while ( seek.next() )
             {
@@ -2159,7 +2159,7 @@ public class SeekCursorTest
     {
         from.setValue( fromInclusive );
         to.setValue( toExclusive );
-        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGen, unstableGen, generationSupplier,
+        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGen, unstableGen, genSupplier,
                 failingRootCatchup, unstableGen );
     }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleIdProvider.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleIdProvider.java
@@ -35,12 +35,12 @@ class SimpleIdProvider implements IdProvider
     }
 
     @Override
-    public long acquireNewId( long stableGeneration, long unstableGeneration )
+    public long acquireNewId( long stableGen, long unstableGen )
     {
         if ( !releasedIds.isEmpty() )
         {
             Pair<Long,Long> free = releasedIds.peek();
-            if ( free.getLeft() <= stableGeneration )
+            if ( free.getLeft() <= stableGen )
             {
                 releasedIds.poll();
                 return free.getRight();
@@ -51,9 +51,9 @@ class SimpleIdProvider implements IdProvider
     }
 
     @Override
-    public void releaseId( long stableGeneration, long unstableGeneration, long id )
+    public void releaseId( long stableGen, long unstableGen, long id )
     {
-        releasedIds.add( Pair.of( unstableGeneration, id ) );
+        releasedIds.add( Pair.of( unstableGen, id ) );
     }
 
     long lastId()

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
@@ -40,10 +40,10 @@ import static org.neo4j.index.internal.gbptree.TreeNode.NO_NODE_FLAG;
 
 public class TreeNodeTest
 {
-    private static final int STABLE_GENERATION = 1;
-    private static final int CRASH_GENERATION = 2;
-    private static final int UNSTABLE_GENERATION = 3;
-    private static final int HIGH_GENERATION = 4;
+    private static final int STABLE_GEN = 1;
+    private static final int CRASH_GEN = 2;
+    private static final int UNSTABLE_GEN = 3;
+    private static final int HIGH_GEN = 4;
 
     private static final int PAGE_SIZE = 512;
     private final PageCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
@@ -64,60 +64,60 @@ public class TreeNodeTest
     public void shouldInitializeLeaf() throws Exception
     {
         // WHEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         assertEquals( TreeNode.NODE_TYPE_TREE_NODE, node.nodeType( cursor ) );
         assertTrue( node.isLeaf( cursor ) );
         assertFalse( node.isInternal( cursor ) );
-        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
+        assertEquals( UNSTABLE_GEN, node.gen( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
-        assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( NO_NODE_FLAG, newGen( cursor, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
     public void shouldInitializeInternal() throws Exception
     {
         // WHEN
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         assertEquals( TreeNode.NODE_TYPE_TREE_NODE, node.nodeType( cursor ) );
         assertFalse( node.isLeaf( cursor ) );
         assertTrue( node.isInternal( cursor ) );
-        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
+        assertEquals( UNSTABLE_GEN, node.gen( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
-        assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( NO_NODE_FLAG, newGen( cursor, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
     public void shouldWriteAndReadMaxGen() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
-        node.setGen( cursor, GenSafePointer.MAX_GENERATION );
+        node.setGen( cursor, GenSafePointer.MAX_GEN );
 
         // THEN
         long gen = node.gen( cursor );
-        assertEquals( GenSafePointer.MAX_GENERATION, gen );
+        assertEquals( GenSafePointer.MAX_GEN, gen );
     }
 
     @Test
     public void shouldThrowIfWriteTooLargeGen() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         try
         {
-            node.setGen( cursor, GenSafePointer.MAX_GENERATION + 1 );
+            node.setGen( cursor, GenSafePointer.MAX_GEN + 1 );
             fail( "Expected throw" );
         }
         catch ( IllegalArgumentException e )
@@ -130,12 +130,12 @@ public class TreeNodeTest
     public void shouldThrowIfWriteTooSmallGen() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         try
         {
-            node.setGen( cursor, GenSafePointer.MIN_GENERATION - 1 );
+            node.setGen( cursor, GenSafePointer.MIN_GEN - 1 );
             fail( "Expected throw" );
         }
         catch ( IllegalArgumentException e )
@@ -167,7 +167,7 @@ public class TreeNodeTest
     public void shouldSetAndGetKeyInLeaf() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         shouldSetAndGetKey();
@@ -177,7 +177,7 @@ public class TreeNodeTest
     public void shouldSetAndGetKeyInInternal() throws Exception
     {
         // GIVEN
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         shouldSetAndGetKey();
@@ -209,7 +209,7 @@ public class TreeNodeTest
     public void shouldRemoveKeyInLeaf() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         shouldRemoveKey();
@@ -219,7 +219,7 @@ public class TreeNodeTest
     public void shouldRemoveKeyInInternal() throws Exception
     {
         // GIVEN
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         shouldRemoveKey();
@@ -229,7 +229,7 @@ public class TreeNodeTest
     public void shouldSetAndGetValue() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong value = layout.newKey();
 
         // WHEN
@@ -250,7 +250,7 @@ public class TreeNodeTest
     public void shouldRemoveValue() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong value = layout.newKey();
         long firstValue = 123456789;
         value.setValue( firstValue );
@@ -274,7 +274,7 @@ public class TreeNodeTest
     public void shouldOverwriteValue() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong value = layout.newValue();
         value.setValue( 1 );
         node.insertValueAt( cursor, value, 0, 0 );
@@ -292,18 +292,18 @@ public class TreeNodeTest
     public void shouldSetAndGetChild() throws Exception
     {
         // GIVEN
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
         long firstChild = 123456789;
-        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GEN, UNSTABLE_GEN );
 
         long otherChild = 987654321;
-        node.insertChildAt( cursor, otherChild, 1, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, otherChild, 1, 1, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
-        assertEquals( firstChild, childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( otherChild, childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( firstChild, childAt( cursor, 0, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( otherChild, childAt( cursor, 1, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
@@ -311,22 +311,22 @@ public class TreeNodeTest
     {
         // GIVEN
         long child = GenSafePointer.MIN_POINTER;
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, child, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
+        node.insertChildAt( cursor, child, 0, 0, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
         long overwrittenChild = child + 1;
-        node.setChildAt( cursor, overwrittenChild, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setChildAt( cursor, overwrittenChild, 0, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
-        assertEquals( overwrittenChild, childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( overwrittenChild, childAt( cursor, 0, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
     public void shouldSetAndGetKeyCount() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         assertEquals( 0, node.keyCount( cursor ) );
 
         // WHEN
@@ -341,35 +341,35 @@ public class TreeNodeTest
     public void shouldSetAndGetSiblings() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
-        node.setLeftSibling( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setRightSibling( cursor, 456, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setLeftSibling( cursor, 123, STABLE_GEN, UNSTABLE_GEN );
+        node.setRightSibling( cursor, 456, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
-        assertEquals( 123, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( 456, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( 123, leftSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( 456, rightSibling( cursor, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
     public void shouldSetAndNewGen() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
-        node.setNewGen( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setNewGen( cursor, 123, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
-        assertEquals( 123, newGen( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( 123, newGen( cursor, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
     public void shouldReadAndInsertKeys() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong key = layout.newKey();
         key.setValue( 1 );
         node.insertKeyAt( cursor, key, 0, 0 );
@@ -390,7 +390,7 @@ public class TreeNodeTest
     public void shouldReadAndInsertValues() throws Exception
     {
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         MutableLong value = layout.newKey();
         value.setValue( 1 );
         node.insertValueAt( cursor, value, 0, 0 );
@@ -414,17 +414,17 @@ public class TreeNodeTest
         long firstChild = GenSafePointer.MIN_POINTER;
         long secondChild = firstChild + 1;
         long thirdChild = secondChild + 1;
-        node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.insertChildAt( cursor, thirdChild, 1, 1, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeInternal( cursor, STABLE_GEN, UNSTABLE_GEN );
+        node.insertChildAt( cursor, firstChild, 0, 0, STABLE_GEN, UNSTABLE_GEN );
+        node.insertChildAt( cursor, thirdChild, 1, 1, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
-        node.insertChildAt( cursor, secondChild, 1, 2, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.insertChildAt( cursor, secondChild, 1, 2, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
-        assertEquals( firstChild, childAt( cursor, 0, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( secondChild, childAt( cursor, 1, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( thirdChild, childAt( cursor, 2, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( firstChild, childAt( cursor, 0, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( secondChild, childAt( cursor, 1, STABLE_GEN, UNSTABLE_GEN ) );
+        assertEquals( thirdChild, childAt( cursor, 2, STABLE_GEN, UNSTABLE_GEN ) );
     }
 
     @Test
@@ -433,7 +433,7 @@ public class TreeNodeTest
         // This test doesn't care about sorting, that's an aspect that lies outside of TreeNode, really
 
         // GIVEN
-        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.initializeLeaf( cursor, STABLE_GEN, UNSTABLE_GEN );
         int maxKeyCount = node.leafMaxKeyCount();
         // add +1 to these to simplify some array logic in the test itself
         long[] expectedKeys = new long[maxKeyCount + 1];
@@ -520,12 +520,12 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromAbsoluteOffsetSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long gen = UNSTABLE_GEN;
         long pointer = 12;
-        node.setRightSibling( cursor, pointer, STABLE_GENERATION, gen );
+        node.setRightSibling( cursor, pointer, STABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.rightSibling( cursor, STABLE_GENERATION, gen );
+        long readResult = node.rightSibling( cursor, STABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -538,14 +538,14 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromAbsoluteOffsetSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long gen = HIGH_GEN;
         long oldPointer = 12;
         long pointer = 123;
-        node.setRightSibling( cursor, oldPointer, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setRightSibling( cursor, pointer, UNSTABLE_GENERATION, gen );
+        node.setRightSibling( cursor, oldPointer, STABLE_GEN, UNSTABLE_GEN );
+        node.setRightSibling( cursor, pointer, UNSTABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.rightSibling( cursor, UNSTABLE_GENERATION, gen );
+        long readResult = node.rightSibling( cursor, UNSTABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -558,13 +558,13 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromLogicalPosSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long gen = UNSTABLE_GEN;
         long pointer = 12;
         int childPos = 2;
-        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, STABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, gen );
+        long readResult = node.childAt( cursor, childPos, STABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -577,13 +577,13 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromLogicalPosZeroSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long gen = UNSTABLE_GEN;
         long pointer = 12;
         int childPos = 0;
-        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, STABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, gen );
+        long readResult = node.childAt( cursor, childPos, STABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -596,15 +596,15 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromLogicalPosZeroSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long gen = HIGH_GEN;
         long oldPointer = 13;
         long pointer = 12;
         int childPos = 0;
-        node.setChildAt( cursor, oldPointer, childPos, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, gen );
+        node.setChildAt( cursor, oldPointer, childPos, STABLE_GEN, UNSTABLE_GEN );
+        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, gen );
+        long readResult = node.childAt( cursor, childPos, UNSTABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -617,15 +617,15 @@ public class TreeNodeTest
     public void shouldReadPointerGenFromLogicalPosSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long gen = HIGH_GEN;
         long oldPointer = 12;
         long pointer = 123;
         int childPos = 2;
-        node.setChildAt( cursor, oldPointer, childPos, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, gen );
+        node.setChildAt( cursor, oldPointer, childPos, STABLE_GEN, UNSTABLE_GEN );
+        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GEN, gen );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, gen );
+        long readResult = node.childAt( cursor, childPos, UNSTABLE_GEN, gen );
         long readGen = node.pointerGen( cursor, readResult );
 
         // THEN
@@ -638,7 +638,7 @@ public class TreeNodeTest
     public void shouldThrowIfReadingPointerGenOnWriteResult() throws Exception
     {
         // GIVEN
-        long writeResult = GenSafePointerPair.write( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long writeResult = GenSafePointerPair.write( cursor, 123, STABLE_GEN, UNSTABLE_GEN );
 
         try
         {
@@ -676,10 +676,10 @@ public class TreeNodeTest
         // GIVEN
         long child = 101;
         int pos = 3;
-        node.setChildAt( cursor, child, pos, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setChildAt( cursor, child, pos, STABLE_GEN, UNSTABLE_GEN );
 
         // WHEN
-        long result = node.childAt( cursor, pos, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long result = node.childAt( cursor, pos, STABLE_GEN, UNSTABLE_GEN );
 
         // THEN
         assertTrue( GenSafePointerPair.isLogicalPos( result ) );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
@@ -146,7 +146,7 @@ public class TreeStatePairTest
                 cursor.putLong( cursor.getOffset(), ~someOfTheBits );
             }
         },
-        VALID // stableGeneration:5 and unstableGeneration:6
+        VALID // stableGen:5 and unstableGen:6
         {
             @Override
             void write( PageCursor cursor ) throws IOException
@@ -154,7 +154,7 @@ public class TreeStatePairTest
                 TreeState.write( cursor, 5, 6, 7, 8, 9, 10, 11, 12, 13 );
             }
         },
-        CRASH_VALID // stableGeneration:5 and unstableGeneration:7, i.e. crashed from VALID state
+        CRASH_VALID // stableGen:5 and unstableGen:7, i.e. crashed from VALID state
         {
             @Override
             void write( PageCursor cursor ) throws IOException
@@ -162,7 +162,7 @@ public class TreeStatePairTest
                 TreeState.write( cursor, 5, 7, 7, 8, 9, 10, 11, 12, 13 );
             }
         },
-        WIDE_VALID // stableGeneration:4 and unstableGeneration:8, i.e. crashed but wider gap between generations
+        WIDE_VALID // stableGen:4 and unstableGen:8, i.e. crashed but wider gap between generations
         {
             @Override
             void write( PageCursor cursor ) throws IOException
@@ -170,7 +170,7 @@ public class TreeStatePairTest
                 TreeState.write( cursor, 4, 8, 9, 10, 11, 12, 13, 14, 15 );
             }
         },
-        OLD_VALID // stableGeneration:2 and unstableGeneration:3
+        OLD_VALID // stableGen:2 and unstableGen:3
         {
             @Override
             void write( PageCursor cursor ) throws IOException

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
@@ -90,16 +90,16 @@ public class TreeStateTest
     }
 
     @Test
-    public void shouldNotWriteInvalidStableGeneration() throws Exception
+    public void shouldNotWriteInvalidStableGen() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
+        long gen = GenSafePointer.MAX_GEN + 1;
 
         // WHEN
         try
         {
             long pageId = cursor.getCurrentPageId();
-            write( cursor, new TreeState( pageId, generation, 2, 3, 4, 5, 6, 7, 8, 9, true ) );
+            write( cursor, new TreeState( pageId, gen, 2, 3, 4, 5, 6, 7, 8, 9, true ) );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )
@@ -109,16 +109,16 @@ public class TreeStateTest
     }
 
     @Test
-    public void shouldNotWriteInvalidUnstableGeneration() throws Exception
+    public void shouldNotWriteInvalidUnstableGen() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
+        long gen = GenSafePointer.MAX_GEN + 1;
 
         // WHEN
         try
         {
             long pageId = cursor.getCurrentPageId();
-            write( cursor, new TreeState( pageId, 1, generation, 3, 4, 5, 6, 7, 8, 9, true ) );
+            write( cursor, new TreeState( pageId, 1, gen, 3, 4, 5, 6, 7, 8, 9, true ) );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )
@@ -138,8 +138,8 @@ public class TreeStateTest
     private void write( PageCursor cursor, TreeState origin )
     {
         TreeState.write( cursor,
-                origin.stableGeneration(),
-                origin.unstableGeneration(),
+                origin.stableGen(),
+                origin.unstableGen(),
                 origin.rootId(),
                 origin.rootGen(),
                 origin.lastId(),


### PR DESCRIPTION
In code, be consistent with using 'gen' instead of 'generation'.
In comments, use 'generation'