### PR TITLE
Overwriting property with same value no longer generates write command

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1034,7 +1034,12 @@ public class StateHandlingStatementOperations implements
         Property existingProperty = existingPropertyValue == null ?
                 Property.noGraphProperty( property.propertyKeyId() ) :
                 Property.property( property.propertyKeyId(), existingPropertyValue );
-        state.txState().graphDoReplaceProperty( existingProperty, property );
+
+        if ( !property.equals( existingProperty ) )
+        {
+            state.txState().graphDoReplaceProperty( existingProperty, property );
+        }
+
         return existingProperty;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -964,10 +964,12 @@ public class StateHandlingStatementOperations implements
             NodeItem node = cursor.get();
             Property existingProperty = readProperty( property.propertyKeyId(), node, EntityType.NODE );
 
+            // TODO Explicitly auto-index properties, even if setting the same value as the existing one.
+            // This because there are established ways of rebuilding auto-indexes which involves this function.
+            autoIndexProperty( nodeId, property, ops, existingProperty, autoIndexing.nodes() );
+
             if ( !property.equals( existingProperty ) )
             {
-                autoIndexProperty( nodeId, property, ops, existingProperty, autoIndexing.nodes() );
-
                 state.txState().nodeDoReplaceProperty( node.id(), existingProperty, property );
 
                 DefinedProperty before = definedPropertyOrNull( existingProperty );
@@ -1013,9 +1015,12 @@ public class StateHandlingStatementOperations implements
             RelationshipItem relationship = cursor.get();
             Property existingProperty = readProperty( property.propertyKeyId(), relationship, EntityType.RELATIONSHIP );
 
+            // TODO Explicitly auto-index properties, even if setting the same value as the existing one.
+            // This because there are established ways of rebuilding auto-indexes which involves this function.
+            autoIndexProperty( relationshipId, property, ops, existingProperty, autoIndexing.relationships() );
+
             if ( !property.equals( existingProperty ) )
             {
-                autoIndexProperty( relationshipId, property, ops, existingProperty, autoIndexing.relationships() );
                 state.txState().relationshipDoReplaceProperty( relationship.id(), existingProperty, property );
             }
             return existingProperty;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
@@ -126,17 +126,23 @@ class ExpectedTransactionData
     void assignedProperty( Node node, String key, Object value, Object valueBeforeTx )
     {
         valueBeforeTx = removeProperty( expectedRemovedNodeProperties, node, key, valueBeforeTx );
-        Map<String,PropertyEntryImpl<Node>> map = expectedAssignedNodeProperties.get( node );
-        PropertyEntryImpl<Node> prev = map.get( key );
-        map.put( key, property( node, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
+        if ( !value.equals( valueBeforeTx ) )
+        {
+            Map<String,PropertyEntryImpl<Node>> map = expectedAssignedNodeProperties.get( node );
+            PropertyEntryImpl<Node> prev = map.get( key );
+            map.put( key, property( node, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
+        }
     }
 
     void assignedProperty( Relationship rel, String key, Object value, Object valueBeforeTx )
     {
         valueBeforeTx = removeProperty( expectedRemovedRelationshipProperties, rel, key, valueBeforeTx );
-        Map<String,PropertyEntryImpl<Relationship>> map = expectedAssignedRelationshipProperties.get( rel );
-        PropertyEntryImpl<Relationship> prev = map.get( key );
-        map.put( key, property( rel, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
+        if ( !value.equals( valueBeforeTx ) )
+        {
+            Map<String,PropertyEntryImpl<Relationship>> map = expectedAssignedRelationshipProperties.get( rel );
+            PropertyEntryImpl<Relationship> prev = map.get( key );
+            map.put( key, property( rel, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
+        }
     }
 
     void assignedLabel( Node node, Label label )


### PR DESCRIPTION
It seems obvious, but setting a node/relationship property to the same value
as it already is doesn't require any change to that node/relationship.
Even so this was the case previously. A command would be generated, property
record would be updates on apply, indexing changes would be applied...
all for nothing.