### PR TITLE
Revert exposing Token creation permission

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/ProcedureCallMode.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/ProcedureCallMode.scala
@@ -27,7 +27,6 @@ object ProcedureCallMode {
   def fromAccessMode(mode: ProcedureAccessMode): ProcedureCallMode = mode match {
     case ProcedureReadOnlyAccess(overrides) => LazyReadOnlyCallMode(overrides)
     case ProcedureReadWriteAccess(overrides) => EagerReadWriteCallMode(overrides)
-    case ProcedureTokenWriteAccess(overrides) => TokenWriteCallMode(overrides)
     case ProcedureSchemaWriteAccess(overrides) => SchemaWriteCallMode(overrides)
     case ProcedureDbmsAccess(overrides) => DbmsCallMode(overrides)
   }
@@ -53,19 +52,6 @@ case class EagerReadWriteCallMode(allowed: Array[String]) extends ProcedureCallM
   override def callProcedure(ctx: QueryContext, name: QualifiedName, args: Seq[Any]): Iterator[Array[AnyRef]] = {
     val builder = ArrayBuffer.newBuilder[Array[AnyRef]]
     val iterator = ctx.callReadWriteProcedure(name, args, allowed)
-    while (iterator.hasNext) {
-      builder += iterator.next()
-    }
-    builder.result().iterator
-  }
-}
-
-case class TokenWriteCallMode(allowed: Array[String]) extends ProcedureCallMode {
-  override val queryType: InternalQueryType = SCHEMA_WRITE
-
-  override def callProcedure(ctx: QueryContext, name: QualifiedName, args: Seq[Any]): Iterator[Array[AnyRef]] = {
-    val builder = ArrayBuffer.newBuilder[Array[AnyRef]]
-    val iterator = ctx.callTokenWriteProcedure(name, args, allowed)
     while (iterator.hasNext) {
       builder += iterator.next()
     }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
@@ -187,9 +187,6 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   override def callReadWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
     singleDbHit(inner.callReadWriteProcedure(name, args, allowed))
 
-  override def callTokenWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
-    singleDbHit(inner.callTokenWriteProcedure(name, args, allowed))
-
   override def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
     singleDbHit(inner.callSchemaWriteProcedure(name, args, allowed))
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
@@ -71,6 +71,5 @@ sealed trait  ProcedureAccessMode
 
 case class ProcedureReadOnlyAccess(allowed: Array[String]) extends ProcedureAccessMode
 case class ProcedureReadWriteAccess(allowed: Array[String]) extends ProcedureAccessMode
-case class ProcedureTokenWriteAccess(allowed: Array[String]) extends ProcedureAccessMode
 case class ProcedureSchemaWriteAccess(allowed: Array[String]) extends ProcedureAccessMode
 case class ProcedureDbmsAccess(allowed: Array[String]) extends ProcedureAccessMode

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
@@ -159,8 +159,6 @@ trait QueryContext extends TokenContext {
 
   def callReadWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]]
 
-  def callTokenWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]]
-
   def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]]
 
   def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]]

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
@@ -125,8 +125,6 @@ trait QueryContextAdaptation {
 
   override def callReadWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): scala.Iterator[Array[AnyRef]] = ???
 
-  override def callTokenWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] = ???
-
   override def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] = ???
 
   override def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] = ???

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
@@ -135,9 +135,6 @@ class ExceptionTranslatingQueryContextFor3_1(val inner: QueryContext) extends Qu
   override def callReadWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] =
     translateIterator(inner.callReadWriteProcedure(name, args, allowed))
 
-  override def callTokenWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]):
-  Iterator[Array[AnyRef]] = translateIterator(inner.callTokenWriteProcedure(name, args, allowed))
-
   override def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] =
     translateIterator(inner.callSchemaWriteProcedure(name, args, allowed))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -166,7 +166,6 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapperv3_1, logger: I
     case Mode.READ => ProcedureReadOnlyAccess(allowed)
     case Mode.DEFAULT => ProcedureReadOnlyAccess(allowed)
     case Mode.WRITE => ProcedureReadWriteAccess(allowed)
