### PR TITLE
Better naming in index module

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
@@ -230,8 +230,8 @@ class ConsistencyChecker<KEY>
         boolean isInternal = false;
         boolean isLeaf = false;
         int keyCount;
-        long heir;
-        long heirGeneration;
+        long successor;
+        long successorGeneration;
 
         long leftSiblingPointer;
         long rightSiblingPointer;
@@ -247,7 +247,7 @@ class ConsistencyChecker<KEY>
             assertNoCrashOrBrokenPointerInGSPP(
                     cursor, stableGeneration, unstableGeneration, "RightSibling", TreeNode.BYTE_POS_RIGHTSIBLING, node );
             assertNoCrashOrBrokenPointerInGSPP(
-                    cursor, stableGeneration, unstableGeneration, "Heir", TreeNode.BYTE_POS_HEIR, node );
+                    cursor, stableGeneration, unstableGeneration, "Successor", TreeNode.BYTE_POS_SUCCESSOR, node );
 
             // for assertSiblings
             leftSiblingPointer = node.leftSibling( cursor, stableGeneration, unstableGeneration );
@@ -258,8 +258,8 @@ class ConsistencyChecker<KEY>
             rightSiblingPointer = pointer( rightSiblingPointer );
             currentNodeGeneration = node.generation( cursor );
 
-            heir = node.heir( cursor, stableGeneration, unstableGeneration );
-            heirGeneration = node.pointerGeneration( cursor, heir );
+            successor = node.successor( cursor, stableGeneration, unstableGeneration );
+            successorGeneration = node.pointerGeneration( cursor, successor );
 
             keyCount = node.keyCount( cursor );
             if ( keyCount > node.internalMaxKeyCount() && keyCount > node.leafMaxKeyCount() )
@@ -283,7 +283,7 @@ class ConsistencyChecker<KEY>
         assertPointerGenerationMatchesGeneration( cursor, currentNodeGeneration, expectedGeneration );
         assertSiblings( cursor, currentNodeGeneration, leftSiblingPointer, leftSiblingPointerGeneration, rightSiblingPointer,
                 rightSiblingPointerGeneration, level );
-        checkHeirPointerGeneration( cursor, heir, heirGeneration );
+        checkSuccessorPointerGeneration( cursor, successor, successorGeneration );
 
         if ( isInternal )
         {
@@ -299,15 +299,15 @@ class ConsistencyChecker<KEY>
                 " to be ≤ pointer generation:" + expectedGeneration;
     }
 
