### PR TITLE
NODE KEY constraint as syntactic sugar over uniqueness and existence

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/IndexDescriptor.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/IndexDescriptor.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, PropertyKeyId}
 object IndexDescriptor {
   def apply(label: Int, property: Int): IndexDescriptor = IndexDescriptor(LabelId(label), Seq(PropertyKeyId(property)))
 
-  def apply(label: Int, properties: Seq[Int]): IndexDescriptor = IndexDescriptor(LabelId(label), properties.toSeq.map(PropertyKeyId))
+  def apply(label: Int, properties: Seq[Int]): IndexDescriptor = IndexDescriptor(LabelId(label), properties.map(PropertyKeyId))
 
   def apply(label: LabelId, property: PropertyKeyId): IndexDescriptor = IndexDescriptor(label, Seq(property))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/QueryTagger.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/QueryTagger.scala
@@ -290,6 +290,7 @@ object QueryTagger extends QueryTagger[String] {
     lift[ASTNode] {
       case x: CreateIndex => Set(CreateIndexTag)
       case x: DropIndex => Set(DropIndexTag)
+      case x: CreateNodeKeyConstraint => Set(CreateConstraintTag)
       case x: CreateUniquePropertyConstraint => Set(CreateConstraintTag)
       case x: CreateNodePropertyExistenceConstraint => Set(CreateConstraintTag)
       case x: CreateRelationshipPropertyExistenceConstraint => Set(CreateConstraintTag)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -52,15 +52,19 @@ case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[CompilerContex
           context.notificationLogger.notifications, context.typeConverter.asPublicType))
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case CreateUniquePropertyConstraint(node, label, prop) =>
+      // CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
+      case CreateUniquePropertyConstraint(node, label, props) =>
         Some(PureSideEffectExecutionPlan("CreateUniqueConstraint", SCHEMA_WRITE, (ctx) => {
-          ctx.createUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyToId(ctx)(prop.propertyKey)))
+          val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey))
+          ctx.createUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyKeyIds))
         }))
 
       // DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case DropUniquePropertyConstraint(_, label, prop) =>
