### PR TITLE
NODE KEY constraint as full stack constraint combining features of uniqueness and existence constraints

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -37,8 +37,6 @@ import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
-import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor.Type.UNIQUE;
-
 /**
  * Note that this class builds up an in-memory representation of the complete schema store by being used in
  * multiple phases.
@@ -156,7 +154,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         {
             checkSchema( rule, record, records, engine );
 
-            if ( rule.getConstraintDescriptor().type() == UNIQUE )
+            if ( rule.getConstraintDescriptor().type().enforcesUniqueness() )
             {
                 DynamicRecord previousObligation = indexObligations.put( rule.getOwnedIndex(), record.clone() );
                 if ( previousObligation != null )
@@ -201,7 +199,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         public void checkConstraintRule( ConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {
-            if ( rule.getConstraintDescriptor().type() == UNIQUE )
+            if ( rule.getConstraintDescriptor().type().enforcesUniqueness() )
             {
                 DynamicRecord obligation = constraintObligations.get( rule.getId() );
                 if ( obligation == null )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -154,7 +154,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         {
             checkSchema( rule, record, records, engine );
 
-            if ( rule.getConstraintDescriptor().type().enforcesUniqueness() )
+            if ( rule.getConstraintDescriptor().enforcesUniqueness() )
             {
                 DynamicRecord previousObligation = indexObligations.put( rule.getOwnedIndex(), record.clone() );
                 if ( previousObligation != null )
@@ -199,7 +199,7 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         public void checkConstraintRule( ConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {
-            if ( rule.getConstraintDescriptor().type().enforcesUniqueness() )
+            if ( rule.getConstraintDescriptor().enforcesUniqueness() )
             {
                 DynamicRecord obligation = constraintObligations.get( rule.getId() );
                 if ( obligation == null )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -52,7 +52,7 @@ public class MandatoryProperties
         SchemaStorage schemaStorage = new SchemaStorage( storeAccess.getSchemaStore() );
         for ( ConstraintRule rule : constraintsIgnoringMalformed( schemaStorage ) )
         {
-            if ( rule.getConstraintDescriptor().type().enforcesPropertyExistence() )
+            if ( rule.getConstraintDescriptor().enforcesPropertyExistence() )
             {
                 rule.schema().processWith( constraintRecorder );
             }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -40,8 +40,6 @@ import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.Utils;
 
-import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor.Type.EXISTS;
-
 public class MandatoryProperties
 {
     private final PrimitiveIntObjectMap<int[]> nodes = Primitive.intObjectMap();
@@ -54,7 +52,7 @@ public class MandatoryProperties
         SchemaStorage schemaStorage = new SchemaStorage( storeAccess.getSchemaStore() );
         for ( ConstraintRule rule : constraintsIgnoringMalformed( schemaStorage ) )
         {
-            if ( rule.getConstraintDescriptor().type() == EXISTS )
+            if ( rule.getConstraintDescriptor().type().enforcesPropertyExistence() )
             {
                 rule.schema().processWith( constraintRecorder );
             }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/IndexDescriptor.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/IndexDescriptor.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, PropertyKeyId}
 object IndexDescriptor {
   def apply(label: Int, property: Int): IndexDescriptor = IndexDescriptor(LabelId(label), Seq(PropertyKeyId(property)))
 
-  def apply(label: Int, properties: Seq[Int]): IndexDescriptor = IndexDescriptor(LabelId(label), properties.toSeq.map(PropertyKeyId))
+  def apply(label: Int, properties: Seq[Int]): IndexDescriptor = IndexDescriptor(LabelId(label), properties.map(PropertyKeyId))
 
   def apply(label: LabelId, property: PropertyKeyId): IndexDescriptor = IndexDescriptor(label, Seq(property))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/QueryTagger.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/QueryTagger.scala
@@ -290,6 +290,7 @@ object QueryTagger extends QueryTagger[String] {
     lift[ASTNode] {
       case x: CreateIndex => Set(CreateIndexTag)
       case x: DropIndex => Set(DropIndexTag)
+      case x: CreateNodeKeyConstraint => Set(CreateConstraintTag)
       case x: CreateUniquePropertyConstraint => Set(CreateConstraintTag)
       case x: CreateNodePropertyExistenceConstraint => Set(CreateConstraintTag)
       case x: CreateRelationshipPropertyExistenceConstraint => Set(CreateConstraintTag)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallOrSchemaCommandPlanBuilder.scala
@@ -52,15 +52,19 @@ case object ProcedureCallOrSchemaCommandPlanBuilder extends Phase[CompilerContex
           context.notificationLogger.notifications, context.typeConverter.asPublicType))
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case CreateUniquePropertyConstraint(node, label, prop) =>
+      // CREATE CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
+      case CreateUniquePropertyConstraint(node, label, props) =>
         Some(PureSideEffectExecutionPlan("CreateUniqueConstraint", SCHEMA_WRITE, (ctx) => {
-          ctx.createUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyToId(ctx)(prop.propertyKey)))
+          val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey))
+          ctx.createUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyKeyIds))
         }))
 
       // DROP CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
-      case DropUniquePropertyConstraint(_, label, prop) =>
+      // DROP CONSTRAINT ON (node:Label) ASSERT (node.prop1,node.prop2) IS UNIQUE
+      case DropUniquePropertyConstraint(_, label, props) =>
         Some(PureSideEffectExecutionPlan("DropUniqueConstraint", SCHEMA_WRITE, (ctx) => {
-          ctx.dropUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyToId(ctx)(prop.propertyKey)))
+          val propertyKeyIds = props.map(p => propertyToId(ctx)(p.propertyKey))
+          ctx.dropUniqueConstraint(IndexDescriptor(labelToId(ctx)(label), propertyKeyIds))
         }))
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop EXISTS

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
@@ -111,6 +111,12 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   override def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V =
     singleDbHit(inner.getOrCreateFromSchemaState(key, creator))
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean =
+    singleDbHit(inner.createNodeKeyConstraint(descriptor))
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    singleDbHit(inner.dropNodeKeyConstraint(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean =
     singleDbHit(inner.createUniqueConstraint(descriptor))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
@@ -102,6 +102,11 @@ trait QueryContext extends TokenContext {
   def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V
 
   /* return true if the constraint was created, false if preexisting, throws if failed */
+  def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean
+
+  def dropNodeKeyConstraint(descriptor: IndexDescriptor)
+
+  /* return true if the constraint was created, false if preexisting, throws if failed */
   def createUniqueConstraint(descriptor: IndexDescriptor): Boolean
 
   def dropUniqueConstraint(descriptor: IndexDescriptor)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
@@ -44,6 +44,8 @@ trait QueryContextAdaptation {
 
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = ???
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = ???
+
   override def getOrCreateRelTypeId(relTypeName: String): Int = ???
 
   override def getPropertiesForRelationship(relId: Long): scala.Iterator[Int] = ???
@@ -79,6 +81,8 @@ trait QueryContextAdaptation {
   override def getLabelsForNode(node: Long): scala.Iterator[Int] = ???
 
   override def dropUniqueConstraint(descriptor: IndexDescriptor): Unit = ???
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor): Unit = ???
 
   // Check if a runtime value is a node, relationship, path or some such value returned from
   override def isGraphKernelResultValue(v: Any): Boolean = ???

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
@@ -111,6 +111,12 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def getOrCreateFromSchemaState[K, V](key: K, creator: => V): V =
     translateException(inner.getOrCreateFromSchemaState(key, creator))
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean =
+    translateException(inner.createNodeKeyConstraint(descriptor))
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    translateException(inner.dropNodeKeyConstraint(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean =
     translateException(inner.createUniqueConstraint(descriptor))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -489,7 +489,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   }
 
   override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
-    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.uniqueForSchema(descriptor))
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.nodeKeyForSchema(descriptor))
 
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = try {
     transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(descriptor)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -481,6 +481,16 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def dropIndexRule(descriptor: IndexDescriptor) =
     transactionalContext.statement.schemaWriteOperations().indexDrop(descriptor)
 
+  override def createNodeKeyConstraint(descriptor: IndexDescriptor): Boolean = try {
+    transactionalContext.statement.schemaWriteOperations().nodeKeyConstraintCreate(descriptor)
+    true
+  } catch {
+    case existing: AlreadyConstrainedException => false
+  }
+
+  override def dropNodeKeyConstraint(descriptor: IndexDescriptor) =
+    transactionalContext.statement.schemaWriteOperations().constraintDrop(ConstraintDescriptorFactory.uniqueForSchema(descriptor))
+
   override def createUniqueConstraint(descriptor: IndexDescriptor): Boolean = try {
     transactionalContext.statement.schemaWriteOperations().uniquePropertyConstraintCreate(descriptor)
     true

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Command.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Command.scala
@@ -89,6 +89,10 @@ trait RelationshipPropertyConstraintCommand extends PropertyConstraintCommand {
   def relType: RelTypeName
 }
 
+case class CreateNodeKeyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
+
+case class DropNodeKeyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
+
 case class CreateUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand
 
 case class DropUniquePropertyConstraint(variable: Variable, label: LabelName, properties: Seq[Property])(val position: InputPosition) extends UniquePropertyConstraintCommand

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Command.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Command.scala
@@ -32,11 +32,13 @@ trait Command extends Parser
   def Command: Rule1[ast.Command] = rule(
     CreateUniqueConstraint
       | CreateUniqueCompositeConstraint
+      | CreateNodeKeyConstraint
       | CreateNodePropertyExistenceConstraint
       | CreateRelationshipPropertyExistenceConstraint
       | CreateIndex
       | DropUniqueConstraint
       | DropUniqueCompositeConstraint
+      | DropNodeKeyConstraint
       | DropNodePropertyExistenceConstraint
       | DropRelationshipPropertyExistenceConstraint
       | DropIndex
@@ -63,6 +65,10 @@ trait Command extends Parser
     group(keyword("CREATE") ~~ UniqueCompositeConstraintSyntax) ~~>> (ast.CreateUniquePropertyConstraint(_, _, _))
   }
 
+  def CreateNodeKeyConstraint: Rule1[ast.CreateNodeKeyConstraint] = rule {
+    group(keyword("CREATE") ~~ NodeKeyConstraintSyntax) ~~>> (ast.CreateNodeKeyConstraint(_, _, _))
+  }
+
   def CreateNodePropertyExistenceConstraint: Rule1[ast.CreateNodePropertyExistenceConstraint] = rule {
     group(keyword("CREATE") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.CreateNodePropertyExistenceConstraint(_, _, _))
   }
@@ -80,6 +86,10 @@ trait Command extends Parser
     group(keyword("DROP") ~~ UniqueCompositeConstraintSyntax) ~~>> (ast.DropUniquePropertyConstraint(_, _, _))
   }
 
+  def DropNodeKeyConstraint: Rule1[ast.DropNodeKeyConstraint] = rule {
+    group(keyword("DROP") ~~ NodeKeyConstraintSyntax) ~~>> (ast.DropNodeKeyConstraint(_, _, _))
+  }
+
   def DropNodePropertyExistenceConstraint: Rule1[ast.DropNodePropertyExistenceConstraint] = rule {
     group(keyword("DROP") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.DropNodePropertyExistenceConstraint(_, _, _))
   }
@@ -93,6 +103,9 @@ trait Command extends Parser
       zeroOrMore(Expression, separator = CommaSep) ~~ ")"
     ) ~~> (_.toIndexedSeq))
   }
+
+  private def NodeKeyConstraintSyntax: Rule3[Variable, LabelName, Seq[Property]] = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
+    keyword("ASSERT") ~~ "(" ~~ PropertyExpressions ~~ ")" ~~ keyword("IS NODE KEY")
 
   private def UniqueConstraintSyntax: Rule3[Variable, LabelName, Property] = keyword("CONSTRAINT ON") ~~ "(" ~~ Variable ~~ NodeLabel ~~ ")" ~~
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Expressions.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/parser/Expressions.scala
@@ -180,7 +180,7 @@ trait Expressions extends Parser
     Expression1 ~ oneOrMore(WS ~ PropertyLookup)
   }
 
-  private def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {
+  def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {
     operator(".") ~~ (PropertyKeyName ~~>> (ast.Property(_: ast.Expression, _)))
   }
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
@@ -28,5 +28,6 @@ public enum ConstraintType
     UNIQUENESS,
     NODE_PROPERTY_EXISTENCE,
     RELATIONSHIP_PROPERTY_EXISTENCE,
+    NODE_KEY
     ;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -54,7 +54,8 @@ public interface SchemaWriteOperations
     void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( LabelSchemaDescriptor descriptor )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWriteOperations.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -51,6 +52,9 @@ public interface SchemaWriteOperations
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( NewIndexDescriptor descriptor ) throws DropIndexFailureException;
+
+    NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( LabelSchemaDescriptor descriptor )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodeKeyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodeKeyConstraint.java
@@ -62,12 +62,9 @@ public class NodeKeyConstraint extends NodePropertyConstraint
     {
         String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
-        String properties =
-                SchemaUtil.niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + "." );
-        if ( descriptor.getPropertyIds().length > 1 )
-        {
-            properties = "(" + properties + ")";
-        }
+        String properties = SchemaUtil
+                .niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + ".",
+                        descriptor.getPropertyIds().length > 1 );
         return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS NODE KEY", boundIdentifier, labelName, properties );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodeKeyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodeKeyConstraint.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.constraints;
