### PR TITLE
Tell user that consistency check is running

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -32,6 +32,10 @@ import static java.lang.String.format;
 
 public class AdminTool
 {
+
+    static final int STATUS_SUCCESS = 0;
+    public static final int STATUS_ERROR = 1;
+
     public static void main( String[] args ) throws IOException
     {
         Path homeDir = Paths.get( System.getenv().getOrDefault( "NEO4J_HOME", "" ) );
@@ -159,7 +163,7 @@ public class AdminTool
 
     private void failure( String message, Exception e )
     {
-        failure( message, e, 1 );
+        failure( message, e, STATUS_ERROR );
     }
 
     private void failure( String message, Exception e, int code )
@@ -179,6 +183,6 @@ public class AdminTool
 
     private void success()
     {
-        outsideWorld.exit( 0 );
+        outsideWorld.exit( STATUS_SUCCESS );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -149,7 +149,7 @@ public class AdminTool
 
     private void commandFailed( CommandFailed e )
     {
-        failure( "command failed", e );
+        failure( "command failed", e, e.code() );
     }
 
     private void failure()
@@ -159,17 +159,22 @@ public class AdminTool
 
     private void failure( String message, Exception e )
     {
+        failure( message, e, 1 );
+    }
+
+    private void failure( String message, Exception e, int code )
+    {
         if ( debug )
         {
             outsideWorld.printStacktrace( e );
         }
-        failure( format( "%s: %s", message, e.getMessage() ) );
+        failure( format( "%s: %s", message, e.getMessage() ), code );
     }
 
-    private void failure( String message )
+    private void failure( String message, int code )
     {
         outsideWorld.stdErrLine( message );
-        outsideWorld.exit( 1 );
+        outsideWorld.exit( code );
     }
 
     private void success()

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandFailed.java
@@ -21,18 +21,32 @@ package org.neo4j.commandline.admin;
 
 public class CommandFailed extends Exception
 {
-    public CommandFailed( String message, Exception cause )
+    private final int code;
+
+    public CommandFailed( String message, Throwable cause, int code )
     {
         super( message, cause );
+        this.code = code;
     }
 
-    public CommandFailed( Throwable cause )
+    public CommandFailed( String message, Throwable cause )
     {
-        super( cause );
+        this( message, cause, 1 );
     }
 
     public CommandFailed( String message )
     {
+        this( message, 1 );
+    }
+
+    public CommandFailed( String message, int code )
+    {
         super( message );
+        this.code = code;
+    }
+
+    public int code()
+    {
+        return code;
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminToolTest.java
@@ -38,6 +38,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.neo4j.commandline.admin.AdminTool.STATUS_ERROR;
+import static org.neo4j.commandline.admin.AdminTool.STATUS_SUCCESS;
 
 public class AdminToolTest
 {
@@ -56,7 +58,7 @@ public class AdminToolTest
         OutsideWorld outsideWorld = mock( OutsideWorld.class );
         new AdminTool( new CannedLocator( new NullCommandProvider() ), new NullBlockerLocator(), outsideWorld, false )
                 .execute( null, null, "null" );
-        verify( outsideWorld ).exit( 0 );
+        verify( outsideWorld ).exit( STATUS_SUCCESS );
     }
 
     @Test
@@ -75,7 +77,7 @@ public class AdminToolTest
         new AdminTool( new NullCommandLocator(), new NullBlockerLocator(), outsideWorld, false ).execute( null, null );
         verify( outsideWorld ).stdErrLine( "you must provide a command" );
         verify( outsideWorld ).stdErrLine( "usage: neo4j-admin <command>" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -89,7 +91,7 @@ public class AdminToolTest
         new AdminTool( cannedCommand( "exception", command ), new NullBlockerLocator(), outsideWorld, false )
                 .execute( null, null, "exception" );
         verify( outsideWorld ).stdErrLine( "unexpected error: the-exception-message" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -131,7 +133,7 @@ public class AdminToolTest
         new AdminTool( cannedCommand( "exception", command ), new NullBlockerLocator(), outsideWorld, false )
                 .execute( null, null, "exception" );
         verify( outsideWorld ).stdErrLine( "command failed: the-failure-message" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -174,7 +176,7 @@ public class AdminToolTest
                 .execute( null, null, "exception" );
         InOrder inOrder = inOrder( outsideWorld );
         inOrder.verify( outsideWorld ).stdErrLine( "the-usage-message" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -195,7 +197,7 @@ public class AdminToolTest
                 .execute( null, null, "command" );
 
         verify( outsideWorld ).stdErrLine( "command failed: the explanation" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -220,7 +222,7 @@ public class AdminToolTest
                 .execute( null, null, "command" );
 
         verify( outsideWorld ).stdErrLine( "command failed: trueBlocker explanation" );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     @Test
@@ -253,7 +255,7 @@ public class AdminToolTest
         verifyNoMoreInteractions( command );
         verify( outsideWorld ).stdErrLine( "unknown argument: --help" );
         verify( outsideWorld ).stdErrLine( "usage: neo4j-admin command " );
-        verify( outsideWorld ).exit( 1 );
+        verify( outsideWorld ).exit( STATUS_ERROR );
     }
 
     private CannedLocator cannedCommand( final String name, AdminCommand command )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -85,6 +85,8 @@ public class OnlineBackupCommand implements AdminCommand
         return arguments;
     }
 
+    static final int STATUS_CC_ERROR = 2;
+    static final int STATUS_CC_INCONSISTENT = 3;
     static final int MAX_OLD_BACKUPS = 1000;
     private final BackupService backupService;
     private final Path homeDir;
@@ -249,7 +251,7 @@ public class OnlineBackupCommand implements AdminCommand
                 if ( !ccResult.isSuccessful() )
                 {
                     throw new CommandFailed( String.format( "Inconsistencies found. See '%s' for details.",
-                            ccResult.reportFile() ), 3 );
+                            ccResult.reportFile() ), STATUS_CC_INCONSISTENT );
                 }
             }
             catch ( Throwable e )
@@ -258,7 +260,8 @@ public class OnlineBackupCommand implements AdminCommand
                 {
                     throw (CommandFailed) e;
                 }
-                throw new CommandFailed( "Failed to do consistency check on backup: " + e.getMessage(), e, 2 );
+                throw new CommandFailed( "Failed to do consistency check on backup: " + e.getMessage(), e,
+                        STATUS_CC_ERROR );
             }
         }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -236,6 +236,7 @@ public class OnlineBackupCommand implements AdminCommand
         {
             try
             {
+                outsideWorld.stdOutLine( "Doing consistency check..." );
                 ConsistencyCheckService.Result ccResult = consistencyCheckService
                         .runFullConsistencyCheck( destination, config,
                                 ProgressMonitorFactory.textual( outsideWorld.errorStream() ),

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -249,12 +249,16 @@ public class OnlineBackupCommand implements AdminCommand
                 if ( !ccResult.isSuccessful() )
                 {
                     throw new CommandFailed( String.format( "Inconsistencies found. See '%s' for details.",
-                            ccResult.reportFile() ) );
+                            ccResult.reportFile() ), 3 );
                 }
             }
-            catch ( Exception e )
+            catch ( Throwable e )
             {
-                throw new CommandFailed( "Failed to do consistency check on backup: " + e.getMessage(), e );
+                if ( e instanceof CommandFailed )
+                {
+                    throw (CommandFailed) e;
+                }
+                throw new CommandFailed( "Failed to do consistency check on backup: " + e.getMessage(), e, 2 );
             }
         }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -276,6 +276,7 @@ public class OnlineBackupCommandTest
 
         verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
         verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verify( outsideWorld ).stdOutLine( "Backup complete." );
         verifyNoMoreInteractions( backupService );
     }
@@ -290,6 +291,7 @@ public class OnlineBackupCommandTest
 
         verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
         verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verifyNoMoreInteractions( backupService );
     }
 
