### PR TITLE
exit with error when unrecognized arguments are given to `neo4j-admin`

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/HelpCommand.java
@@ -19,11 +19,8 @@
  */
 package org.neo4j.commandline.admin;
 
-import java.nio.file.Path;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
-
-import org.neo4j.commandline.arguments.Arguments;
 
 import static java.lang.String.format;
 

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/MandatoryNamedArg.java
@@ -69,8 +69,8 @@ public class MandatoryNamedArg implements NamedArgument
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        return Args.parse( args ).interpretOption( name, mandatory(), identity() );
+        return parsedArgs.interpretOption( name, mandatory(), identity() );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/NamedArgument.java
@@ -51,13 +51,13 @@ public interface NamedArgument
     /**
      * Parses the option (or possible default value) out of program arguments.
      */
-    String parse( String... args );
+    String parse( Args parsedArgs );
 
     /**
      * Returns true if this argument was given explicitly on the command line
      */
-    default boolean has( String[] args )
+    default boolean has( Args parsedArgs )
     {
-        return Args.parse( args ).has( name() );
+        return parsedArgs.has( name() );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalBooleanArg.java
@@ -38,10 +38,8 @@ public class OptionalBooleanArg extends OptionalNamedArg
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        return Boolean.toString( Args.withFlags( name() )
-                .parse( args )
-                .getBoolean( name, Boolean.parseBoolean( defaultValue ) ) );
+        return Boolean.toString( parsedArgs.getBoolean( name, Boolean.parseBoolean( defaultValue ) ) );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalNamedArg.java
@@ -86,9 +86,9 @@ public class OptionalNamedArg implements NamedArgument
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        String value = Args.parse( args ).interpretOption( name, withDefault( defaultValue ), identity() );
+        String value = parsedArgs.interpretOption( name, withDefault( defaultValue ), identity() );
         if ( allowedValues.length > 0 )
         {
             for ( String allowedValue : allowedValues )

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/OptionalPositionalArgument.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.commandline.arguments;
 
+import org.neo4j.helpers.Args;
+
 public class OptionalPositionalArgument implements PositionalArgument
 {
     protected final String value;
@@ -40,5 +42,11 @@ public class OptionalPositionalArgument implements PositionalArgument
     public String usage()
     {
         return String.format( "[<%s>]", value );
+    }
+
+    @Override
+    public String parse( Args parsedArgs )
+    {
+        return parsedArgs.orphans().get( position );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/PositionalArgument.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.commandline.arguments;
 
+import org.neo4j.helpers.Args;
+
 public interface PositionalArgument
 {
     /**
@@ -30,4 +32,9 @@ public interface PositionalArgument
      * Represents the option in the usage string.
      */
     String usage();
+
+    /**
+     * Parses the option (or possible default value) out of program arguments.
+     */
+    String parse( Args parsedArgs );
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/Database.java
@@ -23,6 +23,7 @@ package org.neo4j.commandline.arguments.common;
 import java.io.File;
 
 import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.helpers.Args;
 
 public class Database extends OptionalNamedArg
 {
@@ -42,8 +43,8 @@ public class Database extends OptionalNamedArg
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        return validate( super.parse( args ) );
+        return validate( super.parse( parsedArgs ) );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/MandatoryCanonicalPath.java
@@ -22,6 +22,7 @@ package org.neo4j.commandline.arguments.common;
 
 import org.neo4j.commandline.Util;
 import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.helpers.Args;
 
 public class MandatoryCanonicalPath extends MandatoryNamedArg
 {
@@ -42,8 +43,8 @@ public class MandatoryCanonicalPath extends MandatoryNamedArg
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        return canonicalize( super.parse( args ) );
+        return canonicalize( super.parse( parsedArgs ) );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/arguments/common/OptionalCanonicalPath.java
@@ -22,6 +22,7 @@ package org.neo4j.commandline.arguments.common;
 
 import org.neo4j.commandline.Util;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.helpers.Args;
 
 public class OptionalCanonicalPath extends OptionalNamedArg
 {
@@ -42,8 +43,8 @@ public class OptionalCanonicalPath extends OptionalNamedArg
     }
 
     @Override
-    public String parse( String... args )
+    public String parse( Args parsedArgs )
     {
-        return canonicalize( super.parse( args ) );
+        return canonicalize( super.parse( parsedArgs ) );
     }
 }

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/ArgumentsTest.java
@@ -20,12 +20,18 @@
 package org.neo4j.commandline.arguments;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.commandline.admin.IncorrectUsage;
 
 import static org.junit.Assert.assertEquals;
 
 public class ArgumentsTest
 {
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     private Arguments builder;
 
@@ -33,6 +39,73 @@ public class ArgumentsTest
     public void setup()
     {
         builder = new Arguments();
+    }
+
+    @Test
+    public void throwsOnUnexpectedLongArgument() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized option: 'stacktrace'" );
+
+        builder.withDatabase().parse( new String[]{ "--stacktrace" } );
+    }
+
+    @Test
+    public void throwsOnUnexpectedLongArgumentWithValue() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized option: 'stacktrace'" );
+
+        builder.withDatabase().parse( new String[]{ "--stacktrace=true" } );
+    }
+
+    @Test
+    public void throwsOnUnexpectedShortArgument() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized option: 'f'" );
+
+        builder.withDatabase().parse( new String[]{ "-f" } );
+    }
+
+    @Test
+    public void throwsOnUnexpectedShortArgumentWithValue() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized option: 'f'" );
+
+        builder.withDatabase().parse( new String[]{ "-f=bob" } );
+    }
+
+    @Test
+    public void throwsOnUnexpectedPositionalArgument() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized arguments: 'bob sob'" );
+
+        builder.withDatabase().parse( new String[]{ "bob", "sob" } );
+    }
+
+    @Test
+    public void throwsOnUnexpectedPositionalArgumentWhenExpectingSome() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "unrecognized arguments: 'three four'" );
+
+        builder.withMandatoryPositionalArgument( 0, "first" )
+                .withOptionalPositionalArgument( 1, "second" )
+                .parse( new String[]{ "one", "two", "three", "four" } );
+    }
+
+    @Test
+    public void throwsOnTooFewPositionalArguments() throws Exception
+    {
+        expected.expect( IncorrectUsage.class );
+        expected.expectMessage( "not enough arguments" );
+
+        builder.withMandatoryPositionalArgument( 0, "first" )
+                .withOptionalPositionalArgument( 1, "second" )
+                .parse( new String[]{} );
     }
 
     @Test

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/OptionalBooleanArgTest.java
@@ -21,6 +21,8 @@ package org.neo4j.commandline.arguments;
 
 import org.junit.Test;
 
