### PR TITLE
Show allocated memory and page hits/faults in `dbms.listQueries`

### DIFF
--- a/community/common/src/main/java/org/neo4j/resources/CpuClock.java
+++ b/community/common/src/main/java/org/neo4j/resources/CpuClock.java
@@ -17,14 +17,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.time;
+package org.neo4j.resources;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 
+/**
+ * Measures CPU time by thread.
+ */
 public abstract class CpuClock
 {
-    public static CpuClock CPU_CLOCK = new CpuClock()
+    public static final CpuClock CPU_CLOCK = new CpuClock()
     {
         private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 
@@ -60,7 +63,8 @@ public abstract class CpuClock
      *
      * @param threadId
      *         the id of the thread to get the used CPU time for.
-     * @return the current CPU time used by the thread, in nanoseconds.
+     * @return the current CPU time used by the thread, in nanoseconds, or {@code -1} if getting the CPU time is not
+     * supported.
      */
     public abstract long cpuTimeNanos( long threadId );
 }

--- a/community/common/src/main/java/org/neo4j/resources/HeapAllocation.java
+++ b/community/common/src/main/java/org/neo4j/resources/HeapAllocation.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.resources;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import static java.lang.Character.toUpperCase;
+
+public abstract class HeapAllocation
+{
+    public static final HeapAllocation HEAP_ALLOCATION = load( ManagementFactory.getThreadMXBean() );
+    public static final HeapAllocation NOT_AVAILABLE = new HeapAllocation()
+    {
+        @Override
+        public long allocatedBytes( long threadId )
+        {
+            return -1;
+        }
+    };
+
+    /**
+     * Returns the current CPU time used by the thread, in nanoseconds.
+     *
+     * @param thread
+     *         the thread to get the used CPU time for.
+     * @return the current CPU time used by the thread, in nanoseconds.
+     */
+    public final long allocatedBytes( Thread thread )
+    {
+        return allocatedBytes( thread.getId() );
+    }
+
+    /**
+     * Returns the current CPU time used by the thread, in nanoseconds.
+     *
+     * @param threadId
+     *         the id of the thread to get the used CPU time for.
+     * @return the current CPU time used by the thread, in nanoseconds.
+     */
+    public abstract long allocatedBytes( long threadId );
+
+    private static HeapAllocation load( ThreadMXBean bean )
+    {
+        Class<HeapAllocation> base = HeapAllocation.class;
+        StringBuilder name = new StringBuilder().append( base.getPackage().getName() ).append( '.' );
+        String pkg = bean.getClass().getPackage().getName();
+        int start = 0;
+        int end = pkg.indexOf( '.', start );
+        while ( end > 0 )
+        {
+            name.append( toUpperCase( pkg.charAt( start ) ) ).append( pkg.substring( start + 1, end ) );
+            start = end + 1;
+            end = pkg.indexOf( '.', start );
+        }
+        name.append( toUpperCase( pkg.charAt( start ) ) ).append( pkg.substring( start + 1 ) );
+        name.append( base.getSimpleName() );
+        try
+        {
+            return (HeapAllocation) Class.forName( name.toString() )
+                    .getDeclaredMethod( "load", ThreadMXBean.class )
+                    .invoke( null, bean );
+        }
+        catch ( Throwable e )
+        {
+            return NOT_AVAILABLE;
+        }
+    }
+}

--- a/community/common/src/main/java/org/neo4j/resources/SunManagementHeapAllocation.java
+++ b/community/common/src/main/java/org/neo4j/resources/SunManagementHeapAllocation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.resources;
+
+import com.sun.management.ThreadMXBean;
+
+class SunManagementHeapAllocation extends HeapAllocation
+{
+    /**
+     * Invoked from {@link HeapAllocation#load(java.lang.management.ThreadMXBean)} through reflection.
+     */
+    @SuppressWarnings( "unused" )
+    static HeapAllocation load( java.lang.management.ThreadMXBean bean )
+    {
+        if ( ThreadMXBean.class.isInstance( bean ) )
+        {
+            return new SunManagementHeapAllocation( (ThreadMXBean) bean );
+        }
+        return NOT_AVAILABLE;
+    }
+
+    private final ThreadMXBean threadMXBean;
+
+    private SunManagementHeapAllocation( ThreadMXBean threadMXBean )
+    {
+        this.threadMXBean = threadMXBean;
+    }
+
+    @Override
+    public long allocatedBytes( long threadId )
+    {
+        if ( !threadMXBean.isThreadAllocatedMemorySupported() )
+        {
+            return -1;
+        }
+        if ( !threadMXBean.isThreadAllocatedMemoryEnabled() )
+        {
+            threadMXBean.setThreadAllocatedMemoryEnabled( true );
+        }
+        return threadMXBean.getThreadAllocatedBytes( threadId );
+    }
+}

--- a/community/common/src/test/java/org/neo4j/resources/SunManagementHeapAllocationTest.java
+++ b/community/common/src/test/java/org/neo4j/resources/SunManagementHeapAllocationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.lang.Thread.currentThread;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.neo4j.resources.HeapAllocation.HEAP_ALLOCATION;
+import static org.neo4j.resources.HeapAllocation.NOT_AVAILABLE;
+
+public class SunManagementHeapAllocationTest
+{
+    @Before
+    public void onlyOnSupportedJvms()
+    {
+        assumeFalse( HEAP_ALLOCATION == NOT_AVAILABLE );
+    }
+
+    @Test
+    public void shouldLoadHeapAllocation() throws Exception
+    {
+        assertNotSame( NOT_AVAILABLE, HEAP_ALLOCATION );
+        assertThat( HEAP_ALLOCATION, instanceOf( SunManagementHeapAllocation.class ) );
+    }
+
+    @Test
+    public void shouldMeasureAllocation() throws Exception
+    {
+        // given
+        long allocatedBytes = HEAP_ALLOCATION.allocatedBytes( currentThread() );
+
+        // when
+        List<Object> objects = new ArrayList<>();
+        for ( int i = 0; i < 17; i++ )
+        {
+            objects.add( new Object() );
+        }
+
+        // then
+        assertThat( allocatedBytes, Matchers.lessThan( HEAP_ALLOCATION.allocatedBytes( currentThread() ) ) );
+        assertEquals( 17, objects.size() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -473,7 +473,6 @@ public class GraphDatabaseSettings implements LoadableConfig
             "Log entries are written to the file _query.log_ located in the Logs directory. " +
             "For location of the Logs directory, see <<file-locations>>. " +
             "This feature is available in the Neo4j Enterprise Edition." )
-
     public static final Setting<Boolean> log_queries = setting("dbms.logs.query.enabled", BOOLEAN, FALSE );
 
     @Description("Path of the logs directory")
@@ -485,16 +484,16 @@ public class GraphDatabaseSettings implements LoadableConfig
             ( logs ) -> new File( logs, "query.log" ),
             PATH );
 
-    @Description( "Log parameters for executed queries that took longer than the configured threshold." )
+    @Description( "Log parameters for the executed queries being logged." )
     public static final Setting<Boolean> log_queries_parameter_logging_enabled = setting( "dbms.logs.query.parameter_logging_enabled", BOOLEAN, TRUE );
 
-    @Description( "Log detailed time information for executed queries that took longer than the configured threshold." )
+    @Description( "Log detailed time information for the executed queries being logged." )
     public static final Setting<Boolean> log_queries_detailed_time_logging_enabled = setting( "dbms.logs.query.time_logging_enabled", BOOLEAN, FALSE );
 
-    @Description( "Log allocated bytes for executed queries that took longer than the configured threshold." )
+    @Description( "Log allocated bytes for the executed queries being logged." )
     public static final Setting<Boolean> log_queries_allocation_logging_enabled = setting( "dbms.logs.query.allocation_logging_enabled", BOOLEAN, FALSE );
 
-    @Description( "Log page hits and page faults for executed queries that took longer than the configured threshold." )
+    @Description( "Log page hits and page faults for the executed queries being logged." )
     public static final Setting<Boolean> log_queries_page_detail_logging_enabled = setting( "dbms.logs.query.page_logging_enabled", BOOLEAN, FALSE );
 
     @Description("If the execution of query takes more time than this threshold, the query is logged - " +

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -488,6 +488,12 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Description( "Log parameters for executed queries that took longer than the configured threshold." )
     public static final Setting<Boolean> log_queries_parameter_logging_enabled = setting( "dbms.logs.query.parameter_logging_enabled", BOOLEAN, TRUE );
 
+    @Description( "Log detailed time information for executed queries that took longer than the configured threshold." )
+    public static final Setting<Boolean> log_queries_detailed_time_logging_enabled = setting( "dbms.logs.query.time_logging_enabled", BOOLEAN, FALSE );
+
+    @Description( "Log allocated bytes for executed queries that took longer than the configured threshold." )
+    public static final Setting<Boolean> log_queries_allocation_logging_enabled = setting( "dbms.logs.query.allocation_logging_enabled", BOOLEAN, FALSE );
+
     @Description("If the execution of query takes more time than this threshold, the query is logged - " +
                  "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
     public static final Setting<Long> log_queries_threshold = setting("dbms.logs.query.threshold", DURATION, "0s");

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -494,6 +494,9 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Description( "Log allocated bytes for executed queries that took longer than the configured threshold." )
     public static final Setting<Boolean> log_queries_allocation_logging_enabled = setting( "dbms.logs.query.allocation_logging_enabled", BOOLEAN, FALSE );
 
+    @Description( "Log page hits and page faults for executed queries that took longer than the configured threshold." )
+    public static final Setting<Boolean> log_queries_page_detail_logging_enabled = setting( "dbms.logs.query.page_logging_enabled", BOOLEAN, FALSE );
+
     @Description("If the execution of query takes more time than this threshold, the query is logged - " +
                  "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
     public static final Setting<Long> log_queries_threshold = setting("dbms.logs.query.threshold", DURATION, "0s");

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
@@ -243,11 +243,6 @@ public class ExecutingQuery
         return clientConnection;
     }
 
-    public String connectionDetailsForLogging()
-    {
-        return clientConnection.asConnectionDetails();
-    }
-
     private LockWaitEvent waitForLock( boolean exclusive, ResourceType resourceType, long[] resourceIds )
     {
         WaitingOnLockEvent event = new WaitingOnLockEvent(

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/ExecutingQuery.java
@@ -153,7 +153,7 @@ public class ExecutingQuery
         // just needs to be captured at some point...
         long activeLockCount = this.activeLockCount.getAsLong();
         long heapAllocatedBytes = heapAllocation.allocatedBytes( threadExecutingTheQuery );
-        QuerySnapshot.PageCounterValues pageCounters = new QuerySnapshot.PageCounterValues( pageCursorCounters );
+        PageCounterValues pageCounters = new PageCounterValues( pageCursorCounters );
 
         // - at this point we are done capturing the "live" state, and can start computing the snapshot -
         long planningTimeNanos = (status.isPlanning() ? currentTimeNanos : planningDoneNanos) - startTimeNanos;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/PageCounterValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/PageCounterValues.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.query;
+
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
+
+class PageCounterValues
+{
+    final long hits, faults;
+
+    PageCounterValues( PageCursorCounters page )
+    {
+        this.hits = page.hits();
+        this.faults = page.faults();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 
 public class QuerySnapshot
@@ -65,17 +64,6 @@ public class QuerySnapshot
         this.resourceInfo = resourceInfo;
         this.activeLockCount = activeLockCount;
         this.allocatedBytes = allocatedBytes;
-    }
-
-    static class PageCounterValues
-    {
-        final long hits, faults;
-
-        PageCounterValues( PageCursorCounters page )
-        {
-            this.hits = page.hits();
-            this.faults = page.faults();
-        }
     }
 
     public long internalQueryId()

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 
 public class QuerySnapshot
@@ -38,10 +39,12 @@ public class QuerySnapshot
     private final Map<String,Object> resourceInfo;
     private final long activeLockCount;
     private final long allocatedBytes;
+    private final PageCounterValues page;
 
     QuerySnapshot(
             ExecutingQuery query,
             PlannerInfo plannerInfo,
+            PageCounterValues page,
             long planningTimeMillis,
             long elapsedTimeMillis,
             long cpuTimeMillis,
@@ -53,6 +56,7 @@ public class QuerySnapshot
     {
         this.query = query;
         this.plannerInfo = plannerInfo;
+        this.page = page;
         this.planningTimeMillis = planningTimeMillis;
         this.elapsedTimeMillis = elapsedTimeMillis;
         this.cpuTimeMillis = cpuTimeMillis;
@@ -61,6 +65,17 @@ public class QuerySnapshot
         this.resourceInfo = resourceInfo;
         this.activeLockCount = activeLockCount;
         this.allocatedBytes = allocatedBytes;
+    }
+
+    static class PageCounterValues
+    {
+        final long hits, faults;
+
+        PageCounterValues( PageCursorCounters page )
+        {
+            this.hits = page.hits();
+            this.faults = page.faults();
+        }
     }
 
     public long internalQueryId()
@@ -202,5 +217,15 @@ public class QuerySnapshot
     public Long allocatedBytes()
     {
         return allocatedBytes < 0 ? null : allocatedBytes;
+    }
+
+    public long pageHits()
+    {
+        return page.hits;
+    }
+
+    public long pageFaults()
+    {
+        return page.faults;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/query/QuerySnapshot.java
@@ -37,6 +37,7 @@ public class QuerySnapshot
     private final String status;
     private final Map<String,Object> resourceInfo;
     private final long activeLockCount;
+    private final long allocatedBytes;
 
     QuerySnapshot(
             ExecutingQuery query,
@@ -47,7 +48,8 @@ public class QuerySnapshot
             long waitTimeMillis,
             String status,
             Map<String,Object> resourceInfo,
-            long activeLockCount )
+            long activeLockCount,
+            long allocatedBytes )
     {
         this.query = query;
         this.plannerInfo = plannerInfo;
@@ -58,6 +60,7 @@ public class QuerySnapshot
         this.status = status;
         this.resourceInfo = resourceInfo;
         this.activeLockCount = activeLockCount;
+        this.allocatedBytes = allocatedBytes;
     }
 
     public long internalQueryId()
@@ -164,11 +167,12 @@ public class QuerySnapshot
     /**
      * Time that the CPU has actively spent working on things related to this query.
      *
-     * @return the time in milliseconds that the CPU has spent on this query.
+     * @return the time in milliseconds that the CPU has spent on this query, or {@code null} if the cpu time could not
+     * be measured.
      */
-    public long cpuTimeMillis()
+    public Long cpuTimeMillis()
     {
-        return cpuTimeMillis;
+        return cpuTimeMillis < 0 ? null : cpuTimeMillis;
     }
 
     /**
@@ -181,10 +185,22 @@ public class QuerySnapshot
      * actually waiting on the lock rather than doing active work). In most cases such "lock bookkeeping time" is going
      * to be dwarfed by the idle time.
      *
-     * @return the time in milliseconds that this query was de-scheduled.
+     * @return the time in milliseconds that this query was de-scheduled, or {@code null} if the cpu time could not be
+     * measured.
      */
-    public long idleTimeMillis()
+    public Long idleTimeMillis()
     {
-        return elapsedTimeMillis - cpuTimeMillis - waitTimeMillis;
+        return cpuTimeMillis < 0 ? null : (elapsedTimeMillis - cpuTimeMillis - waitTimeMillis);
+    }
+
+    /**
+     * The number of bytes allocated by the query.
+     *
+     * @return the number of bytes allocated by the execution of the query, or {@code null} if the memory allocation
+     * could not be measured.
+     */
+    public Long allocatedBytes()
+    {
+        return allocatedBytes < 0 ? null : allocatedBytes;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -26,7 +26,8 @@ import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.impl.api.operations.QueryRegistrationOperations;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 import org.neo4j.kernel.impl.util.MonotonicCounter;
-import org.neo4j.time.CpuClock;
+import org.neo4j.resources.CpuClock;
+import org.neo4j.resources.HeapAllocation;
 import org.neo4j.time.SystemNanoClock;
 
 public class StackingQueryRegistrationOperations implements QueryRegistrationOperations
@@ -63,7 +64,8 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
         Thread thread = Thread.currentThread();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, clientConnection, statement.username(), queryText, queryParameters,
-                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount, thread, clock, CpuClock.CPU_CLOCK );
+                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount, thread, clock,
+                        CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -64,8 +64,9 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
         Thread thread = Thread.currentThread();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, clientConnection, statement.username(), queryText, queryParameters,
-                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount, thread, clock,
-                        CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
+                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount,
+                        statement.getPageCursorTracer(),
+                        thread, clock, CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.impl.locking.ActiveLock;
+import org.neo4j.resources.HeapAllocation;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
 import org.neo4j.test.FakeCpuClock;
@@ -103,8 +104,8 @@ public class ExecutingQueryStatusTest
                                 null,
                                 PageCursorTracer.NULL, Thread.currentThread(),
                                 clock,
-                                new FakeCpuClock(),
-                                new FakeHeapAllocation() ), clock.nanos() );
+                                FakeCpuClock.NOT_AVAILABLE,
+                                HeapAllocation.NOT_AVAILABLE ), clock.nanos() );
         clock.forward( 1025, TimeUnit.MILLISECONDS );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.impl.locking.ActiveLock;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
@@ -100,7 +101,7 @@ public class ExecutingQueryStatusTest
                                 null,
                                 null,
                                 null,
-                                Thread.currentThread(),
+                                PageCursorTracer.NULL, Thread.currentThread(),
                                 clock,
                                 new FakeCpuClock(),
                                 new FakeHeapAllocation() ), clock.nanos() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.impl.locking.ActiveLock;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
 import org.neo4j.test.FakeCpuClock;
+import org.neo4j.test.FakeHeapAllocation;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
 
@@ -101,7 +102,8 @@ public class ExecutingQueryStatusTest
                                 null,
                                 Thread.currentThread(),
                                 clock,
-                                FakeCpuClock.CPU_CLOCK ), clock.nanos() );
+                                new FakeCpuClock(),
+                                new FakeHeapAllocation() ), clock.nanos() );
         clock.forward( 1025, TimeUnit.MILLISECONDS );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryTest.java