+      // DROP CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
+      case DropUniquePropertyConstraint(_, label, props) =>
         Some(PureSideEffectExecutionPlan("DropUniqueConstraint", SCHEMA_WRITE, (ctx) => {
-          ctx.dropUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyToId(ctx)(prop.propertyKey)))
+          val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey))
+          ctx.dropUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyKeyIds))
         }))
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
@@ -111,6 +111,12 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   override def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V =
     singleDbHit(inner.getOrCreateFromSchemaState(key, creator))
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean =
+    singleDbHit(inner.createNodeKeyConstraint(descriptor))
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    singleDbHit(inner.dropNodeKeyConstraint(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean =
     singleDbHit(inner.createUniqueConstraint(descriptor))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
@@ -102,6 +102,11 @@ trait QueryContext extends TokenContext {
   def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V
 
   /* return true if the constraint was created, false if preexisting, throws if failed */
+  def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean
+
+  def dropNodeKeyConstraint(descriptor: IndexDescriptor)
+
+  /* return true if the constraint was created, false if preexisting, throws if failed */
   def createUniqueConstraint(descriptor: IndexDescriptor): Boolean
 
   def dropUniqueConstraint(descriptor: IndexDescriptor)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
@@ -44,6 +44,8 @@ trait QueryContextAdaptation {
 
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = ???
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = ???
+
   override def getOrCreateRelTypeId(relTypeName: String): Int = ???
 
   override def getPropertiesForRelationship(relId: Long): scala.Iterator[Int] = ???
@@ -79,6 +81,8 @@ trait QueryContextAdaptation {
   override def getLabelsForNode(node: Long): scala.Iterator[Int] = ???
 
   override def dropUniqueConstraint(descriptor: IndexDescriptor): Unit = ???
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor): Unit = ???
 
   // Check if a runtime value is a node, relationship, path or some such value returned from
   override def isGraphKernelResultValue(v: Any): Boolean = ???

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
@@ -111,6 +111,12 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V =
     translateException(inner.getOrCreateFromSchemaState(key, creator))
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean =
+    translateException(inner.createNodeKeyConstraint(descriptor))
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    translateException(inner.dropNodeKeyConstraint(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean =
     translateException(inner.createUniqueConstraint(descriptor))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -489,7 +489,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   }
 
   override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
-    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.uniqueForSchema(descriptor))
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.nodeKeyForSchema(descriptor))
 
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = try {
     transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(descriptor)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -481,6 +481,16 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def dropIndexRule(descriptor: IndexDescriptor) =
     transactionalContext.statement.schemaWriteOperations().indexDrop(descriptor)
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = try {
+    transactionalContext.statement.schemaWriteOperations().nodeKeyConstraintCreate(descriptor)
+    true
+  } catch {
+    case existing: AlreadyConstrainedException => false
+  }
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.uniqueForSchema(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = try {
     transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(descriptor)
     true

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Command.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Command.scala
@@ -89,6 +89,10 @@ trait RelationshipPropertyConstraintCommand extends PropertyConstraintCommand {
   def relType: RelTypeName
 }
 
+case class CreateNodeKeyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
+
+case class DropNodeKeyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
+
 case class CreateUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
 
 case class DropUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Command.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Command.scala
@@ -32,11 +32,13 @@ trait Command extends Parser
   def Command: Rule1[ast.Command] = rule(
     CreateUniqueConstraint
       | CreateUniqueCompositeConstraint
+      | CreateNodeKeyConstraint
       | CreateNodePropertyExistenceConstraint
       | CreateRelationshipPropertyExistenceConstraint
       | CreateIndex
       | DropUniqueConstraint
       | DropUniqueCompositeConstraint
+      | DropNodeKeyConstraint
       | DropNodePropertyExistenceConstraint
       | DropRelationshipPropertyExistenceConstraint
       | DropIndex
@@ -63,6 +65,10 @@ trait Command extends Parser
     group(keyword("CREATE") ~~ UniqueCompositeConstraintSyntax) ~~>> (ast.CreateUniquePropertyConstraint(_, _, _))
   }
 
+  def CreateNodeKeyConstraint: Rule1[ast.CreateNodeKeyConstraint] = rule {
+    group(keyword("CREATE") ~~ NodeKeyConstraintSyntax) ~~>> (ast.CreateNodeKeyConstraint(_, _, _))
+  }
+
   def CreateNodePropertyExistenceConstraint: Rule1[ast.CreateNodePropertyExistenceConstraint] = rule {
     group(keyword("CREATE") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.CreateNodePropertyExistenceConstraint(_, _, _))
   }
@@ -80,6 +86,10 @@ trait Command extends Parser
     group(keyword("DROP") ~~ UniqueCompositeConstraintSyntax) ~~>> (ast.DropUniquePropertyConstraint(_, _, _))
   }
 
+  def DropNodeKeyConstraint: Rule1[ast.DropNodeKeyConstraint] = rule {
+    group(keyword("DROP") ~~ NodeKeyConstraintSyntax) ~~>> (ast.DropNodeKeyConstraint(_, _, _))
+  }
+
   def DropNodePropertyExistenceConstraint: Rule1[ast.DropNodePropertyExistenceConstraint] = rule {
     group(keyword("DROP") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.DropNodePropertyExistenceConstraint(_, _, _))
   }
@@ -93,6 +103,9 @@ trait Command extends Parser
       zeroOrMore(Expression, separator = CommaSep) ~~ ")"
     ) ~~> (_.toIndexedSeq))
   }
+
+  private def NodeKeyConstraintSyntax: Rule3[Variable, LabelName, Seq[Property]] = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+    keyword("ASSERT") ~~ "(" ~~ PropertyExpressions ~~ ")" ~~ keyword("IS NODE KEY")
 
   private def UniqueConstraintSyntax: Rule3[Variable, LabelName, Property] = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Expressions.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Expressions.scala
@@ -180,7 +180,7 @@ trait Expressions extends Parser
     Expression1 ~ oneOrMore(WS ~ PropertyLookup)
   }
 
-  private def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {
+  def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {
     operator(".") ~~ (PropertyKeyName ~~>> (ast.Property(_: ast.Expression, _)))
   }
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
@@ -28,5 +28,6 @@ public enum ConstraintType
     UNIQUENESS,
     NODE_PROPERTY_EXISTENCE,
     RELATIONSHIP_PROPERTY_EXISTENCE,
+    NODE_KEY
     ;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -51,6 +52,10 @@ public interface SchemaWriteOperations
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
+
+    NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( LabelSchemaDescriptor descriptor )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api.constraints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
 
@@ -35,18 +34,6 @@ public class NodePropertyExistenceConstraint extends NodePropertyConstraint
     public NodePropertyExistenceConstraint( LabelSchemaDescriptor descriptor )
     {
         super( descriptor );
-    }
-
-    @Override
-    public void added( ChangeVisitor visitor ) throws CreateConstraintFailureException
-    {
-        visitor.visitAddedNodePropertyExistenceConstraint( this );
-    }
-
-    @Override
-    public void removed( ChangeVisitor visitor )
-    {
-        visitor.visitRemovedNodePropertyExistenceConstraint( this );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api.constraints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 
@@ -32,27 +31,6 @@ import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 @Deprecated
 public interface PropertyConstraint
 {
-    interface ChangeVisitor
-    {
-        void visitAddedUniquePropertyConstraint( UniquenessConstraint constraint );
-
-        void visitRemovedUniquePropertyConstraint( UniquenessConstraint constraint );
-
-        void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint )
-                throws CreateConstraintFailureException;
-
-        void visitRemovedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint );
-
-        void visitAddedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint )
-                throws CreateConstraintFailureException;
-
-        void visitRemovedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint );
-    }
-
-    void added( ChangeVisitor visitor ) throws CreateConstraintFailureException;
-
-    void removed( ChangeVisitor visitor );
-
     SchemaDescriptor descriptor();
 
     String userDescription( TokenNameLookup tokenNameLookup );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyExistenceConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyExistenceConstraint.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api.constraints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 