@@ -304,6 +306,7 @@ public class OnlineBackupCommandTest
 
         verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
         verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
+        verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verifyNoMoreInteractions( backupService );
     }
 
@@ -328,6 +331,7 @@ public class OnlineBackupCommandTest
         verify( mockFs ).renameFile( eq( dir ), eq( testDirectory.directory( "ccInc.err.1" ) ) );
         verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
         verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verifyNoMoreInteractions( backupService );
     }
 
@@ -389,6 +393,7 @@ public class OnlineBackupCommandTest
         verify( outsideWorld ).stdErrLine( "Old backup renamed to 'ccInc.err.50'." );
         verify( backupService ).doFullBackup( any(), anyInt(), any(), any(), any(), anyLong(), anyBoolean() );
         verify( outsideWorld ).stdOutLine( "Doing full backup..." );
+        verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verifyNoMoreInteractions( backupService );
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -68,6 +68,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.backup.OnlineBackupCommand.MAX_OLD_BACKUPS;
+import static org.neo4j.backup.OnlineBackupCommand.STATUS_CC_ERROR;
+import static org.neo4j.backup.OnlineBackupCommand.STATUS_CC_INCONSISTENT;
+import static org.neo4j.commandline.admin.AdminTool.STATUS_ERROR;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cypher_planner;
 
 public class OnlineBackupCommandTest