+import org.neo4j.helpers.Args;
+
 import static org.junit.Assert.assertEquals;
 
 public class OptionalBooleanArgTest
@@ -31,10 +33,10 @@ public class OptionalBooleanArgTest
     {
         OptionalBooleanArg arg = new OptionalBooleanArg( "foo", false, "" );
 
-        assertEquals( "false", arg.parse() );
-        assertEquals( "false", arg.parse("--foo=false") );
-        assertEquals( "true", arg.parse("--foo=true") );
-        assertEquals( "true", arg.parse("--foo") );
+        assertEquals( "false", arg.parse( Args.parse() ) );
+        assertEquals( "false", arg.parse( Args.parse( "--foo=false" ) ) );
+        assertEquals( "true", arg.parse( Args.parse( "--foo=true" ) ) );
+        assertEquals( "true", arg.parse( Args.parse( "--foo" ) ) );
     }
 
     @Test
@@ -42,10 +44,10 @@ public class OptionalBooleanArgTest
     {
         OptionalBooleanArg arg = new OptionalBooleanArg( "foo", true, "" );
 
-        assertEquals( "true", arg.parse() );
-        assertEquals( "false", arg.parse("--foo=false") );
-        assertEquals( "true", arg.parse("--foo=true") );
-        assertEquals( "true", arg.parse("--foo") );
+        assertEquals( "true", arg.parse( Args.parse() ) );
+        assertEquals( "false", arg.parse( Args.parse( "--foo=false" ) ) );
+        assertEquals( "true", arg.parse( Args.parse( "--foo=true" ) ) );
+        assertEquals( "true", arg.parse( Args.parse( "--foo" ) ) );
     }
 
     @Test