+
+import java.util.Arrays;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
+
+/**
+ * Description of uniqueness and existence constraint over nodes given a label and a property key id.
+ *
+ * @deprecated use {@link NodeKeyConstraintDescriptor} instead.
+ */
+public class NodeKeyConstraint extends NodePropertyConstraint
+{
+    public NodeKeyConstraint( LabelSchemaDescriptor descriptor )
+    {
+        super( descriptor );
+    }
+
+    public NewIndexDescriptor indexDescriptor()
+    {
+        return NewIndexDescriptorFactory.forSchema( descriptor );
+    }
+
+    @Override
+    public void added( ChangeVisitor visitor )
+    {
+        visitor.visitAddedNodeKeyConstraint( this );
+    }
+
+    @Override
+    public void removed( ChangeVisitor visitor )
+    {
+        visitor.visitRemovedNodeKeyConstraint( this );
+    }
+
+    @Override
+    public String userDescription( TokenNameLookup tokenNameLookup )
+    {
+        String labelName = labelName( tokenNameLookup );
+        String boundIdentifier = labelName.toLowerCase();
+        String properties =
+                SchemaUtil.niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + "." );
+        if ( descriptor.getPropertyIds().length > 1 )
+        {
+            properties = "(" + properties + ")";
+        }
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS NODE KEY", boundIdentifier, labelName, properties );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERT n.property[%s] IS NODE KEY",
+                descriptor.getLabelId(), Arrays.toString( descriptor.getPropertyIds() ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
@@ -38,6 +38,10 @@ public interface PropertyConstraint
 
         void visitRemovedUniquePropertyConstraint( UniquenessConstraint constraint );
 
+        void visitAddedNodeKeyConstraint( NodeKeyConstraint constraint );
+
+        void visitRemovedNodeKeyConstraint( NodeKeyConstraint constraint );
+
         void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint )
                 throws CreateConstraintFailureException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
@@ -19,9 +19,12 @@
  */
 package org.neo4j.kernel.api.constraints;
 
+import java.util.Arrays;
+
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
@@ -60,15 +63,19 @@ public class UniquenessConstraint extends NodePropertyConstraint
     {
         String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
-        return String
-                .format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS UNIQUE", boundIdentifier, labelName, boundIdentifier,
-                        tokenNameLookup.propertyKeyGetName( descriptor.getPropertyId() ) );
+        String properties =
+                SchemaUtil.niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + "." );
+        if ( descriptor.getPropertyIds().length > 1 )
+        {
+            properties = "(" + properties + ")";
+        }
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS UNIQUE", boundIdentifier, labelName, properties );
     }
 
     @Override
     public String toString()
     {
         return String.format( "CONSTRAINT ON ( n:label[%d] ) ASSERT n.property[%d] IS UNIQUE",
-                descriptor.getLabelId(), descriptor.getPropertyId() );
+                descriptor.getLabelId(), Arrays.toString( descriptor.getPropertyIds() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/UniquenessConstraint.java
@@ -63,12 +63,9 @@ public class UniquenessConstraint extends NodePropertyConstraint
     {
         String labelName = labelName( tokenNameLookup );
         String boundIdentifier = labelName.toLowerCase();
-        String properties =
-                SchemaUtil.niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + "." );
-        if ( descriptor.getPropertyIds().length > 1 )
-        {
-            properties = "(" + properties + ")";
-        }
+        String properties = SchemaUtil
+                .niceProperties( tokenNameLookup, descriptor.getPropertyIds(), boundIdentifier + ".",
+                        descriptor.getPropertyIds().length > 1 );
         return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS UNIQUE", boundIdentifier, labelName, properties );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ConstraintViolationTransactionFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ConstraintViolationTransactionFailureException.java
@@ -28,7 +28,7 @@ public class ConstraintViolationTransactionFailureException extends TransactionF
 {
     public ConstraintViolationTransactionFailureException( String msg, KernelException cause )
     {
-        super( Status.Schema.ConstraintValidationFailed, msg, cause );
+        super( Status.Schema.ConstraintValidationFailed, cause, msg );
     }
 
     public ConstraintViolationTransactionFailureException( String msg )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 
 import static java.lang.String.format;
@@ -42,9 +43,9 @@ public class NodePropertyExistenceException extends ConstraintValidationExceptio
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return format( "Node(%d) with label `%s` must have the property `%s`",
+        return format( "Node(%d) with label `%s` must have the properties `%s`",
                 nodeId,
                 tokenNameLookup.labelGetName( schema.getLabelId() ),
-                tokenNameLookup.propertyKeyGetName( schema.getPropertyId() ) );
+                SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceException.java
@@ -43,9 +43,10 @@ public class NodePropertyExistenceException extends ConstraintValidationExceptio
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return format( "Node(%d) with label `%s` must have the properties `%s`",
+        String propertyNoun = (schema.getPropertyIds().length > 1) ? "properties" : "property";
+        return format( "Node(%d) with label `%s` must have the %s `%s`",
                 nodeId,
-                tokenNameLookup.labelGetName( schema.getLabelId() ),
+                tokenNameLookup.labelGetName( schema.getLabelId() ), propertyNoun,
                 SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/UniquePropertyValueValidationException.java
@@ -26,26 +26,26 @@ import java.util.Set;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
 
 public class UniquePropertyValueValidationException extends ConstraintValidationException
 {
     private final Set<IndexEntryConflictException> conflicts;
 
-    public UniquePropertyValueValidationException( UniquenessConstraintDescriptor constraint,
+    public UniquePropertyValueValidationException( IndexBackedConstraintDescriptor constraint,
             ConstraintValidationException.Phase phase, IndexEntryConflictException conflict )
     {
         this( constraint, phase, Collections.singleton( conflict ) );
     }
 
-    public UniquePropertyValueValidationException( UniquenessConstraintDescriptor constraint,
+    public UniquePropertyValueValidationException( IndexBackedConstraintDescriptor constraint,
             ConstraintValidationException.Phase phase, Set<IndexEntryConflictException> conflicts )
     {
         super( constraint, phase, phase == Phase.VERIFICATION ? "Existing data" : "New data" );
         this.conflicts = conflicts;
     }
 
-    public UniquePropertyValueValidationException( UniquenessConstraintDescriptor constraint,
+    public UniquePropertyValueValidationException( IndexBackedConstraintDescriptor constraint,
             ConstraintValidationException.Phase phase, Throwable cause )
     {
         super( constraint, phase, phase == Phase.VERIFICATION ? "Existing data" : "New data", cause );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
@@ -102,29 +102,4 @@ public class LabelSchemaDescriptor implements SchemaDescriptor, LabelSchemaSuppl
     {
         return this;
     }
-
-    public int compareTo( SchemaDescriptor o )
-    {
-        if ( o instanceof LabelSchemaDescriptor )
-        {
-            LabelSchemaDescriptor other = (LabelSchemaDescriptor) o;
-            if ( labelId == other.getLabelId() )
-            {
-                return SchemaUtil.comparePropertyKeyIds( propertyIds, other.getPropertyIds() );
-            }
-            else
-            {
-                return labelId - other.labelId;
-            }
-        }
-        else
-        {
-            return -1;
-        }
-    }
-
-    public interface Supplier extends SchemaDescriptor.Supplier
-    {
-        LabelSchemaDescriptor schema();
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
@@ -102,4 +102,24 @@ public class LabelSchemaDescriptor implements SchemaDescriptor, LabelSchemaSuppl
     {
         return this;
     }
+
+    public int compareTo( SchemaDescriptor o )
+    {
+        if ( o instanceof LabelSchemaDescriptor )
+        {
+            LabelSchemaDescriptor other = (LabelSchemaDescriptor) o;
+            if ( labelId == other.getLabelId() )
+            {
+                return SchemaUtil.comparePropertyKeyIds( propertyIds, other.getPropertyIds() );
+            }
+            else
+            {
+                return labelId - other.labelId;
+            }
+        }
+        else
+        {
+            return -1;
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/LabelSchemaDescriptor.java
@@ -122,4 +122,9 @@ public class LabelSchemaDescriptor implements SchemaDescriptor, LabelSchemaSuppl
             return -1;
         }
     }
+
+    public interface Supplier extends SchemaDescriptor.Supplier
+    {
+        LabelSchemaDescriptor schema();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
@@ -92,25 +92,4 @@ public class RelationTypeSchemaDescriptor implements SchemaDescriptor
     {
         return Arrays.hashCode( propertyIds ) + 31 * relTypeId;
     }
-
-    @Override
-    public int compareTo( SchemaDescriptor o )
-    {
-        if ( o instanceof RelationTypeSchemaDescriptor )
-        {
-            RelationTypeSchemaDescriptor other = (RelationTypeSchemaDescriptor) o;
-            if ( relTypeId == other.getRelTypeId() )
-            {
-                return SchemaUtil.comparePropertyKeyIds( propertyIds, other.getPropertyIds() );
-            }
-            else
-            {
-                return relTypeId - other.getRelTypeId();
-            }
-        }
-        else
-        {
-            return -1;
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/RelationTypeSchemaDescriptor.java
@@ -92,4 +92,25 @@ public class RelationTypeSchemaDescriptor implements SchemaDescriptor
     {
         return Arrays.hashCode( propertyIds ) + 31 * relTypeId;
     }
+
+    @Override
+    public int compareTo( SchemaDescriptor o )
+    {
+        if ( o instanceof RelationTypeSchemaDescriptor )
+        {
+            RelationTypeSchemaDescriptor other = (RelationTypeSchemaDescriptor) o;
+            if ( relTypeId == other.getRelTypeId() )
+            {
+                return SchemaUtil.comparePropertyKeyIds( propertyIds, other.getPropertyIds() );
+            }
+            else
+            {
+                return relTypeId - other.getRelTypeId();
+            }
+        }
+        else
+        {
+            return -1;
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.TokenNameLookup;
  * how this is done in eg. LabelSchemaDescriptor, and the SchemaProcessor and SchemaComputer interfaces need to be
  * extended with methods taking the new concrete type as argument.
  */
-public interface SchemaDescriptor
+public interface SchemaDescriptor extends Comparable<SchemaDescriptor>
 {
     /**
      * Computes some value by feeding this object into the given SchemaComputer.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaDescriptor.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.TokenNameLookup;
  * how this is done in eg. LabelSchemaDescriptor, and the SchemaProcessor and SchemaComputer interfaces need to be
  * extended with methods taking the new concrete type as argument.
  */
-public interface SchemaDescriptor extends Comparable<SchemaDescriptor>
+public interface SchemaDescriptor
 {
     /**
      * Computes some value by feeding this object into the given SchemaComputer.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -31,17 +31,21 @@ public class SchemaUtil
 
     public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds )
     {
-        return niceProperties( tokenNameLookup, propertyIds, "" );
+        return niceProperties( tokenNameLookup, propertyIds, "", false );
     }
 
-    public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds, String prefix )
+    public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds, String prefix,
+            boolean useBrackets )
     {
-        String[] properties = new String[propertyIds.length];
+        StringBuilder properties = new StringBuilder();
+        if ( useBrackets ) { properties.append( "(" ); }
         for ( int i = 0; i < propertyIds.length; i++ )
         {
-            properties[i] = prefix + tokenNameLookup.propertyKeyGetName( propertyIds[i] );
+            if ( i > 0 ) { properties.append( ", " ); }
+            properties.append( prefix ).append( tokenNameLookup.propertyKeyGetName( propertyIds[i] ) );
         }
-        return String.join( ", ", properties );
+        if ( useBrackets ) { properties.append( ")" ); }
+        return properties.toString();
     }
 
     public static TokenNameLookup idTokenNameLookup = new TokenNameLookup() {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -31,10 +31,15 @@ public class SchemaUtil
 
     public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds )
     {
+        return niceProperties( tokenNameLookup, propertyIds, "" );
+    }
+
+    public static String niceProperties( TokenNameLookup tokenNameLookup, int[] propertyIds, String prefix )
+    {
         String[] properties = new String[propertyIds.length];
         for ( int i = 0; i < propertyIds.length; i++ )
         {
-            properties[i] = tokenNameLookup.propertyKeyGetName( propertyIds[i] );
+            properties[i] = prefix + tokenNameLookup.propertyKeyGetName( propertyIds[i] );
         }
         return String.join( ", ", properties );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -38,13 +38,22 @@ public class SchemaUtil
             boolean useBrackets )
     {
         StringBuilder properties = new StringBuilder();
-        if ( useBrackets ) { properties.append( "(" ); }
+        if ( useBrackets )
+        {
+            properties.append( "(" );
+        }
         for ( int i = 0; i < propertyIds.length; i++ )
         {
-            if ( i > 0 ) { properties.append( ", " ); }
+            if ( i > 0 )
+            {
+                properties.append( ", " );
+            }
             properties.append( prefix ).append( tokenNameLookup.propertyKeyGetName( propertyIds[i] ) );
         }
-        if ( useBrackets ) { properties.append( ")" ); }
+        if ( useBrackets )
+        {
+            properties.append( ")" );
+        }
         return properties.toString();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -68,23 +68,4 @@ public class SchemaUtil
             return format( "property[%d]", propertyKeyId );
         }
     };
-
-    public static int comparePropertyKeyIds( int[] these, int[] those )
-    {
-        if ( these.length == those.length )
-        {
-            for ( int i = 0; i < these.length; i++ )
-            {
-                if ( these[i] != those[i] )
-                {
-                    return these[i] - those[i];
-                }
-            }
-            return 0;
-        }
-        else
-        {
-            return these.length - those.length;
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/SchemaUtil.java
@@ -64,4 +64,23 @@ public class SchemaUtil
             return format( "property[%d]", propertyKeyId );
         }
     };
+
+    public static int comparePropertyKeyIds( int[] these, int[] those )
+    {
+        if ( these.length == those.length )
+        {
+            for ( int i = 0; i < these.length; i++ )
+            {
+                if ( these[i] != those[i] )
+                {
+                    return these[i] - those[i];
+                }
+            }
+            return 0;
+        }
+        else
+        {
+            return these.length - those.length;
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintBoundary.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.schema_new.constaints;
 
+import org.neo4j.kernel.api.constraints.NodeKeyConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
@@ -75,6 +76,9 @@ public class ConstraintBoundary
 
             case EXISTS:
                 return new NodePropertyExistenceConstraint( schema );
+
+            case UNIQUE_EXISTS:
+                return new NodeKeyConstraint( schema );
 
             default:
                 throw new UnsupportedOperationException( "Although we cannot get here, this has not been implemented." );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
@@ -45,12 +45,12 @@ public abstract class ConstraintDescriptor implements SchemaDescriptor.Supplier
             this.mustExist = mustExist;
         }
 
-        public boolean enforcesUniqueness()
+        private boolean enforcesUniqueness()
         {
             return isUnique;
         }
 
-        public boolean enforcesPropertyExistence()
+        private boolean enforcesPropertyExistence()
         {
             return mustExist;
         }
@@ -75,6 +75,16 @@ public abstract class ConstraintDescriptor implements SchemaDescriptor.Supplier
     public Type type()
     {
         return type;
+    }
+
+    public boolean enforcesUniqueness()
+    {
+        return type.enforcesUniqueness();
+    }
+
+    public boolean enforcesPropertyExistence()
+    {
+        return type.enforcesPropertyExistence();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptor.java
@@ -32,8 +32,28 @@ public abstract class ConstraintDescriptor implements SchemaDescriptor.Supplier
 {
     public enum Type
     {
-        UNIQUE,
-        EXISTS
+        UNIQUE( true, false ),
+        EXISTS( false, true ),
+        UNIQUE_EXISTS( true, true );
+
+        private final boolean isUnique;
+        private final boolean mustExist;
+
+        Type( boolean isUnique, boolean mustExist )
+        {
+            this.isUnique = isUnique;
+            this.mustExist = mustExist;
+        }
+
+        public boolean enforcesUniqueness()
+        {
+            return isUnique;
+        }
+
+        public boolean enforcesPropertyExistence()
+        {
+            return mustExist;
+        }
     }
 
     public interface Supplier

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactory.java
@@ -45,6 +45,11 @@ public class ConstraintDescriptorFactory
         return new UniquenessConstraintDescriptor( SchemaDescriptorFactory.forLabel( labelId, propertyIds ) );
     }
 
+    public static NodeKeyConstraintDescriptor nodeKeyForLabel( int labelId, int... propertyIds )
+    {
+        return new NodeKeyConstraintDescriptor( SchemaDescriptorFactory.forLabel( labelId, propertyIds ) );
+    }
+
     public static ConstraintDescriptor existsForSchema( SchemaDescriptor schema )
     {
         return schema.computeWith( convertToExistenceConstraint );
@@ -63,6 +68,11 @@ public class ConstraintDescriptorFactory
     public static UniquenessConstraintDescriptor uniqueForSchema( SchemaDescriptor schema )
     {
         return schema.computeWith( convertToUniquenessConstraint );
+    }
+
+    public static NodeKeyConstraintDescriptor nodeKeyForSchema( SchemaDescriptor schema )
+    {
+        return schema.computeWith( convertToNodeKeyConstraint );
     }
 
     private static SchemaComputer<ConstraintDescriptor> convertToExistenceConstraint =
@@ -95,6 +105,26 @@ public class ConstraintDescriptorFactory
                 {
                     throw new UnsupportedOperationException(
                             format( "Cannot create uniqueness constraint for schema '%s' of type %s",
+                                    schema.userDescription( SchemaUtil.idTokenNameLookup ),
+                                    schema.getClass().getSimpleName()
+                            ) );
+                }
+            };
+
+    private static SchemaComputer<NodeKeyConstraintDescriptor> convertToNodeKeyConstraint =
+            new SchemaComputer<NodeKeyConstraintDescriptor>()
+            {
+                @Override
+                public NodeKeyConstraintDescriptor computeSpecific( LabelSchemaDescriptor schema )
+                {
+                    return new NodeKeyConstraintDescriptor( schema );
+                }
+
+                @Override
+                public NodeKeyConstraintDescriptor computeSpecific( RelationTypeSchemaDescriptor schema )
+                {
+                    throw new UnsupportedOperationException(
+                            format( "Cannot create node key constraint for schema '%s' of type %s",
                                     schema.userDescription( SchemaUtil.idTokenNameLookup ),
                                     schema.getClass().getSimpleName()
                             ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.schema_new.constaints;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
+import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
+
+public abstract class IndexBackedConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaDescriptor.Supplier
+{
+    private final LabelSchemaDescriptor schema;
+
+    IndexBackedConstraintDescriptor( Type type, LabelSchemaDescriptor schema )
+    {
+        super( type );
+        this.schema = schema;
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return schema;
+    }
+
+    public NewIndexDescriptor ownedIndexDescriptor()
+    {
+        return NewIndexDescriptorFactory.uniqueForSchema( schema );
+    }
+
+    @Override
+    public String prettyPrint( TokenNameLookup tokenNameLookup )
+    {
+        String labelName = escapeLabelOrRelTyp( tokenNameLookup.labelGetName( schema.getLabelId() ) );
+        String nodeName = labelName.toLowerCase();
+        String properties = SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds(), nodeName + "." );
+        if ( schema().getPropertyIds().length > 1 )
+        {
+            properties = "(" + properties + ")";
+        }
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS %s", nodeName, labelName, properties,
+                constraintTypeText() );
+    }
+
+    protected abstract String constraintTypeText();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
@@ -51,11 +51,8 @@ public abstract class IndexBackedConstraintDescriptor extends ConstraintDescript
     {
         String labelName = escapeLabelOrRelTyp( tokenNameLookup.labelGetName( schema.getLabelId() ) );
         String nodeName = labelName.toLowerCase();
-        String properties = SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds(), nodeName + "." );
-        if ( schema().getPropertyIds().length > 1 )
-        {
-            properties = "(" + properties + ")";
-        }
+        String properties = SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds(), nodeName + ".",
+                schema().getPropertyIds().length > 1 );
         return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s IS %s", nodeName, labelName, properties,
                 constraintTypeText() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/IndexBackedConstraintDescriptor.java
@@ -21,11 +21,12 @@ package org.neo4j.kernel.api.schema_new.constaints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.LabelSchemaSupplier;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
-public abstract class IndexBackedConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaDescriptor.Supplier
+public abstract class IndexBackedConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaSupplier
 {
     private final LabelSchemaDescriptor schema;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeExistenceConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeExistenceConstraintDescriptor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.schema_new.constaints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
 public class NodeExistenceConstraintDescriptor extends ConstraintDescriptor
 {
@@ -43,9 +44,9 @@ public class NodeExistenceConstraintDescriptor extends ConstraintDescriptor
     {
         String labelName = escapeLabelOrRelTyp( tokenNameLookup.labelGetName( schema.getLabelId() ) );
         String nodeName = labelName.toLowerCase();
-        String propertyName = tokenNameLookup.propertyKeyGetName( schema.getPropertyId() );
+        String properties =
+                SchemaUtil.niceProperties( tokenNameLookup, schema.getPropertyIds(), nodeName + ".", false );
 
-        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT exists(%s.%s)",
-                nodeName, labelName, nodeName, propertyName );
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT exists(%s)", nodeName, labelName, properties );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeKeyConstraintDescriptor.java
@@ -21,16 +21,16 @@ package org.neo4j.kernel.api.schema_new.constaints;
 
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 
-public class UniquenessConstraintDescriptor extends IndexBackedConstraintDescriptor
+public class NodeKeyConstraintDescriptor extends IndexBackedConstraintDescriptor
 {
-    UniquenessConstraintDescriptor( LabelSchemaDescriptor schema )
+    NodeKeyConstraintDescriptor( LabelSchemaDescriptor schema )
     {
-        super( Type.UNIQUE, schema );
+        super( Type.UNIQUE_EXISTS, schema );
     }
 
     @Override
     protected String constraintTypeText()
     {
-        return "UNIQUE";
+        return "NODE KEY";
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
@@ -87,7 +88,7 @@ public interface TransactionState extends ReadableTransactionState
 
     void constraintDoAdd( ConstraintDescriptor constraint );
 
-    void constraintDoAdd( UniquenessConstraintDescriptor constraint, long indexId );
+    void constraintDoAdd( IndexBackedConstraintDescriptor constraint, long indexId );
 
     void constraintDoDrop( ConstraintDescriptor constraint );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -25,7 +25,6 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.OrderedPropertyValues;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -77,10 +77,10 @@ public class SchemaProcedure
                 while ( labelsInDatabase.hasNext() )
                 {
                     Label label = labelsInDatabase.next();
+                    int labelId = readOperations.labelGetForName( label.name() );
                     Map<String,Object> properties = new HashMap<>();
 
-                    Iterator<NewIndexDescriptor> indexDescriptorIterator =
-                            readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
+                    Iterator<NewIndexDescriptor> indexDescriptorIterator = readOperations.indexesGetForLabel( labelId );
                     ArrayList<String> indexes = new ArrayList<>();
                     while ( indexDescriptorIterator.hasNext() )
                     {
@@ -92,7 +92,7 @@ public class SchemaProcedure
                     properties.put( "indexes", indexes );
 
                     Iterator<ConstraintDescriptor> nodePropertyConstraintIterator =
-                            readOperations.constraintsGetForLabel( readOperations.labelGetForName( label.name() ) );
+                            readOperations.constraintsGetForLabel( labelId );
                     ArrayList<String> constraints = new ArrayList<>();
                     while ( nodePropertyConstraintIterator.hasNext() )
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -57,6 +57,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -80,7 +81,6 @@ import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_PROPERTY_KEY;
 import static org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException.Phase.VALIDATION;
 import static org.neo4j.kernel.api.schema_new.SchemaDescriptorPredicates.hasProperty;
-import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor.Type.UNIQUE;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.INDEX_ENTRY;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.indexEntryResourceId;
 
@@ -118,7 +118,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             while ( constraints.hasNext() )
             {
                 ConstraintDescriptor constraint = constraints.next();
-                if ( constraint.type() == UNIQUE )
+                if ( constraint.type().enforcesUniqueness() )
                 {
                     UniquenessConstraintDescriptor uniqueConstraint = (UniquenessConstraintDescriptor) constraint;
                     ExactPredicate[] propertyValues = getAllPropertyValues( state, uniqueConstraint.schema(), node );
@@ -555,6 +555,13 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     public void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException
     {
         schemaWriteOperations.uniqueIndexDrop( state, descriptor );
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException
+    {
+        return schemaWriteOperations.nodeKeyConstraintCreate( state, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -119,7 +119,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             while ( constraints.hasNext() )
             {
                 ConstraintDescriptor constraint = constraints.next();
-                if ( constraint.type().enforcesUniqueness() )
+                if ( constraint.enforcesUniqueness() )
                 {
                     IndexBackedConstraintDescriptor uniqueConstraint = (IndexBackedConstraintDescriptor) constraint;
                     ExactPredicate[] propertyValues = getAllPropertyValues( state, uniqueConstraint.schema(), node );
@@ -558,7 +558,8 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
 
     @Override
     public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         Iterator<Cursor<NodeItem>> nodes = new NodeLoadingIterator( nodesGetForLabel( state, descriptor.getLabelId() ),
                 ( id ) -> nodeCursorById( state, id ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.ConstraintBoundary;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
@@ -116,7 +115,7 @@ public class DataIntegrityValidatingStatementOperations implements
             throws AlreadyIndexedException, AlreadyConstrainedException, RepeatedPropertyInCompositeSchemaException
     {
         assertValidDescriptor( descriptor, OperationContext.INDEX_CREATION );
-        assertUniqueIndexDoesNotExist( state, OperationContext.INDEX_CREATION, descriptor );
+        assertIndexDoesNotExist( state, OperationContext.INDEX_CREATION, descriptor );
         return schemaWriteDelegate.indexCreate( state, descriptor );
     }
 
@@ -162,7 +161,7 @@ public class DataIntegrityValidatingStatementOperations implements
         assertConstraintDoesNotExist( state, constraint );
 
         // It is not allowed to create node key constraints on indexed label/property pairs
-        assertUniqueIndexDoesNotExist( state, OperationContext.CONSTRAINT_CREATION, descriptor );
+        assertIndexDoesNotExist( state, OperationContext.CONSTRAINT_CREATION, descriptor );
 
         return schemaWriteDelegate.nodeKeyConstraintCreate( state, descriptor );
     }
@@ -178,7 +177,7 @@ public class DataIntegrityValidatingStatementOperations implements
         assertConstraintDoesNotExist( state, constraint );
 
         // It is not allowed to create uniqueness constraints on indexed label/property pairs
-        assertUniqueIndexDoesNotExist( state, OperationContext.CONSTRAINT_CREATION, descriptor );
+        assertIndexDoesNotExist( state, OperationContext.CONSTRAINT_CREATION, descriptor );
 
         return schemaWriteDelegate.uniquePropertyConstraintCreate( state, descriptor );
     }
@@ -220,7 +219,7 @@ public class DataIntegrityValidatingStatementOperations implements
         schemaWriteDelegate.constraintDrop( state, descriptor );
     }
 
-    private void assertUniqueIndexDoesNotExist( KernelStatement state, OperationContext context,
+    private void assertIndexDoesNotExist( KernelStatement state, OperationContext context,
             LabelSchemaDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -154,8 +154,10 @@ public class DataIntegrityValidatingStatementOperations implements
     @Override
     public NodeKeyConstraintDescriptor nodeKeyConstraintCreate(
             KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
+        assertValidDescriptor( descriptor, OperationContext.CONSTRAINT_CREATION );
         ConstraintDescriptor constraint = ConstraintDescriptorFactory.nodeKeyForSchema( descriptor );
         assertConstraintDoesNotExist( state, constraint );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -341,6 +342,15 @@ public class LockingStatementOperations implements
         {
             acquireExclusiveNodeLock( state, max( startNodeId, endNodeId ) );
         }
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state,LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+    {
+        acquireExclusiveSchemaLock( state );
+        state.assertOpen();
+        return schemaWriteDelegate.nodeKeyConstraintCreate( state, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -346,7 +346,8 @@ public class LockingStatementOperations implements
 
     @Override
     public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state,LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         acquireExclusiveSchemaLock( state );
         state.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1003,7 +1003,8 @@ public class OperationsFacade
 
     @Override
     public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
-            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException
     {
         statement.assertOpen();
         return schemaWrite().nodeKeyConstraintCreate( statement, descriptor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -82,6 +82,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -998,6 +999,14 @@ public class OperationsFacade
     {
         statement.assertOpen();
         schemaWrite().indexDrop( statement, descriptor );
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException
+    {
+        statement.assertOpen();
+        return schemaWrite().nodeKeyConstraintCreate( statement, descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntCollection;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntCollection;
@@ -68,7 +70,9 @@ import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -585,11 +589,10 @@ public class StateHandlingStatementOperations implements
         state.txState().indexDoDrop( descriptor );
     }
 
-    @Override
-    public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+    private IndexBackedConstraintDescriptor indexBackedConstraintCreate( KernelStatement state, IndexBackedConstraintDescriptor constraint )
             throws CreateConstraintFailureException
     {
-        UniquenessConstraintDescriptor constraint = ConstraintDescriptorFactory.uniqueForSchema( descriptor );
+        LabelSchemaDescriptor descriptor = constraint.schema();
         try
         {
             if ( state.hasTxStateWithChanges() &&
@@ -620,6 +623,25 @@ public class StateHandlingStatementOperations implements
         {
             throw new CreateConstraintFailureException( constraint, e );
         }
+    }
+
+    @Override
+    public NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state,
+            LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException
+    {
+        NodeKeyConstraintDescriptor constraint = ConstraintDescriptorFactory.nodeKeyForSchema( descriptor );
+        indexBackedConstraintCreate( state, constraint );
+        return constraint;
+    }
+
+    @Override
+    public UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+            throws CreateConstraintFailureException
+    {
+        UniquenessConstraintDescriptor constraint = ConstraintDescriptorFactory.uniqueForSchema( descriptor );
+        indexBackedConstraintCreate( state, constraint );
+        return constraint;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -51,6 +52,9 @@ public interface SchemaWriteOperations
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
+
+    NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
             throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -54,7 +54,8 @@ public interface SchemaWriteOperations
     void uniqueIndexDrop( KernelStatement state, NewIndexDescriptor descriptor ) throws DropIndexFailureException;
 
     NodeKeyConstraintDescriptor nodeKeyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
-            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException;
+            throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,
+            RepeatedPropertyInCompositeSchemaException;
 
     UniquenessConstraintDescriptor uniquePropertyConstraintCreate( KernelStatement state, LabelSchemaDescriptor descriptor )
             throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
@@ -60,7 +60,7 @@ public class NodeSchemaMatcher
      * @param <EXCEPTION> The type of exception that can be thrown when taking the action
      * @throws EXCEPTION This exception is propagated from the action
      */
-    public <SUPPLIER extends LabelSchemaDescriptor.Supplier,EXCEPTION extends Exception> void onMatchingSchema(
+    public <SUPPLIER extends LabelSchemaSupplier,EXCEPTION extends Exception> void onMatchingSchema(
             KernelStatement state,
             Iterator<SUPPLIER> schemaSuppliers,
             NodeItem node,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcher.java
@@ -32,9 +32,8 @@ import org.neo4j.storageengine.api.NodeItem;
 
 /**
  * This class holds functionality to match LabelSchemaDescriptors to nodes
- * @param <SUPPLIER> the type to match. Must implement LabelSchemaSupplier
  */
-public class NodeSchemaMatcher<SUPPLIER extends LabelSchemaSupplier>
+public class NodeSchemaMatcher
 {
     private final EntityReadOperations readOps;
 
@@ -57,10 +56,11 @@ public class NodeSchemaMatcher<SUPPLIER extends LabelSchemaSupplier>
      * @param specialPropertyId This property id will always count as a match for the descriptor, regardless of
      *                          whether the node has this property or not
      * @param action The action to take on match
+     * @param <SUPPLIER> the type to match. Must implement LabelSchemaDescriptor.Supplier
      * @param <EXCEPTION> The type of exception that can be thrown when taking the action
      * @throws EXCEPTION This exception is propagated from the action
      */
-    public <EXCEPTION extends Exception> void onMatchingSchema(
+    public <SUPPLIER extends LabelSchemaDescriptor.Supplier,EXCEPTION extends Exception> void onMatchingSchema(
             KernelStatement state,
             Iterator<SUPPLIER> schemaSuppliers,
             NodeItem node,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
@@ -47,13 +47,13 @@ public class IndexTxStateUpdater
 {
     private final SchemaReadOperations schemaReadOps;
     private final EntityReadOperations readOps;
-    private final NodeSchemaMatcher<NewIndexDescriptor> nodeIndexMatcher;
+    private final NodeSchemaMatcher nodeIndexMatcher;
 
     public IndexTxStateUpdater( SchemaReadOperations schemaReadOps, EntityReadOperations readOps )
     {
         this.schemaReadOps = schemaReadOps;
         this.readOps = readOps;
-        this.nodeIndexMatcher = new NodeSchemaMatcher<>( readOps );
+        this.nodeIndexMatcher = new NodeSchemaMatcher( readOps );
     }
 
     // LABEL CHANGES

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -962,7 +962,7 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     public void constraintDoDrop( ConstraintDescriptor constraint )
     {
         constraintsChangesDiffSets().remove( constraint );
-        if ( constraint.type().enforcesUniqueness() )
+        if ( constraint.enforcesUniqueness() )
         {
             indexDoDrop( getIndexForIndexBackedConstraint( (IndexBackedConstraintDescriptor) constraint ) );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
@@ -41,6 +41,9 @@ import org.neo4j.storageengine.api.txstate.TxStateVisitor;
  */
 public interface ConstraintSemantics
 {
+    void validateNodeKeyConstraint( Iterator<Cursor<NodeItem>> allNodes, LabelSchemaDescriptor descriptor,
+            BiPredicate<NodeItem,Integer> hasProperty ) throws CreateConstraintFailureException;
+
     void validateNodePropertyExistenceConstraint( Iterator<Cursor<NodeItem>> allNodes, LabelSchemaDescriptor descriptor,
             BiPredicate<NodeItem,Integer> hasProperty ) throws CreateConstraintFailureException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/ConstraintSemantics.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.storageengine.api.NodeItem;
@@ -50,6 +51,9 @@ public interface ConstraintSemantics
     ConstraintDescriptor readConstraint( ConstraintRule rule );
 
     ConstraintRule createUniquenessConstraintRule( long ruleId, UniquenessConstraintDescriptor descriptor, long indexId );
+
+    ConstraintRule createNodeKeyConstraintRule( long ruleId, NodeKeyConstraintDescriptor descriptor, long indexId )
+            throws CreateConstraintFailureException;
 
     ConstraintRule createExistenceConstraint( long ruleId, ConstraintDescriptor descriptor )
             throws CreateConstraintFailureException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.storageengine.api.NodeItem;
@@ -37,18 +38,17 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.storageengine.api.txstate.TxStateVisitor;
 
-import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor.Type.UNIQUE;
-
 public class StandardConstraintSemantics implements ConstraintSemantics
 {
-    public static final String ERROR_MESSAGE = "Property existence constraint requires Neo4j Enterprise Edition";
+    public static final String ERROR_MESSAGE_EXISTS = "Property existence constraint requires Neo4j Enterprise Edition";
+    public static final String ERROR_MESSAGE_NODE_KEY = "Node Key constraint requires Neo4j Enterprise Edition";
 
     @Override
     public void validateNodePropertyExistenceConstraint( Iterator<Cursor<NodeItem>> allNodes,
             LabelSchemaDescriptor descriptor, BiPredicate<NodeItem,Integer> hasProperty )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor );
+        throw propertyExistenceConstraintsNotAllowed( descriptor, ERROR_MESSAGE_NODE_KEY );
     }
 
     @Override
@@ -56,32 +56,35 @@ public class StandardConstraintSemantics implements ConstraintSemantics
             RelationTypeSchemaDescriptor descriptor, BiPredicate<RelationshipItem,Integer> hasPropertyCheck )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor );
+        throw propertyExistenceConstraintsNotAllowed( descriptor, ERROR_MESSAGE_EXISTS );
     }
 
     @Override
     public ConstraintDescriptor readConstraint( ConstraintRule rule )
     {
         ConstraintDescriptor desc = rule.getConstraintDescriptor();
-        if ( desc.type() == UNIQUE )
+        switch ( desc.type() )
         {
-            return desc;
+        case EXISTS:
+            return readNonStandardConstraint( rule, ERROR_MESSAGE_EXISTS );
+        case UNIQUE_EXISTS:
+            return readNonStandardConstraint( rule, ERROR_MESSAGE_NODE_KEY );
         }
-        return readNonStandardConstraint( rule );
+        return desc;
     }
 
-    protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule )
+    protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule, String errorMessage )
     {
         // When opening a store in Community Edition that contains a Property Existence Constraint
-        throw new IllegalStateException( ERROR_MESSAGE );
+        throw new IllegalStateException( errorMessage );
     }
 
-    private CreateConstraintFailureException propertyExistenceConstraintsNotAllowed( SchemaDescriptor descriptor )
+    private CreateConstraintFailureException propertyExistenceConstraintsNotAllowed( SchemaDescriptor descriptor, String errorMessage )
     {
         // When creating a Property Existence Constraint in Community Edition
         return new CreateConstraintFailureException(
                     ConstraintDescriptorFactory.existsForSchema( descriptor ),
-                    new IllegalStateException( ERROR_MESSAGE ) );
+                    new IllegalStateException( errorMessage ) );
     }
 
     @Override
@@ -92,10 +95,17 @@ public class StandardConstraintSemantics implements ConstraintSemantics
     }
 
     @Override
+    public ConstraintRule createNodeKeyConstraintRule(
+            long ruleId, NodeKeyConstraintDescriptor descriptor, long indexId ) throws CreateConstraintFailureException
+    {
+        throw propertyExistenceConstraintsNotAllowed( descriptor.schema(), ERROR_MESSAGE_NODE_KEY );
+    }
+
+    @Override
     public ConstraintRule createExistenceConstraint( long ruleId, ConstraintDescriptor descriptor )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor.schema() );
+        throw propertyExistenceConstraintsNotAllowed( descriptor.schema(), ERROR_MESSAGE_EXISTS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -69,8 +69,9 @@ public class StandardConstraintSemantics implements ConstraintSemantics
             return readNonStandardConstraint( rule, ERROR_MESSAGE_EXISTS );
         case UNIQUE_EXISTS:
             return readNonStandardConstraint( rule, ERROR_MESSAGE_NODE_KEY );
+        default:
+            return desc;
         }
-        return desc;
     }
 
     protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule, String errorMessage )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -48,7 +48,7 @@ public class StandardConstraintSemantics implements ConstraintSemantics
             LabelSchemaDescriptor descriptor, BiPredicate<NodeItem,Integer> hasProperty )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor, ERROR_MESSAGE_NODE_KEY );
+        throw propertyExistenceConstraintsNotAllowed( descriptor );
     }
 
     @Override
@@ -56,7 +56,15 @@ public class StandardConstraintSemantics implements ConstraintSemantics
             RelationTypeSchemaDescriptor descriptor, BiPredicate<RelationshipItem,Integer> hasPropertyCheck )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor, ERROR_MESSAGE_EXISTS );
+        throw propertyExistenceConstraintsNotAllowed( descriptor );
+    }
+
+    @Override
+    public void validateNodeKeyConstraint( Iterator<Cursor<NodeItem>> allNodes,
+            LabelSchemaDescriptor descriptor, BiPredicate<NodeItem,Integer> hasProperty )
+            throws CreateConstraintFailureException
+    {
+        throw nodeKeyConstraintsNotAllowed( descriptor );
     }
 
     @Override
@@ -80,12 +88,20 @@ public class StandardConstraintSemantics implements ConstraintSemantics
         throw new IllegalStateException( errorMessage );
     }
 
-    private CreateConstraintFailureException propertyExistenceConstraintsNotAllowed( SchemaDescriptor descriptor, String errorMessage )
+    private CreateConstraintFailureException propertyExistenceConstraintsNotAllowed( SchemaDescriptor descriptor )
     {
         // When creating a Property Existence Constraint in Community Edition
         return new CreateConstraintFailureException(
-                    ConstraintDescriptorFactory.existsForSchema( descriptor ),
-                    new IllegalStateException( errorMessage ) );
+                ConstraintDescriptorFactory.existsForSchema( descriptor ),
+                new IllegalStateException( ERROR_MESSAGE_EXISTS ) );
+    }
+
+    private CreateConstraintFailureException nodeKeyConstraintsNotAllowed( SchemaDescriptor descriptor )
+    {
+        // When creating a Node Key Constraint in Community Edition
+        return new CreateConstraintFailureException(
+                ConstraintDescriptorFactory.existsForSchema( descriptor ),
+                new IllegalStateException( ERROR_MESSAGE_NODE_KEY ) );
     }
 
     @Override
@@ -99,14 +115,14 @@ public class StandardConstraintSemantics implements ConstraintSemantics
     public ConstraintRule createNodeKeyConstraintRule(
             long ruleId, NodeKeyConstraintDescriptor descriptor, long indexId ) throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor.schema(), ERROR_MESSAGE_NODE_KEY );
+        throw nodeKeyConstraintsNotAllowed( descriptor.schema() );
     }
 
     @Override
     public ConstraintRule createExistenceConstraint( long ruleId, ConstraintDescriptor descriptor )
             throws CreateConstraintFailureException
     {
-        throw propertyExistenceConstraintsNotAllowed( descriptor.schema(), ERROR_MESSAGE_EXISTS );
+        throw propertyExistenceConstraintsNotAllowed( descriptor.schema() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
@@ -42,7 +42,11 @@ public interface InternalSchemaActions
 
     ConstraintDefinition createPropertyUniquenessConstraint( IndexDefinition indexDefinition )
             throws IllegalTokenNameException, TooManyLabelsException, CreateConstraintFailureException,
-                   AlreadyConstrainedException, AlreadyIndexedException;
+            AlreadyConstrainedException, AlreadyIndexedException;
+
+    ConstraintDefinition createNodeKeyConstraint( IndexDefinition indexDefinition )
+            throws IllegalTokenNameException, TooManyLabelsException, CreateConstraintFailureException,
+            AlreadyConstrainedException, AlreadyIndexedException;
 
     ConstraintDefinition createPropertyExistenceConstraint( Label label, String... propertyKey )
             throws IllegalTokenNameException, TooManyLabelsException, CreateConstraintFailureException,
@@ -52,6 +56,8 @@ public interface InternalSchemaActions
             throws CreateConstraintFailureException, AlreadyConstrainedException;
 
     void dropPropertyUniquenessConstraint( Label label, String[] properties );
+
+    void dropNodeKeyConstraint( Label label, String[] properties );
 
     void dropNodePropertyExistenceConstraint( Label label, String[] properties );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.coreapi.schema;
+
+import org.neo4j.graphdb.schema.ConstraintType;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+import static java.lang.String.format;
+
+public class NodeKeyConstraintDefinition extends NodeConstraintDefinition
+{
+    public NodeKeyConstraintDefinition( InternalSchemaActions actions, IndexDefinition indexDefinition )
+    {
+        super( actions, indexDefinition );
+    }
+
+    @Override
+    public void drop()
+    {
+        assertInUnterminatedTransaction();
+        actions.dropPropertyUniquenessConstraint( label, propertyKeys );
+    }
+
+    @Override
+    public ConstraintType getConstraintType()
+    {
+        assertInUnterminatedTransaction();
+        return ConstraintType.NODE_KEY;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ON (%1$s:%2$s) ASSERT %3$s IS UNIQUE",
+                label.name().toLowerCase(), label.name(), propertyText() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodeKeyConstraintDefinition.java
@@ -35,7 +35,7 @@ public class NodeKeyConstraintDefinition extends NodeConstraintDefinition
     public void drop()
     {
         assertInUnterminatedTransaction();
-        actions.dropPropertyUniquenessConstraint( label, propertyKeys );
+        actions.dropNodeKeyConstraint( label, propertyKeys );
     }
 
     @Override
@@ -48,7 +48,7 @@ public class NodeKeyConstraintDefinition extends NodeConstraintDefinition
     @Override
     public String toString()
     {
-        return format( "ON (%1$s:%2$s) ASSERT %3$s IS UNIQUE",
+        return format( "ON (%1$s:%2$s) ASSERT %3$s IS NODE KEY",
                 label.name().toLowerCase(), label.name(), propertyText() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -374,6 +374,7 @@ public class SchemaImpl implements Schema
         // internal storage engine API.
         StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOperations );
         if ( constraint instanceof NodeExistenceConstraintDescriptor ||
+             constraint instanceof NodeKeyConstraintDescriptor ||
              constraint instanceof UniquenessConstraintDescriptor )
         {
             LabelSchemaDescriptor schemaDescriptor = (LabelSchemaDescriptor) constraint.schema();
@@ -526,7 +527,8 @@ public class SchemaImpl implements Schema
                             SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
                     return new NodeKeyConstraintDefinition( this, indexDefinition );
                 }
-                catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException e )
+                catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException |
+                        RepeatedPropertyInCompositeSchemaException e )
                 {
                     throw new ConstraintViolationException(
                             e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -64,6 +64,7 @@ import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -388,6 +389,11 @@ public class SchemaImpl implements Schema
                 return new UniquenessConstraintDefinition( actions, new IndexDefinitionImpl( actions, label,
                         propertyKeys, true ) );
             }
+            else if ( constraint instanceof NodeKeyConstraintDescriptor )
+            {
+                return new NodeKeyConstraintDefinition( actions, new IndexDefinitionImpl( actions, label,
+                        propertyKeys, true ) );
+            }
         }
         else if ( constraint instanceof RelExistenceConstraintDescriptor )
         {
@@ -506,6 +512,41 @@ public class SchemaImpl implements Schema
         }
 
         @Override
+        public ConstraintDefinition createNodeKeyConstraint( IndexDefinition indexDefinition )
+        {
+            try ( Statement statement = ctxSupplier.get() )
+            {
+                try
+                {
+                    int labelId = statement.tokenWriteOperations().labelGetOrCreateForName(
+                            indexDefinition.getLabel().name() );
+                    int[] propertyKeyIds = getOrCreatePropertyKeyIds(
+                            statement.tokenWriteOperations(), indexDefinition );
+                    statement.schemaWriteOperations().nodeKeyConstraintCreate(
+                            SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
+                    return new NodeKeyConstraintDefinition( this, indexDefinition );
+                }
+                catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException e )
+                {
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
+                }
+                catch ( IllegalTokenNameException e )
+                {
+                    throw new IllegalArgumentException( e );
+                }
+                catch ( TooManyLabelsException e )
+                {
+                    throw new IllegalStateException( e );
+                }
+                catch ( InvalidTransactionTypeKernelException e )
+                {
+                    throw new InvalidTransactionTypeException( e.getMessage(), e );
+                }
+            }
+        }
+
+        @Override
         public ConstraintDefinition createPropertyExistenceConstraint( Label label, String... propertyKeys )
         {
             try ( Statement statement = ctxSupplier.get() )
@@ -582,6 +623,30 @@ public class SchemaImpl implements Schema
                     int[] propertyKeyIds = PropertyNameUtils.getPropertyIds( statement.readOperations(), properties );
                     statement.schemaWriteOperations().constraintDrop(
                             ConstraintDescriptorFactory.uniqueForLabel( labelId, propertyKeyIds ) );
+                }
+                catch ( DropConstraintFailureException e )
+                {
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
+                }
+                catch ( InvalidTransactionTypeKernelException e )
+                {
+                    throw new ConstraintViolationException( e.getMessage(), e );
+                }
+            }
+        }
+
+        @Override
+        public void dropNodeKeyConstraint( Label label, String[] properties )
+        {
+            try ( Statement statement = ctxSupplier.get() )
+            {
+                try
+                {
+                    int labelId = statement.readOperations().labelGetForName( label.name() );
+                    int[] propertyKeyIds = PropertyNameUtils.getPropertyIds( statement.readOperations(), properties );
+                    statement.schemaWriteOperations().constraintDrop(
+                            ConstraintDescriptorFactory.nodeKeyForLabel( labelId, propertyKeyIds ) );
                 }
                 catch ( DropConstraintFailureException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -259,7 +259,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         if ( constraint.type().enforcesUniqueness() )
         {
             // Remove the index for the constraint as well
-            visitRemovedIndex( ((UniquenessConstraintDescriptor)constraint).ownedIndexDescriptor() );
+            visitRemovedIndex( ((IndexBackedConstraintDescriptor)constraint).ownedIndexDescriptor() );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -256,7 +256,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         {
             throw new IllegalStateException( "Multiple constraints found for specified label and property." );
         }
-        if ( constraint.type().enforcesUniqueness() )
+        if ( constraint.enforcesUniqueness() )
         {
             // Remove the index for the constraint as well
             visitRemovedIndex( ((IndexBackedConstraintDescriptor)constraint).ownedIndexDescriptor() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -221,7 +221,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         }
     }
 
-    private void visitAddedUniquenessConstraint(UniquenessConstraintDescriptor uniqueConstraint, long constraintId)
+    private void visitAddedUniquenessConstraint( UniquenessConstraintDescriptor uniqueConstraint, long constraintId )
     {
         IndexRule indexRule = schemaStorage.indexGetForSchema( uniqueConstraint.ownedIndexDescriptor() );
         recordState.createSchemaRule( constraintSemantics.createUniquenessConstraintRule(
@@ -229,7 +229,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         recordState.setConstraintIndexOwner( indexRule, constraintId );
     }
 
-    private void visitAddedNodeKeyConstraint(NodeKeyConstraintDescriptor uniqueConstraint, long constraintId)
+    private void visitAddedNodeKeyConstraint( NodeKeyConstraintDescriptor uniqueConstraint, long constraintId )
             throws CreateConstraintFailureException
     {
         IndexRule indexRule = schemaStorage.indexGetForSchema( uniqueConstraint.ownedIndexDescriptor() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.impl.store.record;
 
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
@@ -38,7 +40,7 @@ public class ConstraintRule extends SchemaRule implements ConstraintDescriptor.S
     }
 
     public static ConstraintRule constraintRule(
-            long id, UniquenessConstraintDescriptor descriptor, long ownedIndexRule )
+            long id, IndexBackedConstraintDescriptor descriptor, long ownedIndexRule )
     {
         return new ConstraintRule( id, descriptor, ownedIndexRule );
     }
@@ -50,7 +52,7 @@ public class ConstraintRule extends SchemaRule implements ConstraintDescriptor.S
     }
 
     public static ConstraintRule constraintRule(
-            long id, UniquenessConstraintDescriptor descriptor, long ownedIndexRule, String name )
+            long id, IndexBackedConstraintDescriptor descriptor, long ownedIndexRule, String name )
     {
         return new ConstraintRule( id, descriptor, ownedIndexRule, name );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/ConstraintRule.java
@@ -22,8 +22,6 @@ package org.neo4j.kernel.impl.store.record;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.IndexBackedConstraintDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
-import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
 import static org.neo4j.kernel.api.schema_new.SchemaUtil.idTokenNameLookup;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
@@ -138,13 +138,6 @@ public class SchemaRuleDeserializer2_0to3_1
                 readOwnedIndexRule( buffer ) );
     }
 
-    public static ConstraintRule readNodeKeyConstraintRule( long id, int labelId, ByteBuffer buffer )
-    {
-        return new ConstraintRule( id,
-                ConstraintDescriptorFactory.nodeKeyForLabel( labelId, readConstraintPropertyKeys( buffer ) ),
-                readOwnedIndexRule( buffer ) );
-    }
-
     public static ConstraintRule readNodePropertyExistenceConstraintRule( long id, int labelId, ByteBuffer buffer )
     {
         return new ConstraintRule( id,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
@@ -84,8 +84,6 @@ public class SchemaRuleDeserializer2_0to3_1
             return readNodePropertyExistenceConstraintRule( id, labelId, buffer );
         case RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT:
             return readRelPropertyExistenceConstraintRule( id, labelId, buffer );
-        case NODE_KEY_CONSTRAINT:
-            return readNodeKeyConstraintRule( id, labelId, buffer );
         default:
             throw new IllegalArgumentException( kind.name() );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
@@ -84,6 +84,8 @@ public class SchemaRuleDeserializer2_0to3_1
             return readNodePropertyExistenceConstraintRule( id, labelId, buffer );
         case RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT:
             return readRelPropertyExistenceConstraintRule( id, labelId, buffer );
+        case NODE_KEY_CONSTRAINT:
+            return readNodeKeyConstraintRule( id, labelId, buffer );
         default:
             throw new IllegalArgumentException( kind.name() );
         }
@@ -135,6 +137,13 @@ public class SchemaRuleDeserializer2_0to3_1
     {
         return new ConstraintRule( id,
                 ConstraintDescriptorFactory.uniqueForLabel( labelId, readConstraintPropertyKeys( buffer ) ),
+                readOwnedIndexRule( buffer ) );
+    }
+
+    public static ConstraintRule readNodeKeyConstraintRule( long id, int labelId, ByteBuffer buffer )
+    {
+        return new ConstraintRule( id,
+                ConstraintDescriptorFactory.nodeKeyForLabel( labelId, readConstraintPropertyKeys( buffer ) ),
                 readOwnedIndexRule( buffer ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
@@ -208,7 +208,7 @@ public class SchemaRuleSerialization
 
         length += 1; // constraint type
         ConstraintDescriptor constraintDescriptor = constraintRule.getConstraintDescriptor();
-        if ( constraintDescriptor.type().enforcesUniqueness() )
+        if ( constraintDescriptor.enforcesUniqueness() )
         {
             length += 8; // owned index id
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleSerialization.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.SchemaProcessor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
@@ -50,7 +51,7 @@ public class SchemaRuleSerialization
     private static final byte GENERAL_INDEX = 31, UNIQUE_INDEX = 32;
 
     // Constraint type
-    private static final byte EXISTS_CONSTRAINT = 61, UNIQUE_CONSTRAINT = 62;
+    private static final byte EXISTS_CONSTRAINT = 61, UNIQUE_CONSTRAINT = 62, UNIQUE_EXISTS_CONSTRAINT = 63;
 
     // Schema type
     private static final byte SIMPLE_LABEL = 91, SIMPLE_REL_TYPE = 92;
@@ -154,6 +155,11 @@ public class SchemaRuleSerialization
             target.putLong( constraintRule.getOwnedIndex() );
             break;
 
+        case UNIQUE_EXISTS:
+            target.put( UNIQUE_EXISTS_CONSTRAINT );
+            target.putLong( constraintRule.getOwnedIndex() );
+            break;
+
         default:
             throw new UnsupportedOperationException( format( "Got unknown index descriptor type '%s'.",
                     constraintDescriptor.type() ) );
@@ -202,7 +208,7 @@ public class SchemaRuleSerialization
 
         length += 1; // constraint type
         ConstraintDescriptor constraintDescriptor = constraintRule.getConstraintDescriptor();
-        if ( constraintDescriptor.type() == ConstraintDescriptor.Type.UNIQUE )
+        if ( constraintDescriptor.type().enforcesUniqueness() )
         {
             length += 8; // owned index id
         }
@@ -275,11 +281,18 @@ public class SchemaRuleSerialization
             return ConstraintRule.constraintRule( id, ConstraintDescriptorFactory.existsForSchema( schema ), name );
 
         case UNIQUE_CONSTRAINT:
-            long ownedIndex = source.getLong();
+            long ownedUniqueIndex = source.getLong();
             schema = readSchema( source );
             UniquenessConstraintDescriptor descriptor = ConstraintDescriptorFactory.uniqueForSchema( schema );
             name = readRuleName( id, ConstraintRule.class, source );
-            return ConstraintRule.constraintRule( id, descriptor, ownedIndex, name );
+            return ConstraintRule.constraintRule( id, descriptor, ownedUniqueIndex, name );
+
+        case UNIQUE_EXISTS_CONSTRAINT:
+            long ownedNodeKeyIndex = source.getLong();
+            schema = readSchema( source );
+            NodeKeyConstraintDescriptor nodeKeyConstraintDescriptor = ConstraintDescriptorFactory.nodeKeyForSchema( schema );
+            name = readRuleName( id, ConstraintRule.class, source );
+            return ConstraintRule.constraintRule( id, nodeKeyConstraintDescriptor, ownedNodeKeyIndex, name );
 
         default:
             throw new MalformedSchemaRuleException( format( "Got unknown constraint rule type '%d'.", constraintRuleType ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
@@ -82,7 +82,7 @@ public class IntegrityValidator
         if ( schemaRule instanceof ConstraintRule )
         {
             ConstraintRule constraintRule = (ConstraintRule) schemaRule;
-            if ( constraintRule.getConstraintDescriptor().type().enforcesUniqueness() )
+            if ( constraintRule.getConstraintDescriptor().enforcesUniqueness() )
             {
                 try
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
@@ -82,7 +82,7 @@ public class IntegrityValidator
         if ( schemaRule instanceof ConstraintRule )
         {
             ConstraintRule constraintRule = (ConstraintRule) schemaRule;
-            if ( constraintRule.getConstraintDescriptor().type() == ConstraintDescriptor.Type.UNIQUE )
+            if ( constraintRule.getConstraintDescriptor().type().enforcesUniqueness() )
             {
                 try
                 {

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
@@ -107,7 +107,8 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
         CONSTRAINT_INDEX_RULE( "Constraint index" ),
         UNIQUENESS_CONSTRAINT( "Uniqueness constraint" ),
         NODE_PROPERTY_EXISTENCE_CONSTRAINT( "Node property existence constraint" ),
-        RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT( "Relationship property existence constraint" );
+        RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT( "Relationship property existence constraint" ),
+        NODE_KEY_CONSTRAINT( "Node key constraint" );
 
         private static final Kind[] ALL = values();
 
@@ -156,6 +157,8 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
             {
             case UNIQUE:
                 return UNIQUENESS_CONSTRAINT;
+            case UNIQUE_EXISTS:
+                return NODE_KEY_CONSTRAINT;
             case EXISTS:
                 return descriptor.schema().computeWith( existenceKindMapper );
             default:

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
@@ -99,6 +99,7 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
 
     /**
      * This enum is used for the legacy schema store, and should not be extended.
+     * @see org.neo4j.kernel.impl.store.record.SchemaRuleSerialization for the new (de)serialisation code instead.
      */
     @Deprecated
     public enum Kind
@@ -107,8 +108,7 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
         CONSTRAINT_INDEX_RULE( "Constraint index" ),
         UNIQUENESS_CONSTRAINT( "Uniqueness constraint" ),
         NODE_PROPERTY_EXISTENCE_CONSTRAINT( "Node property existence constraint" ),
-        RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT( "Relationship property existence constraint" ),
-        NODE_KEY_CONSTRAINT( "Node key constraint" );
+        RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT( "Relationship property existence constraint" );
 
         private static final Kind[] ALL = values();
 
@@ -157,8 +157,6 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
             {
             case UNIQUE:
                 return UNIQUENESS_CONSTRAINT;
-            case UNIQUE_EXISTS:
-                return NODE_KEY_CONSTRAINT;
             case EXISTS:
                 return descriptor.schema().computeWith( existenceKindMapper );
             default:

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/SchemaRule.java
@@ -147,7 +147,8 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
             case UNIQUE:
                 return CONSTRAINT_INDEX_RULE;
             default:
-                throw new IllegalStateException( "Cannot end up here, says johant" );
+                throw new IllegalStateException(
+                        "Cannot map descriptor type to legacy schema rule: " + descriptor.type() );
             }
         }
 
@@ -160,7 +161,8 @@ public abstract class SchemaRule implements SchemaDescriptor.Supplier
             case EXISTS:
                 return descriptor.schema().computeWith( existenceKindMapper );
             default:
-                throw new IllegalStateException( "Cannot end up here, says johant" );
+                throw new IllegalStateException(
+                        "Cannot map descriptor type to legacy schema rule: " + descriptor.type() );
             }
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/schema_new/constaints/ConstraintDescriptorFactoryTest.java
@@ -58,12 +58,26 @@ public class ConstraintDescriptorFactoryTest
     }
 
     @Test
+    public void shouldCreateNodeKeyConstraintDescriptors()
+    {
+        ConstraintDescriptor desc;
+
+        desc = ConstraintDescriptorFactory.nodeKeyForLabel( LABEL_ID, 1 );
+        assertThat( desc.type(), equalTo( ConstraintDescriptor.Type.UNIQUE_EXISTS ) );
+        assertThat( desc.schema(), equalTo( SchemaDescriptorFactory.forLabel( LABEL_ID, 1 ) ) );
+    }
+
+    @Test
     public void shouldCreateConstraintDescriptorsFromSchema()
     {
         ConstraintDescriptor desc;
 
         desc = ConstraintDescriptorFactory.uniqueForSchema( SchemaDescriptorFactory.forLabel( LABEL_ID, 1 ) );
         assertThat( desc.type(), equalTo( ConstraintDescriptor.Type.UNIQUE ) );
+        assertThat( desc.schema(), equalTo( SchemaDescriptorFactory.forLabel( LABEL_ID, 1 ) ) );
+
+        desc = ConstraintDescriptorFactory.nodeKeyForSchema( SchemaDescriptorFactory.forLabel( LABEL_ID, 1 ) );
+        assertThat( desc.type(), equalTo( ConstraintDescriptor.Type.UNIQUE_EXISTS ) );
         assertThat( desc.schema(), equalTo( SchemaDescriptorFactory.forLabel( LABEL_ID, 1 ) ) );
 
         desc = ConstraintDescriptorFactory.existsForSchema( SchemaDescriptorFactory.forRelType( REL_TYPE_ID, 1 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/schema/NodeSchemaMatcherTest.java
@@ -69,7 +69,7 @@ public class NodeSchemaMatcherTest
     NewIndexDescriptor indexWithMissingLabel = forLabel( nonExistentLabelId, propId1, propId2 );
     NewIndexDescriptor indexOnSpecialProperty = forLabel( labelId1, propId1, specialPropId );
 
-    private NodeSchemaMatcher<NewIndexDescriptor> nodeSchemaMatcher;
+    private NodeSchemaMatcher nodeSchemaMatcher;
 
     @Before
     public void setup()
@@ -91,7 +91,7 @@ public class NodeSchemaMatcherTest
         when( readOps.nodeGetProperty( state, node, propId2 ) ).thenReturn( "hi2" );
         when( readOps.nodeGetProperty( state, node, unIndexedPropId ) ).thenReturn( "hi3" );
 
-        nodeSchemaMatcher = new NodeSchemaMatcher<>( readOps );
+        nodeSchemaMatcher = new NodeSchemaMatcher( readOps );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
@@ -286,7 +286,7 @@ public class SchemaCacheTest
         @Override
         protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule, String errorMessage )
         {
-            if ( !rule.getConstraintDescriptor().type().enforcesPropertyExistence() )
+            if ( !rule.getConstraintDescriptor().enforcesPropertyExistence() )
             {
                 throw new IllegalStateException( "Unsupported constraint type: " + rule );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
@@ -46,7 +46,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.neo4j.helpers.collection.Iterators.asSet;
-import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor.Type.EXISTS;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 
 public class SchemaCacheTest
@@ -285,9 +284,9 @@ public class SchemaCacheTest
     private static class ConstraintSemantics extends StandardConstraintSemantics
     {
         @Override
-        protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule )
+        protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule, String errorMessage )
         {
-            if ( rule.getConstraintDescriptor().type() != EXISTS )
+            if ( !rule.getConstraintDescriptor().type().enforcesPropertyExistence() )
             {
                 throw new IllegalStateException( "Unsupported constraint type: " + rule );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
@@ -443,46 +443,6 @@ public class SchemaStorageTest
         return db -> db.schema().constraintFor( Label.label( label ) ).assertPropertyIsUnique( prop ).create();
     }
 
-    private Consumer<GraphDatabaseService> nodeKeyConstraint( String label, String prop )
-    {
-        return db -> createNodeKeyConstraint( label, prop );
-    }
-
-    private ConstraintDefinition createNodeKeyConstraint( String label, String prop )
-    {
-        Statement statement = dependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get();
-        InternalSchemaActions actions = mock( InternalSchemaActions.class );
-        IndexDefinitionImpl indexDefinition = new IndexDefinitionImpl( actions, Label.label( label ), prop, true );
-        try
-        {
-            int labelId = statement.tokenWriteOperations().labelGetOrCreateForName(
-                    indexDefinition.getLabel().name() );
-            int[] propertyKeyIds = getOrCreatePropertyKeyIds(
-                    statement.tokenWriteOperations(), indexDefinition );
-            statement.schemaWriteOperations().nodeKeyConstraintCreate(
-                    SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
-            return new NodeKeyConstraintDefinition( actions, indexDefinition );
-        }
-        catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException |
-                RepeatedPropertyInCompositeSchemaException e )
-        {
-            throw new ConstraintViolationException(
-                    e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
-        }
-        catch ( IllegalTokenNameException e )
-        {
-            throw new IllegalArgumentException( e );
-        }
-        catch ( TooManyLabelsException e )
-        {
-            throw new IllegalStateException( e );
-        }
-        catch ( InvalidTransactionTypeKernelException e )
-        {
-            throw new InvalidTransactionTypeException( e.getMessage(), e );
-        }
-    }
-
     @SafeVarargs
     private static void createSchema( Consumer<GraphDatabaseService>... creators )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
@@ -52,6 +52,7 @@ import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
+import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
@@ -462,7 +463,8 @@ public class SchemaStorageTest
                     SchemaDescriptorFactory.forLabel( labelId, propertyKeyIds ) );
             return new NodeKeyConstraintDefinition( actions, indexDefinition );
         }
-        catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException e )
+        catch ( AlreadyConstrainedException | CreateConstraintFailureException | AlreadyIndexedException |
+                RepeatedPropertyInCompositeSchemaException e )
         {
             throw new ConstraintViolationException(
                     e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/record/ConstraintRuleTest.java
@@ -22,12 +22,14 @@ package org.neo4j.kernel.impl.store.record;
 import org.junit.Test;
 
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory.existsForLabel;
 import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory.existsForRelType;
+import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory.nodeKeyForLabel;
 import static org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory.uniqueForLabel;
 import static org.neo4j.test.assertion.Assert.assertException;
 
@@ -60,6 +62,32 @@ public class ConstraintRuleTest extends SchemaRuleTestBase
     }
 
     @Test
+    public void shouldCreateNodeKeyConstraint() throws Exception
+    {
+        // GIVEN
+        ConstraintDescriptor descriptor = nodeKeyForLabel( LABEL_ID, PROPERTY_ID_1 );
+        ConstraintRule constraintRule = ConstraintRule.constraintRule( RULE_ID, descriptor );
+
+        // THEN
+        assertThat( constraintRule.getId(), equalTo( RULE_ID ) );
+        assertThat( constraintRule.schema(), equalTo( descriptor.schema() ) );
+        assertThat( constraintRule.getConstraintDescriptor(), equalTo( descriptor ) );
+        assertException( constraintRule::getOwnedIndex, IllegalStateException.class, "" );
+    }
+
+    @Test
+    public void shouldCreateNodeKeyConstraintWithOwnedIndex() throws Exception
+    {
+        // GIVEN
+        NodeKeyConstraintDescriptor descriptor = nodeKeyForLabel( LABEL_ID, PROPERTY_ID_1 );
+        ConstraintRule constraintRule = ConstraintRule.constraintRule( RULE_ID, descriptor, RULE_ID_2 );
+
+        // THEN
+        assertThat( constraintRule.getConstraintDescriptor(), equalTo( descriptor ) );
+        assertThat( constraintRule.getOwnedIndex(), equalTo( RULE_ID_2 ) );
+    }
+
+    @Test
     public void shouldCreateExistenceConstraint() throws Exception
     {
         // GIVEN
@@ -78,9 +106,11 @@ public class ConstraintRuleTest extends SchemaRuleTestBase
     {
         assertEqualityByDescriptor( existsForLabel( LABEL_ID, PROPERTY_ID_1 ) );
         assertEqualityByDescriptor( uniqueForLabel( LABEL_ID, PROPERTY_ID_1 ) );
+        assertEqualityByDescriptor( nodeKeyForLabel( LABEL_ID, PROPERTY_ID_1 ) );
         assertEqualityByDescriptor( existsForRelType( REL_TYPE_ID, PROPERTY_ID_1 ) );
         assertEqualityByDescriptor( existsForLabel( LABEL_ID, PROPERTY_ID_1, PROPERTY_ID_2 ) );
         assertEqualityByDescriptor( uniqueForLabel( LABEL_ID, PROPERTY_ID_1, PROPERTY_ID_2 ) );
+        assertEqualityByDescriptor( nodeKeyForLabel( LABEL_ID, PROPERTY_ID_1, PROPERTY_ID_2 ) );
     }
 
     private void assertEqualityByDescriptor( UniquenessConstraintDescriptor descriptor )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1325,7 +1325,7 @@ public class BatchInsertTest
         {
             // Then
             assertEquals(
-                    "It is not allowed to create uniqueness constraints and indexes on the same {label;property}",
+                    "It is not allowed to create node keys, uniqueness constraints or indexes on the same {label;property}",
                     e.getMessage() );
         }
     }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -450,6 +450,7 @@ public class Schema extends TransactionProvidingApp
     private static boolean isNodeConstraint( ConstraintDefinition constraint )
     {
         return constraint.isConstraintType( ConstraintType.UNIQUENESS ) ||
+               constraint.isConstraintType( ConstraintType.NODE_KEY ) ||
                constraint.isConstraintType( ConstraintType.NODE_PROPERTY_EXISTENCE );
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -19,16 +19,22 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.cypher.{CypherExecutionException, ExecutionEngineFunSuite, NewPlannerTestSupport}
 import org.neo4j.graphdb.{ConstraintViolationException, Node}
 import org.neo4j.kernel.GraphDatabaseQueryService
+import org.neo4j.test.{TestEnterpriseGraphDatabaseFactory, TestGraphDatabaseFactory}
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 import scala.collection.JavaConverters._
 
 class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
-  test("should be able to create and remove composite uniquness constraints") {
+  override protected def createGraphDatabase(): GraphDatabaseCypherService = {
+    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(databaseConfig().asJava))
+  }
+
+  test("should be able to create and remove composite uniqueness constraints") {
     // When
     executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT n.email IS UNIQUE")
     executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
@@ -86,6 +92,36 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
     a[CypherExecutionException] should be thrownBy {
       executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
     }
+  }
+
+  test("should be able to create and remove single property NODE KEY") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should not(haveConstraints("NODE_KEY:Person(email)"))
+  }
+
+  test("should be able to create and remove multiple property NODE KEY") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname")
+
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+    graph should not(haveConstraints("NODE_KEY:Person(firstname,lastname)"))
   }
 
   case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -114,7 +114,7 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
     executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
 
     // Then
-    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname")
+    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname)")
 
     // When
     executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
@@ -127,11 +127,11 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
   case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
     def apply(graph: GraphDatabaseQueryService): MatchResult = {
       graph.inTx {
-        val constraintName = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
-        val result = expectedConstraints.forall(i => constraintName.contains(i.toString))
+        val constraintNames = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(i => constraintNames.contains(i.toString))
         MatchResult(
           result,
-          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintName.mkString(", ")}",
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintNames.mkString(", ")}",
           s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
         )
       }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.{CypherExecutionException, ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.graphdb.{ConstraintViolationException, Node}
+import org.neo4j.kernel.GraphDatabaseQueryService
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.collection.JavaConverters._
+
+class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("should be able to create and remove composite uniquness constraints") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT n.email IS UNIQUE")
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    graph should haveConstraints("UNIQUENESS:Person(email)", "UNIQUENESS:Person(firstname,lastname)")
+
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    graph should haveConstraints("UNIQUENESS:Person(email)")
+    graph should not(haveConstraints("UNIQUENESS:Person(firstname,lastname)"))
+  }
+
+  test("composite uniqueness constraint should not block adding nodes with different properties") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+
+    // Then
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+  }
+
+  test("composite uniqueness constraint should block adding nodes with same properties") {
+    // When
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+
+    // Then
+    a[ConstraintViolationException] should be thrownBy {
+      createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    }
+  }
+
+  test("composite uniqueness constraint should not fail when we have nodes with different properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+
+    // Then
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+  }
+
+  test("composite uniqueness constraint should fail when we have nodes with same properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+
+    // Then
+    a[CypherExecutionException] should be thrownBy {
+      executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    }
+  }
+
+  case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
+    def apply(graph: GraphDatabaseQueryService): MatchResult = {
+      graph.inTx {
+        val constraintName = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(i => constraintName.contains(i.toString))
+        MatchResult(
+          result,
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintName.mkString(", ")}",
+          s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
+        )
+      }
+    }
+  }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeConstraintAcceptanceTest.scala
@@ -28,13 +28,15 @@ import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 import org.scalatest.matchers.{MatchResult, Matcher}
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.StringHelper._
+import org.neo4j.graphdb.config.Setting
 
 import scala.collection.JavaConverters._
+import scala.collection.Map
 
 class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
-  override protected def createGraphDatabase(): GraphDatabaseCypherService = {
-    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(databaseConfig().asJava))
+  override protected def createGraphDatabase(config: Map[Setting[_], String] = databaseConfig()): GraphDatabaseCypherService = {
+    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(config.asJava))
   }
 
   test("should be able to create and remove composite uniqueness constraints") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertThat
+import org.neo4j.cypher._
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.StringHelper._
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.graphdb.ConstraintViolationException
+import org.neo4j.graphdb.config.Setting
+import org.neo4j.kernel.GraphDatabaseQueryService
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.collection.JavaConverters._
+import scala.collection.Map
+
+class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  override protected def createGraphDatabase(config: Map[Setting[_], String] = databaseConfig()): GraphDatabaseCypherService = {
+    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(config.asJava))
+  }
+
+  test("should be able to create and remove single property NODE KEY") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+
+    // Then
+    graph should not(haveConstraints("NODE_KEY:Person(email)"))
+  }
+
+  test("should be able to create and remove multiple property NODE KEY") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname)")
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    graph should haveConstraints("NODE_KEY:Person(email)")
+    graph should not(haveConstraints("NODE_KEY:Person(firstname,lastname)"))
+  }
+
+  test("composite NODE KEY constraint should not block adding nodes with different properties") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+
+    // Then
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+  }
+
+  test("composite NODE KEY constraint should block adding nodes with same properties") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+
+    // Then
+    a[ConstraintViolationException] should be thrownBy {
+      createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    }
+  }
+
+  test("composite NODE KEY constraint should not fail when we have nodes with different properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
+
+    // Then
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+  }
+
+  test("composite NODE KEY constraint should fail when we have nodes with same properties") {
+    // When
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
+    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+
+    // Then
+    a[CypherExecutionException] should be thrownBy {
+      exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY")
+    }
+  }
+
+  test("trying to add duplicate node when node key constraint exists") {
+    createLabeledNode(Map("name" -> "A"), "Person")
+    exec("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY")
+
+    expectError(
+      "CREATE (n:Person) SET n.name = 'A'",
+      String.format("Node(0) already exists with label `Person` and property `name` = 'A'")
+    )
+  }
+
+  test("trying to add duplicate node when composite NODE KEY constraint exists") {
+    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
+    exec("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY")
+
+    expectError(
+      "CREATE (n:Person) SET n.name = 'A', n.surname = 'B'",
+      String.format("Node(0) already exists with label `Person` and properties `name` = 'A', `surname` = 'B'")
+    )
+  }
+
+  test("trying to add a composite node key constraint when duplicates exist") {
+    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
+    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
+
+    expectError(
+      "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY",
+      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT (person.name, person.surname) IS NODE KEY:%n" +
+        "Both Node(0) and Node(1) have the label `Person` and properties `name` = 'A', `surname` = 'B'")
+    )
+  }
+
+  test("trying to add a node key constraint when duplicates exist") {
+    createLabeledNode(Map("name" -> "A"), "Person")
+    createLabeledNode(Map("name" -> "A"), "Person")
+
+    expectError(
+      "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
+      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS NODE KEY:%n" +
+        "Both Node(0) and Node(1) have the label `Person` and property `name` = 'A'")
+    )
+  }
+
+  test("drop a non existent node key constraint") {
+    expectError(
+      "DROP CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
+      "No such constraint"
+    )
+  }
+
+  test("trying to add duplicate node when composite node key constraint exists") {
+    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
+    exec("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY")
+
+    expectError(
+      "CREATE (n:Person) SET n.name = 'A', n.surname = 'B'",
+      String.format("Node(0) already exists with label `Person` and properties `name` = 'A', `surname` = 'B'")
+    )
+  }
+
+  private def expectError(query: String, expectedError: String) {
+    val error = intercept[CypherException](exec(query))
+    assertThat(error.getMessage, containsString(expectedError))
+  }
+
+  private def exec(query: String) {
+    executeWithCostPlannerAndInterpretedRuntimeOnly(query.fixNewLines).toList
+  }
+
+  case class haveConstraints(expectedConstraints: String*) extends Matcher[GraphDatabaseQueryService] {
+    def apply(graph: GraphDatabaseQueryService): MatchResult = {
+      graph.inTx {
+        val constraintNames = graph.schema().getConstraints.asScala.toList.map(i => s"${i.getConstraintType}:${i.getLabel}(${i.getPropertyKeys.asScala.toList.mkString(",")})")
+        val result = expectedConstraints.forall(i => constraintNames.contains(i.toString))
+        MatchResult(
+          result,
+          s"Expected graph to have constraints ${expectedConstraints.mkString(", ")}, but it was ${constraintNames.mkString(", ")}",
+          s"Expected graph to not have constraints ${expectedConstraints.mkString(", ")}, but it did."
+        )
+      }
+    }
+  }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
@@ -33,22 +33,36 @@ import org.neo4j.graphdb.config.Setting
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class CompositeUniquenessConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
   override protected def createGraphDatabase(config: Map[Setting[_], String] = databaseConfig()): GraphDatabaseCypherService = {
     new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(config.asJava))
   }
 
+  test("should be able to create and remove single property uniqueness constraint") {
+    // When
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
+
+    // Then
+    graph should haveConstraints("UNIQUENESS:Person(email)")
+
+    // When
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
+
+    // Then
+    graph should not(haveConstraints("UNIQUENESS:Person(email)"))
+  }
+
   test("should be able to create and remove composite uniqueness constraints") {
     // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT n.email IS UNIQUE")
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT n.email IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
 
     // Then
     graph should haveConstraints("UNIQUENESS:Person(email)", "UNIQUENESS:Person(firstname,lastname)")
 
     // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE")
 
     // Then
     graph should haveConstraints("UNIQUENESS:Person(email)")
@@ -57,7 +71,7 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
 
   test("composite uniqueness constraint should not block adding nodes with different properties") {
     // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
 
     // Then
     createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
@@ -67,7 +81,7 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
 
   test("composite uniqueness constraint should block adding nodes with same properties") {
     // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
     createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
     createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
 
@@ -84,7 +98,7 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
     createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
 
     // Then
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
   }
 
   test("composite uniqueness constraint should fail when we have nodes with same properties") {
@@ -95,102 +109,23 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
 
     // Then
     a[CypherExecutionException] should be thrownBy {
-      executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
+      exec("CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS UNIQUE")
     }
-  }
-
-  test("should be able to create and remove single property NODE KEY") {
-    // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
-
-    // Then
-    graph should haveConstraints("NODE_KEY:Person(email)")
-
-    // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
-
-    // Then
-    graph should not(haveConstraints("NODE_KEY:Person(email)"))
-  }
-
-  test("should be able to create and remove multiple property NODE KEY") {
-    // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS NODE KEY")
-    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
-
-    // Then
-    graph should haveConstraints("NODE_KEY:Person(email)", "NODE_KEY:Person(firstname,lastname)")
-
-    // When
-    executeWithCostPlannerAndInterpretedRuntimeOnly("DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
-
-    // Then
-    graph should haveConstraints("NODE_KEY:Person(email)")
-    graph should not(haveConstraints("NODE_KEY:Person(firstname,lastname)"))
   }
 
   test("trying to add duplicate node when unique constraint exists") {
     createLabeledNode(Map("name" -> "A"), "Person")
-    executeQuery("CREATE CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE")
+    exec("CREATE CONSTRAINT ON (person:Person) ASSERT person.name IS UNIQUE")
 
     expectError(
       "CREATE (n:Person) SET n.name = 'A'",
       String.format("Node(0) already exists with label `Person` and property `name` = 'A'")
-    )
-  }
-
-  test("trying to add a node key constraint when duplicates exist") {
-    createLabeledNode(Map("name" -> "A"), "Person")
-    createLabeledNode(Map("name" -> "A"), "Person")
-
-    expectError(
-      "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
-      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS NODE KEY:%n" +
-        "Both Node(0) and Node(1) have the label `Person` and property `name` = 'A'")
-    )
-  }
-
-  test("trying to add duplicate node when node key constraint exists") {
-    createLabeledNode(Map("name" -> "A"), "Person")
-    executeQuery("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY")
-
-    expectError(
-      "CREATE (n:Person) SET n.name = 'A'",
-      String.format("Node(0) already exists with label `Person` and property `name` = 'A'")
-    )
-  }
-
-  test("drop a non existent node key constraint") {
-    expectError(
-      "DROP CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
-      "No such constraint"
     )
   }
 
   test("trying to add duplicate node when composite unique constraint exists") {
     createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
-    executeQuery("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS UNIQUE")
-
-    expectError(
-      "CREATE (n:Person) SET n.name = 'A', n.surname = 'B'",
-      String.format("Node(0) already exists with label `Person` and properties `name` = 'A', `surname` = 'B'")
-    )
-  }
-
-  test("trying to add a composite node key constraint when duplicates exist") {
-    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
-    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
-
-    expectError(
-      "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY",
-      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT (person.name, person.surname) IS NODE KEY:%n" +
-        "Both Node(0) and Node(1) have the label `Person` and properties `name` = 'A', `surname` = 'B'")
-    )
-  }
-
-  test("trying to add duplicate node when composite node key constraint exists") {
-    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
-    executeQuery("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY")
+    exec("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS UNIQUE")
 
     expectError(
       "CREATE (n:Person) SET n.name = 'A', n.surname = 'B'",
@@ -199,11 +134,11 @@ class CompositeConstraintAcceptanceTest extends ExecutionEngineFunSuite with New
   }
 
   private def expectError(query: String, expectedError: String) {
-    val error = intercept[CypherException](executeQuery(query))
+    val error = intercept[CypherException](exec(query))
     assertThat(error.getMessage, containsString(expectedError))
   }
 
-  private def executeQuery(query: String) {
+  private def exec(query: String) {
     executeWithCostPlannerAndInterpretedRuntimeOnly(query.fixNewLines).toList
   }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
@@ -49,7 +49,7 @@ public class EnterpriseConstraintSemantics extends StandardConstraintSemantics
     @Override
     protected ConstraintDescriptor readNonStandardConstraint( ConstraintRule rule, String errorMessage )
     {
-        if ( !rule.getConstraintDescriptor().type().enforcesPropertyExistence() )
+        if ( !rule.getConstraintDescriptor().enforcesPropertyExistence() )
         {
             throw new IllegalStateException( "Unsupported constraint type: " + rule );
         }
@@ -156,7 +156,7 @@ public class EnterpriseConstraintSemantics extends StandardConstraintSemantics
 
         void addIfRelevant( ConstraintDescriptor constraint )
         {
-            if ( constraint.type().enforcesPropertyExistence() )
+            if ( constraint.enforcesPropertyExistence() )
             {
                 constraint.schema().processWith( this );
             }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
@@ -87,6 +87,14 @@ public class EnterpriseConstraintSemantics extends StandardConstraintSemantics
         }
     }
 
+    @Override
+    public void validateNodeKeyConstraint( Iterator<Cursor<NodeItem>> allNodes,
+            LabelSchemaDescriptor descriptor, BiPredicate<NodeItem,Integer> hasPropertyCheck )
+            throws CreateConstraintFailureException
+    {
+        validateNodePropertyExistenceConstraint( allNodes, descriptor, hasPropertyCheck );
+    }
+
     private void validateNodePropertyExistenceConstraint( NodeItem node, int propertyKey,
         LabelSchemaDescriptor descriptor, BiPredicate<NodeItem, Integer> hasPropertyCheck ) throws
             CreateConstraintFailureException

--- a/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
@@ -53,6 +53,16 @@ public final class SchemaHelper
         db.execute( String.format( "CREATE CONSTRAINT ON (n:`%s`) ASSERT n.`%s` IS UNIQUE", label, property ) );
     }
 
+    public static void createNodeKeyConstraint( GraphDatabaseService db, Label label, String property )
+    {
+        createNodeKeyConstraint( db, label.name(), property );
+    }
+
+    public static void createNodeKeyConstraint( GraphDatabaseService db, String label, String property )
+    {
+        db.execute( String.format( "CREATE CONSTRAINT ON (n:`%s`) ASSERT (n.`%s`) IS NODE KEY", label, property ) );
+    }
+
     public static void createNodePropertyExistenceConstraint( GraphDatabaseService db, Label label, String property )
     {
         createNodePropertyExistenceConstraint( db, label.name(), property );

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.impl.coreapi.schema.IndexDefinitionImpl;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
+import org.neo4j.kernel.impl.coreapi.schema.NodeKeyConstraintDefinition;
 import org.neo4j.kernel.impl.coreapi.schema.NodePropertyExistenceConstraintDefinition;
 import org.neo4j.kernel.impl.coreapi.schema.RelationshipPropertyExistenceConstraintDefinition;
 import org.neo4j.kernel.impl.coreapi.schema.UniquenessConstraintDefinition;
@@ -45,7 +46,9 @@ public class SchemaWithPECAcceptanceTest
 
     private GraphDatabaseService db;
     private Label label = Labels.MY_LABEL;
+    private Label label2 = Labels.MY_OTHER_LABEL;
     private String propertyKey = "my_property_key";
+    private String propertyKey2 = "my_other_property";
 
     private enum Labels implements Label
     {
@@ -91,10 +94,12 @@ public class SchemaWithPECAcceptanceTest
         // GIVEN
         ConstraintDefinition constraint1 = createUniquenessConstraint( label, propertyKey );
         ConstraintDefinition constraint2 = createNodePropertyExistenceConstraint( label, propertyKey );
+        ConstraintDefinition constraint3 = createNodeKeyConstraint( label, propertyKey2 );
+        createNodeKeyConstraint( label2, propertyKey2 );
         createNodePropertyExistenceConstraint( Labels.MY_OTHER_LABEL, propertyKey );
 
         // WHEN THEN
-        assertThat( getConstraints( db, label ), containsOnly( constraint1, constraint2 ) );
+        assertThat( getConstraints( db, label ), containsOnly( constraint1, constraint2, constraint3 ) );
     }
 
     @Test
@@ -115,9 +120,10 @@ public class SchemaWithPECAcceptanceTest
         ConstraintDefinition constraint1 = createUniquenessConstraint( label, propertyKey );
         ConstraintDefinition constraint2 = createNodePropertyExistenceConstraint( label, propertyKey );
         ConstraintDefinition constraint3 = createRelationshipPropertyExistenceConstraint( Types.MY_TYPE, propertyKey );
+        ConstraintDefinition constraint4 = createNodeKeyConstraint( label, propertyKey2 );
 
         // WHEN THEN
-        assertThat( getConstraints( db ), containsOnly( constraint1, constraint2, constraint3 ) );
+        assertThat( getConstraints( db ), containsOnly( constraint1, constraint2, constraint3, constraint4 ) );
     }
 
     private ConstraintDefinition createUniquenessConstraint( Label label, String propertyKey )
@@ -127,6 +133,15 @@ public class SchemaWithPECAcceptanceTest
         InternalSchemaActions actions = mock( InternalSchemaActions.class );
         IndexDefinition index = new IndexDefinitionImpl( actions, label, new String[]{propertyKey}, true );
         return new UniquenessConstraintDefinition( actions, index );
+    }
+
+    private ConstraintDefinition createNodeKeyConstraint( Label label, String propertyKey )
+    {
+        SchemaHelper.createNodeKeyConstraint( db, label, propertyKey );
+        SchemaHelper.awaitIndexes( db );
+        InternalSchemaActions actions = mock( InternalSchemaActions.class );
+        IndexDefinition index = new IndexDefinitionImpl( actions, label, new String[]{propertyKey}, true );
+        return new NodeKeyConstraintDefinition( actions, index );
     }
 
     private ConstraintDefinition createNodePropertyExistenceConstraint( Label label, String propertyKey )

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -41,11 +41,59 @@ public class StartupConstraintSemanticsTest
     @Test
     public void shouldNotAllowOpeningADatabaseWithPECInCommunityEdition() throws Exception
     {
+        assertThatCommunityCannotStartOnEnterpriseOnlyConstraint( "CREATE CONSTRAINT ON (n:Draconian) ASSERT exists(n.required)",
+                StandardConstraintSemantics.ERROR_MESSAGE_EXISTS );
+    }
+
+    @Test
+    public void shouldNotAllowOpeningADatabaseWithNodeKeyInCommunityEdition() throws Exception
+    {
+        assertThatCommunityCannotStartOnEnterpriseOnlyConstraint( "CREATE CONSTRAINT ON (n:Draconian) ASSERT (n.required) IS NODE KEY",
+                StandardConstraintSemantics.ERROR_MESSAGE_NODE_KEY );
+    }
+
+    @Test
+    public void shouldAllowOpeningADatabaseWithUniqueConstraintInCommunityEdition() throws Exception
+    {
+        assertThatCommunityCanStartOnNormalConstraint( "CREATE CONSTRAINT ON (n:Draconian) ASSERT (n.required) IS UNIQUE" );
+    }
+
+    private void assertThatCommunityCanStartOnNormalConstraint( String constraintCreationQuery )
+    {
         // given
         GraphDatabaseService graphDb = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
         try
         {
-            graphDb.execute( "CREATE CONSTRAINT ON (n:Draconian) ASSERT exists(n.required)" );
+            graphDb.execute( constraintCreationQuery );
+        }
+        finally
+        {
+            graphDb.shutdown();
+        }
+        graphDb = null;
+
+        // when
+        try
+        {
+            graphDb = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
+            // Should not get exception
+        }
+        finally
+        {
+            if ( graphDb != null )
+            {
+                graphDb.shutdown();
+            }
+        }
+    }
+
+    private void assertThatCommunityCannotStartOnEnterpriseOnlyConstraint( String constraintCreationQuery, String errorMessage )
+    {
+        // given
+        GraphDatabaseService graphDb = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
+        try
+        {
+            graphDb.execute( constraintCreationQuery );
         }
         finally
         {
@@ -64,7 +112,7 @@ public class StartupConstraintSemanticsTest
         {
             Throwable error = Exceptions.rootCause( e );
             assertThat( error, instanceOf( IllegalStateException.class ) );
-            assertEquals( StandardConstraintSemantics.ERROR_MESSAGE_EXISTS, error.getMessage() );
+            assertEquals( errorMessage, error.getMessage() );
         }
         finally
         {

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -64,7 +64,7 @@ public class StartupConstraintSemanticsTest
         {
             Throwable error = Exceptions.rootCause( e );
             assertThat( error, instanceOf( IllegalStateException.class ) );
-            assertEquals( StandardConstraintSemantics.ERROR_MESSAGE, error.getMessage() );
+            assertEquals( StandardConstraintSemantics.ERROR_MESSAGE_EXISTS, error.getMessage() );
         }
         finally
         {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaWithPECTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerSchemaWithPECTest.java
@@ -52,6 +52,8 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
         // Given
         SchemaHelper.createUniquenessConstraint( db, label1, propertyKey );
         SchemaHelper.createUniquenessConstraint( db, label2, propertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label1, otherPropertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label2, otherPropertyKey );
 
         SchemaHelper.createNodePropertyExistenceConstraint( db, label2, propertyKey );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType1, propertyKey );
@@ -66,10 +68,13 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
         int labelId2 = labelId( label2 );
         int relTypeId = relationshipTypeId( relType1 );
         int propKeyId = propertyKeyId( propertyKey );
+        int propKeyId2 = propertyKeyId( otherPropertyKey );
 
         assertThat( constraints, containsInAnyOrder(
                 ConstraintDescriptorFactory.uniqueForLabel( labelId1, propKeyId ),
                 ConstraintDescriptorFactory.uniqueForLabel( labelId2, propKeyId ),
+                ConstraintDescriptorFactory.nodeKeyForLabel( labelId1, propKeyId2 ),
+                ConstraintDescriptorFactory.nodeKeyForLabel( labelId2, propKeyId2 ),
                 ConstraintDescriptorFactory.existsForLabel( labelId2, propKeyId ),
                 ConstraintDescriptorFactory.existsForRelType( relTypeId, propKeyId )
             ) );
@@ -83,6 +88,8 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
         SchemaHelper.createNodePropertyExistenceConstraint( db, label2, propertyKey );
 
         SchemaHelper.createUniquenessConstraint( db, label1, propertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label1, otherPropertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label2, otherPropertyKey );
 
         SchemaHelper.awaitIndexes( db );
 
@@ -92,6 +99,7 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
         // Then
         Set<ConstraintDescriptor> expectedConstraints = asSet(
                 uniqueConstraintDescriptor( label1, propertyKey ),
+                nodeKeyConstraintDescriptor( label1, otherPropertyKey ),
                 nodePropertyExistenceDescriptor( label1, propertyKey ) );
 
         assertEquals( expectedConstraints, constraints );
@@ -101,8 +109,10 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
     public void shouldListAllConstraintsForLabelAndProperty()
     {
         // Given
-        SchemaHelper.createUniquenessConstraint( db, label1, propertyKey );
+        SchemaHelper.createUniquenessConstraint( db, label2, propertyKey );
         SchemaHelper.createUniquenessConstraint( db, label1, otherPropertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label1, propertyKey );
+        SchemaHelper.createNodeKeyConstraint( db, label2, otherPropertyKey );
 
         SchemaHelper.createNodePropertyExistenceConstraint( db, label1, propertyKey );
         SchemaHelper.createNodePropertyExistenceConstraint( db, label2, propertyKey );
@@ -115,7 +125,7 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
 
         // Then
         Set<ConstraintDescriptor> expected = asSet(
-                uniqueConstraintDescriptor( label1, propertyKey ),
+                nodeKeyConstraintDescriptor( label1, propertyKey ),
                 nodePropertyExistenceDescriptor( label1, propertyKey ) );
 
         assertEquals( expected, constraints );
@@ -169,6 +179,13 @@ public class StorageLayerSchemaWithPECTest extends StorageLayerTest
         int labelId = labelId( label );
         int propKeyId = propertyKeyId( propertyKey );
         return ConstraintDescriptorFactory.uniqueForLabel( labelId, propKeyId );
+    }
+
+    private ConstraintDescriptor nodeKeyConstraintDescriptor( Label label, String propertyKey )
+    {
+        int labelId = labelId( label );
+        int propKeyId = propertyKeyId( propertyKey );
+        return ConstraintDescriptorFactory.nodeKeyForLabel( labelId, propKeyId );
     }
 
     private ConstraintDescriptor nodePropertyExistenceDescriptor( Label label, String propertyKey )

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
@@ -138,6 +138,7 @@ public class PECListingIT extends AbstractShellIT
 
         // WHEN
         SchemaHelper.createUniquenessConstraint( db, label, "name" );
+//        SchemaHelper.createNodeKeyConstraint( db, label, "surname" );
         SchemaHelper.createNodePropertyExistenceConstraint( db, label, "name" );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType, "since" );
 
@@ -147,8 +148,10 @@ public class PECListingIT extends AbstractShellIT
         executeCommand( "schema",
                 "Indexes",
                 "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
+//                "  ON :Person\\(surname\\) ONLINE \\(for uniqueness constraint\\)",
                 "Constraints",
                 "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
+//                "  ON \\(person:Person\\) ASSERT person.surname IS NODE KEY",
                 "  ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
                 "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/PECListingIT.java
@@ -138,7 +138,7 @@ public class PECListingIT extends AbstractShellIT
 
         // WHEN
         SchemaHelper.createUniquenessConstraint( db, label, "name" );
-//        SchemaHelper.createNodeKeyConstraint( db, label, "surname" );
+        SchemaHelper.createNodeKeyConstraint( db, label, "surname" );
         SchemaHelper.createNodePropertyExistenceConstraint( db, label, "name" );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType, "since" );
 
@@ -147,11 +147,11 @@ public class PECListingIT extends AbstractShellIT
         // THEN
         executeCommand( "schema",
                 "Indexes",
-                "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
-//                "  ON :Person\\(surname\\) ONLINE \\(for uniqueness constraint\\)",
+                "  ON :Person\\(name\\)    ONLINE \\(for uniqueness constraint\\)",
+                "  ON :Person\\(surname\\) ONLINE \\(for uniqueness constraint\\)",
                 "Constraints",
                 "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
-//                "  ON \\(person:Person\\) ASSERT person.surname IS NODE KEY",
+                "  ON \\(person:Person\\) ASSERT person.surname IS NODE KEY",
                 "  ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
                 "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }


### PR DESCRIPTION
This work builds on, but replaces parts of, https://github.com/neo4j/neo4j/pull/9034

Changelog: Composite uniqueness and NODE KEY

* The existing uniqueness constraint has been generalized to multiple properties
* A new NODE KEY constraint has been developed combining the features of a composite uniqueness constraint and property existence constraint over one or more properties