@@ -172,7 +175,7 @@ public class OnlineBackupCommandTest
         final String path = path( "/Idontexist/sasdfasdfa" );
         expected.expect( CommandFailed.class );
         expected.expectMessage( "Directory '" + path + "' does not exist." );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
         execute( backupDir( path ), "--name=mybackup" );
     }
 
@@ -255,7 +258,7 @@ public class OnlineBackupCommandTest
 
         expected.expect( CommandFailed.class );
         expected.expectMessage( "Inconsistencies found. See '" + path + "' for details." );
-        expected.expect( exitCode( 3 ) );
+        expected.expect( exitCode( STATUS_CC_INCONSISTENT ) );
         execute( "--check-consistency=true", backupDir(), "--name=mybackup" );
     }
 
@@ -269,7 +272,7 @@ public class OnlineBackupCommandTest
 
         expected.expect( CommandFailed.class );
         expected.expectMessage( "Failed to do consistency check on backup: craassh" );
-        expected.expect( exitCode( 2 ) );
+        expected.expect( exitCode( STATUS_CC_ERROR ) );
         execute( "--check-consistency=true", backupDir(), "--name=mybackup" );
     }
 
@@ -370,7 +373,7 @@ public class OnlineBackupCommandTest
 
         expected.expectMessage( "Failed to move old backup out of the way: kaboom" );
         expected.expect( CommandFailed.class );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
 
         execute( "--cc-report-dir=" + dir.getParent(), backupDir( dir.getParent() ),
                 "--name=" + dir.getName() );
@@ -424,7 +427,7 @@ public class OnlineBackupCommandTest
 
         expected.expectMessage( "Backup failed: nah-ah" );
         expected.expect( CommandFailed.class );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
 
         execute( "--fallback-to-full=false", backupDir( dir.getParent() ), "--name=" + dir.getName() );
     }
@@ -474,7 +477,7 @@ public class OnlineBackupCommandTest
 
         expected.expect( CommandFailed.class );
         expected.expectMessage( "ailed to move old backup out of the way: too many old backups." );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
         execute( "--cc-report-dir=" + dir.getParent(), backupDir( dir.getParent() ), "--name=" + dir.getName() );
     }
 
@@ -504,7 +507,7 @@ public class OnlineBackupCommandTest
 
         expected.expect( CommandFailed.class );
         expected.expectMessage( "Backup failed: nope" );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
         execute( backupDir( dir.getParent() ), "--name=" + dir.getName() );
     }
 
@@ -523,7 +526,7 @@ public class OnlineBackupCommandTest
         final String path = path( "/aalivnmoimzlckmvPDK" );
         expected.expect( CommandFailed.class );
         expected.expectMessage( "Directory '" + path + "' does not exist." );
-        expected.expect( exitCode( 1 ) );
+        expected.expect( exitCode( STATUS_ERROR ) );
         execute( "--check-consistency", backupDir(), "--name=mybackup",
                 "--cc-report-dir=" + path );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -103,13 +103,9 @@ public class UnbindFromClusterCommand implements AdminCommand
         {
             throw new IncorrectUsage( e.getMessage() );
         }
-        catch ( UnbindFailureException | CannotWriteException | IOException e )
+        catch ( UnbindFailureException | CannotWriteException | IOException | ClusterStateException e )
         {
-            throw new CommandFailed( "Unbind failed: " + e.getMessage(), e );
-        }
-        catch ( ClusterStateException e )
-        {
-            throw new CommandFailed( e );
+            throw new CommandFailed( e.getMessage(), e );
         }
     }
 


### PR DESCRIPTION
changelog: `neo4j-admin backup` now reports different error codes:
- code `1`: backup failed to run
- code `2`: backup succeeded but consistency check failed to run
- code `3`: backup succeeded but consistency check found inconsistencies