--- a/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/arguments/common/DatabaseTest.java
@@ -26,6 +26,8 @@ import org.junit.rules.ExpectedException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.neo4j.helpers.Args;
+
 import static org.junit.Assert.assertEquals;
 
 public class DatabaseTest
@@ -41,12 +43,12 @@ public class DatabaseTest
         Path path = Paths.get( "data", "databases", "graph.db" );
         expected.expect( IllegalArgumentException.class );
         expected.expectMessage( "'database' should be a name but you seem to have specified a path: " + path );
-        arg.parse( "--database=" + path );
+        arg.parse( Args.parse( "--database=" + path ) );
     }
 
     @Test
     public void parseDatabaseName() throws Exception
     {
-        assertEquals( "bob.db", arg.parse( "--database=bob.db" ) );
+        assertEquals( "bob.db", arg.parse( Args.parse( "--database=bob.db" ) ) );
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -110,11 +110,11 @@ public class CheckConsistencyCommand implements AdminCommand
 
         try
         {
-            database = arguments.parse( "database", args );
-            backupPath = arguments.parseOptionalPath( "backup", args );
-            verbose = arguments.parseBoolean( "verbose", args );
-            additionalConfigFile = arguments.parseOptionalPath( "additional-config", args );
-            reportDir = arguments.parseOptionalPath( "report-dir", args )
+            database = arguments.parse( args ).get( "database" );
+            backupPath = arguments.getOptionalPath( "backup" );
+            verbose = arguments.getBoolean( "verbose" );
+            additionalConfigFile = arguments.getOptionalPath( "additional-config" );
+            reportDir = arguments.getOptionalPath( "report-dir" )
                     .orElseThrow( () -> new IllegalArgumentException( "report-dir must be a valid path" ) );
         }
         catch ( IllegalArgumentException e )
@@ -124,7 +124,7 @@ public class CheckConsistencyCommand implements AdminCommand
 
         if ( backupPath.isPresent() )
         {
-            if ( arguments.has( "database", args ) )
+            if ( arguments.has( "database" ) )
             {
                 throw new IncorrectUsage( "Only one of '--database' and '--backup' can be specified." );
             }
@@ -139,33 +139,33 @@ public class CheckConsistencyCommand implements AdminCommand
         try
         {
             // We can remove the loading from config file in 4.0
-            if ( arguments.has( CHECK_GRAPH, args ) )
+            if ( arguments.has( CHECK_GRAPH ) )
             {
-                checkGraph = arguments.parseBoolean( CHECK_GRAPH, args );
+                checkGraph = arguments.getBoolean( CHECK_GRAPH );
             }
             else
             {
                 checkGraph = ConsistencyCheckSettings.consistency_check_graph.from( config );
             }
-            if ( arguments.has( CHECK_INDEXES, args ) )
+            if ( arguments.has( CHECK_INDEXES ) )
             {
-                checkIndexes = arguments.parseBoolean( CHECK_INDEXES, args );
+                checkIndexes = arguments.getBoolean( CHECK_INDEXES );
             }
             else
             {
                 checkIndexes = ConsistencyCheckSettings.consistency_check_indexes.from( config );
             }
-            if ( arguments.has( CHECK_LABEL_SCAN_STORE, args ) )
+            if ( arguments.has( CHECK_LABEL_SCAN_STORE ) )
             {
-                checkLabelScanStore = arguments.parseBoolean( CHECK_LABEL_SCAN_STORE, args );
+                checkLabelScanStore = arguments.getBoolean( CHECK_LABEL_SCAN_STORE );
             }
             else
             {
                 checkLabelScanStore = ConsistencyCheckSettings.consistency_check_label_scan_store.from( config );
             }
-            if ( arguments.has( CHECK_PROPERTY_OWNERS, args ) )
+            if ( arguments.has( CHECK_PROPERTY_OWNERS ) )
             {
-                checkPropertyOwners = arguments.parseBoolean( CHECK_PROPERTY_OWNERS, args );
+                checkPropertyOwners = arguments.getBoolean( CHECK_PROPERTY_OWNERS );
             }
             else
             {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -69,8 +69,8 @@ public class DumpCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        String database = arguments.parse( "database", args );
-        Path archive = calculateArchive( database, arguments.parseMandatoryPath( "to", args ) );
+        String database = arguments.parse( args ).get( "database" );
+        Path archive = calculateArchive( database, arguments.getMandatoryPath( "to" ) );
         Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
 
         try

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -176,9 +176,9 @@ public class ImportCommand implements AdminCommand
 
         try
         {
-            mode = allArguments.parse("mode", args);
-            database = allArguments.parse( "database", args );
-            additionalConfigFile = allArguments.parseOptionalPath( "additional-config", args );
+            mode = allArguments.parse( args ).get("mode" );
+            database = allArguments.get( "database" );
+            additionalConfigFile = allArguments.getOptionalPath( "additional-config" );
         }
         catch ( IllegalArgumentException e )
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -74,9 +74,10 @@ public class LoadCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Path archive = arguments.parseMandatoryPath( "from", args );
-        String database = arguments.parse( "database", args );
-        boolean force = arguments.parseBoolean( "force", args );
+        arguments.parse( args );
+        Path archive = arguments.getMandatoryPath( "from" );
+        String database = arguments.get( "database" );
+        boolean force = arguments.getBoolean( "force" );
 
         Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/VersionCommand.java
@@ -57,7 +57,8 @@ public class VersionCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        final Path storeDir = arguments.parseMandatoryPath( "store", args );
+        arguments.parse( args );
+        final Path storeDir = arguments.getMandatoryPath( "store" );
 
         Validators.CONTAINS_EXISTING_DATABASE.validate( storeDir.toFile() );
 

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommand.java
@@ -65,11 +65,9 @@ public class SetDefaultAdminCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Args parsedArgs = validateArgs( args );
-
         try
         {
-            setDefaultAdmin( parsedArgs.orphans().get( 0 ) );
+            setDefaultAdmin( arguments.parse( args ).get( 0 ) );
         }
         catch ( IncorrectUsage | CommandFailed e )
         {
@@ -79,20 +77,6 @@ public class SetDefaultAdminCommand implements AdminCommand
         {
             throw new CommandFailed( throwable.getMessage(), new RuntimeException( throwable ) );
         }
-    }
-
-    private Args validateArgs( String[] args ) throws IncorrectUsage
-    {
-        Args parsedArgs = Args.parse( args );
-        if ( parsedArgs.orphans().size() < 1 )
-        {
-            throw new IncorrectUsage( "no username specified." );
-        }
-        if ( parsedArgs.orphans().size() > 1 )
-        {
-            throw new IncorrectUsage( "too many arguments." );
-        }
-        return parsedArgs;
     }
 
     private void setDefaultAdmin( String username ) throws Throwable

--- a/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
+++ b/community/security/src/main/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommand.java
@@ -64,11 +64,9 @@ public class SetInitialPasswordCommand implements AdminCommand
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
-        Args parsedArgs = validateArgs( args );
-
         try
         {
-            setPassword( parsedArgs.orphans().get( 0 ) );
+            setPassword( arguments.parse( args ).get( 0 ) );
         }
         catch ( IncorrectUsage | CommandFailed e )
         {
@@ -78,20 +76,6 @@ public class SetInitialPasswordCommand implements AdminCommand
         {
             throw new CommandFailed( throwable.getMessage(), new RuntimeException( throwable ) );
         }
-    }
-
-    private Args validateArgs( String[] args ) throws IncorrectUsage
-    {
-        Args parsedArgs = Args.parse( args );
-        if ( parsedArgs.orphans().size() < 1 )
-        {
-            throw new IncorrectUsage( "No password specified." );
-        }
-        if ( parsedArgs.orphans().size() > 1 )
-        {
-            throw new IncorrectUsage( "Too many arguments." );
-        }
-        return parsedArgs;
     }
 
     private void setPassword( String password ) throws Throwable

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -132,7 +132,7 @@ public class SetDefaultAdminCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "no username specified." );
+        verify( out ).stdErrLine( "not enough arguments" );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
         verify( out, times( 2 ) ).stdErrLine( "" );
@@ -150,7 +150,7 @@ public class SetDefaultAdminCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_ADMIN, "foo", "bar" );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "too many arguments." );
+        verify( out ).stdErrLine( "unrecognized arguments: 'bar'" );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
         verify( out, times( 2 ) ).stdErrLine( "" );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -89,14 +89,14 @@ public class SetDefaultAdminCommandTest
     public void shouldFailForNoArguments() throws Exception
     {
         assertException( () -> setDefaultAdmin.execute( new String[0] ), IncorrectUsage.class,
-                "no username specified." );
+                "not enough arguments" );
     }
 
     @Test
     public void shouldFailForTooManyArguments() throws Exception
     {
         String[] arguments = {"", "123", "321"};
-        assertException( () -> setDefaultAdmin.execute( arguments ), IncorrectUsage.class, "too many arguments." );
+        assertException( () -> setDefaultAdmin.execute( arguments ), IncorrectUsage.class, "unrecognized arguments: '123 321'" );
     }
 
     @Test

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -111,7 +111,7 @@ public class SetInitialPasswordCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "No password specified." );
+        verify( out ).stdErrLine( "not enough arguments" );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
         verify( out, times( 2 ) ).stdErrLine( "" );