-    case Mode.TOKEN => ProcedureTokenWriteAccess(allowed)
     case Mode.SCHEMA => ProcedureSchemaWriteAccess(allowed)
     case Mode.DBMS => ProcedureDbmsAccess(allowed)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -616,15 +616,6 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     callProcedure(name, args, call)
   }
 
-  override def callTokenWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
-    val call: KernelProcedureCall =
-      if (shouldElevate(allowed))
-        transactionalContext.statement.procedureCallOperations.procedureCallTokenOverride(_, _)
-      else
-        transactionalContext.statement.procedureCallOperations.procedureCallToken(_, _)
-    callProcedure(name, args, call)
-  }
-
   override def callSchemaWriteProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) = {
     val call: KernelProcedureCall =
       if (shouldElevate(allowed))

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
@@ -73,27 +73,6 @@ public interface ProcedureCallOperations
             throws ProcedureException;
 
     /**
-     * Invoke a read/write and token create procedure by name.
-     * @param name the name of the procedure.
-     * @param arguments the procedure arguments.
-     * @return an iterator containing the procedure results.
-     * @throws ProcedureException if there was an exception thrown during procedure execution.
-     */
-    RawIterator<Object[], ProcedureException> procedureCallToken(
-            QualifiedName name, Object[] arguments )
-            throws ProcedureException;
-    /**
-     * Invoke a read/write and token create procedure by name, and set the transaction's access mode to
-     * {@link AccessMode.Static#TOKEN_WRITE TOKEN_WRITE} for the duration of the procedure execution.
-     * @param name the name of the procedure.
-     * @param arguments the procedure arguments.
-     * @return an iterator containing the procedure results.
-     * @throws ProcedureException if there was an exception thrown during procedure execution.
-     */
-    RawIterator<Object[], ProcedureException> procedureCallTokenOverride( QualifiedName name, Object[] arguments )
-            throws ProcedureException;
-
-    /**
      * Invoke a schema write procedure by name.
      * @param name the name of the procedure.
      * @param arguments the procedure arguments.

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.builtinprocs;
 
-
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
@@ -28,7 +27,7 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import static org.neo4j.procedure.Mode.TOKEN;
+import static org.neo4j.procedure.Mode.WRITE;
 
 public class TokenProcedures
 {
@@ -36,7 +35,7 @@ public class TokenProcedures
     public KernelTransaction tx;
 
     @Description( "Create a label" )
-    @Procedure( name = "db.createLabel", mode = TOKEN )
+    @Procedure( name = "db.createLabel", mode = WRITE )
     public void createLabel( @Name( "newLabel" ) String newLabel )
             throws IllegalTokenNameException, TooManyLabelsException
     {
@@ -44,14 +43,14 @@ public class TokenProcedures
     }
 
     @Description( "Create a RelationshipType" )
-    @Procedure( name = "db.createRelationshipType", mode = TOKEN )
+    @Procedure( name = "db.createRelationshipType", mode = WRITE )
     public void createRelationshipType( @Name( "newRelationshipType" ) String newRelationshipType )
             throws IllegalTokenNameException    {
         tx.acquireStatement().tokenWriteOperations().relationshipTypeGetOrCreateForName( newRelationshipType );
     }
 
     @Description( "Create a Property" )
-    @Procedure( name = "db.createProperty", mode = TOKEN )
+    @Procedure( name = "db.createProperty", mode = WRITE )
     public void createProperty( @Name( "newProperty" ) String newProperty ) throws IllegalTokenNameException
     {
         tx.acquireStatement().tokenWriteOperations().propertyKeyGetOrCreateForName( newProperty );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1541,36 +1541,14 @@ public class OperationsFacade
             throw accessMode.onViolation( format( "Write operations are not allowed for %s.",
                     tx.securityContext().description() ) );
         }
-        return callProcedure( name, input, new RestrictedAccessMode( tx.securityContext().mode(), procedures.getWriteMode() ) );
+        return callProcedure( name, input, new RestrictedAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
     }
 
     @Override
     public RawIterator<Object[],ProcedureException> procedureCallWriteOverride( QualifiedName name, Object[] input )
             throws ProcedureException
     {
-        return callProcedure( name, input, new OverriddenAccessMode( tx.securityContext().mode(), procedures.getWriteMode() ) );
-    }
-
-    @Override
-    public RawIterator<Object[],ProcedureException> procedureCallToken( QualifiedName name, Object[] input )
-            throws ProcedureException
-    {
-        AccessMode accessMode = tx.securityContext().mode();
-        if ( !accessMode.allowsTokenCreates() )
-        {
-            throw accessMode.onViolation( format( "Token create operations are not allowed for %s.",
-                    tx.securityContext().description() ) );
-        }
-        return callProcedure( name, input,
-                new RestrictedAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
-    }
-
-    @Override
-    public RawIterator<Object[],ProcedureException> procedureCallTokenOverride( QualifiedName name, Object[] input )
-            throws ProcedureException
-    {
-        return callProcedure( name, input,
-                new OverriddenAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
+        return callProcedure( name, input, new OverriddenAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -272,7 +272,6 @@ public class CommunityEditionModule extends EditionModule
         }
         else
         {
-            procedures.writerCreateToken( true );
             platformModule.life.add( platformModule.dependencies.satisfyDependency( AuthManager.NO_AUTH ) );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.api.proc.Context;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.builtinprocs.SpecialBuiltInProcedures;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -53,7 +52,6 @@ public class Procedures extends LifecycleAdapter
     private final ThrowingConsumer<Procedures, ProcedureException> builtin;
     private final File pluginDir;
     private final Log log;
-    private AccessMode writeMode;
 
     public Procedures()
     {
@@ -218,26 +216,5 @@ public class Procedures extends LifecycleAdapter
 
         // And register built-in procedures
         builtin.accept( this );
-    }
-
-    private boolean changed = false;
-
-    public void writerCreateToken( boolean allow )
-    {
-        if ( !changed )
-        {
-            writeMode = allow ? AccessMode.Static.TOKEN_WRITE : AccessMode.Static.WRITE;
-            changed = true;
-        }
-    }
-
-    public AccessMode getWriteMode()
-    {
-        return writeMode;
-    }
-
-    public boolean isAllowWriteTokenCreate()
-    {
-        return writeMode.equals( AccessMode.Static.TOKEN_WRITE );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/procedure/Mode.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Mode.java
@@ -33,7 +33,5 @@ public enum Mode
     /** This procedure will perform system operations - i.e. not against the graph */
     DBMS,
     /** This procedure will only perform read operations against the graph */
-    DEFAULT,
-    /** This procedure may perform both read and write operations against the graph and create new tokens */
-    TOKEN
+    DEFAULT
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -53,7 +53,6 @@ public class CommunitySecurityModule extends SecurityModule
 
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
 
-        procedures.writerCreateToken( true );
         BasicAuthManager authManager =
                 new BasicAuthManager( userRepository, passwordPolicy, Clocks.systemClock(), initialUserRepository );
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -201,7 +201,7 @@ public class EnterpriseBuiltInDbmsProcedures
         Procedures procedures = graph.getDependencyResolver().resolveDependency( Procedures.class );
         return procedures.getAllProcedures().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
-                .map( sig -> new ProcedureResult( sig, procedures.isAllowWriteTokenCreate() ) );
+                .map( ProcedureResult::new );
     }
 
     @SuppressWarnings( "WeakerAccess" )
