### PR TITLE
Check for repeated properties in composite indexes and constraints

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -298,6 +298,8 @@ public interface Status
     enum Schema implements Status
     {
         // client errors
+        RepeatedPropertyInCompositeSchema( ClientError,
+                "Unable to create composite index or constraint because a property was specified in several positions." ),
         ConstraintAlreadyExists( ClientError,
                 "Unable to perform operation because it would clash with a pre-existing constraint." ),
         ConstraintNotFound( ClientError,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
@@ -40,7 +41,7 @@ public interface SchemaWriteOperations
      * @param schemaDescriptor
      */
     NewIndexDescriptor indexCreate( LabelSchemaDescriptor schemaDescriptor )
-            throws AlreadyIndexedException, AlreadyConstrainedException;
+            throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException;
 
     /** Drops a {@link NewIndexDescriptor} from the database */
     void indexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
@@ -52,14 +53,17 @@ public interface SchemaWriteOperations
     void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     NodeExistenceConstraintDescriptor nodePropertyExistenceConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException;
+            throws CreateConstraintFailureException, AlreadyConstrainedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     RelExistenceConstraintDescriptor relationshipPropertyExistenceConstraintCreate(
-            RelationTypeSchemaDescriptor relationshipPropertyDescriptor ) throws
-            CreateConstraintFailureException, AlreadyConstrainedException;
+            RelationTypeSchemaDescriptor relationshipPropertyDescriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     void constraintDrop( ConstraintDescriptor constraint ) throws DropConstraintFailureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RepeatedPropertyInCompositeSchemaException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RepeatedPropertyInCompositeSchemaException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
+
+public class RepeatedPropertyInCompositeSchemaException extends SchemaKernelException
+{
+    private final SchemaDescriptor schema;
+    private final OperationContext context;
+
+    public RepeatedPropertyInCompositeSchemaException( SchemaDescriptor schema, OperationContext context )
+    {
+        super( Status.Schema.RepeatedPropertyInCompositeSchema, format(
+                schema, context, SchemaUtil.idTokenNameLookup ) );
+        this.schema = schema;
+        this.context = context;
+    }
+
+    @Override
+    public String getUserMessage( TokenNameLookup tokenNameLookup )
+    {
+        return format( schema, context, tokenNameLookup );
+    }
+
+    private static String format(
+            SchemaDescriptor schema, OperationContext context, TokenNameLookup tokenNameLookup )
+    {
+        String schemaName;
+        switch ( context )
+        {
+        case INDEX_CREATION:
+            schemaName = "Index";
+            break;
+
+        case CONSTRAINT_CREATION:
+            schemaName = "Constraint";
+            break;
+
+        default:
+            schemaName = "Schema object";
+            break;
+        }
+        return String.format( "%s on %s includes a property more than once.",
+                schemaName, schema.userDescription( tokenNameLookup ) );
+
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.exceptions.schema.UnableToValidateConstraintException;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -539,7 +540,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public NewIndexDescriptor indexCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyIndexedException, AlreadyConstrainedException
+            throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException
     {
         return schemaWriteOperations.indexCreate( state, descriptor );
     }
@@ -558,7 +559,8 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         return schemaWriteOperations.uniquePropertyConstraintCreate( state, descriptor );
     }
@@ -567,7 +569,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     public NodeExistenceConstraintDescriptor nodePropertyExistenceConstraintCreate(
                 KernelStatement state,
                 LabelSchemaDescriptor descriptor
-    ) throws AlreadyConstrainedException, CreateConstraintFailureException
+    ) throws AlreadyConstrainedException, CreateConstraintFailureException, RepeatedPropertyInCompositeSchemaException
     {
         Iterator<Cursor<NodeItem>> nodes = new NodeLoadingIterator( nodesGetForLabel( state, descriptor.getLabelId() ),
                 ( id ) -> nodeCursorById( state, id ) );
@@ -580,7 +582,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     public RelExistenceConstraintDescriptor relationshipPropertyExistenceConstraintCreate(
                 KernelStatement state,
                 RelationTypeSchemaDescriptor descriptor
-    ) throws AlreadyConstrainedException, CreateConstraintFailureException
+    ) throws AlreadyConstrainedException, CreateConstraintFailureException, RepeatedPropertyInCompositeSchemaException
     {
         try ( Cursor<RelationshipItem> cursor = relationshipCursorGetAll( state ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -127,7 +128,7 @@ public class LockingStatementOperations implements
 
     @Override
     public NewIndexDescriptor indexCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyIndexedException, AlreadyConstrainedException
+            throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();
@@ -345,7 +346,8 @@ public class LockingStatementOperations implements
 
     @Override
     public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state,LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();
@@ -354,7 +356,8 @@ public class LockingStatementOperations implements
 
     @Override
     public NodeExistenceConstraintDescriptor nodePropertyExistenceConstraintCreate( KernelStatement state,
-            LabelSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException
+            LabelSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException,
+            RepeatedPropertyInCompositeSchemaException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();
@@ -363,7 +366,9 @@ public class LockingStatementOperations implements
 
     @Override
     public RelExistenceConstraintDescriptor relationshipPropertyExistenceConstraintCreate( KernelStatement state,
-            RelationTypeSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException
+            RelationTypeSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException,
+            RepeatedPropertyInCompositeSchemaException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.InternalIndexState;
@@ -989,7 +990,7 @@ public class OperationsFacade
     // <SchemaWrite>
     @Override
     public NewIndexDescriptor indexCreate( LabelSchemaDescriptor descriptor )
-            throws AlreadyIndexedException, AlreadyConstrainedException
+            throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException
     {
         statement.assertOpen();
         return schemaWrite().indexCreate( statement, descriptor );
@@ -1004,7 +1005,8 @@ public class OperationsFacade
 
     @Override
     public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         statement.assertOpen();
         return schemaWrite().uniquePropertyConstraintCreate( statement, descriptor );
@@ -1012,7 +1014,8 @@ public class OperationsFacade
 
     @Override
     public NodeExistenceConstraintDescriptor nodePropertyExistenceConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         statement.assertOpen();
         return schemaWrite().nodePropertyExistenceConstraintCreate( statement, descriptor );
@@ -1021,7 +1024,8 @@ public class OperationsFacade
     @Override
     public RelExistenceConstraintDescriptor relationshipPropertyExistenceConstraintCreate(
             RelationTypeSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         statement.assertOpen();
         return schemaWrite().relationshipPropertyExistenceConstraintCreate( statement, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
@@ -40,7 +41,7 @@ public interface SchemaWriteOperations
      * {@code labelId}.
      */
     NewIndexDescriptor indexCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyIndexedException, AlreadyConstrainedException;
+            throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException;
 
     /** Drops a {@link NewIndexDescriptor} from the database */
     void indexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
@@ -52,13 +53,17 @@ public interface SchemaWriteOperations
     void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException;
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     NodeExistenceConstraintDescriptor nodePropertyExistenceConstraintCreate( KernelStatement state,
-            LabelSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException;
+            LabelSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException,
+            RepeatedPropertyInCompositeSchemaException;
 
     RelExistenceConstraintDescriptor relationshipPropertyExistenceConstraintCreate( KernelStatement state,
-            RelationTypeSchemaDescriptor descriptor ) throws AlreadyConstrainedException, CreateConstraintFailureException;
+            RelationTypeSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException,
+            RepeatedPropertyInCompositeSchemaException;
 
     void constraintDrop( KernelStatement state, ConstraintDescriptor constraint ) throws DropConstraintFailureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -59,11 +59,11 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.schema.NodeMultiPropertyDescriptor;
-import org.neo4j.kernel.api.schema.NodePropertyDescriptor;
 import org.neo4j.kernel.api.schema.RelationshipPropertyDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
@@ -429,7 +429,7 @@ public class SchemaImpl implements Schema
                     statement.schemaWriteOperations().indexCreate( descriptor );
                     return indexDefinition;
                 }
-                catch ( AlreadyIndexedException | AlreadyConstrainedException e )
+                catch ( AlreadyIndexedException | AlreadyConstrainedException | RepeatedPropertyInCompositeSchemaException e )
                 {
                     throw new ConstraintViolationException(
                             e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
@@ -490,7 +490,8 @@ public class SchemaImpl implements Schema
                             SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
                     return new UniquenessConstraintDefinition( this, indexDefinition );
                 }
-                catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException e )
+                catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException |
+                        RepeatedPropertyInCompositeSchemaException e )
                 {
                     throw new ConstraintViolationException(
                             e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
@@ -524,7 +525,8 @@ public class SchemaImpl implements Schema
                                     SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
                     return new NodePropertyExistenceConstraintDefinition( this, label, propertyKeys );
                 }
-                catch ( AlreadyConstrainedException | CreateConstraintFailureException e )
+                catch ( AlreadyConstrainedException | CreateConstraintFailureException |
+                        RepeatedPropertyInCompositeSchemaException e )
                 {
                     throw new ConstraintViolationException(
                             e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
@@ -558,7 +560,8 @@ public class SchemaImpl implements Schema
                             SchemaDescriptorFactory.forRelType( typeId, propertyKeyId ) );
                     return new RelationshipPropertyExistenceConstraintDefinition( this, type, propertyKey );
                 }
-                catch ( AlreadyConstrainedException | CreateConstraintFailureException e )
+                catch ( AlreadyConstrainedException | CreateConstraintFailureException |
+                        RepeatedPropertyInCompositeSchemaException e )
                 {
                     throw new ConstraintViolationException(
                             e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );


### PR DESCRIPTION
changelog: Creating composite indexes or constraints where the same property occurs in more than one position is no longer allowed