@@ -35,18 +34,6 @@ public class RelationshipPropertyExistenceConstraint extends RelationshipPropert
     public RelationshipPropertyExistenceConstraint( RelationTypeSchemaDescriptor descriptor )
     {
         super( descriptor );
-    }
-
-    @Override
-    public void added( ChangeVisitor visitor ) throws CreateConstraintFailureException
-    {
-        visitor.visitAddedRelationshipPropertyExistenceConstraint( this );
-    }
-
-    @Override
-    public void removed( ChangeVisitor visitor )
-    {
-        visitor.visitRemovedRelationshipPropertyExistenceConstraint( this );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.constraints;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
@@ -44,25 +45,17 @@ public class UniquenessConstraint extends NodePropertyConstraint
     }
 
     @Override
-    public void added( ChangeVisitor visitor )
-    {
-        visitor.visitAddedUniquePropertyConstraint( this );
-    }
-
-    @Override
-    public void removed( ChangeVisitor visitor )
-    {
-        visitor.visitRemovedUniquePropertyConstraint( this );
-    }
-
-    @Override
     public String userDescription( TokenNameLookup tokenNameLookup )
     {
         String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
-        return String
-                .format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS UNIQUE", boundIdentifier, labelName, boundIdentifier,
-                        tokenNameLookup.propertyKeyGetName( descriptor.getPropertyId() ) );
+        String properties = SchemaUtil
+                .niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + "." );
+        if ( descriptor.isComposite() )
+        {
+            properties = "(" + properties + ")";
+        }
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS UNIQUE", boundIdentifier, labelName, properties );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
@@ -97,6 +97,11 @@ public class LabelSchemaDescriptor implements SchemaDescriptor
         return "LabelSchemaDescriptor( " + userDescription( SchemaUtil.idTokenNameLookup ) + " )";
     }
 
+    public boolean isComposite()
+    {
+        return propertyIds.length > 1;
+    }
+
     public interface Supplier extends SchemaDescriptor.Supplier
     {
         LabelSchemaDescriptor schema();

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 
-import static java.lang.String.format;
-
 public class RelationTypeSchemaDescriptor implements SchemaDescriptor
 {
     private final int relTypeId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -31,10 +31,15 @@ public class SchemaUtil
 
     public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds )
     {
+        return niceProperties( tokenNameLookup, propertyIds, "" );
+    }
+
+    public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds, String prefix )
+    {
         String[] properties = new String[propertyIds.length];
         for ( int i = 0; i < propertyIds.length; i++ )
         {
-            properties[i] = tokenNameLookup.propertyKeyGetName( propertyIds[i] );
+            properties[i] = prefix + tokenNameLookup.propertyKeyGetName( propertyIds[i] );
         }
         return String.join( ", ", properties );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.schema_new.constaints;
 
+import org.neo4j.kernel.api.constraints.NodeKeyConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
@@ -75,6 +76,9 @@ public class ConstraintBoundary
 
             case EXISTS:
                 return new NodePropertyExistenceConstraint( schema );
+
+            case UNIQUE_EXISTS:
+                return new NodeKeyConstraint( schema );
 
             default:
                 throw new UnsupportedOperationException( "Although we cannot get here, this has not been implemented." );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
@@ -77,7 +77,7 @@ public class ConstraintBoundary
             case EXISTS:
                 return new NodePropertyExistenceConstraint( schema );
 
-            case UNIQUE_EXISTS:
+            case NODE_KEY:
                 return new NodeKeyConstraint( schema );
 
             default:

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
@@ -34,7 +34,7 @@ public abstract class ConstraintDescriptor implements SchemaDescriptor.Supplier
     {
         UNIQUE,
         EXISTS,
-        UNIQUE_EXISTS
+        NODE_KEY
     }
 
     public interface Supplier

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
@@ -33,7 +33,8 @@ public abstract class ConstraintDescriptor implements SchemaDescriptor.Supplier
     public enum Type
     {
         UNIQUE,
-        EXISTS
+        EXISTS,
+        UNIQUE_EXISTS
     }
 
     public interface Supplier

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactory.java
@@ -65,6 +65,11 @@ public class ConstraintDescriptorFactory
         return schema.computeWith( convertToUniquenessConstraint );
     }
 
