### PR TITLE
Lenient transaction log reader

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -158,6 +158,7 @@ import org.neo4j.logging.Logger;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StoreReadLayer;
 
+import static org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler.STRICT;
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;
 
 public class NeoStoreDataSource implements Lifecycle, IndexProviders
@@ -448,7 +449,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                     indexConfigStore, updateableSchemaState::clear, legacyIndexTransactionOrdering );
 
             LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader =
-                    new VersionAwareLogEntryReader<>( storageEngine.commandReaderFactory() );
+                    new VersionAwareLogEntryReader<>( storageEngine.commandReaderFactory(), STRICT );
 
             TransactionIdStore transactionIdStore = dependencies.resolveDependency( TransactionIdStore.class );
             LogVersionRepository logVersionRepository = dependencies.resolveDependency( LogVersionRepository.class );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionableChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PositionableChannel.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import java.io.IOException;
+
+public interface PositionableChannel
+{
+    void setCurrentPosition( long byteOffset ) throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadChannel.java
@@ -34,7 +34,7 @@ import static java.lang.System.arraycopy;
  * spanning more than one file, by properly implementing {@link #next(StoreChannel)}.
  * @param <T> The type of StoreChannel wrapped
  */
-public class ReadAheadChannel<T extends StoreChannel> implements ReadableClosableChannel
+public class ReadAheadChannel<T extends StoreChannel> implements ReadableClosableChannel, PositionableChannel
 {
     public static final int DEFAULT_READ_AHEAD_SIZE = 1024 * 4;
 
@@ -187,6 +187,7 @@ public class ReadAheadChannel<T extends StoreChannel> implements ReadableClosabl
         aheadBuffer.position( remaining );
     }
 
+    @Override
     public void setCurrentPosition( long byteOffset ) throws IOException
     {
         long positionRelativeToAheadBuffer = byteOffset - (channel.position() - aheadBuffer.limit());

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.entry;
+
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+
+/**
+ * Decides what happens to invalid log entries read by {@link LogEntryReader}.
+ */
+public interface InvalidLogEntryHandler
+{
+    /**
+     * Allows no invalid log entries.
+     */
+    public static final InvalidLogEntryHandler STRICT = new InvalidLogEntryHandler()
+    {
+    };
+
+    /**
+     * Log entry couldn't be read correctly. Could be invalid log entry in the log.
+     *
+     * @param e error during reading a log entry.
+     * @param position {@link LogPosition} of the start of the log entry attempted to be read.
+     * @return {@code true} if this error is accepted, otherwise {@code false} which means the exception
+     * causing this will be thrown by the caller.
+     */
+    default boolean handleInvalidEntry( Exception e, LogPosition position )
+    {   // consider invalid by default
+        return false;
+    }
+
+    /**
+     * Tells this handler that, given that there were invalid entries, handler thinks they are OK
+     * to skip and that one or more entries after a bad section could be read then a certain number
+     * of bytes contained invalid log data and were therefore skipped. Log entry reading continues
+     * after this call.
+     *
+     * @param bytesSkipped number of bytes skipped.
+     */
+    default void bytesSkipped( long bytesSkipped )
+    {   // do nothing by default
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/InvalidLogEntryHandler.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.impl.transaction.log.LogPosition;
 /**
  * Decides what happens to invalid log entries read by {@link LogEntryReader}.
  */
-public interface InvalidLogEntryHandler
+public abstract class InvalidLogEntryHandler
 {
     /**
      * Allows no invalid log entries.
@@ -41,7 +41,7 @@ public interface InvalidLogEntryHandler
      * @return {@code true} if this error is accepted, otherwise {@code false} which means the exception
      * causing this will be thrown by the caller.
      */
-    default boolean handleInvalidEntry( Exception e, LogPosition position )
+    public boolean handleInvalidEntry( Exception e, LogPosition position )
     {   // consider invalid by default
         return false;
     }
@@ -54,7 +54,7 @@ public interface InvalidLogEntryHandler
      *
      * @param bytesSkipped number of bytes skipped.
      */
-    default void bytesSkipped( long bytesSkipped )
+    public void bytesSkipped( long bytesSkipped )
     {   // do nothing by default
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
@@ -31,7 +31,7 @@ import static java.lang.System.currentTimeMillis;
  */
 class LogEntrySanity
 {
-    private static final long UNREASONABLY_LONG_TIME = TimeUnit.DAYS.toMillis( 30 * 356 /*years*/ );
+    private static final long UNREASONABLY_LONG_TIME = TimeUnit.DAYS.toMillis( 30 * 365 /*years*/ );
     private static final int UNREASONABLY_HIGH_SERVER_ID = 10_000_000;
 
     static boolean logEntryMakesSense( LogEntry entry )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntrySanity.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.entry;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
+import static java.lang.Math.abs;
+import static java.lang.System.currentTimeMillis;
+
+/**
+ * Sanity checking for read {@link LogEntry log entries}.
+ */
+class LogEntrySanity
+{
+    private static final long UNREASONABLY_LONG_TIME = TimeUnit.DAYS.toMillis( 30 * 356 /*years*/ );
+    private static final int UNREASONABLY_HIGH_SERVER_ID = 10_000_000;
+
+    static boolean logEntryMakesSense( LogEntry entry )
+    {
+        if ( entry == null )
+        {
+            return false;
+        }
+
+        if ( entry instanceof IdentifiableLogEntry )
+        {
+            IdentifiableLogEntry iEntry = (IdentifiableLogEntry) entry;
+            entry = iEntry.getEntry();
+        }
+
+        if ( entry instanceof LogEntryStart )
+        {
+            return startEntryMakesSense( (LogEntryStart) entry );
+        }
+        else if ( entry instanceof LogEntryCommit )
+        {
+            return commitEntryMakesSense( (LogEntryCommit) entry );
+        }
+        return true;
+    }
+
+    static boolean commitEntryMakesSense( LogEntryCommit entry )
+    {
+        return timeMakesSense( entry.getTimeWritten() ) && transactionIdMakesSense( entry );
+    }
+
+    private static boolean transactionIdMakesSense( LogEntryCommit entry )
+    {
+        return entry.getTxId() > TransactionIdStore.BASE_TX_ID;
+    }
+
+    static boolean startEntryMakesSense( LogEntryStart entry )
+    {
+        return serverIdMakesSense( entry.getLocalId() ) &&
+                serverIdMakesSense( entry.getMasterId() ) &&
+                timeMakesSense( entry.getTimeWritten() );
+    }
+
+    private static boolean serverIdMakesSense( int serverId )
+    {
+        return serverId >= 0 && serverId < UNREASONABLY_HIGH_SERVER_ID;
+    }
+
+    static boolean timeMakesSense( long time )
+    {
+        return abs( currentTimeMillis() - time ) < UNREASONABLY_LONG_TIME;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
@@ -155,7 +155,7 @@ public enum LogEntryVersion
     {
         byte flattenedVersion = (byte) -version;
 
-        if ( flattenedVersion < LOOKUP_BY_VERSION.length)
+        if ( flattenedVersion >= 0 && flattenedVersion < LOOKUP_BY_VERSION.length )
         {
             return LOOKUP_BY_VERSION[flattenedVersion];
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
@@ -70,10 +70,6 @@ public class VersionAwareLogEntryReader<SOURCE extends ReadableClosablePositionA
             {
                 channel.getCurrentPosition( positionMarker );
 
-                /*
-                 * if the read type is negative than it is actually the log entry version
-                 * so we need to read an extra byte which will contain the type
-                 */
                 byte typeCode;
                 byte versionCode;
                 try
@@ -82,6 +78,8 @@ public class VersionAwareLogEntryReader<SOURCE extends ReadableClosablePositionA
                     versionCode = 0;
                     if ( typeCode < 0 )
                     {
+                        // if the read type is negative than it is actually the log entry version
+                        // so we need to read an extra byte which will contain the type
                         versionCode = typeCode;
                         typeCode = channel.get();
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
-import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
+import org.neo4j.kernel.impl.transaction.log.PositionableChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.storageengine.api.CommandReaderFactory;
 import org.neo4j.storageengine.api.ReadPastEndException;
@@ -122,7 +122,7 @@ public class VersionAwareLogEntryReader<SOURCE extends ReadableClosablePositionA
                     if ( channelSupportsPositioning( channel ) &&
                             invalidLogEntryHandler.handleInvalidEntry( e, position ) )
                     {
-                        ((ReadAheadLogChannel)channel).setCurrentPosition( positionMarker.getByteOffset() + 1 );
+                        ((PositionableChannel)channel).setCurrentPosition( positionMarker.getByteOffset() + 1 );
                         skipped++;
                         continue;
                     }
@@ -143,6 +143,6 @@ public class VersionAwareLogEntryReader<SOURCE extends ReadableClosablePositionA
 
     private boolean channelSupportsPositioning( SOURCE channel )
     {
-        return channel instanceof ReadAheadLogChannel;
+        return channel instanceof PositionableChannel;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
@@ -477,7 +477,7 @@ public class VersionAwareLogEntryReaderTest
         assertEquals( secondStartTime, readSecondStartEntry.getTimeWritten() );
     }
 
-    static class AcceptingInvalidLogEntryHandler implements InvalidLogEntryHandler
+    static class AcceptingInvalidLogEntryHandler extends InvalidLogEntryHandler
     {
         long bytesSkipped;
         Exception e;

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
@@ -36,6 +36,7 @@ import org.neo4j.helpers.Args;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCommand;
@@ -50,6 +51,7 @@ import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.ReaderLogVersionBridge;
 import org.neo4j.kernel.impl.transaction.log.TransactionLogEntryCursor;
+import org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
@@ -74,6 +76,7 @@ public class DumpLogicalLog
     private static final String TO_FILE = "tofile";
     private static final String TX_FILTER = "txfilter";
     private static final String CC_FILTER = "ccfilter";
+    private static final String LENIENT = "lenient";
 
     private final FileSystemAbstraction fileSystem;
 
@@ -83,7 +86,8 @@ public class DumpLogicalLog
     }
 
     public void dump( String filenameOrDirectory, PrintStream out,
-            Predicate<LogEntry[]> filter, Function<LogEntry,String> serializer ) throws IOException
+            Predicate<LogEntry[]> filter, Function<LogEntry,String> serializer,
+            InvalidLogEntryHandler invalidLogEntryHandler ) throws IOException
     {
         File file = new File( filenameOrDirectory );
         printFile( file, out );
@@ -135,8 +139,10 @@ public class DumpLogicalLog
 
         PhysicalLogVersionedStoreChannel channel = new PhysicalLogVersionedStoreChannel(
                 fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
-        ReadableClosablePositionAwareChannel logChannel = new ReadAheadLogChannel( channel, bridge, DEFAULT_READ_AHEAD_SIZE );
-        LogEntryReader<ReadableClosablePositionAwareChannel> entryReader = new VersionAwareLogEntryReader<>();
+        ReadableClosablePositionAwareChannel logChannel = new ReadAheadLogChannel( channel, bridge,
+                DEFAULT_READ_AHEAD_SIZE );
+        LogEntryReader<ReadableClosablePositionAwareChannel> entryReader = new VersionAwareLogEntryReader<>(
+                new RecordStorageCommandReaderFactory(), invalidLogEntryHandler );
 
         IOCursor<LogEntry> entryCursor = new LogEntryCursor( entryReader, logChannel );
         TransactionLogEntryCursor transactionCursor = new TransactionLogEntryCursor( entryCursor );
@@ -281,7 +287,7 @@ public class DumpLogicalLog
     }
 
     /**
-     * Usage: [--txfilter "regex"] [--ccfilter cc-report-file] [--tofile] storeDirOrFile1 storeDirOrFile2 ...
+     * Usage: [--txfilter "regex"] [--ccfilter cc-report-file] [--tofile] [--lenient] storeDirOrFile1 storeDirOrFile2 ...
      *
      * --txfilter
      * Will match regex against each {@link LogEntry} and if there is a match,
@@ -294,21 +300,35 @@ public class DumpLogicalLog
      *
      * --tofile
      * Redirects output to dump-logical-log.txt in the store directory
+     *
+     * --lenient
+     * Will attempt to read log entries even if some look broken along the way
      */
     public static void main( String args[] ) throws IOException
     {
-        Args arguments = Args.withFlags( TO_FILE ).parse( args );
+        Args arguments = Args.withFlags( TO_FILE, LENIENT ).parse( args );
         TimeZone timeZone = parseTimeZoneConfig( arguments );
         Predicate<LogEntry[]> filter = parseFilter( arguments, timeZone );
         Function<LogEntry,String> serializer = parseSerializer( filter, timeZone );
+        Function<PrintStream,InvalidLogEntryHandler> invalidLogEntryHandler = parseInvalidLogEntryHandler( arguments );
         try ( Printer printer = getPrinter( arguments ) )
         {
             for ( String fileAsString : arguments.orphans() )
             {
-                new DumpLogicalLog( new DefaultFileSystemAbstraction() )
-                        .dump( fileAsString, printer.getFor( fileAsString ), filter, serializer );
+                PrintStream out = printer.getFor( fileAsString );
+                new DumpLogicalLog( new DefaultFileSystemAbstraction() ).dump( fileAsString, out, filter, serializer,
+                        invalidLogEntryHandler.apply( out ) );
             }
         }
+    }
+
+    private static Function<PrintStream,InvalidLogEntryHandler> parseInvalidLogEntryHandler( Args arguments )
+    {
+        if ( arguments.getBoolean( LENIENT ) )
+        {
+            return out -> new LenientInvalidLogEntryHandler( out );
+        }
+        return out -> InvalidLogEntryHandler.STRICT;
     }
 
     @SuppressWarnings( "unchecked" )

--- a/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
@@ -28,7 +28,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler;
  * Is less strict with invalid log entries, allowing reader to try and read through bad sections.
  * Prints problems along the way.
  */
-class LenientInvalidLogEntryHandler implements InvalidLogEntryHandler
+class LenientInvalidLogEntryHandler extends InvalidLogEntryHandler
 {
     private final PrintStream out;
 
@@ -40,13 +40,13 @@ class LenientInvalidLogEntryHandler implements InvalidLogEntryHandler
     @Override
     public boolean handleInvalidEntry( Exception e, LogPosition position )
     {
-        out.println( "Read broken entry error:" + e + " will go one byte ahead and try again" );
+        out.println( "Read broken entry with error:" + e + ", will go one byte ahead and try again" );
         return true;
     }
 
     @Override
     public void bytesSkipped( long bytesSkipped )
     {
-        out.println( "... skipped " + bytesSkipped + " bytes of weird tx log data" );
+        out.println( "... skipped " + bytesSkipped + " bytes of indecipherable transaction log data" );
     }
 }

--- a/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tools.dump;
+
+import java.io.PrintStream;
+
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler;
+
+/**
+ * Is less strict with invalid log entries, allowing reader to try and read through bad sections.
+ * Prints problems along the way.
+ */
+class LenientInvalidLogEntryHandler implements InvalidLogEntryHandler
+{
+    private final PrintStream out;
+
+    LenientInvalidLogEntryHandler( PrintStream out )
+    {
+        this.out = out;
+    }
+
+    @Override
+    public boolean handleInvalidVersion( byte typeCode, byte versionCode )
+    {
+        out.println( "Read header of an entry which doesn't make sense version:" + versionCode +
+                ", type:" + typeCode + " will go one byte ahead and try again" );
+        return true;
+    }
+
+    @Override
+    public boolean handleInvalidEntry( Exception e, LogPosition position )
+    {
+        out.println( "Read broken entry error:" + e + " will go one byte ahead and try again" );
+        return true;
+    }
+
+    @Override
+    public void bytesSkipped( long bytesSkipped )
+    {
+        out.println( "... skipped " + bytesSkipped + " bytes of weird tx log data" );
+    }
+}

--- a/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/LenientInvalidLogEntryHandler.java
@@ -38,14 +38,6 @@ class LenientInvalidLogEntryHandler implements InvalidLogEntryHandler
     }
 
     @Override
-    public boolean handleInvalidVersion( byte typeCode, byte versionCode )
-    {
-        out.println( "Read header of an entry which doesn't make sense version:" + versionCode +
-                ", type:" + typeCode + " will go one byte ahead and try again" );
-        return true;
-    }
-
-    @Override
     public boolean handleInvalidEntry( Exception e, LogPosition position )
     {
         out.println( "Read broken entry error:" + e + " will go one byte ahead and try again" );


### PR DESCRIPTION
Reading transaction logs can now be more lenient and attempt to read through bad sections. This feature becomes very handy when debugging damaged transaction log files.

By default log reading is strict, but can be made lenient when merely dumping transaction logs to text and in similar tooling.