@@ -127,7 +127,7 @@ public class SetInitialPasswordCommandIT
         tool.execute( homeDir.toPath(), confDir.toPath(), SET_PASSWORD, "foo", "bar" );
         assertNoAuthIniFile();
 
-        verify( out ).stdErrLine( "Too many arguments." );
+        verify( out ).stdErrLine( "unrecognized arguments: 'bar'" );
         verify( out, times( 2 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
         verify( out, times( 2 ) ).stdErrLine( "" );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -53,7 +53,6 @@ public class SetInitialPasswordCommandTest
 {
     private SetInitialPasswordCommand setPasswordCommand;
     private File authInitFile;
-    private File authFile;
     private FileSystemAbstraction fileSystem;
 
     private final EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
@@ -71,21 +70,21 @@ public class SetInitialPasswordCommandTest
         setPasswordCommand = new SetInitialPasswordCommand( testDir.directory( "home" ).toPath(),
                 testDir.directory( "conf" ).toPath(), mock );
         authInitFile = CommunitySecurityModule.getInitialUserRepositoryFile( setPasswordCommand.loadNeo4jConfig() );
-        authFile = CommunitySecurityModule.getUserRepositoryFile( setPasswordCommand.loadNeo4jConfig() );
+        CommunitySecurityModule.getUserRepositoryFile( setPasswordCommand.loadNeo4jConfig() );
     }
 
     @Test
     public void shouldFailSetPasswordWithNoArguments() throws Exception
     {
         assertException( () -> setPasswordCommand.execute( new String[0] ), IncorrectUsage.class,
-                "No password specified." );
+                "not enough arguments" );
     }
 
     @Test
     public void shouldFailSetPasswordWithTooManyArguments() throws Exception
     {
         String[] arguments = {"", "123", "321"};
-        assertException( () -> setPasswordCommand.execute( arguments ), IncorrectUsage.class, "Too many arguments." );
+        assertException( () -> setPasswordCommand.execute( arguments ), IncorrectUsage.class, "unrecognized arguments: '123 321'" );
     }
 
     @Test

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -40,6 +40,7 @@ import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.TimeUtil;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -122,14 +123,14 @@ public class OnlineBackupCommand implements AdminCommand
         try
         {
             address = toHostnamePort( new HostnamePort( "localhost", 6362 ) )
-                    .apply( arguments.parse( "from", args ) );
-            folder = arguments.parseMandatoryPath( "backup-dir", args );
-            name = arguments.parse( "name", args );
-            fallbackToFull = arguments.parseBoolean( "fallback-to-full", args );
-            doConsistencyCheck = arguments.parseBoolean( "check-consistency", args );
-            timeout = parseTimeout( args );
-            additionalConfig = arguments.parseOptionalPath( "additional-config", args );
-            reportDir = arguments.parseOptionalPath( "cc-report-dir", args ).orElseThrow( () ->
+                    .apply( arguments.parse( args ).get( "from" ) );
+            folder = arguments.getMandatoryPath( "backup-dir" );
+            name = arguments.get( "name" );
+            fallbackToFull = arguments.getBoolean( "fallback-to-full" );
+            doConsistencyCheck = arguments.getBoolean( "check-consistency" );
+            timeout = arguments.get( "timeout", TimeUtil.parseTimeMillis );
+            additionalConfig = arguments.getOptionalPath( "additional-config" );
+            reportDir = arguments.getOptionalPath( "cc-report-dir" ).orElseThrow( () ->
                     new IllegalArgumentException( "cc-report-dir must be a path" ) );
         }
         catch ( IllegalArgumentException e )
@@ -155,33 +156,33 @@ public class OnlineBackupCommand implements AdminCommand
         try
         {
             // We can remove the loading from config file in 4.0
-            if ( arguments.has( "cc-graph", args ) )
+            if ( arguments.has( "cc-graph" ) )
             {
-                checkGraph = arguments.parseBoolean( "cc-graph", args );
+                checkGraph = arguments.getBoolean( "cc-graph" );
             }
             else
             {
                 checkGraph = ConsistencyCheckSettings.consistency_check_graph.from( config );
             }
-            if ( arguments.has( "cc-indexes", args ) )
+            if ( arguments.has( "cc-indexes" ) )
             {
-                checkIndexes = arguments.parseBoolean( "cc-indexes", args );
+                checkIndexes = arguments.getBoolean( "cc-indexes" );
             }
             else
             {
                 checkIndexes = ConsistencyCheckSettings.consistency_check_indexes.from( config );
             }
-            if ( arguments.has( "cc-label-scan-store", args ) )
+            if ( arguments.has( "cc-label-scan-store" ) )
             {
-                checkLabelScanStore = arguments.parseBoolean( "cc-label-scan-store", args );
+                checkLabelScanStore = arguments.getBoolean( "cc-label-scan-store" );
             }
             else
             {
                 checkLabelScanStore = ConsistencyCheckSettings.consistency_check_label_scan_store.from( config );
             }
-            if ( arguments.has( "cc-property-owners", args ) )
+            if ( arguments.has( "cc-property-owners" ) )
             {
-                checkPropertyOwners = arguments.parseBoolean( "cc-property-owners", args );
+                checkPropertyOwners = arguments.getBoolean( "cc-property-owners" );
             }
             else
             {

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -71,9 +71,9 @@ public class RestoreDatabaseCli implements AdminCommand
 
         try
         {
-            databaseName = arguments.parse( "database", incomingArguments );
-            fromPath = arguments.parse("from", incomingArguments);
-            forceOverwrite = arguments.parseBoolean("force", incomingArguments);
+            databaseName = arguments.parse( incomingArguments ).get( "database" );
+            fromPath = arguments.get( "from" );
+            forceOverwrite = arguments.getBoolean( "force" );
         }
         catch ( IllegalArgumentException e )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -58,7 +58,7 @@ public class UnbindFromClusterCommand implements AdminCommand
         this.outsideWorld = outsideWorld;
     }
 
-    public static Arguments arguments()
+    static Arguments arguments()
     {
         return arguments;
     }
@@ -72,17 +72,12 @@ public class UnbindFromClusterCommand implements AdminCommand
         return config.with( additionalConfig );
     }
 
-    private static List<Class<?>> settings()
-    {
-        return Arrays.asList( GraphDatabaseSettings.class, DatabaseManagementSystemSettings.class );
-    }
-
     @Override
     public void execute( String[] args ) throws IncorrectUsage, CommandFailed
     {
         try
         {
-            Config config = loadNeo4jConfig( homeDir, configDir, arguments.parse( "database", args ) );
+            Config config = loadNeo4jConfig( homeDir, configDir, arguments.parse( args ).get( "database" ) );
             File dataDirectory = config.get( DatabaseManagementSystemSettings.data_directory );
             Path pathToSpecificDatabase = config.get( DatabaseManagementSystemSettings.database_path ).toPath();
 


### PR DESCRIPTION
Mostly a reminder that a few more commands exist in 3.2 than 3.1.

See https://github.com/neo4j/neo4j/pull/9038