+    public static NodeKeyConstraintDescriptor nodeKeyForSchema( LabelSchemaDescriptor schema )
+    {
+        return new NodeKeyConstraintDescriptor( schema );
+    }
+
     private static SchemaComputer<ConstraintDescriptor> convertToExistenceConstraint =
             new SchemaComputer<ConstraintDescriptor>()
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.schema_new.constaints;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
+
+/**
+ * This class represents the NODE KEY constraints, internally is enforced by a composite uniqueness constraint and
+ * one existence constraint per property. This descriptor should only be used to drop and list the NODE KEY
+ * constraint.
+ */
+public class NodeKeyConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaDescriptor.Supplier
+{
+    private final LabelSchemaDescriptor schema;
+    private final UniquenessConstraintDescriptor uniquenessConstraint;
+    private final NodeExistenceConstraintDescriptor[] existenceConstraints;
+
+    NodeKeyConstraintDescriptor( LabelSchemaDescriptor schema )
+    {
+        super( Type.UNIQUE_EXISTS );
+        this.schema = schema;
+        this.uniquenessConstraint = new UniquenessConstraintDescriptor( schema );
+        this.existenceConstraints = new NodeExistenceConstraintDescriptor[schema.getPropertyIds().length];
+        for ( int i = 0; i < schema.getPropertyIds().length; i++ )
+        {
+            this.existenceConstraints[i] = ConstraintDescriptorFactory.existsForSchema(
+                    SchemaDescriptorFactory.forLabel( schema.getLabelId(), schema.getPropertyIds()[i] ) );
+        }
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return schema;
+    }
+
+    public UniquenessConstraintDescriptor ownedUniquenessConstraint()
+    {
+        return uniquenessConstraint;
+    }
+
+    public NodeExistenceConstraintDescriptor[] ownedExistenceConstraints()
+    {
+        return existenceConstraints;
+    }
+
+    @Override
+    public String prettyPrint( TokenNameLookup tokenNameLookup )
+    {
+        String labelName = escapeLabelOrRelTyp( tokenNameLookup.labelGetName( schema.getLabelId() ) );
+        String nodeName = labelName.toLowerCase();
+        String properties = SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds(), nodeName + "." );
+        if ( schema.getPropertyIds().length > 1 )
+        {
+            properties = "(" + properties + ")";
+        }
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS NODE KEY", nodeName, labelName, properties );
+    }
+
+    /**
+     * Method to use when listing constraints, to transform uniqueness and existence constraints into NODE
+     * KEY constraints. Constraints that cannot be transformed are returned as unchanged.
+     */
+    public static Iterator<ConstraintDescriptor> addNodeKeys( Iterator<ConstraintDescriptor> constraints )
+    {
+        List<UniquenessConstraintDescriptor> allUniqueConstraints = new ArrayList<>();
+        Map<SchemaDescriptor,ConstraintDescriptor> allExistenceConstraints = new HashMap<>();
+        while ( constraints.hasNext() )
+        {
+            ConstraintDescriptor constraint = constraints.next();
+            if ( constraint.type() == ConstraintDescriptor.Type.UNIQUE )
+            {
+                allUniqueConstraints.add( (UniquenessConstraintDescriptor) constraint );
+            }
+            else if ( constraint.type() == ConstraintDescriptor.Type.EXISTS )
+            {
+                allExistenceConstraints.put( constraint.schema(), constraint );
+            }
+            else
+            {
+                throw new IllegalStateException(
+                        "NODE KEY constraints are syntactic sugar and should not exist in the SchemaStore" );
+            }
+        }
+
+        return new Iterator<ConstraintDescriptor>()
+        {
+            private Iterator<UniquenessConstraintDescriptor> uniquenessIterator = allUniqueConstraints.iterator();
+
+            @Override
+            public boolean hasNext()
+            {
+                return uniquenessIterator.hasNext() || !allExistenceConstraints.isEmpty();
+            }
+
+            @Override
+            public ConstraintDescriptor next()
+            {
+                if ( uniquenessIterator.hasNext() )
+                {
+                    UniquenessConstraintDescriptor constraint = uniquenessIterator.next();
+                    NodeKeyConstraintDescriptor nodeKeyConstraintDescriptor =
+                            ConstraintDescriptorFactory.nodeKeyForSchema( constraint.schema() );
+                    boolean allExistenceConstraintsExists = true;
+                    for ( NodeExistenceConstraintDescriptor existenceConstraintDescriptor :
+                            nodeKeyConstraintDescriptor
+                                    .ownedExistenceConstraints() )
+                    {
+                        if ( !allExistenceConstraints.containsKey( existenceConstraintDescriptor.schema() ) )
+                        {
+                            allExistenceConstraintsExists = false;
+                        }
+                    }
+                    if ( allExistenceConstraintsExists )
+                    {
+                        for ( NodeExistenceConstraintDescriptor existenceConstraintDescriptor :
+                                nodeKeyConstraintDescriptor
+                                        .ownedExistenceConstraints() )
+                        {
+                            allExistenceConstraints.remove( existenceConstraintDescriptor.schema() );
+                        }
+                        return nodeKeyConstraintDescriptor;
+                    }
+                    else
+                    {
+                        return constraint;
+                    }
+                }
+                else
+                {
+                    SchemaDescriptor next = allExistenceConstraints.keySet().iterator().next();
+                    return allExistenceConstraints.remove( next );
+                }
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
@@ -44,7 +44,7 @@ public class NodeKeyConstraintDescriptor extends ConstraintDescriptor implements
 
     NodeKeyConstraintDescriptor( LabelSchemaDescriptor schema )
     {
-        super( Type.UNIQUE_EXISTS );
+        super( Type.NODE_KEY );
         this.schema = schema;
         this.uniquenessConstraint = new UniquenessConstraintDescriptor( schema );
         this.existenceConstraints = new NodeExistenceConstraintDescriptor[schema.getPropertyIds().length];

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -182,7 +183,7 @@ public class BuiltInProcedures
         ReadOperations operations = statement.readOperations();
         TokenNameLookup tokens = new StatementTokenNameLookup( operations );
 
-        return asList( operations.constraintsGetAll() )
+        return asList( NodeKeyConstraintDescriptor.addNodeKeys( operations.constraintsGetAll() ) )
                 .stream()
                 .map( ( constraint ) -> constraint.prettyPrint( tokens ) )
                 .sorted()

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintBoundary;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.coreapi.schema.PropertyNameUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -77,10 +78,10 @@ public class SchemaProcedure
                 while ( labelsInDatabase.hasNext() )
                 {
                     Label label = labelsInDatabase.next();
+                    int labelId = readOperations.labelGetForName( label.name() );
                     Map<String,Object> properties = new HashMap<>();
 
-                    Iterator<NewIndexDescriptor> indexDescriptorIterator =
-                            readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
+                    Iterator<NewIndexDescriptor> indexDescriptorIterator = readOperations.indexesGetForLabel( labelId );
                     ArrayList<String> indexes = new ArrayList<>();
                     while ( indexDescriptorIterator.hasNext() )
                     {
@@ -92,7 +93,8 @@ public class SchemaProcedure
                     properties.put( "indexes", indexes );
 
                     Iterator<ConstraintDescriptor> nodePropertyConstraintIterator =
-                            readOperations.constraintsGetForLabel( readOperations.labelGetForName( label.name() ) );
+                            NodeKeyConstraintDescriptor.addNodeKeys(
+                                    readOperations.constraintsGetForLabel( labelId ) );
                     ArrayList<String> constraints = new ArrayList<>();
                     while ( nodePropertyConstraintIterator.hasNext() )
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -57,6 +57,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -555,6 +556,14 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         schemaWriteOperations.uniqueIndexDrop( state, descriptor );
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
+    {
+        return schemaWriteOperations.nodeKeyConstraintCreate( state, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -163,24 +163,23 @@ public class DataIntegrityValidatingStatementOperations implements
             RepeatedPropertyInCompositeSchemaException
     {
         NodeKeyConstraintDescriptor constraint = ConstraintDescriptorFactory.nodeKeyForSchema( descriptor );
-        UniquenessConstraintDescriptor uniquenessConstraintDescriptor =
-                ConstraintDescriptorFactory.uniqueForSchema( descriptor );
-        boolean somethingWasMade = false;
-        if ( !schemaReadDelegate.constraintExists( state, uniquenessConstraintDescriptor ) )
+
+        boolean nodeKeyAlreadyExists = true;
+        if ( !schemaReadDelegate.constraintExists( state, constraint.ownedUniquenessConstraint() ) )
         {
             assertIndexDoesNotExist( state, OperationContext.CONSTRAINT_CREATION, descriptor );
             schemaWriteDelegate.uniquePropertyConstraintCreate( state, descriptor );
-            somethingWasMade = true;
+            nodeKeyAlreadyExists = false;
         }
         for ( NodeExistenceConstraintDescriptor pem : constraint.ownedExistenceConstraints() )
         {
             if ( !schemaReadDelegate.constraintExists( state, pem ) )
             {
                 schemaWriteDelegate.nodePropertyExistenceConstraintCreate( state, pem.schema() );
-                somethingWasMade = true;
+                nodeKeyAlreadyExists = false;
             }
         }
-        if ( !somethingWasMade )
+        if ( nodeKeyAlreadyExists )
         {
             throw new AlreadyConstrainedException( constraint, OperationContext.CONSTRAINT_CREATION,
                     new StatementTokenNameLookup( state.readOperations() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -341,6 +342,16 @@ public class LockingStatementOperations implements
         {
             acquireExclusiveNodeLock( state, max( startNodeId, endNodeId ) );
         }
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state,LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
+    {
+        acquireExclusiveSchemaLock( state );
+        state.assertOpen();
+        return schemaWriteDelegate.nodeKeyConstraintCreate( state, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -82,6 +82,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -998,6 +999,15 @@ public class OperationsFacade
     {
         statement.assertOpen();
         schemaWrite().indexDrop( statement, descriptor );
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
+    {
+        statement.assertOpen();
+        return schemaWrite().nodeKeyConstraintCreate( statement, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -69,6 +69,7 @@ import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -586,6 +587,14 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state,
+            LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException
+    {
+        throw new IllegalStateException( "NODE KEY Constraints are syntactic sugar and are handled higher in the cake." );
+    }
+
+    @Override
     public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
             throws CreateConstraintFailureException
     {
@@ -705,6 +714,8 @@ public class StateHandlingStatementOperations implements
     @Override
     public void constraintDrop( KernelStatement state, ConstraintDescriptor constraint )
     {
+        assert constraint.type() != ConstraintDescriptor.Type.UNIQUE_EXISTS :
+                "The NODE KEY constraint is synthetic, and is dropped at a higher layer in the cake.";
         state.txState().constraintDoDrop( constraint );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -714,7 +714,7 @@ public class StateHandlingStatementOperations implements
     @Override
     public void constraintDrop( KernelStatement state, ConstraintDescriptor constraint )
     {
-        assert constraint.type() != ConstraintDescriptor.Type.UNIQUE_EXISTS :
+        assert constraint.type() != ConstraintDescriptor.Type.NODE_KEY :
                 "The NODE KEY constraint is synthetic, and is dropped at a higher layer in the cake.";
         state.txState().constraintDoDrop( constraint );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -51,6 +52,10 @@ public interface SchemaWriteOperations
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
+
+    NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
             throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
@@ -48,7 +48,7 @@ public class NodeKeyConstraintDefinition extends NodeConstraintDefinition
     @Override
     public String toString()
     {
-        return format( "ON (%1$s:%2$s) ASSERT %3$s IS UNIQUE",
+        return format( "ON (%1$s:%2$s) ASSERT %3$s IS NODE KEY",
                 label.name().toLowerCase(), label.name(), propertyText() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.coreapi.schema;
+
+import org.neo4j.graphdb.schema.ConstraintType;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+import static java.lang.String.format;
+
+public class NodeKeyConstraintDefinition extends NodeConstraintDefinition
+{
+    public NodeKeyConstraintDefinition( InternalSchemaActions actions, IndexDefinition indexDefinition )
+    {
+        super( actions, indexDefinition );
+    }
+
+    @Override
+    public void drop()
+    {
+        assertInUnterminatedTransaction();
+        actions.dropPropertyUniquenessConstraint( label, propertyKeys );
+    }
+
+    @Override
+    public ConstraintType getConstraintType()
+    {
+        assertInUnterminatedTransaction();
+        return ConstraintType.NODE_KEY;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ON (%1$s:%2$s) ASSERT %3$s IS UNIQUE",
+                label.name().toLowerCase(), label.name(), propertyText() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -214,6 +214,10 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
                     schemaStorage.newRuleId(), constraint ) );
             break;
 
+        case UNIQUE_EXISTS:
+            throw new IllegalStateException(
+                    "NODE KEY constraints should not make it this deep into the stack: " + constraint );
+
         default:
             throw new IllegalStateException( constraint.type().toString() );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -214,7 +214,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
                     schemaStorage.newRuleId(), constraint ) );
             break;
 
-        case UNIQUE_EXISTS:
+        case NODE_KEY:
             throw new IllegalStateException(
                     "NODE KEY constraints should not make it this deep into the stack: " + constraint );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -152,13 +152,17 @@ public class BuiltInProceduresTest
     {
         // Given
         givenUniqueConstraint( "User", "name" );
-        givenNodePropExistenceConstraint( "User", "name" );
+        givenNodePropExistenceConstraint( "Site", "url" );
+        // the parts for a NODE KEY
+        givenUniqueConstraint( "Computer", "mac" );
+        givenNodePropExistenceConstraint( "Computer", "mac" );
 
         // When/Then
         assertThat( call( "db.constraints" ),
-                contains(
-                        record( "CONSTRAINT ON ( user:User ) ASSERT exists(user.name)" ),
-                        record( "CONSTRAINT ON ( user:User ) ASSERT user.name IS UNIQUE" ) ) );
+                containsInAnyOrder(
+                        record( "CONSTRAINT ON ( site:Site ) ASSERT exists(site.url)" ),
+                        record( "CONSTRAINT ON ( user:User ) ASSERT user.name IS UNIQUE" ),
+                        record( "CONSTRAINT ON ( computer:Computer ) ASSERT computer.mac IS NODE KEY" ) ) );
     }
 
     @Test
@@ -166,14 +170,14 @@ public class BuiltInProceduresTest
     {
         // Given
         givenUniqueConstraint( "FOO:BAR", "x.y" );
-        givenNodePropExistenceConstraint( "FOO:BAR", "x.y" );
+        givenNodePropExistenceConstraint( "FOO:BAR", "x.z" );
 
         // When/Then
         List<Object[]> call = call( "db.constraints" );
         assertThat( call,
                 contains(
                         record( "CONSTRAINT ON ( `foo:bar`:`FOO:BAR` ) ASSERT `foo:bar`.x.y IS UNIQUE" ),
-                        record( "CONSTRAINT ON ( `foo:bar`:`FOO:BAR` ) ASSERT exists(`foo:bar`.x.y)" ) ) );
+                        record( "CONSTRAINT ON ( `foo:bar`:`FOO:BAR` ) ASSERT exists(`foo:bar`.x.z)" ) ) );
     }
 
     @Test

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -450,7 +450,8 @@ public class Schema extends TransactionProvidingApp
     private static boolean isNodeConstraint( ConstraintDefinition constraint )
     {
         return constraint.isConstraintType( ConstraintType.UNIQUENESS ) ||
-               constraint.isConstraintType( ConstraintType.NODE_PROPERTY_EXISTENCE );
+                constraint.isConstraintType( ConstraintType.NODE_PROPERTY_EXISTENCE ) ||
+                constraint.isConstraintType( ConstraintType.NODE_KEY );
     }
 
     private static boolean isRelationshipConstraint( ConstraintDefinition constraint )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.{CypherExecutionException, ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.graphdb.{ConstraintViolationException, Node}
+import org.neo4j.kernel.GraphDatabaseQueryService
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.collection.JavaConverters._
+
+class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("should be able to create and remove composite uniquness constraints") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT n.email IS UNIQUE")
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    graph should haveConstraints("UNIQUENESS:Person(email)", "UNIQUENESS:Person(firstname,lastname)")
+
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    graph should haveConstraints("UNIQUENESS:Person(email)")
+    graph should not(haveConstraints("UNIQUENESS:Person(firstname,lastname)"))
+  }
+
+  test("composite uniqueness constraint should not block adding nodes with different properties") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+  }
+
+  test("composite uniqueness constraint should block adding nodes with same properties") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+
+    // Then
+    a[ConstraintViolationException] should be thrownBy {
+      createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    }
+  }
+
+  test("composite uniqueness constraint should not fail when we have nodes with different properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+
+    // Then
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+  }
+
+  test("composite uniqueness constraint should fail when we have nodes with same properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+
+    // Then
+    a[CypherExecutionException] should be thrownBy {
+      executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    }
+  }
+
+  case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
+    def apply(graph: GraphDatabaseQueryService): MatchResult = {
+      graph.inTx {
+        val constraintName = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(i => constraintName.contains(i.toString))
+        MatchResult(
+          result,
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintName.mkString(", ")}",
+          s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
+        )
+      }
+    }
+  }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -19,20 +19,14 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.cypher.{CypherExecutionException, ExecutionEngineFunSuite, NewPlannerTestSupport}
-import org.neo4j.graphdb.{ConstraintViolationException, Node}
+import org.neo4j.graphdb.ConstraintViolationException
 import org.neo4j.kernel.GraphDatabaseQueryService
-import org.neo4j.test.{TestEnterpriseGraphDatabaseFactory, TestGraphDatabaseFactory}
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 import scala.collection.JavaConverters._
 
 class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
-
-  override protected def createGraphDatabase(): GraphDatabaseCypherService = {
-    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(databaseConfig().asJava))
-  }
 
   test("should be able to create and remove composite uniquness constraints") {
     // When

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -128,7 +128,14 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
     executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.b,n.c) IS NODE KEY")
 
     // Then
-//    graph should haveConstraints("NODE_KEY:Person(a,b)", "NODE_KEY:Person(b,c)")
+    graph should haveConstraints("NODE_KEY:Person(a,b)", "NODE_KEY:Person(b,c)")
+
+    intercept[ConstraintValidationException](executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (n:Person{ a: 42, b: 23})"))
+    intercept[ConstraintValidationException](executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (n:Person{ b: 42, c: 23})"))
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (:Person {a: 1, b: 2, c: 3})")
+    intercept[CypherExecutionException](executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (:Person {a: 1, b: 2, c: 666})"))
+    intercept[CypherExecutionException](executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (:Person {a: 666, b: 2, c: 3})"))
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE (:Person {a: 666, b: 2, c: 666})")
 
     // When
     executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.a,n.b) IS NODE KEY")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -114,7 +114,7 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
     executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
 
     // Then
-    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname")
+    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname)")
 
     // When
     executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
@@ -127,11 +127,12 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
   case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
     def apply(graph: GraphDatabaseQueryService): MatchResult = {
       graph.inTx {
-        val constraintName = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
-        val result = expectedConstraints.forall(i => constraintName.contains(i.toString))
+        val constraintDefinitions = graph.schema().getConstraints.asScala.toList
+        val constraintNames = constraintDefinitions.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(expected => constraintNames.contains(expected))
         MatchResult(
           result,
-          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintName.mkString(", ")}",
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintNames.mkString(", ")}",
           s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
         )
       }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeKeyConstraintAcceptanceTest.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.InternalExecutionResult
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException, ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.kernel.GraphDatabaseQueryService
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.collection.JavaConverters._
+
+class NodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  override protected def createGraphDatabase(): GraphDatabaseCypherService = {
+    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(databaseConfig().asJava))
+  }
+
+  test("should be able to create and remove single property NODE KEY") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+
+    intercept[ConstraintValidationException](exec("CREATE (:Person)"))
+    exec("CREATE (:Person {email: 42})")
+    intercept[CypherExecutionException](exec("CREATE (:Person {email: 42})"))
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveNoConstraints()
+  }
+
+  test("should fail to create NODE KEY on node without property") {
+    // When
+    exec("CREATE (:Person)")
+
+    // Then
+    intercept[CypherExecutionException](exec(
+      "CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY"))
+    graph should haveNoConstraints()
+  }
+
+  test("should fail to create NODE KEY on duplicate values") {
+    // When
+    exec("CREATE (:Person {email: 42})")
+    exec("CREATE (:Person {email: 42})")
+
+    // Then
+    intercept[CypherExecutionException](exec(
+      "CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY"))
+    graph should haveNoConstraints()
+  }
+
+  test("should fail to create NODE KEY on node without secondary property") {
+    // When
+    exec("CREATE (:Person {email: 42})")
+
+    // Then
+    intercept[CypherExecutionException](exec(
+      "CREATE CONSTRAINT ON (n:Person) ASSERT (n.email,n.name) IS NODE KEY"))
+    graph should haveNoConstraints()
+  }
+
+  test("should idempotently enrich preexisting uniqueness constraint") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+  }
+
+  test("should silently ignore duplicate NODE KEY constraint") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email,n.name) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email,n.name) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email,name)")
+  }
+
+  test("should be able to create and remove multiple property NODE KEY") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname)")
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+    graph should not(haveConstraints("NODE_KEY:Person(firstname,lastname)"))
+  }
+
+  test("should be able to create and remove overlapping NODE KEY constraints") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.a,n.b) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.b,n.c) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(a,b)", "NODE_KEY:Person(b,c)")
+
+    intercept[ConstraintValidationException](exec("CREATE (n:Person{ a: 42, b: 23})"))
+    intercept[ConstraintValidationException](exec("CREATE (n:Person{ b: 42, c: 23})"))
+    exec("CREATE (:Person {a: 1, b: 2, c: 3})")
+    intercept[CypherExecutionException](exec("CREATE (:Person {a: 1, b: 2, c: 666})"))
+    intercept[CypherExecutionException](exec("CREATE (:Person {a: 666, b: 2, c: 3})"))
+    exec("CREATE (:Person {a: 666, b: 2, c: 666})")
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.a,n.b) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(b,c)")
+    graph should not(haveConstraints("NODE_KEY:Person(a,b)"))
+  }
+
+  case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
+    def apply(graph: GraphDatabaseQueryService): MatchResult = {
+      graph.inTx {
+        val constraintDefinitions = graph.schema().getConstraints.asScala.toList
+        val constraintNames = constraintDefinitions.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(expected => constraintNames.contains(expected))
+        MatchResult(
+          result,
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintNames.mkString(", ")}",
+          s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
+        )
+      }
+    }
+  }
+
+  case class haveNoConstraints() extends Matcher[GraphDatabaseQueryService] {
+    def apply(graph: GraphDatabaseQueryService): MatchResult = {
+      graph.inTx {
+        val constraintDefinitions = graph.schema().getConstraints.asScala.toList
+        val constraintNames = constraintDefinitions.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        MatchResult(
+          constraintNames.isEmpty,
+          s"Expected graph to not have constraints, but it had ${constraintNames.mkString(", ")}",
+          s"Expected graph to have constraints, but it didn't."
+        )
+      }
+    }
+  }
+
+  def exec(q: String): InternalExecutionResult = {
+    executeWithCostPlannerAndInterpretedRuntimeOnly(q)
+  }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
@@ -53,6 +53,16 @@ public final class SchemaHelper
         db.execute( String.format( "CREATE CONSTRAINT ON (n:`%s`) ASSERT n.`%s` IS UNIQUE", label, property ) );
     }
 
