### PR TITLE
align and improve heartbeat response handling

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Candidate.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Candidate.java
@@ -103,12 +103,13 @@ class Candidate implements RaftMessageHandler
 
                 if ( isQuorum( ctx.votingMembers().size(), outcome.getVotesForMe().size() ) )
                 {
-
                     outcome.setLeader( ctx.myself() );
                     Appending.appendNewEntry( ctx, outcome, new NewLeaderBarrier() );
+                    Leader.sendHeartbeats( ctx, outcome );
 
                     outcome.setLastLogIndexBeforeWeBecameLeader( ctx.entryLog().appendIndex() );
                     outcome.electedLeader();
+                    outcome.renewElectionTimeout();
                     outcome.setNextRole( LEADER );
                     log.info( "Moving to LEADER state at term %d (I am %s), voted for by %s",
                             ctx.term(), ctx.myself(), outcome.getVotesForMe() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
@@ -53,6 +53,7 @@ public class RaftState implements ReadableRaftState
 
     private MemberId leader;
     private Set<MemberId> votesForMe = new HashSet<>();
+    private Set<MemberId> heartbeatResponses = new HashSet<>();
     private FollowerStates<MemberId> followerStates = new FollowerStates<>();
     private long leaderCommit = -1;
     private long commitIndex = -1;
@@ -141,6 +142,12 @@ public class RaftState implements ReadableRaftState
     }
 
     @Override
+    public Set<MemberId> heartbeatResponses()
+    {
+        return heartbeatResponses;
+    }
+
+    @Override
     public long lastLogIndexBeforeWeBecameLeader()
     {
         return lastLogIndexBeforeWeBecameLeader;
@@ -180,6 +187,7 @@ public class RaftState implements ReadableRaftState
 
         leaderCommit = outcome.getLeaderCommit();
         votesForMe = outcome.getVotesForMe();
+        heartbeatResponses = outcome.getHeartbeatResponses();
         lastLogIndexBeforeWeBecameLeader = outcome.getLastLogIndexBeforeWeBecameLeader();
         followerStates = outcome.getFollowerStates();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
@@ -43,6 +43,8 @@ public interface ReadableRaftState
 
     Set<MemberId> votesForMe();
 
+    Set<MemberId> heartbeatResponses();
+
     long lastLogIndexBeforeWeBecameLeader();
 
     FollowerStates<MemberId> followerStates();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
@@ -42,21 +42,22 @@ import static java.lang.String.format;
 public class ComparableRaftState implements ReadableRaftState
 {
     protected final MemberId myself;
-    private final Set votingMembers;
-    private final Set replicationMembers;
+    private final Set<MemberId> votingMembers;
+    private final Set<MemberId> replicationMembers;
     private final Log log;
     protected long term = 0;
     protected MemberId leader;
     private long leaderCommit = -1;
     private MemberId votedFor = null;
-    private Set votesForMe = new HashSet<>();
+    private Set<MemberId> votesForMe = new HashSet<>();
+    private Set<MemberId> heartbeatResponses = new HashSet<>();
     private long lastLogIndexBeforeWeBecameLeader = -1;
-    private FollowerStates followerStates = new FollowerStates<>();
+    private FollowerStates<MemberId> followerStates = new FollowerStates<>();
     protected final RaftLog entryLog;
     private final InFlightMap<RaftLogEntry> inFlightMap;
     private long commitIndex = -1;
 
-    ComparableRaftState( MemberId myself, Set votingMembers, Set replicationMembers,
+    ComparableRaftState( MemberId myself, Set<MemberId> votingMembers, Set<MemberId> replicationMembers,
                          RaftLog entryLog, InFlightMap<RaftLogEntry> inFlightMap, LogProvider logProvider )
     {
         this.myself = myself;
@@ -67,7 +68,7 @@ public class ComparableRaftState implements ReadableRaftState
         this.log = logProvider.getLog( getClass() );
     }
 
-    public ComparableRaftState( ReadableRaftState original ) throws IOException
+    ComparableRaftState( ReadableRaftState original ) throws IOException
     {
         this( original.myself(), original.votingMembers(), original.replicationMembers(),
                 new ComparableRaftLog( original.entryLog() ), new InFlightMap<>(), NullLogProvider.getInstance() );
@@ -80,13 +81,13 @@ public class ComparableRaftState implements ReadableRaftState
     }
 
     @Override
-    public Set votingMembers()
+    public Set<MemberId> votingMembers()
     {
         return votingMembers;
     }
 
     @Override
-    public Set replicationMembers()
+    public Set<MemberId> replicationMembers()
     {
         return replicationMembers;
     }
@@ -116,9 +117,15 @@ public class ComparableRaftState implements ReadableRaftState
     }
 
     @Override
-    public Set votesForMe()
+    public Set<MemberId> votesForMe()
     {
         return votesForMe;
+    }
+
+    @Override
+    public Set<MemberId> heartbeatResponses()
+    {
+        return heartbeatResponses;
     }
 
     @Override
@@ -128,7 +135,7 @@ public class ComparableRaftState implements ReadableRaftState
     }
 
     @Override
-    public FollowerStates followerStates()
+    public FollowerStates<MemberId> followerStates()
     {
         return followerStates;
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -43,6 +42,7 @@ import org.neo4j.causalclustering.core.consensus.roles.follower.FollowerState;
 import org.neo4j.causalclustering.core.consensus.roles.follower.FollowerStates;
 import org.neo4j.causalclustering.core.consensus.term.TermState;
 import org.neo4j.causalclustering.core.consensus.vote.VoteState;
+import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Collections.emptySet;
@@ -78,8 +78,8 @@ public class RaftStateTest
         }};
 
         Outcome raftTestMemberOutcome =
-                new Outcome( CANDIDATE, 0, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true,
-                        logCommands, emptyOutgoingMessages(), Collections.emptySet(), -1 );
+                new Outcome( CANDIDATE, 0, null, -1, null, emptySet(), -1, initialFollowerStates(), true,
+                        logCommands, emptyOutgoingMessages(), emptySet(), -1, emptySet() );
 
         //when
         raftState.update(raftTestMemberOutcome);
@@ -102,12 +102,12 @@ public class RaftStateTest
                 new InMemoryStateStorage<>( new VoteState( ) ),
                 new InFlightMap<>(), NullLogProvider.getInstance() );
 
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), Collections.emptySet(), -1) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
 
         // when
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, new FollowerStates<>(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), Collections.emptySet(), -1) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, new FollowerStates<>(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
 
         // then
         assertEquals( 0, raftState.followerStates().size() );
@@ -118,7 +118,7 @@ public class RaftStateTest
         return new ArrayList<>();
     }
 
-    private FollowerStates initialFollowerStates()
+    private FollowerStates<MemberId> initialFollowerStates()
     {
         return new FollowerStates<>( new FollowerStates<>(), member( 1 ), new FollowerState() );
     }
@@ -131,13 +131,13 @@ public class RaftStateTest
     private class FakeMembership implements RaftMembership
     {
         @Override
-        public Set votingMembers()
+        public Set<MemberId> votingMembers()
         {
             return emptySet();
         }
 
         @Override
-        public Set replicationMembers()
+        public Set<MemberId> replicationMembers()
         {
             return emptySet();
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/identity/RaftTestMember.java
@@ -29,11 +29,6 @@ public class RaftTestMember
 
     public static MemberId member( int id )
     {
-        MemberId member = testMembers.get( id );
-        if ( member == null ) {
-            member = new MemberId( UUID.randomUUID() );
-            testMembers.put( id, member );
-        }
-        return member;
+        return testMembers.computeIfAbsent( id, k -> new MemberId( UUID.randomUUID() ) );
     }
 }


### PR DESCRIPTION
The heartbeat responses were not handled using the state/outcome pattern
used for all other core logic, this has been addressed.

The election timer is now also reset when becoming a leader and
heartbeats are immediately sent out as well.