@@ -30,6 +30,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
@@ -54,8 +55,10 @@ import static org.junit.Assert.assertThat;
 public class ExecutingQueryTest
 {
     private final FakeClock clock = Clocks.fakeClock( ZonedDateTime.parse( "2016-12-03T15:10:00+01:00" ) );
-    private final FakeCpuClock cpuClock = new FakeCpuClock().add( randomLong( 0x1_0000_0000L ) );
-    private final FakeHeapAllocation heapAllocation = new FakeHeapAllocation().add( randomLong( 0x1_0000_0000L ) );
+    @Rule
+    public final FakeCpuClock cpuClock = new FakeCpuClock().add( randomLong( 0x1_0000_0000L ) );
+    @Rule
+    public final FakeHeapAllocation heapAllocation = new FakeHeapAllocation().add( randomLong( 0x1_0000_0000L ) );
     private final PageCursorCountersStub page = new PageCursorCountersStub();
     private long lockCount;
     private ExecutingQuery query = new ExecutingQuery(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -27,8 +27,9 @@ import java.util.stream.Collectors;
 
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
+import org.neo4j.resources.HeapAllocation;
 import org.neo4j.time.Clocks;
-import org.neo4j.time.CpuClock;
+import org.neo4j.resources.CpuClock;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
@@ -117,8 +118,6 @@ public class ExecutingQueryListTest
     {
         return new ExecutingQuery( queryId, ClientConnectionInfo.EMBEDDED_CONNECTION, "me", query,
                 Collections.emptyMap(), Collections.emptyMap(), () -> 0, Thread.currentThread(),
-                Clocks.nanoClock(),
-                CpuClock.CPU_CLOCK
-        );
+                Clocks.nanoClock(), CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 import org.neo4j.resources.HeapAllocation;
@@ -117,7 +118,7 @@ public class ExecutingQueryListTest
     private ExecutingQuery createExecutingQuery( int queryId, String query )
     {
         return new ExecutingQuery( queryId, ClientConnectionInfo.EMBEDDED_CONNECTION, "me", query,
-                Collections.emptyMap(), Collections.emptyMap(), () -> 0, Thread.currentThread(),
+                Collections.emptyMap(), Collections.emptyMap(), () -> 0, PageCursorTracer.NULL, Thread.currentThread(),
                 Clocks.nanoClock(), CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -21,11 +21,15 @@ package org.neo4j.test;
 
 import java.util.concurrent.TimeUnit;
 
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongLongMap;
 import org.neo4j.resources.CpuClock;
 
-public class FakeCpuClock extends CpuClock
+public class FakeCpuClock extends CpuClock implements TestRule
 {
     public static final CpuClock NOT_AVAILABLE = new CpuClock()
     {
@@ -57,5 +61,25 @@ public class FakeCpuClock extends CpuClock
     {
         cpuTimes.put( threadId, cpuTimeNanos( threadId ) + nanos );
         return this;
+    }
+
+    @Override
+    public Statement apply( Statement base, Description description )
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                try
+                {
+                    base.evaluate();
+                }
+                finally
+                {
+                    cpuTimes.close();
+                }
+            }
+        };
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
@@ -19,43 +19,30 @@
  */
 package org.neo4j.test;
 
-import java.util.concurrent.TimeUnit;
-
-import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongLongMap;
-import org.neo4j.resources.CpuClock;
+import org.neo4j.resources.HeapAllocation;
 
-public class FakeCpuClock extends CpuClock
+import static java.lang.Thread.currentThread;
+import static org.neo4j.collection.primitive.Primitive.offHeapLongLongMap;
+
+public class FakeHeapAllocation extends HeapAllocation
 {
-    public static final CpuClock NOT_AVAILABLE = new CpuClock()
-    {
-        @Override
-        public long cpuTimeNanos( long threadId )
-        {
-            return -1;
-        }
-    };
-    private final PrimitiveLongLongMap cpuTimes = Primitive.offHeapLongLongMap();
+    private final PrimitiveLongLongMap allocation = offHeapLongLongMap();
 
     @Override
-    public long cpuTimeNanos( long threadId )
+    public long allocatedBytes( long threadId )
     {
-        return Math.max( 0, cpuTimes.get( threadId ) );
+        return Math.max( 0, allocation.get( threadId ) );
     }
 
-    public FakeCpuClock add( long delta, TimeUnit unit )
+    public FakeHeapAllocation add( long bytes )
     {
-        return add( unit.toNanos( delta ) );
+        return add( currentThread().getId(), bytes );
     }
 
-    public FakeCpuClock add( long nanos )
+    public FakeHeapAllocation add( long threadId, long bytes )
     {
-        return add( Thread.currentThread().getId(), nanos );
-    }
-
-    public FakeCpuClock add( long threadId, long nanos )
-    {
-        cpuTimes.put( threadId, cpuTimeNanos( threadId ) + nanos );
+        allocation.put( threadId, allocatedBytes( threadId ) + bytes );
         return this;
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -69,12 +69,14 @@ public class QueryStatusResult
     public final long activeLockCount;
     /** @since Neo4j 3.2 */
     public final long elapsedTimeMillis; // TODO: this field should be of a Duration type (when Cypher supports that)
-    /** @since Neo4j 3.2 */
-    public final long cpuTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
+    /** @since Neo4j 3.2, will be {@code null} if measuring CPU time is not supported. */
+    public final Long cpuTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
     /** @since Neo4j 3.2 */
     public final long waitTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
     /** @since Neo4j 3.2 */
-    public final long idleTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
+    public final Long idleTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
+    /** @since Neo4j 3.2, will be {@code null} if measuring allocation is not supported. */
+    public final Long allocatedBytes;
 
     QueryStatusResult( ExecutingQuery query ) throws InvalidArgumentsException
     {
@@ -105,6 +107,7 @@ public class QueryStatusResult
         this.planner = query.planner();
         this.runtime = query.runtime();
         this.indexes = query.indexes();
+        this.allocatedBytes = query.allocatedBytes();
     }
 
     private static String formatTime( final long startTime )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -77,6 +77,10 @@ public class QueryStatusResult
     public final Long idleTimeMillis; // TODO: we want this field to be of a Duration type (when Cypher supports that)
     /** @since Neo4j 3.2, will be {@code null} if measuring allocation is not supported. */
     public final Long allocatedBytes;
+    /** @since Neo4j 3.2 */
+    public final long pageHits;
+    /** @since Neo4j 3.2 */
+    public final long pageFaults;
 
     QueryStatusResult( ExecutingQuery query ) throws InvalidArgumentsException
     {
@@ -108,6 +112,8 @@ public class QueryStatusResult
         this.runtime = query.runtime();
         this.indexes = query.indexes();
         this.allocatedBytes = query.allocatedBytes();
+        this.pageHits = query.pageHits();
+        this.pageFaults = query.pageFaults();
     }
 
     private static String formatTime( final long startTime )

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -271,6 +271,22 @@ public class ListQueriesProcedureTest
     }
 
     @Test
+    public void shouldContainPageHitsAndPageFaults() throws Exception
+    {
+        // given
+        String query = "MATCH (n) SET n.v = n.v + 1";
+        try ( Resource<Node> test = test( db::createNode, Transaction::acquireWriteLock, query ) )
+        {
+            // when
+            Map<String,Object> data = getQueryListing( query );
+
+            // then
+            assertThat( data, hasEntry( equalTo( "pageHits" ), instanceOf( Long.class ) ) );
+            assertThat( data, hasEntry( equalTo( "pageFaults" ), instanceOf( Long.class ) ) );
+        }
+    }
+
+    @Test
     public void shouldListUsedIndexes() throws Exception
     {
         // given

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/ListQueriesProcedureTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.enterprise.builtinprocs;
 
+import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -351,6 +353,19 @@ public class ListQueriesProcedureTest
             assertThat( index, hasEntry( "identifier", "n" ) );
             assertThat( index, hasEntry( "label", "Node" ) );
             assertThat( index, hasEntry( "propertyKey", "value" ) );
+        }
+    }
+
+    @Ignore
+    @Test
+    public void sampleOutput() throws Exception
+    {
+        String query = "MATCH (n) SET n.v = n.v + 1";
+        db.execute( query ).close(); // ensure it's cached first
+        try ( Resource<Node> test = test( db::createNode, Transaction::acquireWriteLock, query );
+              PrintWriter out = new PrintWriter( System.out ) )
+        {
+            db.execute( "CALL dbms.listQueries" ).writeAsStringTo( out );
         }
     }
 

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogEntryContent.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogEntryContent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+
+enum QueryLogEntryContent
+{
+    LOG_PARAMETERS( GraphDatabaseSettings.log_queries_parameter_logging_enabled ),
+    LOG_DETAILED_TIME( GraphDatabaseSettings.log_queries_detailed_time_logging_enabled ),
+    LOG_ALLOCATED_BYTES( GraphDatabaseSettings.log_queries_allocation_logging_enabled ),
+    LOG_PAGE_DETAILS( GraphDatabaseSettings.log_queries_page_detail_logging_enabled );
+    private final Setting<Boolean> setting;
+
+    QueryLogEntryContent( Setting<Boolean> setting )
+    {
+        this.setting = setting;
+    }
+
+    boolean enabledIn( Config config )
+    {
+        return config.get( setting );
+    }
+}

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogFormatter.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogFormatter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.neo4j.helpers.Strings;
+import org.neo4j.kernel.api.query.QuerySnapshot;
+
+class QueryLogFormatter
+{
+    static void formatPageDetails( StringBuilder result, QuerySnapshot query )
+    {
+        result.append( query.pageHits() ).append( " page hits, " );
+        result.append( query.pageFaults() ).append( " page faults - " );
+    }
+
+    static void formatAllocatedBytes( StringBuilder result, QuerySnapshot query )
+    {
+        Long bytes = query.allocatedBytes();
+        if ( bytes != null )
+        {
+            result.append( bytes ).append( " B - " );
+        }
+    }
+
+    static void formatDetailedTime( StringBuilder result, QuerySnapshot query )
+    {
+        result.append( "(planning: " ).append( query.planningTimeMillis() );
+        Long cpuTime = query.cpuTimeMillis();
+        if ( cpuTime != null )
+        {
+            result.append( ", cpu: " ).append( cpuTime );
+        }
+        result.append( ", waiting: " ).append( query.waitTimeMillis() );
+        result.append( ") - " );
+    }
+
+    static void formatMap( StringBuilder result, Map<String,Object> params )
+    {
+        formatMap( result, params, Collections.emptySet() );
+    }
+
+    static void formatMap( StringBuilder result, Map<String,Object> params, Collection<String> obfuscate )
+    {
+        result.append( '{' );
+        if ( params != null )
+        {
+            String sep = "";
+            for ( Map.Entry<String,Object> entry : params.entrySet() )
+            {
+                result
+                        .append( sep )
+                        .append( entry.getKey() )
+                        .append( ": " );
+
+                if ( obfuscate.contains( entry.getKey() ) )
+                {
+                    result.append( "******" );
+                }
+                else
+                {
+                    formatValue( result, entry.getValue() );
+                }
+                sep = ", ";
+            }
+        }
+        result.append( "}" );
+    }
+
+    private static void formatValue( StringBuilder result, Object value )
+    {
+        if ( value instanceof Map<?,?> )
+        {
+            formatMap( result, (Map<String,Object>) value );
+        }
+        else if ( value instanceof String )
+        {
+            result.append( '\'' ).append( value ).append( '\'' );
+        }
+        else
+        {
+            result.append( Strings.prettyPrint( value ) );
+        }
+    }
+}

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.kernel.api.query.ExecutingQuery;
+import org.neo4j.kernel.api.query.QuerySnapshot;
+import org.neo4j.logging.Log;
+
+class QueryLogger implements QueryExecutionMonitor
+{
+    private final Log log;
+    private final long thresholdMillis;
+    private final boolean logQueryParameters, logDetailedTime, logAllocatedBytes, logPageDetails;
+
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(
+            // call signature
+            "(?:(?i)call)\\s+dbms(?:\\.security)?\\.change(?:User)?Password\\(" +
+            // optional username parameter, in single, double quotes, or parametrized
+            "(?:\\s*(?:'(?:(?<=\\\\)'|[^'])*'|\"(?:(?<=\\\\)\"|[^\"])*\"|[^,]*)\\s*,)?" +
+            // password parameter, in single, double quotes, or parametrized
+            "\\s*('(?:(?<=\\\\)'|[^'])*'|\"(?:(?<=\\\\)\"|[^\"])*\"|\\$\\w*|\\{\\w*\\})\\s*\\)" );
+
+    QueryLogger( Log log, long thresholdMillis, EnumSet<QueryLogEntryContent> flags )
+    {
+        this.log = log;
+        this.thresholdMillis = thresholdMillis;
+        this.logQueryParameters = flags.contains( QueryLogEntryContent.LOG_PARAMETERS );
+        this.logDetailedTime = flags.contains( QueryLogEntryContent.LOG_DETAILED_TIME );
+        this.logAllocatedBytes = flags.contains( QueryLogEntryContent.LOG_ALLOCATED_BYTES );
+        this.logPageDetails = flags.contains( QueryLogEntryContent.LOG_PAGE_DETAILS );
+    }
+
+    @Override
+    public void startQueryExecution( ExecutingQuery query )
+    {
+    }
+
+    @Override
+    public void endFailure( ExecutingQuery query, Throwable failure )
+    {
+        log.error( logEntry( query.snapshot() ), failure );
+    }
+
+    @Override
+    public void endSuccess( ExecutingQuery query )
+    {
+        QuerySnapshot snapshot = query.snapshot();
+        if ( snapshot.elapsedTimeMillis() >= thresholdMillis )
+        {
+            log.info( logEntry( snapshot ) );
+        }
+    }
+
+    private String logEntry( QuerySnapshot query )
+    {
+        String sourceString = query.clientConnection().asConnectionDetails();
+        String queryText = query.queryText();
+
+        Set<String> passwordParams = new HashSet<>();
+        Matcher matcher = PASSWORD_PATTERN.matcher( queryText );
+
+        while ( matcher.find() )
+        {
+            String password = matcher.group( 1 ).trim();
+            if ( password.charAt( 0 ) == '$' )
+            {
+                passwordParams.add( password.substring( 1 ) );
+            }
+            else if ( password.charAt( 0 ) == '{' )
+            {
+                passwordParams.add( password.substring( 1, password.length() - 1 ) );
+            }
+            else
+            {
+                queryText = queryText.replace( password, "******" );
+                password = "";
+            }
+        }
+
+        StringBuilder result = new StringBuilder();
+        result.append( query.elapsedTimeMillis() ).append( " ms: " );
+        if ( logDetailedTime )
+        {
+            QueryLogFormatter.formatDetailedTime( result, query );
+        }
+        if ( logAllocatedBytes )
+        {
+            QueryLogFormatter.formatAllocatedBytes( result, query );
+        }
+        if ( logPageDetails )
+        {
+            QueryLogFormatter.formatPageDetails( result, query );
+        }
+        result.append( sourceString ).append( " - " ).append( queryText );
+        if ( logQueryParameters )
+        {
+            QueryLogFormatter.formatMap( result.append(" - "), query.queryParameters(), passwordParams );
+        }
+        QueryLogFormatter.formatMap( result.append(" - "), query.transactionAnnotationData() );
+        return result.toString();
+    }
+}

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -73,7 +73,8 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
     {
         LOG_PARAMETERS( GraphDatabaseSettings.log_queries_parameter_logging_enabled ),
         LOG_DETAILED_TIME( GraphDatabaseSettings.log_queries_detailed_time_logging_enabled ),
-        LOG_ALLOCATED_BYTES( GraphDatabaseSettings.log_queries_allocation_logging_enabled );
+        LOG_ALLOCATED_BYTES( GraphDatabaseSettings.log_queries_allocation_logging_enabled ),
+        LOG_PAGE_DETAILS( GraphDatabaseSettings.log_queries_page_detail_logging_enabled );
         private final Setting<Boolean> setting;
 
         Flag( Setting<Boolean> setting )
@@ -166,7 +167,7 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
     {
         private final Log log;
         private final long thresholdMillis;
-        private final boolean logQueryParameters, logDetailedTime, logAllocatedBytes;
+        private final boolean logQueryParameters, logDetailedTime, logAllocatedBytes, logPageDetails;
 
         private static final Pattern PASSWORD_PATTERN = Pattern.compile(
                 // call signature
@@ -183,6 +184,7 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
             this.logQueryParameters = flags.contains( Flag.LOG_PARAMETERS );
             this.logDetailedTime = flags.contains( Flag.LOG_DETAILED_TIME );
             this.logAllocatedBytes = flags.contains( Flag.LOG_ALLOCATED_BYTES );
+            this.logPageDetails = flags.contains( Flag.LOG_PAGE_DETAILS );
         }
 
         @Override
@@ -253,6 +255,11 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
                 {
                     result.append( bytes ).append( " B - " );
                 }
+            }
+            if ( logPageDetails )
+            {
+                result.append( query.pageHits() ).append( " page hits, " );
+                result.append( query.pageFaults() ).append( " page faults - " );
             }
             result.append( sourceString ).append( " - " ).append( queryText );
             if ( logQueryParameters )

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
 import org.neo4j.kernel.api.query.ExecutingQuery;
-import org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.QueryLogger;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 import org.neo4j.kernel.impl.query.clientconnection.ShellConnectionInfo;
 import org.neo4j.logging.AssertableLogProvider;
@@ -48,10 +47,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.neo4j.helpers.collection.MapUtil.map;
-import static org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.Flag.LOG_ALLOCATED_BYTES;
-import static org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.Flag.LOG_DETAILED_TIME;
-import static org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.Flag.LOG_PAGE_DETAILS;
-import static org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.Flag.LOG_PARAMETERS;
+import static org.neo4j.kernel.impl.query.QueryLogEntryContent.LOG_ALLOCATED_BYTES;
+import static org.neo4j.kernel.impl.query.QueryLogEntryContent.LOG_DETAILED_TIME;
+import static org.neo4j.kernel.impl.query.QueryLogEntryContent.LOG_PAGE_DETAILS;
+import static org.neo4j.kernel.impl.query.QueryLogEntryContent.LOG_PARAMETERS;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class QueryLoggerTest
@@ -468,9 +467,9 @@ public class QueryLoggerTest
                 containsString( " 17 page hits, 12 page faults - " ) ) );
     }
 
-    private QueryLogger queryLogger( LogProvider logProvider, QueryLoggerKernelExtension.Flag... flags )
+    private QueryLogger queryLogger( LogProvider logProvider, QueryLogEntryContent... flags )
     {
-        EnumSet<QueryLoggerKernelExtension.Flag> flagSet = EnumSet.noneOf( QueryLoggerKernelExtension.Flag.class );
+        EnumSet<QueryLogEntryContent> flagSet = EnumSet.noneOf( QueryLogEntryContent.class );
         Collections.addAll( flagSet, flags );
         return new QueryLogger( logProvider.getLog( getClass() ), 10/*ms*/, flagSet );
     }

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
@@ -63,8 +64,10 @@ public class QueryLoggerTest
     private static final String QUERY_3 = "MATCH (c)-[:FOO]->(d) RETURN d.size";
     private static final String QUERY_4 = "MATCH (n) WHERE n.age IN {ages} RETURN n";
     private final FakeClock clock = Clocks.fakeClock();
-    private final FakeCpuClock cpuClock = new FakeCpuClock();
-    private final FakeHeapAllocation heapAllocation = new FakeHeapAllocation();
+    @Rule
+    public final FakeCpuClock cpuClock = new FakeCpuClock();
+    @Rule
+    public final FakeHeapAllocation heapAllocation = new FakeHeapAllocation();
     private long pageHits, pageFaults;
 
     @Test

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -34,8 +34,9 @@ import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
 import org.neo4j.kernel.impl.query.clientconnection.ShellConnectionInfo;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.resources.HeapAllocation;
 import org.neo4j.time.Clocks;
-import org.neo4j.time.CpuClock;
+import org.neo4j.resources.CpuClock;
 import org.neo4j.time.FakeClock;
 
 import static java.lang.String.format;
@@ -451,6 +452,7 @@ public class QueryLoggerTest
                 () -> 0,
                 Thread.currentThread(),
                 clock,
-                CpuClock.CPU_CLOCK );
+                CpuClock.CPU_CLOCK,
+                HeapAllocation.HEAP_ALLOCATION );
     }
 }

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -137,16 +137,16 @@ dbms.connector.https.enabled=true
 # Maximum number of history files for the query log.
 #dbms.logs.query.rotation.keep_number=7
 