@@ -212,7 +212,7 @@ public class EnterpriseBuiltInDbmsProcedures
         public final String description;
         public final List<String> roles;
 
-        public ProcedureResult( ProcedureSignature signature, boolean publisherTokenCreate )
+        public ProcedureResult( ProcedureSignature signature )
         {
             this.name = signature.name().toString();
             this.signature = signature.toString();
@@ -229,11 +229,6 @@ public class EnterpriseBuiltInDbmsProcedures
                 roles.add( "reader" );
             case WRITE:
                 roles.add( "publisher" );
-            case TOKEN:
-                if ( publisherTokenCreate )
-                {
-                    roles.add( "publisher" );
-                }
             case SCHEMA:
                 roles.add( "architect" );
             default:

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -100,7 +100,6 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         }
         else
         {
-            procedures.writerCreateToken( false );
             platformModule.life.add( platformModule.dependencies.satisfyDependency( EnterpriseAuthManager.NO_AUTH ) );
         }
     }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -91,9 +91,6 @@ public class EnterpriseSecurityModule extends SecurityModule
             );
         life.add( securityLog );
 
-        boolean allowTokenCreate = config.get( SecuritySettings.allow_publisher_create_token );
-        PredefinedRolesBuilder.setAllowPublisherTokenCreate( allowTokenCreate );
-        procedures.writerCreateToken( allowTokenCreate );
         EnterpriseAuthAndUserManager authManager = newAuthManager( config, logProvider, securityLog, fileSystem, jobScheduler );
         life.add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