-    private void checkHeirPointerGeneration( PageCursor cursor, long heir, long heirGeneration )
+    private void checkSuccessorPointerGeneration( PageCursor cursor, long successor, long successorGeneration )
             throws IOException
     {
-        if ( TreeNode.isNode( heir ) )
+        if ( TreeNode.isNode( successor ) )
         {
             cursor.setCursorException( "WARNING: we ended up on an old generation " + cursor.getCurrentPageId() +
-                    " which had heir:" + pointer( heir ) );
+                    " which had successor:" + pointer( successor ) );
             long origin = cursor.getCurrentPageId();
-            node.goTo( cursor, "heir", heir );
+            node.goTo( cursor, "successor", successor );
             try
             {
                 long nodeGeneration;
@@ -317,7 +317,7 @@ class ConsistencyChecker<KEY>
                 }
                 while ( cursor.shouldRetry() );
 
-                assertPointerGenerationMatchesGeneration( cursor, nodeGeneration, heirGeneration );
+                assertPointerGenerationMatchesGeneration( cursor, nodeGeneration, successorGeneration );
             }
             finally
             {

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/ConsistencyChecker.java
@@ -32,7 +32,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointer;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointer;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.checkOutOfBounds;
 
 /**
@@ -64,11 +64,11 @@ class ConsistencyChecker<KEY>
         this.unstableGeneration = unstableGeneration;
     }
 
-    public boolean check( PageCursor cursor, long expectedGen ) throws IOException
+    public boolean check( PageCursor cursor, long expectedGeneration ) throws IOException
     {
         assertOnTreeNode( cursor );
         KeyRange<KEY> openRange = new KeyRange<>( comparator, null, null, layout, null );
-        boolean result = checkSubtree( cursor, openRange, expectedGen, 0 );
+        boolean result = checkSubtree( cursor, openRange, expectedGeneration, 0 );
 
         // Assert that rightmost node on each level has empty right sibling.
         rightmostPerLevel.forEach( RightmostInChain::assertLast );
@@ -224,20 +224,20 @@ class ConsistencyChecker<KEY>
         }
     }
 
-    private boolean checkSubtree( PageCursor cursor, KeyRange<KEY> range, long expectedGen, int level )
+    private boolean checkSubtree( PageCursor cursor, KeyRange<KEY> range, long expectedGeneration, int level )
             throws IOException
     {
         boolean isInternal = false;
         boolean isLeaf = false;
         int keyCount;
         long heir;
-        long heirGen;
+        long heirGeneration;
 
         long leftSiblingPointer;
         long rightSiblingPointer;
-        long leftSiblingPointerGen;
-        long rightSiblingPointerGen;
-        long currentNodeGen;
+        long leftSiblingPointerGeneration;
+        long rightSiblingPointerGeneration;
+        long currentNodeGeneration;
 
         do
         {
@@ -252,14 +252,14 @@ class ConsistencyChecker<KEY>
             // for assertSiblings
             leftSiblingPointer = node.leftSibling( cursor, stableGeneration, unstableGeneration );
             rightSiblingPointer = node.rightSibling( cursor, stableGeneration, unstableGeneration );
-            leftSiblingPointerGen = node.pointerGen( cursor, leftSiblingPointer );
-            rightSiblingPointerGen = node.pointerGen( cursor, rightSiblingPointer );
+            leftSiblingPointerGeneration = node.pointerGeneration( cursor, leftSiblingPointer );
+            rightSiblingPointerGeneration = node.pointerGeneration( cursor, rightSiblingPointer );
             leftSiblingPointer = pointer( leftSiblingPointer );
             rightSiblingPointer = pointer( rightSiblingPointer );
-            currentNodeGen = node.gen( cursor );
+            currentNodeGeneration = node.generation( cursor );
 
             heir = node.heir( cursor, stableGeneration, unstableGeneration );
-            heirGen = node.pointerGen( cursor, heir );
+            heirGeneration = node.pointerGeneration( cursor, heir );
 
             keyCount = node.keyCount( cursor );
             if ( keyCount > node.internalMaxKeyCount() && keyCount > node.leafMaxKeyCount() )
@@ -280,10 +280,10 @@ class ConsistencyChecker<KEY>
                     " isn't a tree node, parent expected range " + range );
         }
 
-        assertPointerGenMatchesGen( cursor, currentNodeGen, expectedGen );
-        assertSiblings( cursor, currentNodeGen, leftSiblingPointer, leftSiblingPointerGen, rightSiblingPointer,
-                rightSiblingPointerGen, level );
-        checkHeirPointerGen( cursor, heir, heirGen );
+        assertPointerGenerationMatchesGeneration( cursor, currentNodeGeneration, expectedGeneration );
+        assertSiblings( cursor, currentNodeGeneration, leftSiblingPointer, leftSiblingPointerGeneration, rightSiblingPointer,
+                rightSiblingPointerGeneration, level );
+        checkHeirPointerGeneration( cursor, heir, heirGeneration );
 
         if ( isInternal )
         {
@@ -292,13 +292,14 @@ class ConsistencyChecker<KEY>
         return true;
     }
 
-    private static void assertPointerGenMatchesGen( PageCursor cursor, long nodeGen, long expectedGen )
+    private static void assertPointerGenerationMatchesGeneration( PageCursor cursor, long nodeGeneration,
+            long expectedGeneration )
     {
-        assert nodeGen <= expectedGen : "Expected node:" + cursor.getCurrentPageId() + " gen:" + nodeGen +
-                " to be ≤ pointer gen:" + expectedGen;
+        assert nodeGeneration <= expectedGeneration : "Expected node:" + cursor.getCurrentPageId() + " generation:" + nodeGeneration +
+                " to be ≤ pointer generation:" + expectedGeneration;
     }
 
-    private void checkHeirPointerGen( PageCursor cursor, long heir, long heirGen )
+    private void checkHeirPointerGeneration( PageCursor cursor, long heir, long heirGeneration )
             throws IOException
     {
         if ( TreeNode.isNode( heir ) )
@@ -309,14 +310,14 @@ class ConsistencyChecker<KEY>
             node.goTo( cursor, "heir", heir );
             try
             {
-                long nodeGen;
+                long nodeGeneration;
                 do
                 {
-                    nodeGen = node.gen( cursor );
+                    nodeGeneration = node.generation( cursor );
                 }
                 while ( cursor.shouldRetry() );
 
-                assertPointerGenMatchesGen( cursor, nodeGen, heirGen );
+                assertPointerGenerationMatchesGeneration( cursor, nodeGeneration, heirGeneration );
             }
             finally
             {
@@ -326,8 +327,8 @@ class ConsistencyChecker<KEY>
     }
 
     // Assumption: We traverse the tree from left to right on every level
-    private void assertSiblings( PageCursor cursor, long currentNodeGen, long leftSiblingPointer,
-            long leftSiblingPointerGen, long rightSiblingPointer, long rightSiblingPointerGen, int level )
+    private void assertSiblings( PageCursor cursor, long currentNodeGeneration, long leftSiblingPointer,
+            long leftSiblingPointerGeneration, long rightSiblingPointer, long rightSiblingPointerGeneration, int level )
     {
         // If this is the first time on this level, we will add a new entry
         for ( int i = rightmostPerLevel.size(); i <= level; i++ )
@@ -336,8 +337,8 @@ class ConsistencyChecker<KEY>
         }
         RightmostInChain rightmost = rightmostPerLevel.get( level );
 
-        rightmost.assertNext( cursor, currentNodeGen, leftSiblingPointer, leftSiblingPointerGen, rightSiblingPointer,
-                rightSiblingPointerGen );
+        rightmost.assertNext( cursor, currentNodeGeneration, leftSiblingPointer, leftSiblingPointerGeneration, rightSiblingPointer,
+                rightSiblingPointerGeneration );
     }
 
     private void assertSubtrees( PageCursor cursor, KeyRange<KEY> range, int keyCount, int level )
@@ -352,11 +353,11 @@ class ConsistencyChecker<KEY>
         while ( pos < keyCount )
         {
             long child;
-            long childGen;
+            long childGeneration;
             do
             {
                 child = childAt( cursor, pos );
-                childGen = node.pointerGen( cursor, child );
+                childGeneration = node.pointerGeneration( cursor, child );
                 node.keyAt( cursor, readKey, pos );
             }
             while ( cursor.shouldRetry() );
@@ -369,7 +370,7 @@ class ConsistencyChecker<KEY>
             }
 
             node.goTo( cursor, "child at pos " + pos, child );
-            checkSubtree( cursor, childRange, childGen, level + 1 );
+            checkSubtree( cursor, childRange, childGeneration, level + 1 );
 
             node.goTo( cursor, "parent", pageId );
 
@@ -379,18 +380,18 @@ class ConsistencyChecker<KEY>
 
         // Check last child
         long child;
-        long childGen;
+        long childGeneration;
         do
         {
             child = childAt( cursor, pos );
-            childGen = node.pointerGen( cursor, child );
+            childGeneration = node.pointerGeneration( cursor, child );
         }
         while ( cursor.shouldRetry() );
         checkAfterShouldRetry( cursor );
 
         node.goTo( cursor, "child at pos " + pos, child );
         childRange = range.restrictLeft( prev );
-        checkSubtree( cursor, childRange, childGen, level + 1 );
+        checkSubtree( cursor, childRange, childGeneration, level + 1 );
         node.goTo( cursor, "parent", pageId );
     }
 
@@ -440,22 +441,22 @@ class ConsistencyChecker<KEY>
         cursor.setOffset( offset );
         long currentNodeId = cursor.getCurrentPageId();
         // A
-        long generationA = GenSafePointer.readGeneration( cursor );
-        long pointerA = GenSafePointer.readPointer( cursor );
-        short checksumA = GenSafePointer.readChecksum( cursor );
-        boolean correctChecksumA = GenSafePointer.checksumOf( generationA, pointerA ) == checksumA;
-        byte stateA = GenSafePointerPair.pointerState(
+        long generationA = GenerationSafePointer.readGeneration( cursor );
+        long pointerA = GenerationSafePointer.readPointer( cursor );
+        short checksumA = GenerationSafePointer.readChecksum( cursor );
+        boolean correctChecksumA = GenerationSafePointer.checksumOf( generationA, pointerA ) == checksumA;
+        byte stateA = GenerationSafePointerPair.pointerState(
                 stableGeneration, unstableGeneration, generationA, pointerA, correctChecksumA );
-        boolean okA = stateA != GenSafePointerPair.BROKEN && stateA != GenSafePointerPair.CRASH;
+        boolean okA = stateA != GenerationSafePointerPair.BROKEN && stateA != GenerationSafePointerPair.CRASH;
 
         // B
-        long generationB = GenSafePointer.readGeneration( cursor );
-        long pointerB = GenSafePointer.readPointer( cursor );
-        short checksumB = GenSafePointer.readChecksum( cursor );
-        boolean correctChecksumB = GenSafePointer.checksumOf( generationB, pointerB ) == checksumB;
-        byte stateB = GenSafePointerPair.pointerState(
+        long generationB = GenerationSafePointer.readGeneration( cursor );
+        long pointerB = GenerationSafePointer.readPointer( cursor );
+        short checksumB = GenerationSafePointer.readChecksum( cursor );
+        boolean correctChecksumB = GenerationSafePointer.checksumOf( generationB, pointerB ) == checksumB;
+        byte stateB = GenerationSafePointerPair.pointerState(
                 stableGeneration, unstableGeneration, generationB, pointerB, correctChecksumB );
-        boolean okB = stateB != GenSafePointerPair.BROKEN && stateB != GenSafePointerPair.CRASH;
+        boolean okB = stateB != GenerationSafePointerPair.BROKEN && stateB != GenerationSafePointerPair.CRASH;
 
         if ( !(okA && okB) )
         {
@@ -472,7 +473,7 @@ class ConsistencyChecker<KEY>
     private static String stateToString( long generationA, long pointerA, byte stateA )
     {
         return format( "generation=%d, pointer=%d, state=%s",
-                generationA, pointerA, GenSafePointerPair.pointerStateName( stateA ) );
+                generationA, pointerA, GenerationSafePointerPair.pointerStateName( stateA ) );
     }
 
     private static class KeyRange<KEY>

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenCleaner.java
@@ -176,7 +176,7 @@ class CrashGenCleaner
         do
         {
             hasCrashed =
-                    hasCrashedGSPP( cursor, TreeNode.BYTE_POS_HEIR ) ||
+                    hasCrashedGSPP( cursor, TreeNode.BYTE_POS_SUCCESSOR ) ||
                     hasCrashedGSPP( cursor, TreeNode.BYTE_POS_LEFTSIBLING ) ||
                     hasCrashedGSPP( cursor, TreeNode.BYTE_POS_RIGHTSIBLING );
 
@@ -195,13 +195,13 @@ class CrashGenCleaner
 
     private boolean hasCrashedGSPP( PageCursor cursor, int gsppOffset )
     {
-        return hasCrashedGSP( cursor, gsppOffset ) || hasCrashedGSP( cursor, gsppOffset + GenSafePointer.SIZE );
+        return hasCrashedGSP( cursor, gsppOffset ) || hasCrashedGSP( cursor, gsppOffset + GenerationSafePointer.SIZE );
     }
 
     private boolean hasCrashedGSP( PageCursor cursor, int offset )
     {
         cursor.setOffset( offset );
-        long generation = GenSafePointer.readGeneration( cursor );
+        long generation = GenerationSafePointer.readGeneration( cursor );
         return generation > stableGeneration && generation < unstableGeneration;
     }
 
@@ -209,7 +209,7 @@ class CrashGenCleaner
 
     private void cleanTreeNode( TreeNode<?,?> treeNode, PageCursor cursor, AtomicInteger cleanedPointers )
     {
-        cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_HEIR, cleanedPointers );
+        cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_SUCCESSOR, cleanedPointers );
         cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_LEFTSIBLING, cleanedPointers );
         cleanCrashedGSPP( cursor, TreeNode.BYTE_POS_RIGHTSIBLING, cleanedPointers );
 
@@ -226,7 +226,7 @@ class CrashGenCleaner
     private void cleanCrashedGSPP( PageCursor cursor, int gsppOffset, AtomicInteger cleanedPointers )
     {
         cleanCrashedGSP( cursor, gsppOffset, cleanedPointers );
-        cleanCrashedGSP( cursor, gsppOffset + GenSafePointer.SIZE, cleanedPointers );
+        cleanCrashedGSP( cursor, gsppOffset + GenerationSafePointer.SIZE, cleanedPointers );
     }
 
     /**
@@ -237,7 +237,7 @@ class CrashGenCleaner
         if ( hasCrashedGSP( cursor, gspOffset ) )
         {
             cursor.setOffset( gspOffset );
-            GenSafePointer.clean( cursor );
+            GenerationSafePointer.clean( cursor );
             cleanedPointers.incrementAndGet();
         }
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
@@ -39,7 +39,7 @@ import static org.neo4j.helpers.Exceptions.launderedException;
 /**
  * Scans the entire tree and checks all GSPPs, replacing all CRASH gen GSPs with zeros.
  */
-class CrashGenCleaner
+class CrashGenerationCleaner
 {
     private final PagedFile pagedFile;
     private final TreeNode<?,?> treeNode;
@@ -52,7 +52,7 @@ class CrashGenCleaner
     private final Monitor monitor;
     private final long internalMaxKeyCount;
 
-    CrashGenCleaner( PagedFile pagedFile, TreeNode<?,?> treeNode, long lowTreeNodeId, long highTreeNodeId,
+    CrashGenerationCleaner( PagedFile pagedFile, TreeNode<?,?> treeNode, long lowTreeNodeId, long highTreeNodeId,
             long stableGeneration, long unstableGeneration, Monitor monitor )
     {
         this.pagedFile = pagedFile;

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreeListIdProvider.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreeListIdProvider.java
@@ -74,8 +74,8 @@ class FreeListIdProvider implements IdProvider
      * About the free-list id/offset variables below:
      * <pre>
      * Every cell in picture contains generation, page id is omitted for briefness.
-     * StableGen   = 1
-     * UnstableGen = 2
+     * StableGeneration   = 1
+     * UnstableGeneration = 2
      *
      *        {@link #readPos}                         {@link #writePos}
      *        v                               v

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/FreelistNode.java
@@ -39,10 +39,10 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
  */
 class FreelistNode
 {
-    private static final int PAGE_ID_SIZE = GenSafePointer.POINTER_SIZE;
+    private static final int PAGE_ID_SIZE = GenerationSafePointer.POINTER_SIZE;
     private static final int BYTE_POS_NEXT = TreeNode.BYTE_POS_NODE_TYPE + Byte.BYTES;
     private static final int HEADER_LENGTH = BYTE_POS_NEXT + PAGE_ID_SIZE;
-    private static final int ENTRY_SIZE = GenSafePointer.GENERATION_SIZE + PAGE_ID_SIZE;
+    private static final int ENTRY_SIZE = GenerationSafePointer.GENERATION_SIZE + PAGE_ID_SIZE;
     static final long NO_PAGE_ID = TreeNode.NO_NODE_FLAG;
 
     private final int maxEntries;
@@ -64,7 +64,7 @@ class FreelistNode
             throw new IllegalArgumentException( "Tried to write pageId " + pageId + " which means null" );
         }
         assertPos( pos );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenerationSafePointer.assertGenerationOnWrite( unstableGeneration );
         cursor.setOffset( entryOffset( pos ) );
         cursor.putInt( (int) unstableGeneration );
         put6BLong( cursor, pageId );

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -127,7 +127,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
      * Version of the format that makes up the tree. This includes:
      * <ul>
      * <li>{@link TreeNode} format, header, keys, children, values</li>
-     * <li>{@link GenSafePointer} and {@link GenSafePointerPair}</li>
+     * <li>{@link GenerationSafePointer} and {@link GenerationSafePointerPair}</li>
      * <li>{@link IdSpace} i.e. which pages are fixed</li>
      * <li>{@link TreeState} and {@link TreeStatePair}</li>
      * </ul>
@@ -311,7 +311,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
     {
         this.indexFile = indexFile;
         this.monitor = monitor;
-        this.generation = Generation.generation( GenSafePointer.MIN_GENERATION, GenSafePointer.MIN_GENERATION + 1 );
+        this.generation = Generation.generation( GenerationSafePointer.MIN_GENERATION, GenerationSafePointer.MIN_GENERATION + 1 );
         long rootId = IdSpace.MIN_TREE_NODE_ID;
         setRoot( rootId, Generation.unstableGeneration( generation ) );
         this.layout = layout;
@@ -434,7 +434,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
             while ( cursor.shouldRetry() );
         }
         generation = Generation.generation( state.stableGeneration(), state.unstableGeneration() );
-        setRoot( state.rootId(), state.rootGen() );
+        setRoot( state.rootId(), state.rootGeneration() );
 
         long lastId = state.lastId();
         long freeListWritePageId = state.freeListWritePageId();
@@ -643,11 +643,11 @@ public class GBPTree<KEY,VALUE> implements Closeable
         long unstableGeneration = unstableGeneration( generation );
 
         PageCursor cursor = pagedFile.io( 0L /*ignored*/, PagedFile.PF_SHARED_READ_LOCK );
-        long rootGen = root.goTo( cursor );
+        long rootGeneration = root.goTo( cursor );
 
         // Returns cursor which is now initiated with left-most leaf node for the specified range
         return new SeekCursor<>( cursor, bTreeNode, fromInclusive, toExclusive, layout,
-                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, rootGen );
+                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, rootGeneration );
     }
 
     /**
@@ -892,8 +892,8 @@ public class GBPTree<KEY,VALUE> implements Closeable
             ConsistencyChecker<KEY> consistencyChecker = new ConsistencyChecker<>( bTreeNode, layout,
                     stableGeneration( generation ), unstableGeneration );
 
-            long rootGen = root.goTo( cursor );
-            boolean check = consistencyChecker.check( cursor, rootGen );
+            long rootGeneration = root.goTo( cursor );
+            boolean check = consistencyChecker.check( cursor, rootGeneration );
             root.goTo( cursor );
 
             PrimitiveLongSet freelistIds = Primitive.longSet();
@@ -909,7 +909,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
     public String toString()
     {
         long generation = this.generation;
-        return format( "GB+Tree[file:%s, layout:%s, gen:%d/%d]",
+        return format( "GB+Tree[file:%s, layout:%s, generation:%d/%d]",
                 indexFile.getAbsolutePath(), layout,
                 stableGeneration( generation ), unstableGeneration( generation ) );
     }
@@ -977,7 +977,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
         private void setRoot( long rootPointer )
         {
-            long rootId = GenSafePointerPair.pointer( rootPointer );
+            long rootId = GenerationSafePointerPair.pointer( rootPointer );
             GBPTree.this.setRoot( rootId, unstableGeneration );
             treeLogic.initialize( cursor );
         }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -864,7 +864,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         // and zero out all CRASH pointers.
 
         long generation = this.generation;
-        new CrashGenCleaner( pagedFile, bTreeNode, IdSpace.MIN_TREE_NODE_ID,freeList.lastId() + 1,
+        new CrashGenerationCleaner( pagedFile, bTreeNode, IdSpace.MIN_TREE_NODE_ID,freeList.lastId() + 1,
                 stableGeneration( generation ), unstableGeneration( generation ), monitor ).clean();
     }
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/Generation.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/Generation.java
@@ -41,8 +41,8 @@ class Generation
      */
     public static long generation( long stableGeneration, long unstableGeneration )
     {
-        GenSafePointer.assertGenerationOnWrite( stableGeneration );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenerationSafePointer.assertGenerationOnWrite( stableGeneration );
+        GenerationSafePointer.assertGenerationOnWrite( unstableGeneration );
 
         return (stableGeneration << STABLE_GENERATION_SHIFT) | unstableGeneration;
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointer.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GenerationSafePointer.java
@@ -26,9 +26,9 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.getUnsignedInt;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
 
 /**
- * Provides static methods for getting and manipulating GSP (gen-safe pointer) data.
+ * Provides static methods for getting and manipulating GSP (generation-safe pointer) data.
  * All interaction is made using a {@link PageCursor}. These methods are about a single GSP,
- * whereas the normal use case of a GSP is in pairs ({@link GenSafePointerPair GSPP}).
+ * whereas the normal use case of a GSP is in pairs ({@link GenerationSafePointerPair GSPP}).
  * <p>
  * A GSP consists of [generation,pointer,checksum]. Checksum is calculated from generation and pointer.
  * <p>
@@ -45,7 +45,7 @@ import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
  * <li>{@link #verifyChecksum(PageCursor, long, long)}</li>
  * </ol>
  */
-class GenSafePointer
+class GenerationSafePointer
 {
     private static final int EMPTY_POINTER = 0;
     private static final int EMPTY_GENERATION = 0;
@@ -138,7 +138,7 @@ class GenSafePointer
      * @param generation generation of the pointer.
      * @param pointer pointer itself.
      *
-     * @return a {@code short} which is the checksum of the gen-pointer.
+     * @return a {@code short} which is the checksum of the generation-pointer.
      */
     public static short checksumOf( long generation, long pointer )
     {

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -323,7 +323,7 @@ class InternalTreeLogic<KEY,VALUE>
      * {@link StructurePropagation} is provided from outside to minimize garbage.
      * <p>
      * When this method returns, {@code structurePropagation} will be populated with information about split or new
-     * gen version of root. This needs to be handled by caller.
+     * generation version of root. This needs to be handled by caller.
      * <p>
      * Leaves cursor at the page which was last updated. No guarantees on offset.
      *
@@ -1157,7 +1157,7 @@ class InternalTreeLogic<KEY,VALUE>
         if ( TreeNode.isNode( leftSibling ) )
         {
             // Go to left sibling and read stuff
-            try ( PageCursor leftSiblingCursor = cursor.openLinkedCursor( GenSafePointerPair.pointer( leftSibling ) ) )
+            try ( PageCursor leftSiblingCursor = cursor.openLinkedCursor( GenerationSafePointerPair.pointer( leftSibling ) ) )
             {
                 leftSiblingCursor.next();
                 int leftSiblingKeyCount = bTreeNode.keyCount( leftSiblingCursor );
@@ -1180,7 +1180,7 @@ class InternalTreeLogic<KEY,VALUE>
         else if ( TreeNode.isNode( rightSibling ) )
         {
             try ( PageCursor rightSiblingCursor = cursor.openLinkedCursor(
-                    GenSafePointerPair.pointer( rightSibling ) ) )
+                    GenerationSafePointerPair.pointer( rightSibling ) ) )
             {
                 rightSiblingCursor.next();
                 int rightSiblingKeyCount = bTreeNode.keyCount( rightSiblingCursor );
@@ -1341,8 +1341,8 @@ class InternalTreeLogic<KEY,VALUE>
             throws IOException
     {
         long oldId = cursor.getCurrentPageId();
-        long nodeGen = bTreeNode.gen( cursor );
-        if ( nodeGen == unstableGeneration )
+        long nodeGeneration = bTreeNode.generation( cursor );
+        if ( nodeGeneration == unstableGeneration )
         {
             // Don't copy
             return;
@@ -1354,7 +1354,7 @@ class InternalTreeLogic<KEY,VALUE>
         {
             bTreeNode.goTo( heirCursor, "heir", heirId );
             cursor.copyTo( 0, heirCursor, 0, cursor.getCurrentPageSize() );
-            bTreeNode.setGen( heirCursor, unstableGeneration );
+            bTreeNode.setGeneration( heirCursor, unstableGeneration );
             bTreeNode.setHeir( heirCursor, TreeNode.NO_NODE_FLAG, stableGeneration, unstableGeneration );
         }
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
@@ -22,7 +22,7 @@ package org.neo4j.index.internal.gbptree;
 import org.neo4j.io.pagecache.PageCursor;
 
 /**
- * Methods for ensuring a read {@link GenSafePointer GSP pointer} is valid.
+ * Methods for ensuring a read {@link GenerationSafePointer GSP pointer} is valid.
  */
 class PointerChecking
 {
@@ -30,13 +30,13 @@ class PointerChecking
      * Checks a read pointer for success/failure and throws appropriate exception with failure information
      * if failure. Must be called after a consistent read from page cache (after {@link PageCursor#shouldRetry()}.
      *
-     * @param result result from {@link GenSafePointerPair#FLAG_READ} or
-     * {@link GenSafePointerPair#write(PageCursor, long, long, long)}.
+     * @param result result from {@link GenerationSafePointerPair#FLAG_READ} or
+     * {@link GenerationSafePointerPair#write(PageCursor, long, long, long)}.
      * @param allowNoNode If {@link TreeNode#NO_NODE_FLAG} is allowed as pointer value.
      */
     static void checkPointer( long result, boolean allowNoNode )
     {
-        GenSafePointerPair.assertSuccess( result );
+        GenerationSafePointerPair.assertSuccess( result );
         if ( allowNoNode && !TreeNode.isNode( result ) )
         {
             return;

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RightmostInChain.java
@@ -35,12 +35,12 @@ class RightmostInChain
 {
     private long currentRightmostNode = TreeNode.NO_NODE_FLAG;
     private long currentRightmostRightSiblingPointer = TreeNode.NO_NODE_FLAG;
-    private long currentRightmostRightSiblingPointerGen;
-    private long currentRightmostNodeGen;
+    private long currentRightmostRightSiblingPointerGeneration;
+    private long currentRightmostNodeGeneration;
 
-    void assertNext( PageCursor cursor, long newRightmostNodeGen,
-            long newRightmostLeftSiblingPointer, long newRightmostLeftSiblingPointerGen,
-            long newRightmostRightSiblingPointer, long newRightmostRightSiblingPointerGen )
+    void assertNext( PageCursor cursor, long newRightmostNodeGeneration,
+            long newRightmostLeftSiblingPointer, long newRightmostLeftSiblingPointerGeneration,
+            long newRightmostRightSiblingPointer, long newRightmostRightSiblingPointerGeneration )
     {
         long newRightmostNode = cursor.getCurrentPageId();
 
@@ -50,57 +50,58 @@ class RightmostInChain
         {
             errorMessageBuilder.append( format( "Sibling pointer does align with tree structure%n" ) );
         }
-        if ( currentRightmostNodeGen > newRightmostLeftSiblingPointerGen && currentRightmostNode != NO_NODE_FLAG )
+        if ( currentRightmostNodeGeneration > newRightmostLeftSiblingPointerGeneration && currentRightmostNode != NO_NODE_FLAG )
         {
-            errorMessageBuilder.append( format( "Sibling pointer gen differs from expected%n" ) );
+            errorMessageBuilder.append( format( "Sibling pointer generation differs from expected%n" ) );
         }
         if ( newRightmostNode != currentRightmostRightSiblingPointer &&
                 (currentRightmostRightSiblingPointer != NO_NODE_FLAG || currentRightmostNode != NO_NODE_FLAG) )
         {
             errorMessageBuilder.append( format( "Sibling pointer does not align with tree structure%n" ) );
         }
-        if ( currentRightmostRightSiblingPointerGen < newRightmostNodeGen &&
+        if ( currentRightmostRightSiblingPointerGeneration < newRightmostNodeGeneration &&
                 currentRightmostRightSiblingPointer != NO_NODE_FLAG )
         {
-            errorMessageBuilder.append( format( "Sibling pointer gen differs from expected%n" ) );
+            errorMessageBuilder.append( format( "Sibling pointer generation differs from expected%n" ) );
         }
 
         String errorMessage = errorMessageBuilder.toString();
         if ( !errorMessage.equals( "" ) )
         {
-            setPatternException( cursor, newRightmostNodeGen, newRightmostLeftSiblingPointer, newRightmostLeftSiblingPointerGen, newRightmostNode, errorMessage );
+            setPatternException( cursor, newRightmostNodeGeneration, newRightmostLeftSiblingPointer, newRightmostLeftSiblingPointerGeneration, newRightmostNode, errorMessage );
         }
 
         // Update currentRightmostNode = newRightmostNode;
         currentRightmostNode = newRightmostNode;
-        currentRightmostNodeGen = newRightmostNodeGen;
+        currentRightmostNodeGeneration = newRightmostNodeGeneration;
         currentRightmostRightSiblingPointer = newRightmostRightSiblingPointer;
-        currentRightmostRightSiblingPointerGen = newRightmostRightSiblingPointerGen;
+        currentRightmostRightSiblingPointerGeneration = newRightmostRightSiblingPointerGeneration;
     }
 
-    private void setPatternException( PageCursor cursor, long newRightmostGen, long leftSibling,
-            long leftSiblingGen, long newRightmost, String errorMessage )
+    private void setPatternException( PageCursor cursor, long newRightmostGeneration, long leftSibling,
+            long leftSiblingGeneration, long newRightmost, String errorMessage )
     {
         cursor.setCursorException( format( "%s" +
                         "  Left siblings view:  %s%n" +
                         "  Right siblings view: %s%n", errorMessage,
-                leftPattern( currentRightmostNode, currentRightmostNodeGen, currentRightmostRightSiblingPointerGen,
+                leftPattern( currentRightmostNode, currentRightmostNodeGeneration,
+                        currentRightmostRightSiblingPointerGeneration,
                         currentRightmostRightSiblingPointer ),
-                rightPattern( newRightmost, newRightmostGen, leftSiblingGen, leftSibling ) ) );
+                rightPattern( newRightmost, newRightmostGeneration, leftSiblingGeneration, leftSibling ) ) );
     }
 
-    private String leftPattern( long actualLeftSibling, long actualLeftSiblingGen, long expectedRightSiblingGen,
-            long expectedRightSibling )
+    private String leftPattern( long actualLeftSibling, long actualLeftSiblingGeneration,
+            long expectedRightSiblingGeneration, long expectedRightSibling )
     {
-        return format( "{%d(%d)}-(%d)->{%d}", actualLeftSibling, actualLeftSiblingGen, expectedRightSiblingGen,
+        return format( "{%d(%d)}-(%d)->{%d}", actualLeftSibling, actualLeftSiblingGeneration, expectedRightSiblingGeneration,
                 expectedRightSibling );
     }
 
-    private String rightPattern( long actualRightSibling, long actualRightSiblingGen, long expectedLeftSiblingGen,
-            long expectedLeftSibling )
+    private String rightPattern( long actualRightSibling, long actualRightSiblingGeneration,
+            long expectedLeftSiblingGeneration, long expectedLeftSibling )
     {
-        return format( "{%d}<-(%d)-{%d(%d)}", expectedLeftSibling, expectedLeftSiblingGen, actualRightSibling,
-                actualRightSiblingGen );
+        return format( "{%d}<-(%d)-{%d(%d)}", expectedLeftSibling, expectedLeftSiblingGeneration, actualRightSibling,
+                actualRightSiblingGeneration );
     }
 
     void assertLast()

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -245,7 +245,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     /**
      * Generation of the pointer which was last followed, either a
      * {@link TreeNode#rightSibling(PageCursor, long, long) sibling} during scan or otherwise following
-     * {@link TreeNode#heir(PageCursor, long, long) heir} or
+     * {@link TreeNode#successor(PageCursor, long, long) successor} or
      * {@link TreeNode#childAt(PageCursor, int, long, long) child}.
      */
     private long lastFollowedPointerGeneration;
@@ -278,16 +278,16 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     /**
      * Set within should retry loop.
      * <p>
-     * Pointer to heir of node.
+     * Pointer to successor of node.
      */
-    private long heir;
+    private long successor;
 
     /**
      * Set within should retry loop.
      * <p>
-     * Generation of heir pointer
+     * Generation of successor pointer
      */
-    private long heirGeneration;
+    private long successorGeneration;
 
     /**
      * Set within should retry loop.
@@ -432,14 +432,14 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             else if ( !saneRead() )
             {
                 throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
-                        "  nodeType:%d%n  currentNodeGeneration:%d%n  heir:%d%n  heirGeneration:%d%n" +
+                        "  nodeType:%d%n  currentNodeGeneration:%d%n  successor:%d%n  successorGeneration:%d%n" +
                         "  isInternal:%b%n  keyCount:%d%n  maxKeyCount:%d%n  searchResult:%d%n  pos:%d%n" +
                         "  childId:%d%n  childIdGeneration:%d",
-                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, heir, heirGeneration,
+                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, successor, successorGeneration,
                         isInternal, keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGeneration );
             }
 
-            if ( goToHeir() )
+            if ( goToSuccessor() )
             {
                 continue;
             }
@@ -529,10 +529,10 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             else if ( !saneRead() )
             {
                 throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
-                        "  nodeType:%d%n  currentNodeGeneration:%d%n  heir:%d%n  heirGeneration:%d%n" +
+                        "  nodeType:%d%n  currentNodeGeneration:%d%n  successor:%d%n  successorGeneration:%d%n" +
                         "  keyCount:%d%n  maxKeyCount:%d%n  searchResult:%d%n  pos:%d%n" +
                         "  rightSibling:%d%n  rightSiblingGeneration:%d",
-                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, heir, heirGeneration,
+                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, successor, successorGeneration,
                         keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGeneration );
             }
 
@@ -541,7 +541,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 continue;
             }
 
-            if ( goToHeir() )
+            if ( goToSuccessor() )
             {
                 continue;
             }
@@ -644,11 +644,11 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     }
 
     /**
-     * Calls {@link #goTo(long, long, String, boolean)} with heir fields.
+     * Calls {@link #goTo(long, long, String, boolean)} with successor fields.
      */
-    private boolean goToHeir() throws IOException
+    private boolean goToSuccessor() throws IOException
     {
-        return goTo( heir, heirGeneration, "heir", true );
+        return goTo( successor, successorGeneration, "successor", true );
     }
 
     /**
@@ -737,10 +737,10 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
         currentNodeGeneration = bTreeNode.generation( cursor );
 
-        heir = bTreeNode.heir( cursor, stableGeneration, unstableGeneration );
-        if ( GenerationSafePointerPair.isSuccess( heir ) )
+        successor = bTreeNode.successor( cursor, stableGeneration, unstableGeneration );
+        if ( GenerationSafePointerPair.isSuccess( successor ) )
         {
-            heirGeneration = bTreeNode.pointerGeneration( cursor, heir );
+            successorGeneration = bTreeNode.pointerGeneration( cursor, successor );
         }
         isInternal = TreeNode.isInternal( cursor );
         // Find the left-most key within from-range

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -238,9 +238,9 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     private boolean concurrentWriteHappened;
 
     /**
-     * {@link TreeNode#gen(PageCursor) generation} of the current leaf node, read every call to {@link #next()}.
+     * {@link TreeNode#generation(PageCursor) generation} of the current leaf node, read every call to {@link #next()}.
      */
-    private long currentNodeGen;
+    private long currentNodeGeneration;
 
     /**
      * Generation of the pointer which was last followed, either a
@@ -248,13 +248,13 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * {@link TreeNode#heir(PageCursor, long, long) heir} or
      * {@link TreeNode#childAt(PageCursor, int, long, long) child}.
      */
-    private long lastFollowedPointerGen;
+    private long lastFollowedPointerGeneration;
 
     /**
-     * Cached {@link TreeNode#gen(PageCursor) generation} of the current leaf node, read every time a pointer
+     * Cached {@link TreeNode#generation(PageCursor) generation} of the current leaf node, read every time a pointer
      * is followed to a new node. Used to ensure that a node hasn't been reused between two calls to {@link #next()}.
      */
-    private long expectedCurrentNodeGen;
+    private long expectedCurrentNodeGeneration;
 
     /**
      * Decide if seeker is configured to seek forwards or backwards.
@@ -287,7 +287,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * <p>
      * Generation of heir pointer
      */
-    private long heirGen;
+    private long heirGeneration;
 
     /**
      * Set within should retry loop.
@@ -309,7 +309,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * <p>
      * Generation of {@link #pointerId}.
      */
-    private long pointerGen;
+    private long pointerGeneration;
 
     /**
      * Result from {@link KeySearch#search(PageCursor, TreeNode, Object, Object, int)}.
@@ -331,7 +331,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * <p>
      * Generation of {@link #prevSiblingId}.
      */
-    private long prevSiblingGen;
+    private long prevSiblingGeneration;
 
     /**
      * Set by linked cursor scouting next sibling to go to when seeking backwards.
@@ -355,7 +355,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
     SeekCursor( PageCursor cursor, TreeNode<KEY,VALUE> bTreeNode, KEY fromInclusive, KEY toExclusive,
             Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration, LongSupplier generationSupplier,
-            Supplier<Root> rootCatchup, long lastFollowedPointerGen ) throws IOException
+            Supplier<Root> rootCatchup, long lastFollowedPointerGeneration ) throws IOException
     {
         this.cursor = cursor;
         this.fromInclusive = fromInclusive;
@@ -366,7 +366,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         this.generationSupplier = generationSupplier;
         this.bTreeNode = bTreeNode;
         this.rootCatchup = rootCatchup;
-        this.lastFollowedPointerGen = lastFollowedPointerGen;
+        this.lastFollowedPointerGeneration = lastFollowedPointerGeneration;
         this.mutableKey = layout.newKey();
         this.mutableValue = layout.newValue();
         this.prevKey = layout.newKey();
@@ -416,7 +416,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 if ( isInternal )
                 {
                     pointerId = bTreeNode.childAt( cursor, pos, stableGeneration, unstableGeneration );
-                    pointerGen = readPointerGenOnSuccess( pointerId );
+                    pointerGeneration = readPointerGenerationOnSuccess( pointerId );
                 }
             }
             while ( cursor.shouldRetry() );
@@ -432,10 +432,11 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             else if ( !saneRead() )
             {
                 throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
-                        "  nodeType:%d%n  currentNodeGen:%d%n  heir:%d%n  heirGen:%d%n  isInternal:%b%n" +
-                        "  keyCount:%d%n  maxKeyCount:%d%n  searchResult:%d%n  pos:%d%n  childId:%d%n  childIdGen:%d",
-                        cursor.getCurrentPageId(), nodeType, currentNodeGen, heir, heirGen,
-                        isInternal, keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGen );
+                        "  nodeType:%d%n  currentNodeGeneration:%d%n  heir:%d%n  heirGeneration:%d%n" +
+                        "  isInternal:%b%n  keyCount:%d%n  maxKeyCount:%d%n  searchResult:%d%n  pos:%d%n" +
+                        "  childId:%d%n  childIdGeneration:%d",
+                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, heir, heirGeneration,
+                        isInternal, keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGeneration );
             }
 
             if ( goToHeir() )
@@ -445,7 +446,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
             if ( isInternal )
             {
-                goTo( pointerId, pointerGen, "child", false );
+                goTo( pointerId, pointerGeneration, "child", false );
             }
         }
         while ( isInternal );
@@ -496,7 +497,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                     {
                         // We may need to go to previous sibling to find correct place to start seeking from
                         prevSiblingId = readPrevSibling();
-                        prevSiblingGen = readPointerGenOnSuccess( prevSiblingId );
+                        prevSiblingGeneration = readPointerGenerationOnSuccess( prevSiblingId );
                     }
                 }
 
@@ -505,7 +506,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 {
                     // Read right sibling
                     pointerId = readNextSibling();
-                    pointerGen = readPointerGenOnSuccess( pointerId );
+                    pointerGeneration = readPointerGenerationOnSuccess( pointerId );
                 }
                 if ( 0 <= pos && pos < keyCount )
                 {
@@ -528,11 +529,11 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             else if ( !saneRead() )
             {
                 throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
-                        "  nodeType:%d%n  currentNodeGen:%d%n  heir:%d%n  heirGen:%d%n" +
+                        "  nodeType:%d%n  currentNodeGeneration:%d%n  heir:%d%n  heirGeneration:%d%n" +
                         "  keyCount:%d%n  maxKeyCount:%d%n  searchResult:%d%n  pos:%d%n" +
-                        "  rightSibling:%d%n  rightSiblingGen:%d",
-                        cursor.getCurrentPageId(), nodeType, currentNodeGen, heir, heirGen,
-                        keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGen );
+                        "  rightSibling:%d%n  rightSiblingGeneration:%d",
+                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, heir, heirGeneration,
+                        keyCount, maxKeyCount, searchResult, pos, pointerId, pointerGeneration );
             }
 
             if ( !verifyFirstKeyInNodeIsExpectedAfterGoTo() )
@@ -547,7 +548,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
             if ( !seekForward && pos >= keyCount )
             {
-                goTo( prevSiblingId, prevSiblingGen, "prev sibling", true );
+                goTo( prevSiblingId, prevSiblingGeneration, "prev sibling", true );
                 // Continue in the read loop above so that we can continue reading from previous sibling
                 // or on next position
                 continue;
@@ -617,7 +618,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * there's a generation catch-up made and the read will have to be re-attempted.
      *
      * @param pointerId read result containing pointer id to go to.
-     * @param pointerGen generation of {@code pointerId}.
+     * @param pointerGeneration generation of {@code pointerId}.
      * @param type type of pointer, e.g. "child" or "sibling" or so.
      * @return {@code true} if context was updated or {@link PageCursor} was moved, both cases meaning that
      * caller should retry its most recent read, otherwise {@code false} meaning that nothing happened.
@@ -625,7 +626,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      * @throws TreeInconsistencyException if {@code allowNoNode} is {@code true} and {@code pointerId}
      * contains a "null" tree node id.
      */
-    private boolean goTo( long pointerId, long pointerGen, String type, boolean allowNoNode ) throws IOException
+    private boolean goTo( long pointerId, long pointerGeneration, String type, boolean allowNoNode ) throws IOException
     {
         if ( pointerCheckingWithGenerationCatchup( pointerId, allowNoNode ) )
         {
@@ -635,7 +636,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         else if ( !allowNoNode || TreeNode.isNode( pointerId ) )
         {
             bTreeNode.goTo( cursor, type, pointerId );
-            lastFollowedPointerGen = pointerGen;
+            lastFollowedPointerGeneration = pointerGeneration;
             concurrentWriteHappened = true;
             return true;
         }
@@ -647,17 +648,17 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      */
     private boolean goToHeir() throws IOException
     {
-        return goTo( heir, heirGen, "heir", true );
+        return goTo( heir, heirGeneration, "heir", true );
     }
 
     /**
      * @return generation of {@code pointerId}, if the pointer id was successfully read.
      */
-    private long readPointerGenOnSuccess( long pointerId )
+    private long readPointerGenerationOnSuccess( long pointerId )
     {
-        if ( GenSafePointerPair.isSuccess( pointerId ) )
+        if ( GenerationSafePointerPair.isSuccess( pointerId ) )
         {
-            return bTreeNode.pointerGen( cursor, pointerId );
+            return bTreeNode.pointerGeneration( cursor, pointerId );
         }
         return -1; // this value doesn't matter
     }
@@ -734,12 +735,12 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             return false;
         }
 
-        currentNodeGen = bTreeNode.gen( cursor );
+        currentNodeGeneration = bTreeNode.generation( cursor );
 
         heir = bTreeNode.heir( cursor, stableGeneration, unstableGeneration );
-        if ( GenSafePointerPair.isSuccess( heir ) )
+        if ( GenerationSafePointerPair.isSuccess( heir ) )
         {
-            heirGen = bTreeNode.pointerGen( cursor, heir );
+            heirGeneration = bTreeNode.pointerGeneration( cursor, heir );
         }
         isInternal = TreeNode.isInternal( cursor );
         // Find the left-most key within from-range
@@ -750,7 +751,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
 
     private boolean endedUpOnExpectedNode()
     {
-        return nodeType == TreeNode.NODE_TYPE_TREE_NODE && verifyNodeGenInvariants();
+        return nodeType == TreeNode.NODE_TYPE_TREE_NODE && verifyNodeGenerationInvariants();
     }
 
     /**
@@ -796,7 +797,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 // TODO: Check if rightSibling is within expected range before calling next.
                 // TODO: Possibly by getting highest expected from IdProvider
                 bTreeNode.goTo( cursor, "sibling", pointerId );
-                lastFollowedPointerGen = pointerGen;
+                lastFollowedPointerGeneration = pointerGeneration;
                 if ( first )
                 {
                     // Have not yet found first hit among leaves.
@@ -819,7 +820,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 {
                     bTreeNode.goTo( cursor, "sibling", pointerId );
                     verifyExpectedFirstAfterGoToNext = true;
-                    lastFollowedPointerGen = pointerGen;
+                    lastFollowedPointerGeneration = pointerGeneration;
                 }
                 else
                 {
@@ -850,7 +851,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         // Read header but to local variables and not global once
         byte nodeType;
         int keyCount = -1;
-        try ( PageCursor scout = this.cursor.openLinkedCursor( GenSafePointerPair.pointer( pointerId ) ) )
+        try ( PageCursor scout = this.cursor.openLinkedCursor( GenerationSafePointerPair.pointer( pointerId ) ) )
         {
             scout.next();
             nodeType = TreeNode.nodeType( scout );
@@ -947,7 +948,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     private void prepareToStartFromRoot() throws IOException
     {
         generationCatchup();
-        lastFollowedPointerGen = rootCatchup.get().goTo( cursor );
+        lastFollowedPointerGeneration = rootCatchup.get().goTo( cursor );
         if ( !first )
         {
             layout.copyKey( prevKey, fromInclusive );
@@ -962,11 +963,11 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      *
      * @return {@code true} if generation matches, otherwise {@code false} if seek needs to be restarted from root.
      */
-    private boolean verifyNodeGenInvariants()
+    private boolean verifyNodeGenerationInvariants()
     {
-        if ( lastFollowedPointerGen != 0 )
+        if ( lastFollowedPointerGeneration != 0 )
         {
-            if ( currentNodeGen > lastFollowedPointerGen )
+            if ( currentNodeGeneration > lastFollowedPointerGeneration )
             {
                 // We've just followed a pointer to a new node, we have arrived there and made
                 // the first read on it. It looks like the node we arrived at have a higher generation
@@ -974,10 +975,10 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 // following the pointer and reading the node after getting there.
                 return false;
             }
-            lastFollowedPointerGen = 0;
-            expectedCurrentNodeGen = currentNodeGen;
+            lastFollowedPointerGeneration = 0;
+            expectedCurrentNodeGeneration = currentNodeGeneration;
         }
-        else if ( currentNodeGen != expectedCurrentNodeGen )
+        else if ( currentNodeGeneration != expectedCurrentNodeGeneration )
         {
             // We've read more than once from this node and between reads the node generation has changed.
             // This means the node has been reused.
@@ -997,7 +998,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      */
     private boolean pointerCheckingWithGenerationCatchup( long pointer, boolean allowNoNode )
     {
-        if ( !GenSafePointerPair.isSuccess( pointer ) )
+        if ( !GenerationSafePointerPair.isSuccess( pointer ) )
         {
             // An unexpected sibling read, this could have been caused by a concurrent checkpoint
             // where generation has been incremented. Re-read generation and, if changed since this

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -24,8 +24,8 @@ import java.util.Comparator;
 
 import org.neo4j.io.pagecache.PageCursor;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.NO_LOGICAL_POS;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.NO_LOGICAL_POS;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.read;
 
 /**
  * Methods to manipulate single tree node such as set and get header fields,
@@ -37,9 +37,9 @@ import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
  * <pre>
  * # = empty space
  *
- * [                            HEADER   82B                      ]|[      KEYS     ]|[     CHILDREN             ]
- * [NODETYPE][TYPE][GEN][KEYCOUNT][RIGHTSIBLING][LEFTSIBLING][HEIR]|[[KEY][KEY]...##]|[[CHILD][CHILD][CHILD]...##]
- *  0         1     6    10        34            58
+ * [                                   HEADER   82B                      ]|[      KEYS     ]|[     CHILDREN             ]
+ * [NODETYPE][TYPE][GENERATION][KEYCOUNT][RIGHTSIBLING][LEFTSIBLING][HEIR]|[[KEY][KEY]...##]|[[CHILD][CHILD][CHILD]...##]
+ *  0         1     6           10        34            58
  * </pre>
  * Calc offset for key i (starting from 0)
  * HEADER_LENGTH + i * SIZE_KEY
@@ -50,9 +50,9 @@ import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
  * Using Separate design the leaf nodes should look like
  *
  * <pre>
- * [                            HEADER   82B                      ]|[      KEYS     ]|[     VALUES        ]
- * [NODETYPE][TYPE][GEN][KEYCOUNT][RIGHTSIBLING][LEFTSIBLING][HEIR]|[[KEY][KEY]...##]|[[VALUE][VALUE]...##]
- *  0         1     6    10        34            58
+ * [                                   HEADER   82B                      ]|[      KEYS     ]|[     VALUES        ]
+ * [NODETYPE][TYPE][GENERATION][KEYCOUNT][RIGHTSIBLING][LEFTSIBLING][HEIR]|[[KEY][KEY]...##]|[[VALUE][VALUE]...##]
+ *  0         1     6           10        34            58
  * </pre>
  *
  * Calc offset for key i (starting from 0)
@@ -71,10 +71,10 @@ class TreeNode<KEY,VALUE>
     static final byte NODE_TYPE_TREE_NODE = 1;
     static final byte NODE_TYPE_FREE_LIST_NODE = 2;
 
-    static final int SIZE_PAGE_REFERENCE = GenSafePointerPair.SIZE;
+    static final int SIZE_PAGE_REFERENCE = GenerationSafePointerPair.SIZE;
     static final int BYTE_POS_TYPE = BYTE_POS_NODE_TYPE + Byte.BYTES;
-    static final int BYTE_POS_GEN = BYTE_POS_TYPE + Byte.BYTES;
-    static final int BYTE_POS_KEYCOUNT = BYTE_POS_GEN + Integer.BYTES;
+    static final int BYTE_POS_GENERATION = BYTE_POS_TYPE + Byte.BYTES;
+    static final int BYTE_POS_KEYCOUNT = BYTE_POS_GENERATION + Integer.BYTES;
     static final int BYTE_POS_RIGHTSIBLING = BYTE_POS_KEYCOUNT + Integer.BYTES;
     static final int BYTE_POS_LEFTSIBLING = BYTE_POS_RIGHTSIBLING + SIZE_PAGE_REFERENCE;
     static final int BYTE_POS_HEIR = BYTE_POS_LEFTSIBLING + SIZE_PAGE_REFERENCE;
@@ -123,7 +123,7 @@ class TreeNode<KEY,VALUE>
     {
         cursor.putByte( BYTE_POS_NODE_TYPE, NODE_TYPE_TREE_NODE );
         cursor.putByte( BYTE_POS_TYPE, type );
-        setGen( cursor, unstableGeneration );
+        setGeneration( cursor, unstableGeneration );
         setKeyCount( cursor, 0 );
         setRightSibling( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
         setLeftSibling( cursor, NO_NODE_FLAG, stableGeneration, unstableGeneration );
@@ -152,9 +152,9 @@ class TreeNode<KEY,VALUE>
         return cursor.getByte( BYTE_POS_TYPE ) == INTERNAL_FLAG;
     }
 
-    long gen( PageCursor cursor )
+    long generation( PageCursor cursor )
     {
-        return cursor.getInt( BYTE_POS_GEN ) & GenSafePointer.GENERATION_MASK;
+        return cursor.getInt( BYTE_POS_GENERATION ) & GenerationSafePointer.GENERATION_MASK;
     }
 
     int keyCount( PageCursor cursor )
@@ -180,10 +180,10 @@ class TreeNode<KEY,VALUE>
         return read( cursor, stableGeneration, unstableGeneration, NO_LOGICAL_POS );
     }
 
-    void setGen( PageCursor cursor, long generation )
+    void setGeneration( PageCursor cursor, long generation )
     {
-        GenSafePointer.assertGenerationOnWrite( generation );
-        cursor.putInt( BYTE_POS_GEN, (int) generation );
+        GenerationSafePointer.assertGenerationOnWrite( generation );
+        cursor.putInt( BYTE_POS_GENERATION, (int) generation );
     }
 
     void setKeyCount( PageCursor cursor, int count )
@@ -194,36 +194,36 @@ class TreeNode<KEY,VALUE>
     void setRightSibling( PageCursor cursor, long rightSiblingId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_RIGHTSIBLING );
-        long result = GenSafePointerPair.write( cursor, rightSiblingId, stableGeneration, unstableGeneration );
-        GenSafePointerPair.assertSuccess( result );
+        long result = GenerationSafePointerPair.write( cursor, rightSiblingId, stableGeneration, unstableGeneration );
+        GenerationSafePointerPair.assertSuccess( result );
     }
 
     void setLeftSibling( PageCursor cursor, long leftSiblingId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_LEFTSIBLING );
-        long result = GenSafePointerPair.write( cursor, leftSiblingId, stableGeneration, unstableGeneration );
-        GenSafePointerPair.assertSuccess( result );
+        long result = GenerationSafePointerPair.write( cursor, leftSiblingId, stableGeneration, unstableGeneration );
+        GenerationSafePointerPair.assertSuccess( result );
     }
 
     void setHeir( PageCursor cursor, long heirId, long stableGeneration, long unstableGeneration )
     {
         cursor.setOffset( BYTE_POS_HEIR );
-        long result = GenSafePointerPair.write( cursor, heirId, stableGeneration, unstableGeneration );
-        GenSafePointerPair.assertSuccess( result );
+        long result = GenerationSafePointerPair.write( cursor, heirId, stableGeneration, unstableGeneration );
+        GenerationSafePointerPair.assertSuccess( result );
     }
 
-    long pointerGen( PageCursor cursor, long readResult )
+    long pointerGeneration( PageCursor cursor, long readResult )
     {
-        if ( !GenSafePointerPair.isRead( readResult ) )
+        if ( !GenerationSafePointerPair.isRead( readResult ) )
         {
             throw new IllegalArgumentException( "Expected read result, but got " + readResult );
         }
-        int offset = GenSafePointerPair.genOffset( readResult );
-        int gsppOffset = GenSafePointerPair.isLogicalPos( readResult ) ? childOffset( offset ) : offset;
-        int gspOffset = GenSafePointerPair.resultIsFromSlotA( readResult ) ?
-                gsppOffset : gsppOffset + GenSafePointer.SIZE;
+        int offset = GenerationSafePointerPair.generationOffset( readResult );
+        int gsppOffset = GenerationSafePointerPair.isLogicalPos( readResult ) ? childOffset( offset ) : offset;
+        int gspOffset = GenerationSafePointerPair.resultIsFromSlotA( readResult ) ?
+                        gsppOffset : gsppOffset + GenerationSafePointer.SIZE;
         cursor.setOffset( gspOffset );
-        return GenSafePointer.readGeneration( cursor );
+        return GenerationSafePointer.readGeneration( cursor );
     }
 
     // BODY METHODS
@@ -312,7 +312,7 @@ class TreeNode<KEY,VALUE>
 
     void writeChild( PageCursor cursor, long child, long stableGeneration, long unstableGeneration)
     {
-        GenSafePointerPair.write( cursor, child, stableGeneration, unstableGeneration );
+        GenerationSafePointerPair.write( cursor, child, stableGeneration, unstableGeneration );
     }
 
     /**
@@ -374,7 +374,7 @@ class TreeNode<KEY,VALUE>
 
     static boolean isNode( long node )
     {
-        return GenSafePointerPair.pointer( node ) != NO_NODE_FLAG;
+        return GenerationSafePointerPair.pointer( node ) != NO_NODE_FLAG;
     }
 
     int keySize()
@@ -400,7 +400,7 @@ class TreeNode<KEY,VALUE>
     void goTo( PageCursor cursor, String messageOnError, long nodeId )
             throws IOException
     {
-        PageCursorUtil.goTo( cursor, messageOnError, GenSafePointerPair.pointer( nodeId ) );
+        PageCursorUtil.goTo( cursor, messageOnError, GenerationSafePointerPair.pointer( nodeId ) );
     }
 
     @Override

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -108,7 +108,7 @@ class TreePrinter<KEY,VALUE>
 
         if ( printHeader )
         {
-            //[TYPE][GEN][KEYCOUNT] ([RIGHTSIBLING][LEFTSIBLING][HEIR]))
+            //[TYPE][GEN][KEYCOUNT] ([RIGHTSIBLING][LEFTSIBLING][SUCCESSOR]))
             long generation = -1;
             do
             {

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreePrinter.java
@@ -28,7 +28,7 @@ import org.neo4j.io.pagecache.PageCursor;
 
 import static java.lang.String.format;
 import static org.neo4j.index.internal.gbptree.ConsistencyChecker.assertOnTreeNode;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointer;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointer;
 
 /**
  * Utility class for printing a {@link GBPTree}, either whole or sub-tree.
@@ -112,11 +112,11 @@ class TreePrinter<KEY,VALUE>
             long generation = -1;
             do
             {
-                generation = node.gen( cursor );
+                generation = node.generation( cursor );
 
             } while ( cursor.shouldRetry() );
             String treeNodeType = isLeaf ? "leaf" : "internal";
-            out.print( format( "{%d,%s,gen=%d,keyCount=%d}",
+            out.print( format( "{%d,%s,generation=%d,keyCount=%d}",
                     cursor.getCurrentPageId(), treeNodeType, generation, keyCount ) );
         }
         else

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -60,7 +60,7 @@ class TreeState
     /**
      * Generation of {@link #rootId}.
      */
-    private final long rootGen;
+    private final long rootGeneration;
 
     /**
      * Highest allocated page id in the store. This id may not be in use currently and cannot decrease
@@ -95,7 +95,7 @@ class TreeState
      */
     private boolean valid;
 
-    TreeState( long pageId, long stableGeneration, long unstableGeneration, long rootId, long rootGen, long lastId,
+    TreeState( long pageId, long stableGeneration, long unstableGeneration, long rootId, long rootGeneration, long lastId,
             long freeListWritePageId, long freeListReadPageId, int freeListWritePos, int freeListReadPos,
             boolean valid )
     {
@@ -103,7 +103,7 @@ class TreeState
         this.stableGeneration = stableGeneration;
         this.unstableGeneration = unstableGeneration;
         this.rootId = rootId;
-        this.rootGen = rootGen;
+        this.rootGeneration = rootGeneration;
         this.lastId = lastId;
         this.freeListWritePageId = freeListWritePageId;
         this.freeListReadPageId = freeListReadPageId;
@@ -132,9 +132,9 @@ class TreeState
         return rootId;
     }
 
-    long rootGen()
+    long rootGeneration()
     {
-        return rootGen;
+        return rootGeneration;
     }
 
     long lastId()
@@ -175,23 +175,23 @@ class TreeState
      * @param stableGeneration stable generation.
      * @param unstableGeneration unstable generation.
      * @param rootId root id.
-     * @param rootGen root generation.
+     * @param rootGeneration root generation.
      * @param lastId last id.
      * @param freeListWritePageId free-list page id to write released ids into.
      * @param freeListReadPageId free-list page id to read released ids from.
      * @param freeListWritePos offset into free-list write page id to write released ids into.
      * @param freeListReadPos offset into free-list read page id to read released ids from.
      */
-    static void write( PageCursor cursor, long stableGeneration, long unstableGeneration, long rootId, long rootGen,
-            long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
+    static void write( PageCursor cursor, long stableGeneration, long unstableGeneration, long rootId,
+            long rootGeneration, long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
             int freeListReadPos )
     {
-        GenSafePointer.assertGenerationOnWrite( stableGeneration );
-        GenSafePointer.assertGenerationOnWrite( unstableGeneration );
+        GenerationSafePointer.assertGenerationOnWrite( stableGeneration );
+        GenerationSafePointer.assertGenerationOnWrite( unstableGeneration );
 
-        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGeneration, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos ); // Write state
-        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        writeStateOnce( cursor, stableGeneration, unstableGeneration, rootId, rootGeneration, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos ); // Write checksum
     }
 
@@ -230,27 +230,27 @@ class TreeState
     private static TreeState readStateOnce( PageCursor cursor )
     {
         long pageId = cursor.getCurrentPageId();
-        long stableGeneration = cursor.getInt() & GenSafePointer.GENERATION_MASK;
-        long unstableGeneration = cursor.getInt() & GenSafePointer.GENERATION_MASK;
+        long stableGeneration = cursor.getInt() & GenerationSafePointer.GENERATION_MASK;
+        long unstableGeneration = cursor.getInt() & GenerationSafePointer.GENERATION_MASK;
         long rootId = cursor.getLong();
-        long rootGen = cursor.getLong();
+        long rootGeneration = cursor.getLong();
         long lastId = cursor.getLong();
         long freeListWritePageId = cursor.getLong();
         long freeListReadPageId = cursor.getLong();
         int freeListWritePos = cursor.getInt();
         int freeListReadPos = cursor.getInt();
-        return new TreeState( pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        return new TreeState( pageId, stableGeneration, unstableGeneration, rootId, rootGeneration, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, true );
     }
 
     private static void writeStateOnce( PageCursor cursor, long stableGeneration, long unstableGeneration, long rootId,
-            long rootGen, long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
+            long rootGeneration, long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos,
             int freeListReadPos )
     {
         cursor.putInt( (int) stableGeneration );
         cursor.putInt( (int) unstableGeneration );
         cursor.putLong( rootId );
-        cursor.putLong( rootGen );
+        cursor.putLong( rootGeneration );
         cursor.putLong( lastId );
         cursor.putLong( freeListWritePageId );
         cursor.putLong( freeListReadPageId );
@@ -261,10 +261,10 @@ class TreeState
     @Override
     public String toString()
     {
-        return String.format( "pageId=%d, stableGeneration=%d, unstableGeneration=%d, rootId=%d, rootGen=%d, " +
+        return String.format( "pageId=%d, stableGeneration=%d, unstableGeneration=%d, rootId=%d, rootGeneration=%d, " +
                 "lastId=%d, freeListWritePageId=%d, freeListReadPageId=%d, freeListWritePos=%d, freeListReadPos=%d, " +
                 "valid=%b",
-                pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+                pageId, stableGeneration, unstableGeneration, rootId, rootGeneration, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, valid );
     }
 
@@ -280,7 +280,7 @@ class TreeState
                 stableGeneration == treeState.stableGeneration &&
                 unstableGeneration == treeState.unstableGeneration &&
                 rootId == treeState.rootId &&
-                rootGen == treeState.rootGen &&
+                rootGeneration == treeState.rootGeneration &&
                 lastId == treeState.lastId &&
                 freeListWritePageId == treeState.freeListWritePageId &&
                 freeListReadPageId == treeState.freeListReadPageId &&
@@ -292,7 +292,7 @@ class TreeState
     @Override
     public int hashCode()
     {
-        return Objects.hash( pageId, stableGeneration, unstableGeneration, rootId, rootGen, lastId,
+        return Objects.hash( pageId, stableGeneration, unstableGeneration, rootId, rootGeneration, lastId,
                 freeListWritePageId, freeListReadPageId, freeListWritePos, freeListReadPos, valid );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
@@ -52,13 +52,13 @@ public class ConsistencyCheckerTest
 
         cursor.next( 0 );
         treeNode.initializeInternal( cursor, stableGeneration, crashGeneration );
-        treeNode.setHeir( cursor, pointer, stableGeneration, crashGeneration );
+        treeNode.setSuccessor( cursor, pointer, stableGeneration, crashGeneration );
 
         // WHEN
         try
         {
             assertNoCrashOrBrokenPointerInGSPP( cursor, stableGeneration, unstableGeneration,
-                    pointerFieldName, TreeNode.BYTE_POS_HEIR, treeNode );
+                    pointerFieldName, TreeNode.BYTE_POS_SUCCESSOR, treeNode );
             cursor.checkAndClearCursorException();
             fail( "Should have failed" );
         }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/ConsistencyCheckerTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.index.internal.gbptree.ConsistencyChecker.assertNoCrashOrBrokenPointerInGSPP;
-import static org.neo4j.index.internal.gbptree.GenSafePointer.MIN_GENERATION;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointer.MIN_GENERATION;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.goTo;
 
 public class ConsistencyCheckerTest
@@ -80,7 +80,7 @@ public class ConsistencyCheckerTest
         int pageSize = 256;
         Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();
         TreeNode<MutableLong,MutableLong> node = new TreeNode<>( pageSize, layout );
-        long stableGeneration = GenSafePointer.MIN_GENERATION;
+        long stableGeneration = GenerationSafePointer.MIN_GENERATION;
         long unstableGeneration = stableGeneration + 1;
         SimpleIdProvider idProvider = new SimpleIdProvider();
         InternalTreeLogic<MutableLong,MutableLong> logic = new InternalTreeLogic<>( idProvider, node, layout );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenCleanerTest.java
@@ -424,7 +424,7 @@ public class CrashGenCleanerTest
                     @Override
                     public int offset( TreeNode node )
                     {
-                        return TreeNode.BYTE_POS_HEIR;
+                        return TreeNode.BYTE_POS_SUCCESSOR;
                     }
                 }
     }
@@ -457,7 +457,7 @@ public class CrashGenCleanerTest
         void crashGSPP( PageCursor pageCursor, int offset, int crashGen )
         {
             pageCursor.setOffset( offset );
-            GenSafePointerPair.write( pageCursor, 42, stableGen, crashGen );
+            GenerationSafePointerPair.write( pageCursor, 42, stableGen, crashGen );
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/CrashGenerationCleanerTest.java
@@ -46,7 +46,7 @@ import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
-public class CrashGenCleanerTest
+public class CrashGenerationCleanerTest
 {
     private FileSystemRule fileSystemRule = new DefaultFileSystemRule();
     private PageCacheRule pageCacheRule = new PageCacheRule();
@@ -62,17 +62,17 @@ public class CrashGenCleanerTest
     private PagedFile pagedFile;
     private final Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();
     private final CorruptableTreeNode corruptableTreeNode = new CorruptableTreeNode( PAGE_SIZE, layout );
-    private final int oldStableGen = 9;
-    private final int stableGen = 10;
-    private final int unstableGen = 12;
-    private final int crashGen = 11;
+    private final int oldStableGeneration = 9;
+    private final int stableGeneration = 10;
+    private final int unstableGeneration = 12;
+    private final int crashGeneration = 11;
     private final int firstChildPos = 0;
     private final int middleChildPos = corruptableTreeNode.internalMaxKeyCount() / 2;
     private final int lastChildPos = corruptableTreeNode.internalMaxKeyCount();
     private final List<PageCorruption> possibleCorruptionsInInternal = Arrays.asList(
             crashed( leftSibling() ),
             crashed( rightSibling() ),
-            crashed( newGen() ),
+            crashed( successor() ),
             crashed( child( firstChildPos ) ),
             crashed( child( middleChildPos ) ),
             crashed( child( lastChildPos ) )
@@ -80,7 +80,7 @@ public class CrashGenCleanerTest
     private final List<PageCorruption> possibleCorruptionsInLeaf = Arrays.asList(
             crashed( leftSibling() ),
             crashed( rightSibling() ),
-            crashed( newGen() )
+            crashed( successor() )
     );
 
     private class SimpleMonitor implements GBPTree.Monitor
@@ -123,7 +123,7 @@ public class CrashGenCleanerTest
 
         // WHEN
         SimpleMonitor monitor = new SimpleMonitor();
-        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+        crashGenerationCleaner( pagedFile, 0, pages.length, monitor ).clean();
 
         // THEN
         assertPagesVisisted( monitor, pages.length );
@@ -142,7 +142,7 @@ public class CrashGenCleanerTest
 
         // WHEN
         SimpleMonitor monitor = new SimpleMonitor();
-        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+        crashGenerationCleaner( pagedFile, 0, pages.length, monitor ).clean();
 
         // THEN
         assertPagesVisisted( monitor, 2 );
@@ -162,9 +162,9 @@ public class CrashGenCleanerTest
                 leafWith( crashed( rightSibling() ) ),
                 internalWith( crashed( rightSibling() ) ),
 
-                /* new gen */
-                leafWith( crashed( newGen() ) ),
-                internalWith( crashed( newGen() ) ),
+                /* successor */
+                leafWith( crashed( successor() ) ),
+                internalWith( crashed( successor() ) ),
 
                 /* child */
                 internalWith( crashed( child( firstChildPos ) ) ),
@@ -175,7 +175,7 @@ public class CrashGenCleanerTest
 
         // WHEN
         SimpleMonitor monitor = new SimpleMonitor();
-        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+        crashGenerationCleaner( pagedFile, 0, pages.length, monitor ).clean();
 
         // THEN
         assertPagesVisisted( monitor, pages.length );
@@ -190,11 +190,11 @@ public class CrashGenCleanerTest
                 leafWith(
                         crashed( leftSibling() ),
                         crashed( rightSibling() ),
-                        crashed( newGen() ) ),
+                        crashed( successor() ) ),
                 internalWith(
                         crashed( leftSibling() ),
                         crashed( rightSibling() ),
-                        crashed( newGen() ),
+                        crashed( successor() ),
                         crashed( child( firstChildPos ) ),
                         crashed( child( middleChildPos ) ),
                         crashed( child( lastChildPos ) ) )
@@ -203,7 +203,7 @@ public class CrashGenCleanerTest
 
         // WHEN
         SimpleMonitor monitor = new SimpleMonitor();
-        crashGenCleaner( pagedFile, 0, pages.length, monitor ).clean();
+        crashGenerationCleaner( pagedFile, 0, pages.length, monitor ).clean();
 
         // THEN
         assertPagesVisisted( monitor, pages.length );
@@ -228,18 +228,18 @@ public class CrashGenCleanerTest
 
         // WHEN
         SimpleMonitor monitor = new SimpleMonitor();
-        crashGenCleaner( pagedFile, 0, numberOfPages, monitor ).clean();
+        crashGenerationCleaner( pagedFile, 0, numberOfPages, monitor ).clean();
 
         // THEN
         assertPagesVisisted( monitor, numberOfPages );
         assertCleanedCrashPointers( monitor, totalNumberOfCorruptions.getValue() );
     }
 
-    private CrashGenCleaner crashGenCleaner( PagedFile pagedFile, int lowTreeNodeId, int highTreeNodeId,
+    private CrashGenerationCleaner crashGenerationCleaner( PagedFile pagedFile, int lowTreeNodeId, int highTreeNodeId,
             SimpleMonitor monitor )
     {
-        return new CrashGenCleaner( pagedFile, corruptableTreeNode, lowTreeNodeId, highTreeNodeId,
-                stableGen, unstableGen, monitor );
+        return new CrashGenerationCleaner( pagedFile, corruptableTreeNode, lowTreeNodeId, highTreeNodeId,
+                stableGeneration, unstableGeneration, monitor );
     }
 
     private void initializeFile( PagedFile pagedFile, Page... pages ) throws IOException
@@ -249,7 +249,7 @@ public class CrashGenCleanerTest
             for ( Page page : pages )
             {
                 cursor.next();
-                page.write( cursor, corruptableTreeNode, stableGen, unstableGen, crashGen );
+                page.write( cursor, corruptableTreeNode, stableGeneration, unstableGeneration, crashGeneration );
             }
         }
     }
@@ -333,12 +333,12 @@ public class CrashGenCleanerTest
             this.pageCorruptions = pageCorruptions;
         }
 
-        private void write( PageCursor cursor, CorruptableTreeNode node, int stableGen, int unstableGen, int crashGen )
-                throws IOException
+        private void write( PageCursor cursor, CorruptableTreeNode node, int stableGeneration, int unstableGeneration,
+                int crashGeneration ) throws IOException
         {
-            type.write( cursor, node, oldStableGen, stableGen );
+            type.write( cursor, node, oldStableGeneration, stableGeneration );
             Arrays.stream( pageCorruptions )
-                    .forEach( pc -> pc.corrupt( cursor, node, stableGen, unstableGen, crashGen ) );
+                    .forEach( pc -> pc.corrupt( cursor, node, stableGeneration, unstableGeneration, crashGeneration ) );
         }
     }
 
@@ -347,32 +347,32 @@ public class CrashGenCleanerTest
         LEAF
                 {
                     @Override
-                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGen,
-                            int unstableGen )
+                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGeneration,
+                            int unstableGeneration )
                     {
-                        corruptableTreeNode.initializeLeaf( cursor, stableGen, unstableGen );
+                        corruptableTreeNode.initializeLeaf( cursor, stableGeneration, unstableGeneration );
                     }
                 },
         INTERNAL
                 {
                     @Override
-                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGen,
-                            int unstableGen )
+                    void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode, int stableGeneration,
+                            int unstableGeneration )
                     {
-                        corruptableTreeNode.initializeInternal( cursor, stableGen, unstableGen );
+                        corruptableTreeNode.initializeInternal( cursor, stableGeneration, unstableGeneration );
                         int maxKeyCount = corruptableTreeNode.internalMaxKeyCount();
                         long base = IdSpace.MIN_TREE_NODE_ID;
                         for ( int i = 0; i <= maxKeyCount; i++ )
                         {
                             long child = base + i;
-                            corruptableTreeNode.setChildAt( cursor, child, i, stableGen, unstableGen );
+                            corruptableTreeNode.setChildAt( cursor, child, i, stableGeneration, unstableGeneration );
                         }
                         corruptableTreeNode.setKeyCount( cursor, maxKeyCount );
                     }
                 };
 
         abstract void write( PageCursor cursor, CorruptableTreeNode corruptableTreeNode,
-                int stableGen, int unstableGen );
+                int stableGeneration, int unstableGeneration );
     }
 
     /* GSPPType */
@@ -386,9 +386,9 @@ public class CrashGenCleanerTest
         return SimpleGSPPType.RIGHT_SIBLING;
     }
 
-    private GSPPType newGen()
+    private GSPPType successor()
     {
-        return SimpleGSPPType.NEW_GEN;
+        return SimpleGSPPType.SUCCESSOR;
     }
 
     private GSPPType child( int pos )
@@ -419,7 +419,7 @@ public class CrashGenCleanerTest
                         return TreeNode.BYTE_POS_RIGHTSIBLING;
                     }
                 },
-        NEW_GEN
+        SUCCESSOR
                 {
                     @Override
                     public int offset( TreeNode node )
@@ -437,14 +437,14 @@ public class CrashGenCleanerTest
     /* PageCorruption */
     private PageCorruption crashed( GSPPType gsppType )
     {
-        return ( pageCursor, node, stableGen, unstableGen, crashGen ) ->
-                node.crashGSPP( pageCursor, gsppType.offset( node ), crashGen );
+        return ( pageCursor, node, stableGeneration, unstableGeneration, crashGeneration ) ->
+                node.crashGSPP( pageCursor, gsppType.offset( node ), crashGeneration );
     }
 
     private interface PageCorruption
     {
-        void corrupt( PageCursor pageCursor, CorruptableTreeNode node, int stableGen,
-                int unstableGen, int crashGen );
+        void corrupt( PageCursor pageCursor, CorruptableTreeNode node, int stableGeneration,
+                int unstableGeneration, int crashGeneration );
     }
 
     class CorruptableTreeNode extends TreeNode<MutableLong,MutableLong>
@@ -454,10 +454,10 @@ public class CrashGenCleanerTest
             super( pageSize, layout );
         }
 
-        void crashGSPP( PageCursor pageCursor, int offset, int crashGen )
+        void crashGSPP( PageCursor pageCursor, int offset, int crashGeneration )
         {
             pageCursor.setOffset( offset );
-            GenerationSafePointerPair.write( pageCursor, 42, stableGen, crashGen );
+            GenerationSafePointerPair.write( pageCursor, 42, stableGeneration, crashGeneration );
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.index.internal.gbptree.FreeListIdProvider.NO_MONITOR;
 public class FreeListIdProviderTest
 {
     private static final int PAGE_SIZE = 128;
-    private static final long GENERATION_ONE = GenSafePointer.MIN_GENERATION;
+    private static final long GENERATION_ONE = GenerationSafePointer.MIN_GENERATION;
     private static final long GENERATION_TWO = GENERATION_ONE + 1;
     private static final long GENERATION_THREE = GENERATION_TWO + 1;
     private static final long GENERATION_FOUR = GENERATION_THREE + 1;
@@ -139,7 +139,7 @@ public class FreeListIdProviderTest
         // GIVEN
         PrimitiveLongSet acquired = Primitive.longSet();
         List<Long> acquiredList = new ArrayList<>(); // for quickly finding random to remove
-        long stableGeneration = GenSafePointer.MIN_GENERATION;
+        long stableGeneration = GenerationSafePointer.MIN_GENERATION;
         long unstableGeneration = stableGeneration + 1;
         int iterations = 100;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreelistNodeTest.java
@@ -134,7 +134,7 @@ public class FreelistNodeTest
         // WHEN
         try
         {
-            freelist.write( cursor, GenSafePointer.MAX_GENERATION + 1, 1, 0 );
+            freelist.write( cursor, GenerationSafePointer.MAX_GENERATION + 1, 1, 0 );
             fail( "Should've failed" );
         }
         catch ( IllegalArgumentException e )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairAdditionalTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairAdditionalTest.java
@@ -23,16 +23,16 @@ import org.junit.Test;
 
 import static org.junit.Assert.fail;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointer.MIN_GENERATION;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.MAX_GEN_OFFSET_MASK;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.write;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointer.MIN_GENERATION;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.MAX_GENERATION_OFFSET_MASK;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.read;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.write;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 
-public class GenSafePointerPairAdditionalTest
+public class GenerationSafePointerPairAdditionalTest
 {
     @Test
-    public void shouldFailFastOnTooLargeGenOffset() throws Exception
+    public void shouldFailFastOnTooLargeGenerationOffset() throws Exception
     {
         // GIVEN
         int pageSize = (int) kibiBytes( 8 );
@@ -51,7 +51,7 @@ public class GenSafePointerPairAdditionalTest
         {
             // WHEN
             cursor.setOffset( offset );
-            read( cursor, secondGeneration, thirdGeneration, (int) (MAX_GEN_OFFSET_MASK + 1) );
+            read( cursor, secondGeneration, thirdGeneration, (int) (MAX_GENERATION_OFFSET_MASK + 1) );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerPairTest.java
@@ -36,20 +36,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.FLAG_READ;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.FLAG_WRITE;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.GEN_COMPARISON_MASK;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.NO_LOGICAL_POS;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.READ_OR_WRITE_MASK;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.SHIFT_STATE_A;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.SHIFT_STATE_B;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.failureDescription;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.isRead;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointerStateFromResult;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointerStateName;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.FLAG_READ;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.FLAG_WRITE;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.GENERATION_COMPARISON_MASK;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.NO_LOGICAL_POS;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.READ_OR_WRITE_MASK;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.SHIFT_STATE_A;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.SHIFT_STATE_B;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.failureDescription;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.isRead;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointerStateFromResult;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointerStateName;
 
 @RunWith( Parameterized.class )
-public class GenSafePointerPairTest
+public class GenerationSafePointerPairTest
 {
     private static final int PAGE_SIZE = 128;
     private static final int OLD_STABLE_GENERATION = 1;
@@ -63,54 +63,54 @@ public class GenSafePointerPairTest
     private static final long POINTER_B = 6;
     private static final long WRITTEN_POINTER = 10;
 
-    private static final int EXPECTED_GEN_DISREGARD = -2;
-    private static final int EXPECTED_GEN_B_BIG = -1;
-    private static final int EXPECTED_GEN_EQUAL = 0;
-    private static final int EXPECTED_GEN_A_BIG = 1;
+    private static final int EXPECTED_GENERATION_DISREGARD = -2;
+    private static final int EXPECTED_GENERATION_B_BIG = -1;
+    private static final int EXPECTED_GENERATION_EQUAL = 0;
+    private static final int EXPECTED_GENERATION_A_BIG = 1;
 
     private static final boolean SLOT_A = true;
     private static final boolean SLOT_B = false;
     private static final int GSPP_OFFSET = 5;
     private static final int SLOT_A_OFFSET = GSPP_OFFSET;
-    private static final int SLOT_B_OFFSET = SLOT_A_OFFSET + GenSafePointer.SIZE;
+    private static final int SLOT_B_OFFSET = SLOT_A_OFFSET + GenerationSafePointer.SIZE;
 
     @Parameters( name = "{0},{1},read {2},write {3}" )
     public static Collection<Object[]> data()
     {
         Collection<Object[]> data = new ArrayList<>();
 
-        //             ┌─────────────────┬─────────────────┬───────────────────┬───────────────────────┐
-        //             │ State A         │ State B         │ Read outcome      │ Write outcome         │
-        //             └─────────────────┴─────────────────┴───────────────────┴───────────────────────┘
-        data.add( array( State.EMPTY,      State.EMPTY,      Fail.GEN_DISREGARD, Success.A ) );
-        data.add( array( State.EMPTY,      State.UNSTABLE,   Success.B,          Success.B ) );
-        data.add( array( State.EMPTY,      State.STABLE,     Success.B,          Success.A ) );
-        data.add( array( State.EMPTY,      State.CRASH,      Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.EMPTY,      State.BROKEN,     Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.UNSTABLE,   State.EMPTY,      Success.A,          Success.A ) );
-        data.add( array( State.UNSTABLE,   State.UNSTABLE,   Fail.GEN_EQUAL,     Fail.GEN_EQUAL ) );
-        data.add( array( State.UNSTABLE,   State.STABLE,     Success.A,          Success.A ) );
-        data.add( array( State.UNSTABLE,   State.CRASH,      Fail.GEN_A_BIG,     Fail.GEN_A_BIG ) );
-        data.add( array( State.UNSTABLE,   State.BROKEN,     Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.STABLE,     State.EMPTY,      Success.A,          Success.B ) );
-        data.add( array( State.STABLE,     State.UNSTABLE,   Success.B,          Success.B ) );
-        data.add( array( State.STABLE,     State.OLD_STABLE, Success.A,          Success.B ) );
-        data.add( array( State.OLD_STABLE, State.STABLE,     Success.B,          Success.A ) );
-        data.add( array( State.STABLE,     State.STABLE,     Fail.GEN_EQUAL,     Fail.GEN_EQUAL ) );
-        data.add( array( State.STABLE,     State.CRASH,      Success.A,          Success.B ) );
-        data.add( array( State.STABLE,     State.BROKEN,     Success.A,          Success.B ) );
-        data.add( array( State.CRASH,      State.EMPTY,      Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.CRASH,      State.UNSTABLE,   Fail.GEN_B_BIG,     Fail.GEN_B_BIG ) );
-        data.add( array( State.CRASH,      State.STABLE,     Success.B,          Success.A ) );
-        data.add( array( State.CRASH,      State.OLD_CRASH,  Fail.GEN_A_BIG,     Fail.GEN_A_BIG ) );
-        data.add( array( State.OLD_CRASH,  State.CRASH,      Fail.GEN_B_BIG,     Fail.GEN_B_BIG ) );
-        data.add( array( State.CRASH,      State.CRASH,      Fail.GEN_EQUAL,     Fail.GEN_EQUAL ) );
-        data.add( array( State.CRASH,      State.BROKEN,     Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.BROKEN,     State.EMPTY,      Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.BROKEN,     State.UNSTABLE,   Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
+        //             ┌─────────────────┬─────────────────┬─────────────────-------──┬───────------────────────────┐
+        //             │ State A         │ State B         │ Read outcome             │ Write outcome               │
+        //             └─────────────────┴─────────────────┴──────────────────-------─┴────────────────────------───┘
+        data.add( array( State.EMPTY,      State.EMPTY,      Fail.GENERATION_DISREGARD, Success.A ) );
+        data.add( array( State.EMPTY,      State.UNSTABLE,   Success.B,                 Success.B ) );
+        data.add( array( State.EMPTY,      State.STABLE,     Success.B,                 Success.A ) );
+        data.add( array( State.EMPTY,      State.CRASH,      Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.EMPTY,      State.BROKEN,     Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.UNSTABLE,   State.EMPTY,      Success.A,                 Success.A ) );
+        data.add( array( State.UNSTABLE,   State.UNSTABLE,   Fail.GENERATION_EQUAL,     Fail.GENERATION_EQUAL ) );
+        data.add( array( State.UNSTABLE,   State.STABLE,     Success.A,                  Success.A ) );
+        data.add( array( State.UNSTABLE,   State.CRASH,      Fail.GENERATION_A_BIG,     Fail.GENERATION_A_BIG ) );
+        data.add( array( State.UNSTABLE,   State.BROKEN,     Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.STABLE,     State.EMPTY,      Success.A,                 Success.B ) );
+        data.add( array( State.STABLE,     State.UNSTABLE,   Success.B,                 Success.B ) );
+        data.add( array( State.STABLE,     State.OLD_STABLE, Success.A,                 Success.B ) );
+        data.add( array( State.OLD_STABLE, State.STABLE,     Success.B,                 Success.A ) );
+        data.add( array( State.STABLE,     State.STABLE,     Fail.GENERATION_EQUAL,     Fail.GENERATION_EQUAL ) );
+        data.add( array( State.STABLE,     State.CRASH,      Success.A,                 Success.B ) );
+        data.add( array( State.STABLE,     State.BROKEN,     Success.A,                 Success.B ) );
+        data.add( array( State.CRASH,      State.EMPTY,      Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.CRASH,      State.UNSTABLE,   Fail.GENERATION_B_BIG,     Fail.GENERATION_B_BIG ) );
+        data.add( array( State.CRASH,      State.STABLE,     Success.B,                 Success.A ) );
+        data.add( array( State.CRASH,      State.OLD_CRASH,  Fail.GENERATION_A_BIG,     Fail.GENERATION_A_BIG ) );
+        data.add( array( State.OLD_CRASH,  State.CRASH,      Fail.GENERATION_B_BIG,     Fail.GENERATION_B_BIG ) );
+        data.add( array( State.CRASH,      State.CRASH,      Fail.GENERATION_EQUAL,     Fail.GENERATION_EQUAL ) );
+        data.add( array( State.CRASH,      State.BROKEN,     Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.BROKEN,     State.EMPTY,      Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.BROKEN,     State.UNSTABLE,   Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
         data.add( array( State.BROKEN,     State.STABLE,     Success.B,          Success.A ) );
-        data.add( array( State.BROKEN,     State.CRASH,      Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
-        data.add( array( State.BROKEN,     State.BROKEN,     Fail.GEN_DISREGARD, Fail.GEN_DISREGARD ) );
+        data.add( array( State.BROKEN,     State.CRASH,      Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
+        data.add( array( State.BROKEN,     State.BROKEN,     Fail.GENERATION_DISREGARD, Fail.GENERATION_DISREGARD ) );
 
         return data;
     }
@@ -138,7 +138,7 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long result = GenSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, pos );
+        long result = GenerationSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, pos );
 
         // THEN
         expectedReadOutcome.verifyRead( cursor, result, stateA, stateB, preStatePointerA, preStatePointerB, pos );
@@ -155,7 +155,7 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long result = GenSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, NO_LOGICAL_POS );
+        long result = GenerationSafePointerPair.read( cursor, STABLE_GENERATION, UNSTABLE_GENERATION, NO_LOGICAL_POS );
 
         // THEN
         expectedReadOutcome.verifyRead( cursor, result, stateA, stateB, preStatePointerA, preStatePointerB,
@@ -173,22 +173,22 @@ public class GenSafePointerPairTest
 
         // WHEN
         cursor.setOffset( GSPP_OFFSET );
-        long written = GenSafePointerPair.write( cursor, WRITTEN_POINTER, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long written = GenerationSafePointerPair.write( cursor, WRITTEN_POINTER, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
         expectedWriteOutcome.verifyWrite( cursor, written, stateA, stateB, preStatePointerA, preStatePointerB );
     }
 
-    private static void assertFailure( long result, long readOrWrite, int genComparison,
+    private static void assertFailure( long result, long readOrWrite, int generationComparison,
             byte pointerStateA, byte pointerStateB )
     {
-        assertFalse( GenSafePointerPair.isSuccess( result ) );
+        assertFalse( GenerationSafePointerPair.isSuccess( result ) );
 
         // Raw failure bits
         assertEquals( readOrWrite, result & READ_OR_WRITE_MASK );
-        if ( genComparison != EXPECTED_GEN_DISREGARD )
+        if ( generationComparison != EXPECTED_GENERATION_DISREGARD )
         {
-            assertEquals( genComparisonBits( genComparison ), result & GEN_COMPARISON_MASK );
+            assertEquals( generationComparisonBits( generationComparison ), result & GENERATION_COMPARISON_MASK );
         }
         assertEquals( pointerStateA, pointerStateFromResult( result, SHIFT_STATE_A ) );
         assertEquals( pointerStateB, pointerStateFromResult( result, SHIFT_STATE_B ) );
@@ -196,41 +196,41 @@ public class GenSafePointerPairTest
         // Failure description
         String failureDescription = failureDescription( result );
         assertThat( failureDescription, containsString( isRead( result ) ? "READ" : "WRITE" ) );
-        if ( genComparison != EXPECTED_GEN_DISREGARD )
+        if ( generationComparison != EXPECTED_GENERATION_DISREGARD )
         {
-            assertThat( failureDescription, containsString( genComparisonName( genComparison ) ) );
+            assertThat( failureDescription, containsString( generationComparisonName( generationComparison ) ) );
         }
         assertThat( failureDescription, containsString( pointerStateName( pointerStateA ) ) );
         assertThat( failureDescription, containsString( pointerStateName( pointerStateB ) ) );
     }
 
-    private static String genComparisonName( int genComparison )
+    private static String generationComparisonName( int generationComparison )
     {
-        switch ( genComparison )
+        switch ( generationComparison )
         {
-        case EXPECTED_GEN_B_BIG:
-            return GenSafePointerPair.GEN_COMPARISON_NAME_B_BIG;
-        case EXPECTED_GEN_EQUAL:
-            return GenSafePointerPair.GEN_COMPARISON_NAME_EQUAL;
-        case EXPECTED_GEN_A_BIG:
-            return GenSafePointerPair.GEN_COMPARISON_NAME_A_BIG;
+        case EXPECTED_GENERATION_B_BIG:
+            return GenerationSafePointerPair.GENERATION_COMPARISON_NAME_B_BIG;
+        case EXPECTED_GENERATION_EQUAL:
+            return GenerationSafePointerPair.GENERATION_COMPARISON_NAME_EQUAL;
+        case EXPECTED_GENERATION_A_BIG:
+            return GenerationSafePointerPair.GENERATION_COMPARISON_NAME_A_BIG;
         default:
-            throw new UnsupportedOperationException( String.valueOf( genComparison ) );
+            throw new UnsupportedOperationException( String.valueOf( generationComparison ) );
         }
     }
 
-    private static long genComparisonBits( int genComparison )
+    private static long generationComparisonBits( int generationComparison )
     {
-        switch ( genComparison )
+        switch ( generationComparison )
         {
-        case EXPECTED_GEN_B_BIG:
-            return GenSafePointerPair.FLAG_GEN_B_BIG;
-        case EXPECTED_GEN_EQUAL:
-            return GenSafePointerPair.FLAG_GEN_EQUAL;
-        case EXPECTED_GEN_A_BIG:
-            return GenSafePointerPair.FLAG_GEN_A_BIG;
+        case EXPECTED_GENERATION_B_BIG:
+            return GenerationSafePointerPair.FLAG_GENERATION_B_BIG;
+        case EXPECTED_GENERATION_EQUAL:
+            return GenerationSafePointerPair.FLAG_GENERATION_EQUAL;
+        case EXPECTED_GENERATION_A_BIG:
+            return GenerationSafePointerPair.FLAG_GENERATION_A_BIG;
         default:
-            throw new UnsupportedOperationException( String.valueOf( genComparison ) );
+            throw new UnsupportedOperationException( String.valueOf( generationComparison ) );
         }
     }
 
@@ -248,10 +248,10 @@ public class GenSafePointerPairTest
 
     private static long readSlot( PageCursor cursor )
     {
-        long generation = GenSafePointer.readGeneration( cursor );
-        long pointer = GenSafePointer.readPointer( cursor );
-        short checksum = GenSafePointer.readChecksum( cursor );
-        assertEquals( GenSafePointer.checksumOf( generation, pointer ), checksum );
+        long generation = GenerationSafePointer.readGeneration( cursor );
+        long pointer = GenerationSafePointer.readPointer( cursor );
+        short checksum = GenerationSafePointer.readChecksum( cursor );
+        assertEquals( GenerationSafePointer.checksumOf( generation, pointer ), checksum );
         return pointer;
     }
 
@@ -262,7 +262,7 @@ public class GenSafePointerPairTest
 
     enum State
     {
-        EMPTY( GenSafePointerPair.EMPTY )
+        EMPTY( GenerationSafePointerPair.EMPTY )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
@@ -270,19 +270,19 @@ public class GenSafePointerPairTest
                 return EMPTY_POINTER;
             }
         },
-        BROKEN( GenSafePointerPair.BROKEN )
+        BROKEN( GenerationSafePointerPair.BROKEN )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
                 // write an arbitrary GSP
                 int offset = cursor.getOffset();
-                GenSafePointer.write( cursor, 10, 20 );
+                GenerationSafePointer.write( cursor, 10, 20 );
 
                 // then break its checksum
-                cursor.setOffset( offset + GenSafePointer.SIZE - GenSafePointer.CHECKSUM_SIZE );
-                short checksum = GenSafePointer.readChecksum( cursor );
-                cursor.setOffset( offset + GenSafePointer.SIZE - GenSafePointer.CHECKSUM_SIZE );
+                cursor.setOffset( offset + GenerationSafePointer.SIZE - GenerationSafePointer.CHECKSUM_SIZE );
+                short checksum = GenerationSafePointer.readChecksum( cursor );
+                cursor.setOffset( offset + GenerationSafePointer.SIZE - GenerationSafePointer.CHECKSUM_SIZE );
                 cursor.putShort( (short) ~checksum );
                 return pointer;
             }
@@ -292,60 +292,60 @@ public class GenSafePointerPairTest
             {
                 cursor.setOffset( slotA ? SLOT_A_OFFSET : SLOT_B_OFFSET );
 
-                long generation = GenSafePointer.readGeneration( cursor );
-                long pointer = GenSafePointer.readPointer( cursor );
-                short checksum = GenSafePointer.readChecksum( cursor );
-                assertNotEquals( GenSafePointer.checksumOf( generation, pointer ), checksum );
+                long generation = GenerationSafePointer.readGeneration( cursor );
+                long pointer = GenerationSafePointer.readPointer( cursor );
+                short checksum = GenerationSafePointer.readChecksum( cursor );
+                assertNotEquals( GenerationSafePointer.checksumOf( generation, pointer ), checksum );
             }
         },
-        OLD_CRASH( GenSafePointerPair.CRASH )
+        OLD_CRASH( GenerationSafePointerPair.CRASH )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, OLD_CRASH_GENERATION, pointer );
+                GenerationSafePointer.write( cursor, OLD_CRASH_GENERATION, pointer );
                 return pointer;
             }
         },
-        CRASH( GenSafePointerPair.CRASH )
+        CRASH( GenerationSafePointerPair.CRASH )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, CRASH_GENERATION, pointer );
+                GenerationSafePointer.write( cursor, CRASH_GENERATION, pointer );
                 return pointer;
             }
         },
-        OLD_STABLE( GenSafePointerPair.STABLE )
+        OLD_STABLE( GenerationSafePointerPair.STABLE )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, OLD_STABLE_GENERATION, pointer );
+                GenerationSafePointer.write( cursor, OLD_STABLE_GENERATION, pointer );
                 return pointer;
             }
         },
-        STABLE( GenSafePointerPair.STABLE )
+        STABLE( GenerationSafePointerPair.STABLE )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, STABLE_GENERATION, pointer );
+                GenerationSafePointer.write( cursor, STABLE_GENERATION, pointer );
                 return pointer;
             }
         },
-        UNSTABLE( GenSafePointerPair.UNSTABLE )
+        UNSTABLE( GenerationSafePointerPair.UNSTABLE )
         {
             @Override
             long materialize( PageCursor cursor, long pointer )
             {
-                GenSafePointer.write( cursor, UNSTABLE_GENERATION, pointer );
+                GenerationSafePointer.write( cursor, UNSTABLE_GENERATION, pointer );
                 return pointer;
             }
         };
 
         /**
-         * Actual {@link GenSafePointerPair} pointer state value.
+         * Actual {@link GenerationSafePointerPair} pointer state value.
          */
         private final byte byteValue;
 
@@ -380,7 +380,7 @@ public class GenSafePointerPairTest
     {
         /**
          * @param cursor {@link PageCursor} to read actual result from.
-         * @param result read-result from {@link GenSafePointerPair#read(PageCursor, long, long, int)}.
+         * @param result read-result from {@link GenerationSafePointerPair#read(PageCursor, long, long, int)}.
          * @param stateA state of pointer A when read.
          * @param stateB state of pointer B when read.
          * @param preStatePointerA pointer A as it looked like in pre-state.
@@ -392,7 +392,7 @@ public class GenSafePointerPairTest
 
         /**
          * @param cursor {@link PageCursor} to read actual result from.
-         * @param result write-result from {@link GenSafePointerPair#write(PageCursor, long, long, long)}.
+         * @param result write-result from {@link GenerationSafePointerPair#write(PageCursor, long, long, long)}.
          * @param stateA state of pointer A when written.
          * @param stateB state of pointer B when written.
          * @param preStatePointerA pointer A as it looked like in pre-state.
@@ -421,18 +421,18 @@ public class GenSafePointerPairTest
                 long preStatePointerA, long preStatePointerB, int logicalPos )
         {
             assertSuccess( result );
-            long pointer = GenSafePointerPair.pointer( result );
+            long pointer = GenerationSafePointerPair.pointer( result );
             assertEquals( expectedPointer, pointer );
-            assertEquals( expectedSlot == SLOT_A, GenSafePointerPair.resultIsFromSlotA( result ) );
+            assertEquals( expectedSlot == SLOT_A, GenerationSafePointerPair.resultIsFromSlotA( result ) );
             if ( logicalPos == NO_LOGICAL_POS )
             {
-                assertFalse( GenSafePointerPair.isLogicalPos( result ) );
-                assertEquals( GSPP_OFFSET, GenSafePointerPair.genOffset( result ) );
+                assertFalse( GenerationSafePointerPair.isLogicalPos( result ) );
+                assertEquals( GSPP_OFFSET, GenerationSafePointerPair.generationOffset( result ) );
             }
             else
             {
-                assertTrue( GenSafePointerPair.isLogicalPos( result ) );
-                assertEquals( logicalPos, GenSafePointerPair.genOffset( result ) );
+                assertTrue( GenerationSafePointerPair.isLogicalPos( result ) );
+                assertEquals( logicalPos, GenerationSafePointerPair.generationOffset( result ) );
             }
 
             stateA.verify( cursor, preStatePointerA, SLOT_A, logicalPos );
@@ -445,7 +445,7 @@ public class GenSafePointerPairTest
         {
             assertSuccess( result );
             boolean actuallyWrittenSlot =
-                    (result & GenSafePointerPair.SLOT_MASK) == GenSafePointerPair.FLAG_SLOT_A ? SLOT_A : SLOT_B;
+                    (result & GenerationSafePointerPair.SLOT_MASK) == GenerationSafePointerPair.FLAG_SLOT_A ? SLOT_A : SLOT_B;
             assertEquals( expectedSlot, actuallyWrittenSlot );
 
             if ( expectedSlot == SLOT_A )
@@ -464,29 +464,29 @@ public class GenSafePointerPairTest
 
         private static void assertSuccess( long result )
         {
-            assertTrue( GenSafePointerPair.isSuccess( result ) );
+            assertTrue( GenerationSafePointerPair.isSuccess( result ) );
         }
     }
 
     enum Fail implements Slot
     {
-        GEN_DISREGARD( EXPECTED_GEN_DISREGARD ),
-        GEN_B_BIG( EXPECTED_GEN_B_BIG ),
-        GEN_EQUAL( EXPECTED_GEN_EQUAL ),
-        GEN_A_BIG( EXPECTED_GEN_A_BIG );
+        GENERATION_DISREGARD( EXPECTED_GENERATION_DISREGARD ),
+        GENERATION_B_BIG( EXPECTED_GENERATION_B_BIG ),
+        GENERATION_EQUAL( EXPECTED_GENERATION_EQUAL ),
+        GENERATION_A_BIG( EXPECTED_GENERATION_A_BIG );
 
-        private final int genComparison;
+        private final int generationComparison;
 
-        Fail( int genComparison )
+        Fail( int generationComparison )
         {
-            this.genComparison = genComparison;
+            this.generationComparison = generationComparison;
         }
 
         @Override
         public void verifyRead( PageCursor cursor, long result, State stateA, State stateB,
                 long preStatePointerA, long preStatePointerB, int logicalPos )
         {
-            assertFailure( result, FLAG_READ, genComparison, stateA.byteValue, stateB.byteValue );
+            assertFailure( result, FLAG_READ, generationComparison, stateA.byteValue, stateB.byteValue );
             stateA.verify( cursor, preStatePointerA, SLOT_A, logicalPos );
             stateB.verify( cursor, preStatePointerB, SLOT_B, logicalPos );
         }
@@ -495,7 +495,7 @@ public class GenSafePointerPairTest
         public void verifyWrite( PageCursor cursor, long result, State stateA, State stateB,
                 long preStatePointerA, long preStatePointerB )
         {
-            assertFailure( result, FLAG_WRITE, genComparison, stateA.byteValue, stateB.byteValue );
+            assertFailure( result, FLAG_WRITE, generationComparison, stateA.byteValue, stateB.byteValue );
             stateA.verify( cursor, preStatePointerA, SLOT_A, NO_LOGICAL_POS /*Don't care*/ );
             stateB.verify( cursor, preStatePointerB, SLOT_B, NO_LOGICAL_POS /*Don't care*/ );
         }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationSafePointerTest.java
@@ -30,9 +30,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class GenSafePointerTest
+public class GenerationSafePointerTest
 {
-    private static final int PAGE_SIZE = GenSafePointer.SIZE * 2;
+    private static final int PAGE_SIZE = GenerationSafePointer.SIZE * 2;
     private final PageCursor cursor = ByteArrayPageCursor.wrap( new byte[PAGE_SIZE] );
     private final GSP read = new GSP();
 
@@ -93,7 +93,7 @@ public class GenSafePointerTest
         write( cursor, offset, initial );
 
         // WHEN
-        cursor.putShort( offset + GenSafePointer.SIZE - GenSafePointer.CHECKSUM_SIZE,
+        cursor.putShort( offset + GenerationSafePointer.SIZE - GenerationSafePointer.CHECKSUM_SIZE,
                 (short) (checksumOf( initial ) - 2) );
 
         // THEN
@@ -105,7 +105,7 @@ public class GenSafePointerTest
     public void shouldWriteAndReadGspCloseToGenerationMax() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION;
+        long generation = GenerationSafePointer.MAX_GENERATION;
         GSP expected = gsp( generation, 12345 );
         write( cursor, 0, expected );
 
@@ -123,7 +123,7 @@ public class GenSafePointerTest
     public void shouldWriteAndReadGspCloseToPointerMax() throws Exception
     {
         // GIVEN
-        long pointer = GenSafePointer.MAX_POINTER;
+        long pointer = GenerationSafePointer.MAX_POINTER;
         GSP expected = gsp( 12345, pointer );
         write( cursor, 0, expected );
 
@@ -141,8 +141,8 @@ public class GenSafePointerTest
     public void shouldWriteAndReadGspCloseToGenerationAndPointerMax() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION;
-        long pointer = GenSafePointer.MAX_POINTER;
+        long generation = GenerationSafePointer.MAX_GENERATION;
+        long pointer = GenerationSafePointer.MAX_POINTER;
         GSP expected = gsp( generation, pointer );
         write( cursor, 0, expected );
 
@@ -161,8 +161,8 @@ public class GenSafePointerTest
     public void shouldThrowIfPointerToLarge() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION;
-        long pointer = GenSafePointer.MAX_POINTER + 1;
+        long generation = GenerationSafePointer.MIN_GENERATION;
+        long pointer = GenerationSafePointer.MAX_POINTER + 1;
         GSP broken = gsp( generation, pointer );
 
         // WHEN
@@ -182,8 +182,8 @@ public class GenSafePointerTest
     public void shouldThrowIfPointerToSmall() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION;
-        long pointer = GenSafePointer.MIN_POINTER - 1;
+        long generation = GenerationSafePointer.MIN_GENERATION;
+        long pointer = GenerationSafePointer.MIN_POINTER - 1;
         GSP broken = gsp( generation, pointer );
 
         // WHEN
@@ -203,8 +203,8 @@ public class GenSafePointerTest
     public void shouldThrowIfGenerationToLarge() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
-        long pointer = GenSafePointer.MIN_POINTER;
+        long generation = GenerationSafePointer.MAX_GENERATION + 1;
+        long pointer = GenerationSafePointer.MIN_POINTER;
         GSP broken = gsp( generation, pointer );
 
         // WHEN
@@ -224,8 +224,8 @@ public class GenSafePointerTest
     public void shouldThrowIfGenerationToSmall() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MIN_GENERATION - 1;
-        long pointer = GenSafePointer.MIN_POINTER;
+        long generation = GenerationSafePointer.MIN_GENERATION - 1;
+        long pointer = GenerationSafePointer.MIN_POINTER;
         GSP broken = gsp( generation, pointer );
 
         // WHEN
@@ -253,8 +253,8 @@ public class GenSafePointerTest
         short reference = 0;
         for ( int i = 0; i < count; i++ )
         {
-            gsp.generation = random.nextLong( GenSafePointer.MAX_GENERATION );
-            gsp.pointer = random.nextLong( GenSafePointer.MAX_POINTER );
+            gsp.generation = random.nextLong( GenerationSafePointer.MAX_GENERATION );
+            gsp.pointer = random.nextLong( GenerationSafePointer.MAX_POINTER );
             short checksum = checksumOf( gsp );
             if ( i == 0 )
             {
@@ -282,20 +282,20 @@ public class GenSafePointerTest
     private boolean read( PageCursor cursor, int offset, GSP into )
     {
         cursor.setOffset( offset );
-        into.generation = GenSafePointer.readGeneration( cursor );
-        into.pointer = GenSafePointer.readPointer( cursor );
-        return GenSafePointer.verifyChecksum( cursor, into.generation, into.pointer );
+        into.generation = GenerationSafePointer.readGeneration( cursor );
+        into.pointer = GenerationSafePointer.readPointer( cursor );
+        return GenerationSafePointer.verifyChecksum( cursor, into.generation, into.pointer );
     }
 
     private void write( PageCursor cursor, int offset, GSP gsp )
     {
         cursor.setOffset( offset );
-        GenSafePointer.write( cursor, gsp.generation, gsp.pointer );
+        GenerationSafePointer.write( cursor, gsp.generation, gsp.pointer );
     }
 
     private static short checksumOf( GSP gsp )
     {
-        return GenSafePointer.checksumOf( gsp.generation, gsp.pointer );
+        return GenerationSafePointer.checksumOf( gsp.generation, gsp.pointer );
     }
 
     /**
@@ -348,7 +348,7 @@ public class GenSafePointerTest
         @Override
         public String toString()
         {
-            return "[gen:" + generation + ",p:" + pointer + "]";
+            return "[generation:" + generation + ",p:" + pointer + "]";
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GenerationTest.java
@@ -28,13 +28,13 @@ public class GenerationTest
     @Test
     public void shouldSetLowGenerations() throws Exception
     {
-        shouldComposeAndDecomposeGeneration( GenSafePointer.MIN_GENERATION, GenSafePointer.MIN_GENERATION + 1 );
+        shouldComposeAndDecomposeGeneration( GenerationSafePointer.MIN_GENERATION, GenerationSafePointer.MIN_GENERATION + 1 );
     }
 
     @Test
     public void shouldSetHighGenerations() throws Exception
     {
-        shouldComposeAndDecomposeGeneration( GenSafePointer.MAX_GENERATION - 1, GenSafePointer.MAX_GENERATION );
+        shouldComposeAndDecomposeGeneration( GenerationSafePointer.MAX_GENERATION - 1, GenerationSafePointer.MAX_GENERATION );
     }
 
     private void shouldComposeAndDecomposeGeneration( long stable, long unstable )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PointerCheckingTest.java
@@ -25,14 +25,14 @@ import org.neo4j.io.pagecache.PageCursor;
 
 import static org.junit.Assert.fail;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.NO_LOGICAL_POS;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.read;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.write;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.NO_LOGICAL_POS;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.read;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.write;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.put6BLong;
 
 public class PointerCheckingTest
 {
-    private final PageCursor cursor = ByteArrayPageCursor.wrap( GenSafePointerPair.SIZE );
+    private final PageCursor cursor = ByteArrayPageCursor.wrap( GenerationSafePointerPair.SIZE );
     private final long firstGeneration = 1;
     private final long secondGeneration = 2;
     private final long thirdGeneration = 3;
@@ -56,7 +56,7 @@ public class PointerCheckingTest
     public void checkChildShouldThrowOnReadFailure() throws Exception
     {
         // GIVEN
-        long result = GenSafePointerPair.read( cursor, 0, 1, 123 );
+        long result = GenerationSafePointerPair.read( cursor, 0, 1, 123 );
 
         // WHEN
         try
@@ -171,10 +171,10 @@ public class PointerCheckingTest
         long generation = IdSpace.STATE_PAGE_A;
         long pointer = this.secondGeneration;
 
-        // Can not use GenSafePointer.write because it will fail on pointer assertion.
+        // Can not use GenerationSafePointer.write because it will fail on pointer assertion.
         cursor.putInt( (int) pointer );
         put6BLong( cursor, generation );
-        cursor.putShort( GenSafePointer.checksumOf( generation, pointer ) );
+        cursor.putShort( GenerationSafePointer.checksumOf( generation, pointer ) );
         cursor.rewind();
 
         // WHEN

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointer;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointer;
 import static org.neo4j.index.internal.gbptree.ValueMergers.overwrite;
 
 public class SeekCursorTest
@@ -54,7 +54,7 @@ public class SeekCursorTest
         @Override
         public long getAsLong()
         {
-            return Generation.generation( stableGen, unstableGen );
+            return Generation.generation( stableGeneration, unstableGeneration );
         }
     };
     private static final Supplier<Root> failingRootCatchup = () ->
@@ -79,8 +79,8 @@ public class SeekCursorTest
     private final MutableLong from = layout.newKey();
     private final MutableLong to = layout.newKey();
 
-    private static long stableGen = GenSafePointer.MIN_GENERATION;
-    private static long unstableGen = stableGen + 1;
+    private static long stableGeneration = GenerationSafePointer.MIN_GENERATION;
+    private static long unstableGeneration = stableGeneration + 1;
 
     private long rootId;
     private int numberOfRootSplits;
@@ -88,8 +88,8 @@ public class SeekCursorTest
     @Before
     public void setUp() throws IOException
     {
-        cursor.next( id.acquireNewId( stableGen, unstableGen ) );
-        node.initializeLeaf( cursor, stableGen, unstableGen );
+        cursor.next( id.acquireNewId( stableGeneration, unstableGeneration ) );
+        node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
         updateRoot();
     }
 
@@ -468,7 +468,8 @@ public class SeekCursorTest
         MutableLong primKey = layout.newKey();
         node.keyAt( cursor, primKey, 0 );
         long expectedNext = primKey.longValue();
-        long rightChild = GenSafePointerPair.pointer( node.childAt( cursor, 1, stableGen, unstableGen ) );
+        long rightChild = GenerationSafePointerPair.pointer( node.childAt( cursor, 1, stableGeneration,
+                unstableGeneration ) );
 
         // when
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor( expectedNext, maxKeyCount + 1 ) )
@@ -496,7 +497,8 @@ public class SeekCursorTest
         MutableLong primKey = layout.newKey();
         node.keyAt( cursor, primKey, 0 );
         long expectedNext = primKey.longValue();
-        long rightChild = GenSafePointerPair.pointer( node.childAt( cursor, 1, stableGen, unstableGen ) );
+        long rightChild = GenerationSafePointerPair.pointer( node.childAt( cursor, 1, stableGeneration,
+                unstableGeneration ) );
 
         // when
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor( expectedNext, -1 ) )
@@ -1192,7 +1194,8 @@ public class SeekCursorTest
 
         // WHEN
         try ( SeekCursor<MutableLong,MutableLong> cursor = new SeekCursor<>( this.cursor,
-                node, from, to, layout, stableGen, unstableGen, () -> 0L, failingRootCatchup, unstableGen ) )
+                node, from, to, layout, stableGeneration, unstableGeneration, () -> 0L, failingRootCatchup,
+                unstableGeneration ) )
         {
             // reading a couple of keys
             assertTrue( cursor.next() );
@@ -1240,8 +1243,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
         readCursor.next( pointer( leftChild ) );
         int keyCount = node.keyCount( readCursor );
         node.keyAt( readCursor, from, keyCount - 1 );
@@ -1276,8 +1279,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
         readCursor.next( pointer( leftChild ) );
         int keyCount = node.keyCount( readCursor );
         node.keyAt( readCursor, from, keyCount - 1 );
@@ -1312,8 +1315,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
         readCursor.next( pointer( leftChild ) );
         int keyCount = node.keyCount( readCursor );
         node.keyAt( readCursor, from, keyCount - 2 );
@@ -1349,8 +1352,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
         readCursor.next( pointer( leftChild ) );
         int keyCount = node.keyCount( readCursor );
         node.keyAt( readCursor, from, keyCount - 1 );
@@ -1382,8 +1385,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
 
         // from first key in left child
         readCursor.next( pointer( leftChild ) );
@@ -1416,8 +1419,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
 
         // from first key in left child
         readCursor.next( pointer( rightChild ) );
@@ -1450,8 +1453,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
 
         // from first key in left child
         readCursor.next( pointer( rightChild ) );
@@ -1484,8 +1487,8 @@ public class SeekCursorTest
 
         PageAwareByteArrayCursor readCursor = cursor.duplicate( rootId );
         readCursor.next();
-        long leftChild = childAt( readCursor, 0, stableGen, unstableGen );
-        long rightChild = childAt( readCursor, 1, stableGen, unstableGen );
+        long leftChild = childAt( readCursor, 0, stableGeneration, unstableGeneration );
+        long rightChild = childAt( readCursor, 1, stableGeneration, unstableGeneration );
 
         // from first key in left child
         readCursor.next( pointer( leftChild ) );
@@ -1553,7 +1556,7 @@ public class SeekCursorTest
             // when right sibling pointer is corrupt
             PageAwareByteArrayCursor duplicate = cursor.duplicate( currentNode );
             duplicate.next();
-            long leftChild = childAt( duplicate, 0, stableGen, unstableGen );
+            long leftChild = childAt( duplicate, 0, stableGeneration, unstableGeneration );
             duplicate.next( leftChild );
             corruptGSPP( duplicate, TreeNode.BYTE_POS_RIGHTSIBLING );
 
@@ -1662,8 +1665,8 @@ public class SeekCursorTest
 
         // a checkpoint
         long oldRootId = rootId;
-        long oldStableGen = stableGen;
-        long oldUnstableGen = unstableGen;
+        long oldStableGeneration = stableGeneration;
+        long oldUnstableGeneration = unstableGeneration;
         checkpoint();
         int keyCount = node.keyCount( cursor );
 
@@ -1674,7 +1677,7 @@ public class SeekCursorTest
             i++;
         }
         node.goTo( cursor, "root", rootId );
-        long rightChild = childAt( cursor, 2, stableGen, unstableGen );
+        long rightChild = childAt( cursor, 2, stableGeneration, unstableGeneration );
 
         // when
         // starting a seek on the old root with generation that is not up to date, simulating a concurrent checkpoint
@@ -1682,7 +1685,7 @@ public class SeekCursorTest
         BreadcrumbPageCursor breadcrumbCursor = new BreadcrumbPageCursor( pageCursorForSeeker );
         breadcrumbCursor.next();
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor(
-                i, i + 1, breadcrumbCursor, oldStableGen, oldUnstableGen ) )
+                i, i + 1, breadcrumbCursor, oldStableGeneration, oldUnstableGeneration ) )
         {
             while ( seek.next() )
             {
@@ -1721,8 +1724,8 @@ public class SeekCursorTest
         }
 
         // a checkpoint
-        long oldStableGen = stableGen;
-        long oldUnstableGen = unstableGen;
+        long oldStableGeneration = stableGeneration;
+        long oldUnstableGeneration = unstableGeneration;
         checkpoint();
         int keyCount = node.keyCount( cursor );
 
@@ -1742,7 +1745,7 @@ public class SeekCursorTest
         PageAwareByteArrayCursor pageCursorForSeeker = cursor.duplicate( rootId );
         pageCursorForSeeker.next();
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor(
-                i, i + 1, pageCursorForSeeker, oldStableGen, oldUnstableGen ) )
+                i, i + 1, pageCursorForSeeker, oldStableGeneration, oldUnstableGeneration ) )
         {
             fail( "Expected throw" );
         }
@@ -1766,14 +1769,14 @@ public class SeekCursorTest
         }
 
         // a checkpoint
-        long oldStableGen = stableGen;
-        long oldUnstableGen = unstableGen;
+        long oldStableGeneration = stableGeneration;
+        long oldUnstableGeneration = unstableGeneration;
         checkpoint();
 
-        // and an update to root with a child pointer in new gen
+        // and an update to root with a child pointer in new generation
         insert( i, i * 10 );
         i++;
-        long newRightChild = childAt( cursor, 1, stableGen, unstableGen );
+        long newRightChild = childAt( cursor, 1, stableGeneration, unstableGeneration );
 
         // when
         // starting a seek on the old root with generation that is not up to date, simulating a concurrent checkpoint
@@ -1781,7 +1784,7 @@ public class SeekCursorTest
         BreadcrumbPageCursor breadcrumbCursor = new BreadcrumbPageCursor( pageCursorForSeeker );
         breadcrumbCursor.next();
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor(
-                i, i + 1, breadcrumbCursor, oldStableGen, oldUnstableGen ) )
+                i, i + 1, breadcrumbCursor, oldStableGeneration, oldUnstableGeneration ) )
         {
             while ( seek.next() )
             {
@@ -1806,8 +1809,8 @@ public class SeekCursorTest
         }
 
         // a checkpoint
-        long oldStableGen = stableGen;
-        long oldUnstableGen = unstableGen;
+        long oldStableGeneration = stableGeneration;
+        long oldUnstableGeneration = unstableGeneration;
         checkpoint();
 
         // and update root with an insert in new generation
@@ -1822,7 +1825,7 @@ public class SeekCursorTest
         PageAwareByteArrayCursor pageCursorForSeeker = cursor.duplicate( rootId );
         pageCursorForSeeker.next();
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor(
-                i, i + 1, pageCursorForSeeker, oldStableGen, oldUnstableGen ) )
+                i, i + 1, pageCursorForSeeker, oldStableGeneration, oldUnstableGeneration ) )
         {
             fail( "Expected throw" );
         }
@@ -1838,17 +1841,17 @@ public class SeekCursorTest
     {
         // given
         long id = cursor.getCurrentPageId();
-        long gen = node.gen( cursor );
+        long generation = node.generation( cursor );
         MutableBoolean triggered = new MutableBoolean( false );
         Supplier<Root> rootCatchup = () ->
         {
             triggered.setTrue();
-            return new Root( id, gen );
+            return new Root( id, generation );
         };
 
         // when
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen, unstableGen, generationSupplier, rootCatchup, gen - 1 ) )
+                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, generation - 1 ) )
         {
             // do nothing
         }
@@ -1861,23 +1864,23 @@ public class SeekCursorTest
     public void shouldCatchupRootWhenNodeHasTooNewGenerationWhileTraversingDownTree() throws Exception
     {
         // given
-        long gen = node.gen( cursor );
+        long generation = node.generation( cursor );
         MutableBoolean triggered = new MutableBoolean( false );
 
         // a newer leaf
         long leftChild = cursor.getCurrentPageId();
-        node.initializeLeaf( cursor, stableGen + 1, unstableGen + 1 ); // A newer leaf
+        node.initializeLeaf( cursor, stableGeneration + 1, unstableGeneration + 1 ); // A newer leaf
         cursor.next();
 
         // a root
         long rootId = cursor.getCurrentPageId();
-        node.initializeInternal( cursor, stableGen, unstableGen );
+        node.initializeInternal( cursor, stableGeneration, unstableGeneration );
         long keyInRoot = 10L;
         insertKey.setValue( keyInRoot );
         node.insertKeyAt( cursor, insertKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         // with old pointer to child (simulating reuse of child node)
-        node.setChildAt( cursor, leftChild, 0, stableGen, unstableGen );
+        node.setChildAt( cursor, leftChild, 0, stableGeneration, unstableGeneration );
 
         // a root catchup that records usage
         Supplier<Root> rootCatchup = () ->
@@ -1889,10 +1892,10 @@ public class SeekCursorTest
                 // and set child generation to match pointer
                 cursor.next( leftChild );
                 cursor.zapPage();
-                node.initializeLeaf( cursor, stableGen, unstableGen );
+                node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
 
                 cursor.next( rootId );
-                return new Root( rootId, gen );
+                return new Root( rootId, generation );
             }
             catch ( IOException e )
             {
@@ -1904,7 +1907,7 @@ public class SeekCursorTest
         from.setValue( 1L );
         to.setValue( 2L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen, unstableGen, generationSupplier, rootCatchup, unstableGen ) )
+                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, unstableGeneration ) )
         {
             // do nothing
         }
@@ -1921,7 +1924,7 @@ public class SeekCursorTest
 
         // a newer right leaf
         long rightChild = cursor.getCurrentPageId();
-        node.initializeLeaf( cursor, stableGen, unstableGen );
+        node.initializeLeaf( cursor, stableGeneration, unstableGeneration );
         cursor.next();
 
         Supplier<Root> rootCatchup = () ->
@@ -1931,7 +1934,7 @@ public class SeekCursorTest
                 // Use right child as new start over root to terminate test
                 cursor.next( rightChild );
                 triggered.setTrue();
-                return new Root( cursor.getCurrentPageId(), node.gen( cursor ) );
+                return new Root( cursor.getCurrentPageId(), node.generation( cursor ) );
             }
             catch ( IOException e )
             {
@@ -1941,25 +1944,25 @@ public class SeekCursorTest
 
         // a left leaf
         long leftChild = cursor.getCurrentPageId();
-        node.initializeLeaf( cursor, stableGen - 1, unstableGen - 1 );
+        node.initializeLeaf( cursor, stableGeneration - 1, unstableGeneration - 1 );
         // with an old pointer to right sibling
-        node.setRightSibling( cursor, rightChild, stableGen - 1, unstableGen - 1 );
+        node.setRightSibling( cursor, rightChild, stableGeneration - 1, unstableGeneration - 1 );
         cursor.next();
 
         // a root
-        node.initializeInternal( cursor, stableGen - 1, unstableGen - 1 );
+        node.initializeInternal( cursor, stableGeneration - 1, unstableGeneration - 1 );
         long keyInRoot = 10L;
         insertKey.setValue( keyInRoot );
         node.insertKeyAt( cursor, insertKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
         // with old pointer to child (simulating reuse of internal node)
-        node.setChildAt( cursor, leftChild, 0, stableGen, unstableGen );
+        node.setChildAt( cursor, leftChild, 0, stableGeneration, unstableGeneration );
 
         // when
         from.setValue( 1L );
         to.setValue( 20L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGen - 1, unstableGen - 1, generationSupplier, rootCatchup, unstableGen ) )
+                stableGeneration - 1, unstableGeneration - 1, generationSupplier, rootCatchup, unstableGeneration ) )
         {
             while ( seek.next() )
             {
@@ -2005,10 +2008,10 @@ public class SeekCursorTest
             i++;
         }
         long rootId = cursor.getCurrentPageId();
-        long leftChild = node.childAt( cursor, 0, stableGen, unstableGen );
+        long leftChild = node.childAt( cursor, 0, stableGeneration, unstableGeneration );
 
         // WHEN
-        PageCursorUtil.goTo( cursor, "test", GenSafePointerPair.pointer( leftChild ) );
+        PageCursorUtil.goTo( cursor, "test", GenerationSafePointerPair.pointer( leftChild ) );
         cursor.setOffset( node.BYTE_POS_KEYCOUNT );
         cursor.putInt( keyCount ); // Bad key count
         PageCursorUtil.goTo( cursor, "test", rootId );
@@ -2078,20 +2081,20 @@ public class SeekCursorTest
 
     private void checkpoint()
     {
-        stableGen = unstableGen;
-        unstableGen++;
+        stableGeneration = unstableGeneration;
+        unstableGeneration++;
     }
 
     private void newRootFromSplit( StructurePropagation<MutableLong> split ) throws IOException
     {
         assertTrue( split.hasRightKeyInsert );
-        long rootId = id.acquireNewId( stableGen, unstableGen );
+        long rootId = id.acquireNewId( stableGeneration, unstableGeneration );
         cursor.next( rootId );
-        node.initializeInternal( cursor, stableGen, unstableGen );
+        node.initializeInternal( cursor, stableGeneration, unstableGeneration );
         node.insertKeyAt( cursor, split.rightKey, 0, 0 );
         node.setKeyCount( cursor, 1 );
-        node.setChildAt( cursor, split.midChild, 0, stableGen, unstableGen );
-        node.setChildAt( cursor, split.rightChild, 1, stableGen, unstableGen );
+        node.setChildAt( cursor, split.midChild, 0, stableGeneration, unstableGeneration );
+        node.setChildAt( cursor, split.rightChild, 1, stableGeneration, unstableGeneration );
         split.hasRightKeyInsert = false;
         numberOfRootSplits++;
         updateRoot();
@@ -2101,8 +2104,8 @@ public class SeekCursorTest
     {
         int someBytes = duplicate.getInt( offset );
         duplicate.putInt( offset, ~someBytes );
-        someBytes = duplicate.getInt( offset + GenSafePointer.SIZE );
-        duplicate.putInt( offset + GenSafePointer.SIZE, ~someBytes );
+        someBytes = duplicate.getInt( offset + GenerationSafePointer.SIZE );
+        duplicate.putInt( offset + GenerationSafePointer.SIZE, ~someBytes );
     }
 
     private void insert( long key ) throws IOException
@@ -2119,14 +2122,15 @@ public class SeekCursorTest
     {
         insertKey.setValue( key );
         insertValue.setValue( value );
-        treeLogic.insert( cursor, structurePropagation, insertKey, insertValue, overwrite(), stableGen, unstableGen );
+        treeLogic.insert( cursor, structurePropagation, insertKey, insertValue, overwrite(), stableGeneration,
+                unstableGeneration );
         handleAfterChange();
     }
 
     private void remove( long key ) throws IOException
     {
         insertKey.setValue( key );
-        treeLogic.remove( cursor, structurePropagation, insertKey, insertValue, stableGen, unstableGen );
+        treeLogic.remove( cursor, structurePropagation, insertKey, insertValue, stableGeneration, unstableGeneration );
         handleAfterChange();
     }
 
@@ -2151,16 +2155,16 @@ public class SeekCursorTest
     private SeekCursor<MutableLong,MutableLong> seekCursor( long fromInclusive, long toExclusive,
             PageCursor pageCursor ) throws IOException
     {
-        return seekCursor( fromInclusive, toExclusive, pageCursor, stableGen, unstableGen );
+        return seekCursor( fromInclusive, toExclusive, pageCursor, stableGeneration, unstableGeneration );
     }
 
     private SeekCursor<MutableLong,MutableLong> seekCursor( long fromInclusive, long toExclusive,
-            PageCursor pageCursor, long stableGen, long unstableGen ) throws IOException
+            PageCursor pageCursor, long stableGeneration, long unstableGeneration ) throws IOException
     {
         from.setValue( fromInclusive );
         to.setValue( toExclusive );
-        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGen, unstableGen, generationSupplier,
-                failingRootCatchup, unstableGen );
+        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGeneration, unstableGeneration, generationSupplier,
+                failingRootCatchup, unstableGeneration );
     }
 
     /**
@@ -2172,11 +2176,11 @@ public class SeekCursorTest
         long left = pageCursor.getCurrentPageId();
         long right = left + 1;
 
-        node.setRightSibling( pageCursor, right, stableGen, unstableGen );
+        node.setRightSibling( pageCursor, right, stableGeneration, unstableGeneration );
 
         pageCursor.next( right );
-        node.initializeLeaf( pageCursor, stableGen, unstableGen );
-        node.setLeftSibling( pageCursor, left, stableGen, unstableGen );
+        node.initializeLeaf( pageCursor, stableGeneration, unstableGeneration );
+        node.setLeftSibling( pageCursor, left, stableGeneration, unstableGeneration );
         return left;
     }
 
@@ -2285,9 +2289,9 @@ public class SeekCursorTest
         }
     }
 
-    private long childAt( PageCursor cursor, int pos, long stableGen, long unstableGen )
+    private long childAt( PageCursor cursor, int pos, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.childAt( cursor, pos, stableGen, unstableGen ) );
+        return pointer( node.childAt( cursor, pos, stableGeneration, unstableGeneration ) );
     }
 
     private long keyAt( PageCursor cursor, int pos )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -1524,7 +1524,7 @@ public class SeekCursorTest
         long currentNode = cursor.getCurrentPageId();
         try ( SeekCursor<MutableLong,MutableLong> seek = seekCursor( 0L, i, cursor ) )
         {
-            // when right sibling gets an heir
+            // when right sibling gets an successor
             checkpoint();
             PageAwareByteArrayCursor duplicate = cursor.duplicate( currentNode );
             duplicate.next();
@@ -1581,7 +1581,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldRereadHeirIfReadFailureCausedByCheckpointInLeaf() throws Exception
+    public void shouldRereadSuccessorIfReadFailureCausedByCheckpointInLeaf() throws Exception
     {
         // given
         List<Long> expected = new ArrayList<>();
@@ -1600,7 +1600,7 @@ public class SeekCursorTest
             checkpoint();
             PageAwareByteArrayCursor duplicate = cursor.duplicate( currentNode );
             duplicate.next();
-            insert( i, i * 10, duplicate ); // Create heir of leaf
+            insert( i, i * 10, duplicate ); // Create successor of leaf
             expected.add( i );
 
             while ( seek.next() )
@@ -1615,7 +1615,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldFailHeirIfReadFailureNotCausedByCheckpointInLeaf() throws Exception
+    public void shouldFailSuccessorIfReadFailureNotCausedByCheckpointInLeaf() throws Exception
     {
         // given
         long i = 0L;
@@ -1631,10 +1631,10 @@ public class SeekCursorTest
             checkpoint();
             PageAwareByteArrayCursor duplicate = cursor.duplicate( currentNode );
             duplicate.next();
-            insert( i, i * 10, duplicate ); // Create heir of leaf
+            insert( i, i * 10, duplicate ); // Create successor of leaf
 
-            // and corrupt heir pointer
-            corruptGSPP( duplicate, TreeNode.BYTE_POS_HEIR );
+            // and corrupt successor pointer
+            corruptGSPP( duplicate, TreeNode.BYTE_POS_SUCCESSOR );
 
             // then
             try
@@ -1652,7 +1652,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldRereadHeirIfReadFailureCausedByCheckpointInInternal() throws Exception
+    public void shouldRereadSuccessorIfReadFailureCausedByCheckpointInInternal() throws Exception
     {
         // given
         // a root with two leaves in old generation
@@ -1693,7 +1693,7 @@ public class SeekCursorTest
         }
 
         // then
-        // make sure seek cursor went to heir of root node
+        // make sure seek cursor went to successor of root node
         assertEquals( Arrays.asList( oldRootId, rootId, rightChild ), breadcrumbCursor.getBreadcrumbs() );
     }
 
@@ -1712,7 +1712,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldFailHeirIfReadFailureNotCausedByCheckpointInInternal() throws Exception
+    public void shouldFailSuccessorIfReadFailureNotCausedByCheckpointInInternal() throws Exception
     {
         // given
         // a root with two leaves in old generation
@@ -1736,9 +1736,9 @@ public class SeekCursorTest
             i++;
         }
 
-        // and corrupt heir pointer
+        // and corrupt successor pointer
         cursor.next( rootId );
-        corruptGSPP( cursor, TreeNode.BYTE_POS_HEIR );
+        corruptGSPP( cursor, TreeNode.BYTE_POS_SUCCESSOR );
 
         // when
         // starting a seek on the old root with generation that is not up to date, simulating a concurrent checkpoint
@@ -1792,7 +1792,7 @@ public class SeekCursorTest
         }
 
         // then
-        // make sure seek cursor went to heir of root node
+        // make sure seek cursor went to successor of root node
         assertEquals( Arrays.asList( rootId, newRightChild ), breadcrumbCursor.getBreadcrumbs() );
     }
 
@@ -1817,7 +1817,7 @@ public class SeekCursorTest
         insert( i, i * 10 );
         i++;
 
-        // and corrupt heir pointer
+        // and corrupt successor pointer
         corruptGSPP( cursor, node.childOffset( 1 ) );
 
         // when
@@ -1917,7 +1917,7 @@ public class SeekCursorTest
     }
 
     @Test
-    public void shouldCatchupRootWhenNodeHasTooHeirerationWhileTraversingLeaves() throws Exception
+    public void shouldCatchupRootWhenNodeHasTooNewGenerationWhileTraversingLeaves() throws Exception
     {
         // given
         MutableBoolean triggered = new MutableBoolean( false );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
@@ -74,7 +74,7 @@ public class TreeNodeTest
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, heir( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, successor( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
     }
 
     @Test
@@ -91,7 +91,7 @@ public class TreeNodeTest
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
-        assertEquals( NO_NODE_FLAG, heir( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( NO_NODE_FLAG, successor( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
     }
 
     @Test
@@ -353,16 +353,16 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldSetAndGetHeir() throws Exception
+    public void shouldSetAndGetSuccessor() throws Exception
     {
         // GIVEN
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
-        node.setHeir( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
+        node.setSuccessor( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
-        assertEquals( 123, heir( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
+        assertEquals( 123, successor( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
     }
 
     @Test
@@ -731,8 +731,8 @@ public class TreeNodeTest
         return pointer( node.leftSibling( cursor, stableGeneration, unstableGeneration ) );
     }
 
-    private long heir( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    private long successor( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.heir( cursor, stableGeneration, unstableGeneration ) );
+        return pointer( node.successor( cursor, stableGeneration, unstableGeneration ) );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTest.java
@@ -34,8 +34,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.pointer;
-import static org.neo4j.index.internal.gbptree.GenSafePointerPair.resultIsFromSlotA;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointer;
+import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.resultIsFromSlotA;
 import static org.neo4j.index.internal.gbptree.TreeNode.NO_NODE_FLAG;
 
 public class TreeNodeTest
@@ -70,7 +70,7 @@ public class TreeNodeTest
         assertEquals( TreeNode.NODE_TYPE_TREE_NODE, node.nodeType( cursor ) );
         assertTrue( node.isLeaf( cursor ) );
         assertFalse( node.isInternal( cursor ) );
-        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
+        assertEquals( UNSTABLE_GENERATION, node.generation( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
@@ -87,7 +87,7 @@ public class TreeNodeTest
         assertEquals( TreeNode.NODE_TYPE_TREE_NODE, node.nodeType( cursor ) );
         assertFalse( node.isLeaf( cursor ) );
         assertTrue( node.isInternal( cursor ) );
-        assertEquals( UNSTABLE_GENERATION, node.gen( cursor ) );
+        assertEquals( UNSTABLE_GENERATION, node.generation( cursor ) );
         assertEquals( 0, node.keyCount( cursor ) );
         assertEquals( NO_NODE_FLAG, leftSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
         assertEquals( NO_NODE_FLAG, rightSibling( cursor, STABLE_GENERATION, UNSTABLE_GENERATION ) );
@@ -95,21 +95,21 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldWriteAndReadMaxGen() throws Exception
+    public void shouldWriteAndReadMaxGeneration() throws Exception
     {
         // GIVEN
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // WHEN
-        node.setGen( cursor, GenSafePointer.MAX_GENERATION );
+        node.setGeneration( cursor, GenerationSafePointer.MAX_GENERATION );
 
         // THEN
-        long gen = node.gen( cursor );
-        assertEquals( GenSafePointer.MAX_GENERATION, gen );
+        long generation = node.generation( cursor );
+        assertEquals( GenerationSafePointer.MAX_GENERATION, generation );
     }
 
     @Test
-    public void shouldThrowIfWriteTooLargeGen() throws Exception
+    public void shouldThrowIfWriteTooLargeGeneration() throws Exception
     {
         // GIVEN
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
@@ -117,7 +117,7 @@ public class TreeNodeTest
         // THEN
         try
         {
-            node.setGen( cursor, GenSafePointer.MAX_GENERATION + 1 );
+            node.setGeneration( cursor, GenerationSafePointer.MAX_GENERATION + 1 );
             fail( "Expected throw" );
         }
         catch ( IllegalArgumentException e )
@@ -127,7 +127,7 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldThrowIfWriteTooSmallGen() throws Exception
+    public void shouldThrowIfWriteTooSmallGeneration() throws Exception
     {
         // GIVEN
         node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
@@ -135,7 +135,7 @@ public class TreeNodeTest
         // THEN
         try
         {
-            node.setGen( cursor, GenSafePointer.MIN_GENERATION - 1 );
+            node.setGeneration( cursor, GenerationSafePointer.MIN_GENERATION - 1 );
             fail( "Expected throw" );
         }
         catch ( IllegalArgumentException e )
@@ -310,7 +310,7 @@ public class TreeNodeTest
     public void shouldOverwriteChild() throws Exception
     {
         // GIVEN
-        long child = GenSafePointer.MIN_POINTER;
+        long child = GenerationSafePointer.MIN_POINTER;
         node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
         node.insertChildAt( cursor, child, 0, 0, STABLE_GENERATION, UNSTABLE_GENERATION );
 
@@ -411,7 +411,7 @@ public class TreeNodeTest
     public void shouldReadAndInsertChildren() throws Exception
     {
         // GIVEN
-        long firstChild = GenSafePointer.MIN_POINTER;
+        long firstChild = GenerationSafePointer.MIN_POINTER;
         long secondChild = firstChild + 1;
         long thirdChild = secondChild + 1;
         node.initializeInternal( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
@@ -517,133 +517,133 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldReadPointerGenFromAbsoluteOffsetSlotA() throws Exception
+    public void shouldReadPointerGenerationFromAbsoluteOffsetSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long generation = UNSTABLE_GENERATION;
         long pointer = 12;
-        node.setRightSibling( cursor, pointer, STABLE_GENERATION, gen );
+        node.setRightSibling( cursor, pointer, STABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.rightSibling( cursor, STABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.rightSibling( cursor, STABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertTrue( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldReadPointerGenFromAbsoluteOffsetSlotB() throws Exception
+    public void shouldReadPointerGenerationFromAbsoluteOffsetSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long generation = HIGH_GENERATION;
         long oldPointer = 12;
         long pointer = 123;
         node.setRightSibling( cursor, oldPointer, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setRightSibling( cursor, pointer, UNSTABLE_GENERATION, gen );
+        node.setRightSibling( cursor, pointer, UNSTABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.rightSibling( cursor, UNSTABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.rightSibling( cursor, UNSTABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertFalse( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldReadPointerGenFromLogicalPosSlotA() throws Exception
+    public void shouldReadPointerGenerationFromLogicalPosSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long generation = UNSTABLE_GENERATION;
         long pointer = 12;
         int childPos = 2;
-        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertTrue( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldReadPointerGenFromLogicalPosZeroSlotA() throws Exception
+    public void shouldReadPointerGenerationFromLogicalPosZeroSlotA() throws Exception
     {
         // GIVEN
-        long gen = UNSTABLE_GENERATION;
+        long generation = UNSTABLE_GENERATION;
         long pointer = 12;
         int childPos = 0;
-        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, STABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.childAt( cursor, childPos, STABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertTrue( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldReadPointerGenFromLogicalPosZeroSlotB() throws Exception
+    public void shouldReadPointerGenerationFromLogicalPosZeroSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long generation = HIGH_GENERATION;
         long oldPointer = 13;
         long pointer = 12;
         int childPos = 0;
         node.setChildAt( cursor, oldPointer, childPos, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertFalse( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldReadPointerGenFromLogicalPosSlotB() throws Exception
+    public void shouldReadPointerGenerationFromLogicalPosSlotB() throws Exception
     {
         // GIVEN
-        long gen = HIGH_GENERATION;
+        long generation = HIGH_GENERATION;
         long oldPointer = 12;
         long pointer = 123;
         int childPos = 2;
         node.setChildAt( cursor, oldPointer, childPos, STABLE_GENERATION, UNSTABLE_GENERATION );
-        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, gen );
+        node.setChildAt( cursor, pointer, childPos, UNSTABLE_GENERATION, generation );
 
         // WHEN
-        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, gen );
-        long readGen = node.pointerGen( cursor, readResult );
+        long readResult = node.childAt( cursor, childPos, UNSTABLE_GENERATION, generation );
+        long readGeneration = node.pointerGeneration( cursor, readResult );
 
         // THEN
         assertEquals( pointer, pointer( readResult ) );
-        assertEquals( gen, readGen );
+        assertEquals( generation, readGeneration );
         assertFalse( resultIsFromSlotA( readResult ) );
     }
 
     @Test
-    public void shouldThrowIfReadingPointerGenOnWriteResult() throws Exception
+    public void shouldThrowIfReadingPointerGenerationOnWriteResult() throws Exception
     {
         // GIVEN
-        long writeResult = GenSafePointerPair.write( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
+        long writeResult = GenerationSafePointerPair.write( cursor, 123, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         try
         {
             // WHEN
-            node.pointerGen( cursor, writeResult );
+            node.pointerGeneration( cursor, writeResult );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )
@@ -653,7 +653,7 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldThrowIfReadingPointerGenOnZeroReadResultHeader() throws Exception
+    public void shouldThrowIfReadingPointerGenerationOnZeroReadResultHeader() throws Exception
     {
         // GIVEN
         long pointer = 123;
@@ -661,7 +661,7 @@ public class TreeNodeTest
         try
         {
             // WHEN
-            node.pointerGen( cursor, pointer );
+            node.pointerGeneration( cursor, pointer );
             fail( "Should have failed" );
         }
         catch ( IllegalArgumentException e )
@@ -671,7 +671,7 @@ public class TreeNodeTest
     }
 
     @Test
-    public void shouldUseLogicalGenPosWhenReadingChild() throws Exception
+    public void shouldUseLogicalGenerationPosWhenReadingChild() throws Exception
     {
         // GIVEN
         long child = 101;
@@ -682,7 +682,7 @@ public class TreeNodeTest
         long result = node.childAt( cursor, pos, STABLE_GENERATION, UNSTABLE_GENERATION );
 
         // THEN
-        assertTrue( GenSafePointerPair.isLogicalPos( result ) );
+        assertTrue( GenerationSafePointerPair.isLogicalPos( result ) );
     }
 
     private static long remove( long[] from, int length, int position )
@@ -716,23 +716,23 @@ public class TreeNodeTest
         return false;
     }
 
-    private long childAt( PageCursor cursor, int pos, long stableGen, long unstableGen )
+    private long childAt( PageCursor cursor, int pos, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.childAt( cursor, pos, stableGen, unstableGen ) );
+        return pointer( node.childAt( cursor, pos, stableGeneration, unstableGeneration ) );
     }
 
-    private long rightSibling( PageCursor cursor, long stableGen, long unstableGen )
+    private long rightSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.rightSibling( cursor, stableGen, unstableGen ) );
+        return pointer( node.rightSibling( cursor, stableGeneration, unstableGeneration ) );
     }
 
-    private long leftSibling( PageCursor cursor, long stableGen, long unstableGen )
+    private long leftSibling( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.leftSibling( cursor, stableGen, unstableGen ) );
+        return pointer( node.leftSibling( cursor, stableGeneration, unstableGeneration ) );
     }
 
-    private long heir( PageCursor cursor, long stableGen, long unstableGen )
+    private long heir( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
-        return pointer( node.heir( cursor, stableGen, unstableGen ) );
+        return pointer( node.heir( cursor, stableGeneration, unstableGeneration ) );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
@@ -93,7 +93,7 @@ public class TreeStateTest
     public void shouldNotWriteInvalidStableGeneration() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
+        long generation = GenerationSafePointer.MAX_GENERATION + 1;
 
         // WHEN
         try
@@ -112,7 +112,7 @@ public class TreeStateTest
     public void shouldNotWriteInvalidUnstableGeneration() throws Exception
     {
         // GIVEN
-        long generation = GenSafePointer.MAX_GENERATION + 1;
+        long generation = GenerationSafePointer.MAX_GENERATION + 1;
 
         // WHEN
         try
@@ -141,7 +141,7 @@ public class TreeStateTest
                 origin.stableGeneration(),
                 origin.unstableGeneration(),
                 origin.rootId(),
-                origin.rootGen(),
+                origin.rootGeneration(),
                 origin.lastId(),
                 origin.freeListWritePageId(),
                 origin.freeListReadPageId(),


### PR DESCRIPTION
- Use 'generation' consistently instead of 'gen'
- Use 'successor' instead of 'heir' to describe new version of GBPTree node