-# Log parameters for executed queries (this is enabled by default).
+# Include parameters for the executed queries being logged (this is enabled by default).
 #dbms.logs.query.parameter_logging_enabled=true
 
-# Uncomment this line to include detailed time information for executed queries:
+# Uncomment this line to include detailed time information for the executed queries being logged:
 #dbms.logs.query.time_logging_enabled=true
 
-# Uncomment this line to include bytes allocated by executed queries:
+# Uncomment this line to include bytes allocated by the executed queries being logged:
 #dbms.logs.query.allocation_logging_enabled=true
 
-# Uncomment this line to include page hits and page faults information for executed queries:
+# Uncomment this line to include page hits and page faults information for the executed queries being logged:
 #dbms.logs.query.page_logging_enabled=true
 
 # The security log is always enabled when `dbms.security.auth_enabled=true`, and resides in `logs/security.log`.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -137,6 +137,18 @@ dbms.connector.https.enabled=true
 # Maximum number of history files for the query log.
 #dbms.logs.query.rotation.keep_number=7
 
+# Log parameters for executed queries (this is enabled by default).
+#dbms.logs.query.parameter_logging_enabled=true
+
+# Uncomment this line to include detailed time information for executed queries:
+#dbms.logs.query.time_logging_enabled=true
+
+# Uncomment this line to include bytes allocated by executed queries:
+#dbms.logs.query.allocation_logging_enabled=true
+
+# Uncomment this line to include page hits and page faults information for executed queries:
+#dbms.logs.query.page_logging_enabled=true
+
 # The security log is always enabled when `dbms.security.auth_enabled=true`, and resides in `logs/security.log`.
 
 # Log level for the security log. One of DEBUG, INFO, WARN and ERROR.


### PR DESCRIPTION
Sample output:

```
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| queryId   | username | metaData | query                         | parameters | planner     | runtime       | indexes | startTime                       | elapsedTime    | protocol | clientAddress | requestUri | status    | resourceInformation                                                                          | activeLockCount | elapsedTimeMillis | cpuTimeMillis | waitTimeMillis | idleTimeMillis | allocatedBytes | pageHits | pageFaults |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| "query-1" | ""       | {}       | "MATCH (n) SET n.v = n.v + 1" | {}         | "idp"       | "interpreted" | []      | "2017-03-15T14:27:36.243+01:00" | "00:00:00.177" | <null>   | <null>        | <null>     | "waiting" | {waitTimeMillis -> 169, lockMode -> "EXCLUSIVE", resourceType -> "NODE", resourceIds -> [0]} | 1               | 177               | 12            | 165            | 0              | 617232         | 2        | 0          |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

This change set also adds the ability to include the memory and page hit/fault information in the query log. This is toggled through settings, and off by default in order not to change the format of the query log.