@@ -59,6 +59,7 @@ public class PredefinedRolesBuilder implements RolesBuilder
 
         SimpleRole publisher = new SimpleRole( PUBLISHER );
         publisher.add( WRITE );
+        publisher.add( TOKEN );
         roles.put( PUBLISHER, publisher );
 
         SimpleRole reader = new SimpleRole( READER );
@@ -66,28 +67,6 @@ public class PredefinedRolesBuilder implements RolesBuilder
         roles.put( READER, reader );
 
         return roles;
-    }
-
-    static void setAllowPublisherTokenCreate( boolean allowTokenCreate )
-    {
-
-        SimpleRole publisher = innerRoles.get( PUBLISHER );
-        if ( publisher == null )
-        {
-            return;
-        }
-        if ( allowTokenCreate )
-        {
-            publisher.add( TOKEN );
-        }
-        else
-        {
-            Set<Permission> permissions = publisher.getPermissions();
-            if ( permissions != null )
-            {
-                permissions.remove( TOKEN );
-            }
-        }
     }
 
     public static final RolePermissionResolver rolePermissionResolver = new RolePermissionResolver()

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -325,8 +325,4 @@ public class SecuritySettings
                   "system account." )
     public static final Setting<Boolean> ldap_authorization_connection_pooling =
             setting( "unsupported.dbms.security.ldap.authorization.connection_pooling", BOOLEAN, "true" );
-
-    @Description( "Set to true if users with role `publisher` are allowed to create new tokens." )
-    public static final Setting<Boolean> allow_publisher_create_token =
-            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "true" );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -328,5 +328,5 @@ public class SecuritySettings
 
     @Description( "Set to true if users with role `publisher` are allowed to create new tokens." )
     public static final Setting<Boolean> allow_publisher_create_token =
-            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "false" );
+            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "true" );
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -315,45 +315,6 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         read.closeAndAssertSuccess();
     }
 