+    public static void createNodeKeyConstraint( GraphDatabaseService db, Label label, String property )
+    {
+        createNodeKeyConstraint( db, label.name(), property );
+    }
+
+    public static void createNodeKeyConstraint( GraphDatabaseService db, String label, String property )
+    {
+        db.execute( String.format( "CREATE CONSTRAINT ON (n:`%s`) ASSERT (n.`%s`) IS NODE KEY", label, property ) );
+    }
+
     public static void createNodePropertyExistenceConstraint( GraphDatabaseService db, Label label, String property )
     {
         createNodePropertyExistenceConstraint( db, label.name(), property );

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
@@ -134,11 +134,13 @@ public class PECListingIT extends AbstractShellIT
     {
         // GIVEN
         Label label = label( "Person" );
+        Label computerLabel = label( "Computer" );
         RelationshipType relType = RelationshipType.withName( "KNOWS" );
 
         // WHEN
-        SchemaHelper.createUniquenessConstraint( db, label, "name" );
+        SchemaHelper.createUniquenessConstraint( db, label, "email" );
         SchemaHelper.createNodePropertyExistenceConstraint( db, label, "name" );
+        SchemaHelper.createNodeKeyConstraint( db, computerLabel, "mac" );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType, "since" );
 
         SchemaHelper.awaitIndexes( db );
@@ -146,10 +148,12 @@ public class PECListingIT extends AbstractShellIT
         // THEN
         executeCommand( "schema",
                 "Indexes",
-                "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
+                "  ON :Computer\\(mac\\) ONLINE \\(for uniqueness constraint\\)",
+                "  ON :Person\\(email\\) ONLINE \\(for uniqueness constraint\\)",
                 "Constraints",
-                "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
+                "  ON \\(person:Person\\) ASSERT person.email IS UNIQUE",
                 "  ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
+                "  ON \\(computer:Computer\\) ASSERT computer.mac IS NODE KEY",
                 "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 


### PR DESCRIPTION
Support for the `NODE KEY` constraint. This PR allows `CREATE` and `DROP` over cypher, as well as listing via Core API. 

In this implementation `NODE KEY`s are syntax sugar for doing one uniqueness constraint, and one node property existence constraint per property in the `NODE KEY`. Because of this, extra logic is needed in the `DataIntegrityValidatingStatementOperations` to maintain this illusion outwards so that we don't accidentally delete some part of a NODE KEY, or expose parts to the user. Note also that this means that on upgrade any uniqueness constraints with matching existence constraints will be presented as `NODE KEY` only.

On the plus side the enforcement and internal management of constraints become more direct, and no extra code is needed in the TxState, SchemaStore or constraint enforcement. The orthogonal concepts of property uniqueness and existence remain separated in code. 

changelog: New `NODE KEY` constraint on one or many properties. A `NODE KEY` (eg. `CREATE CONSTRAINT ON (n:Person) ASSERT (n.email,n.name) IS NODE KEY`) implies both that nodes with the given label (`Person`) must have the properties (`email` and `name`), and that the values for these properties are unique among nodes with the label. 