-    //---------- Create Tokens query -------
-
-    @Test
-    public void shouldCreateLabel()
-    {
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createLabel('MySpecialLabel')" );
-        assertSuccess( writeSubject, "MATCH (n:MySpecialLabel) RETURN count(n) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
-    }
-
-    @Test
-    public void shouldCreateRelationshipType()
-    {
-        assertEmpty( schemaSubject, "CREATE (a:Node {id:0}) CREATE ( b:Node {id:1} )" );
-        assertFail( writeSubject,
-                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)",
-                TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
-        assertSuccess( writeSubject, "MATCH (n)-[c:MySpecialRelationship]-(m) RETURN count(c) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject,
-                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)" );
-    }
-
-    @Test
-    public void shouldCreateProperty()
-    {
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createProperty('MySpecialProperty')" );
-        assertSuccess( writeSubject, "MATCH (n) WHERE n.MySpecialProperty IS NULL RETURN count(n) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'" );
-    }
-
     //---------- terminate query -----------
 
     /*

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -34,19 +34,9 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldNotAllowPublisherCreateNewTokens() throws Throwable
+    public void shouldAllowPublisherCreateNewTokens() throws Throwable
     {
         configuredSetup( defaultConfiguration() );
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
-    public void shouldAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "true" ) );
         assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
         assertEmpty( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
                 "CREATE (a)-[:MySpecialRelationship]->(b)" );
@@ -54,21 +44,31 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldNotAllowPublisherCallCreateNewTokensProcedures() throws Throwable
+    public void shouldNotAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
     {
-        configuredSetup( defaultConfiguration() );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
+        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
+                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
     }
 
     @Test
-    public void shouldAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
+    public void shouldAllowPublisherCallCreateNewTokensProcedures() throws Throwable
     {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "true" ) );
+        configuredSetup( defaultConfiguration() );
         assertEmpty( writeSubject, "CALL db.createLabel('MySpecialLabel')" );
         assertEmpty( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
         assertEmpty( writeSubject, "CALL db.createProperty('MySpecialProperty')" );
+    }
+
+    @Test
+    public void shouldNotAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
+        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
     }
 
     @Test

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -34,44 +34,6 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldAllowPublisherCreateNewTokens() throws Throwable
-    {
-        configuredSetup( defaultConfiguration() );
-        assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
-        assertEmpty( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)" );
-        assertEmpty( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'" );
-    }
-
-    @Test
-    public void shouldNotAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
-    public void shouldAllowPublisherCallCreateNewTokensProcedures() throws Throwable
-    {
-        configuredSetup( defaultConfiguration() );
-        assertEmpty( writeSubject, "CALL db.createLabel('MySpecialLabel')" );
-        assertEmpty( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
-        assertEmpty( writeSubject, "CALL db.createProperty('MySpecialProperty')" );
-    }
-
-    @Test
-    public void shouldNotAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
     public void shouldAllowRoleCallCreateNewTokensProceduresWhenConfigured() throws Throwable
     {
         configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "role1" ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -252,34 +252,6 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
     }
 
     @Test
-    public void shouldShowAllowedRolesWhenListingProceduresPublisherCreateToken() throws Throwable
-    {
-        configuredSetup( stringMap(
-                SecuritySettings.procedure_roles.name(), "test.numNodes:counter,user",
-                SecuritySettings.default_allowed.name(), "default",
-                SecuritySettings.allow_publisher_create_token.name(), "true") );
-
-        Map<String,Set<String>> expected = genericMap(
-                "test.staticReadProcedure", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.staticWriteProcedure", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ),
-                "test.staticSchemaProcedure", newSet( "default", ARCHITECT, ADMIN ),
-                "test.annotatedProcedure", newSet( "annotated", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.numNodes", newSet( "counter", "user", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "db.labels", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "dbms.security.changePassword", newSet( ADMIN ),
-                "dbms.procedures", newSet( ADMIN ),
-                "dbms.listQueries", newSet( ADMIN ),
-                "dbms.security.createUser", newSet( ADMIN ),
-                "db.createLabel", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ));
-
-        String call = "CALL dbms.procedures";
-        assertListProceduresHasRoles( adminSubject, expected, call );
-        assertListProceduresHasRoles( schemaSubject, expected, call );
-        assertListProceduresHasRoles( writeSubject, expected, call );
-        assertListProceduresHasRoles( readSubject, expected, call );
-    }
-
-    @Test
     public void shouldShowAllowedRolesWhenListingFunctions() throws Throwable
     {
         configuredSetup( stringMap(

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -242,7 +242,7 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 "dbms.procedures", newSet( ADMIN ),
                 "dbms.listQueries", newSet( ADMIN ),
                 "dbms.security.createUser", newSet( ADMIN ),
-                "db.createLabel", newSet( "default", ARCHITECT, ADMIN ));
+                "db.createLabel", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ));
 
         String call = "CALL dbms.procedures";
         assertListProceduresHasRoles( adminSubject, expected, call );


### PR DESCRIPTION
Remove configuration for setting if Publisher has permission or not
Revert Publisher to have permission
Revert adding Procedure Mode.TOKEN, instead let Mode.WRITE have permission to create new tokens

changelog: Revert change in [#8621](https://github.com/neo4j/neo4j/pull/8621). `Publisher` will now be allowed to create new tokens.