### PR TITLE
Added new role `Editor`

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1541,14 +1541,14 @@ public class OperationsFacade
             throw accessMode.onViolation( format( "Write operations are not allowed for %s.",
                     tx.securityContext().description() ) );
         }
-        return callProcedure( name, input, new RestrictedAccessMode( tx.securityContext().mode(), procedures.getWriteMode() ) );
+        return callProcedure( name, input, new RestrictedAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
     }
 
     @Override
     public RawIterator<Object[],ProcedureException> procedureCallWriteOverride( QualifiedName name, Object[] input )
             throws ProcedureException
     {
-        return callProcedure( name, input, new OverriddenAccessMode( tx.securityContext().mode(), procedures.getWriteMode() ) );
+        return callProcedure( name, input, new OverriddenAccessMode( tx.securityContext().mode(), AccessMode.Static.TOKEN_WRITE ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -272,7 +272,6 @@ public class CommunityEditionModule extends EditionModule
         }
         else
         {
-            procedures.writerCreateToken( true );
             platformModule.life.add( platformModule.dependencies.satisfyDependency( AuthManager.NO_AUTH ) );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -53,7 +53,6 @@ public class Procedures extends LifecycleAdapter
     private final ThrowingConsumer<Procedures, ProcedureException> builtin;
     private final File pluginDir;
     private final Log log;
-    private AccessMode writeMode;
 
     public Procedures()
     {
@@ -218,26 +217,5 @@ public class Procedures extends LifecycleAdapter
 
         // And register built-in procedures
         builtin.accept( this );
-    }
-
-    private boolean changed = false;
-
-    public void writerCreateToken( boolean allow )
-    {
-        if ( !changed )
-        {
-            writeMode = allow ? AccessMode.Static.TOKEN_WRITE : AccessMode.Static.WRITE;
-            changed = true;
-        }
-    }
-
-    public AccessMode getWriteMode()
-    {
-        return writeMode;
-    }
-
-    public boolean isAllowWriteTokenCreate()
-    {
-        return writeMode.equals( AccessMode.Static.TOKEN_WRITE );
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -53,7 +53,6 @@ public class CommunitySecurityModule extends SecurityModule
 
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
 
-        procedures.writerCreateToken( true );
         BasicAuthManager authManager =
                 new BasicAuthManager( userRepository, passwordPolicy, Clocks.systemClock(), initialUserRepository );
 

--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/PredefinedRoles.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/PredefinedRoles.java
@@ -27,5 +27,6 @@ public class PredefinedRoles
     public static final String ADMIN = "admin";
     public static final String ARCHITECT = "architect";
     public static final String PUBLISHER = "publisher";
+    public static final String EDITOR = "editor";
     public static final String READER = "reader";
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -189,7 +189,7 @@ public class EnterpriseBuiltInDbmsProcedures
             this.name = signature.name().toString();
             this.signature = signature.toString();
             this.description = signature.description().orElse( "" );
-            roles = Stream.of( "admin", "reader", "publisher", "architect" ).collect( toList() );
+            roles = Stream.of( "admin", "reader", "editor", "publisher", "architect" ).collect( toList() );
             roles.addAll( Arrays.asList( signature.allowed() ) );
         }
     }
@@ -201,7 +201,7 @@ public class EnterpriseBuiltInDbmsProcedures
         Procedures procedures = graph.getDependencyResolver().resolveDependency( Procedures.class );
         return procedures.getAllProcedures().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
-                .map( sig -> new ProcedureResult( sig, procedures.isAllowWriteTokenCreate() ) );
+                .map( ProcedureResult::new );
     }
 
     @SuppressWarnings( "WeakerAccess" )
@@ -212,7 +212,7 @@ public class EnterpriseBuiltInDbmsProcedures
         public final String description;
         public final List<String> roles;
 
-        public ProcedureResult( ProcedureSignature signature, boolean publisherTokenCreate )
+        public ProcedureResult( ProcedureSignature signature )
         {
             this.name = signature.name().toString();
             this.signature = signature.toString();
@@ -228,12 +228,9 @@ public class EnterpriseBuiltInDbmsProcedures
             case READ:
                 roles.add( "reader" );
             case WRITE:
-                roles.add( "publisher" );
+                roles.add( "editor" );
             case TOKEN:
-                if ( publisherTokenCreate )
-                {
-                    roles.add( "publisher" );
-                }
+                roles.add( "publisher" );
             case SCHEMA:
                 roles.add( "architect" );
             default:

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -100,7 +100,6 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         }
         else
         {
-            procedures.writerCreateToken( false );
             platformModule.life.add( platformModule.dependencies.satisfyDependency( EnterpriseAuthManager.NO_AUTH ) );
         }
     }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -91,9 +91,6 @@ public class EnterpriseSecurityModule extends SecurityModule
             );
         life.add( securityLog );
 
-        boolean allowTokenCreate = config.get( SecuritySettings.allow_publisher_create_token );
-        PredefinedRolesBuilder.setAllowPublisherTokenCreate( allowTokenCreate );
-        procedures.writerCreateToken( allowTokenCreate );
         EnterpriseAuthAndUserManager authManager = newAuthManager( config, logProvider, securityLog, fileSystem, jobScheduler );
         life.add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PredefinedRolesBuilder.java
@@ -27,7 +27,6 @@ import org.apache.shiro.authz.permission.WildcardPermission;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.*;
@@ -37,7 +36,7 @@ public class PredefinedRolesBuilder implements RolesBuilder
     private static final WildcardPermission SCHEMA = new WildcardPermission( "schema:*" );
     private static final WildcardPermission FULL = new WildcardPermission( "*" );
     private static final WildcardPermission TOKEN = new WildcardPermission( "token:*" );
-    private static final WildcardPermission WRITE = new WildcardPermission( "data:*" );
+    private static final WildcardPermission READ_WRITE = new WildcardPermission( "data:*" );
     private static final WildcardPermission READ = new WildcardPermission( "data:read" );
 
     private static final Map<String,SimpleRole> innerRoles = staticBuildRoles();
@@ -53,41 +52,24 @@ public class PredefinedRolesBuilder implements RolesBuilder
 
         SimpleRole architect = new SimpleRole( ARCHITECT );
         architect.add( SCHEMA );
-        architect.add( WRITE );
+        architect.add( READ_WRITE );
         architect.add( TOKEN );
         roles.put( ARCHITECT, architect );
 
         SimpleRole publisher = new SimpleRole( PUBLISHER );
-        publisher.add( WRITE );
+        publisher.add( READ_WRITE );
+        publisher.add( TOKEN );
         roles.put( PUBLISHER, publisher );
+
+        SimpleRole editor = new SimpleRole( EDITOR );
+        editor.add( READ_WRITE );
+        roles.put( EDITOR, editor );
 
         SimpleRole reader = new SimpleRole( READER );
         reader.add( READ );
         roles.put( READER, reader );
 
         return roles;
-    }
-
-    static void setAllowPublisherTokenCreate( boolean allowTokenCreate )
-    {
-
-        SimpleRole publisher = innerRoles.get( PUBLISHER );
-        if ( publisher == null )
-        {
-            return;
-        }
-        if ( allowTokenCreate )
-        {
-            publisher.add( TOKEN );
-        }
-        else
-        {
-            Set<Permission> permissions = publisher.getPermissions();
-            if ( permissions != null )
-            {
-                permissions.remove( TOKEN );
-            }
-        }
     }
 
     public static final RolePermissionResolver rolePermissionResolver = new RolePermissionResolver()
@@ -116,5 +98,4 @@ public class PredefinedRolesBuilder implements RolesBuilder
     {
         return roles;
     }
-
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -325,8 +325,4 @@ public class SecuritySettings
                   "system account." )
     public static final Setting<Boolean> ldap_authorization_connection_pooling =
             setting( "unsupported.dbms.security.ldap.authorization.connection_pooling", BOOLEAN, "true" );
-
-    @Description( "Set to true if users with role `publisher` are allowed to create new tokens." )
-    public static final Setting<Boolean> allow_publisher_create_token =
-            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "true" );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -328,5 +328,5 @@ public class SecuritySettings
 
     @Description( "Set to true if users with role `publisher` are allowed to create new tokens." )
     public static final Setting<Boolean> allow_publisher_create_token =
-            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "false" );
+            setting( "dbms.security.allow_publisher_create_token", BOOLEAN, "true" );
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresInteractionTestBase.java
@@ -45,6 +45,7 @@ import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRol
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.READER;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.EDITOR;
 
 public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInteractionTestBase<S>
 {
@@ -683,6 +684,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
                 "readSubject", listOf( READER ),
                 "schemaSubject", listOf( ARCHITECT ),
                 "writeSubject", listOf( READER, PUBLISHER ),
+                "editorSubject", listOf( EDITOR ),
                 "pwdSubject", listOf( ),
                 "noneSubject", listOf( ),
                 "neo4j", listOf( ADMIN )
@@ -699,6 +701,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
                 "adminSubject", listOf(),
                 "readSubject", listOf(),
                 "schemaSubject", listOf(),
+                "editorSubject", listOf(),
                 "writeSubject", listOf( IS_SUSPENDED ),
                 "pwdSubject", listOf( PWD_CHANGE, IS_SUSPENDED ),
                 "noneSubject", listOf(),
@@ -752,7 +755,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
                 ADMIN, listOf( "adminSubject", "neo4j" ),
                 READER, listOf( "readSubject" ),
                 ARCHITECT, listOf( "schemaSubject" ),
-                PUBLISHER, listOf( "writeSubject" ),
+                PUBLISHER, listOf( "writeSubject" ), EDITOR, listOf( "editorSubject" ),
                 "empty", listOf()
         );
         assertSuccess( adminSubject, "CALL dbms.security.listRoles()",
@@ -947,9 +950,21 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
     {
         testSuccessfulRead( readSubject, 3 );
         testFailWrite( readSubject );
+        testFailTokenWrite( readSubject );
         testFailSchema( readSubject );
         testFailCreateUser( readSubject, PERMISSION_DENIED );
         assertEmpty( readSubject, "CALL dbms.security.changePassword( '321' )" );
+    }
+
+    @Test
+    public void shouldSetCorrectEditorPermissions() throws Exception
+    {
+        testSuccessfulRead( editorSubject, 3 );
+        testSuccessfulWrite( editorSubject );
+        testFailTokenWrite( editorSubject );
+        testFailSchema( editorSubject );
+        testFailCreateUser( editorSubject, PERMISSION_DENIED );
+        assertEmpty( editorSubject, "CALL dbms.security.changePassword( '321' )" );
     }
 
     @Test
@@ -957,6 +972,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
     {
         testSuccessfulRead( writeSubject, 3 );
         testSuccessfulWrite( writeSubject );
+        testSuccessfulTokenWrite( writeSubject );
         testFailSchema( writeSubject );
         testFailCreateUser( writeSubject, PERMISSION_DENIED );
         assertEmpty( writeSubject, "CALL dbms.security.changePassword( '321' )" );
@@ -967,6 +983,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
     {
         testSuccessfulRead( schemaSubject, 3 );
         testSuccessfulWrite( schemaSubject );
+        testSuccessfulTokenWrite( schemaSubject );
         testSuccessfulSchema( schemaSubject );
         testFailCreateUser( schemaSubject, PERMISSION_DENIED );
         assertEmpty( schemaSubject, "CALL dbms.security.changePassword( '321' )" );
@@ -977,6 +994,7 @@ public abstract class AuthProceduresInteractionTestBase<S> extends ProcedureInte
     {
         testSuccessfulRead( adminSubject, 3 );
         testSuccessfulWrite( adminSubject );
+        testSuccessfulTokenWrite( adminSubject );
         testSuccessfulSchema( adminSubject );
         assertEmpty( adminSubject, "CALL dbms.security.createUser('Olivia', 'bar', true)" );
         assertEmpty( adminSubject, "CALL dbms.security.changePassword( '321' )" );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -315,45 +315,6 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         read.closeAndAssertSuccess();
     }
 
-    //---------- Create Tokens query -------
-
-    @Test
-    public void shouldCreateLabel()
-    {
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createLabel('MySpecialLabel')" );
-        assertSuccess( writeSubject, "MATCH (n:MySpecialLabel) RETURN count(n) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
-    }
-
-    @Test
-    public void shouldCreateRelationshipType()
-    {
-        assertEmpty( schemaSubject, "CREATE (a:Node {id:0}) CREATE ( b:Node {id:1} )" );
-        assertFail( writeSubject,
-                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)",
-                TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
-        assertSuccess( writeSubject, "MATCH (n)-[c:MySpecialRelationship]-(m) RETURN count(c) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject,
-                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)" );
-    }
-
-    @Test
-    public void shouldCreateProperty()
-    {
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertEmpty( schemaSubject, "CALL db.createProperty('MySpecialProperty')" );
-        assertSuccess( writeSubject, "MATCH (n) WHERE n.MySpecialProperty IS NULL RETURN count(n) AS count",
-                r -> r.next().get( "count" ).equals( 0 ) );
-        assertEmpty( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'" );
-    }
-
     //---------- terminate query -----------
 
     /*

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -315,6 +315,46 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         read.closeAndAssertSuccess();
     }
 
+    //---------- Create Tokens query -------
+
+    @Test
+    public void shouldCreateLabel()
+    {
+        assertFail( editorSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( editorSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertEmpty( writeSubject, "CALL db.createLabel('MySpecialLabel')" );
+        assertSuccess( writeSubject, "MATCH (n:MySpecialLabel) RETURN count(n) AS count",
+                r -> r.next().get( "count" ).equals( 0 ) );
+        assertEmpty( editorSubject, "CREATE (:MySpecialLabel)" );
+    }
+
+    @Test
+    public void shouldCreateRelationshipType()
+    {
+        assertEmpty( writeSubject, "CREATE (a:Node {id:0}) CREATE ( b:Node {id:1} )" );
+        assertFail( editorSubject,
+                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)",
+                TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( editorSubject, "CALL db.createRelationshipType('MySpecialRelationship')",
+                TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertEmpty( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
+        assertSuccess( editorSubject, "MATCH (n)-[c:MySpecialRelationship]-(m) RETURN count(c) AS count",
+                r -> r.next().get( "count" ).equals( 0 ) );
+        assertEmpty( editorSubject,
+                "MATCH (a:Node), (b:Node) WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:MySpecialRelationship]->(b)" );
+    }
+
+    @Test
+    public void shouldCreateProperty()
+    {
+        assertFail( editorSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( editorSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertEmpty( writeSubject, "CALL db.createProperty('MySpecialProperty')" );
+        assertSuccess( editorSubject, "MATCH (n) WHERE n.MySpecialProperty IS NULL RETURN count(n) AS count",
+                r -> r.next().get( "count" ).equals( 0 ) );
+        assertEmpty( editorSubject, "CREATE (a) SET a.MySpecialProperty = 'a'" );
+    }
+
     //---------- terminate query -----------
 
     /*

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -34,19 +34,9 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldNotAllowPublisherCreateNewTokens() throws Throwable
+    public void shouldAllowPublisherCreateNewTokens() throws Throwable
     {
         configuredSetup( defaultConfiguration() );
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
-    public void shouldAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "true" ) );
         assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
         assertEmpty( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
                 "CREATE (a)-[:MySpecialRelationship]->(b)" );
@@ -54,21 +44,31 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldNotAllowPublisherCallCreateNewTokensProcedures() throws Throwable
+    public void shouldNotAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
     {
-        configuredSetup( defaultConfiguration() );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
+        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
+                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
     }
 
     @Test
-    public void shouldAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
+    public void shouldAllowPublisherCallCreateNewTokensProcedures() throws Throwable
     {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "true" ) );
+        configuredSetup( defaultConfiguration() );
         assertEmpty( writeSubject, "CALL db.createLabel('MySpecialLabel')" );
         assertEmpty( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
         assertEmpty( writeSubject, "CALL db.createProperty('MySpecialProperty')" );
+    }
+
+    @Test
+    public void shouldNotAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
+    {
+        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
+        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
+        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
     }
 
     @Test

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -34,44 +34,6 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
     }
 
     @Test
-    public void shouldAllowPublisherCreateNewTokens() throws Throwable
-    {
-        configuredSetup( defaultConfiguration() );
-        assertEmpty( writeSubject, "CREATE (:MySpecialLabel)" );
-        assertEmpty( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)" );
-        assertEmpty( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'" );
-    }
-
-    @Test
-    public void shouldNotAllowPublisherCreateNewTokensWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
-        assertFail( writeSubject, "CREATE (:MySpecialLabel)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "MATCH (a:Node), (b:Node) WHERE a.number = 0 AND b.number = 1 " +
-                "CREATE (a)-[:MySpecialRelationship]->(b)", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CREATE (a) SET a.MySpecialProperty = 'a'", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
-    public void shouldAllowPublisherCallCreateNewTokensProcedures() throws Throwable
-    {
-        configuredSetup( defaultConfiguration() );
-        assertEmpty( writeSubject, "CALL db.createLabel('MySpecialLabel')" );
-        assertEmpty( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')" );
-        assertEmpty( writeSubject, "CALL db.createProperty('MySpecialProperty')" );
-    }
-
-    @Test
-    public void shouldNotAllowPublisherCallCreateNewTokensProceduresWhenConfigured() throws Throwable
-    {
-        configuredSetup( stringMap( SecuritySettings.allow_publisher_create_token.name(), "false" ) );
-        assertFail( writeSubject, "CALL db.createLabel('MySpecialLabel')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createRelationshipType('MySpecialRelationship')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-        assertFail( writeSubject, "CALL db.createProperty('MySpecialProperty')", TOKEN_CREATE_OPS_NOT_ALLOWED );
-    }
-
-    @Test
     public void shouldAllowRoleCallCreateNewTokensProceduresWhenConfigured() throws Throwable
     {
         configuredSetup( stringMap( SecuritySettings.default_allowed.name(), "role1" ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -47,6 +47,7 @@ import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ADMIN;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.EDITOR;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.READER;
 
@@ -232,40 +233,12 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 SecuritySettings.default_allowed.name(), "default" ) );
 
         Map<String,Set<String>> expected = genericMap(
-                "test.staticReadProcedure", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.staticWriteProcedure", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ),
+                "test.staticReadProcedure", newSet( "default", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
+                "test.staticWriteProcedure", newSet( "default", EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
                 "test.staticSchemaProcedure", newSet( "default", ARCHITECT, ADMIN ),
-                "test.annotatedProcedure", newSet( "annotated", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.numNodes", newSet( "counter", "user", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "db.labels", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "dbms.security.changePassword", newSet( ADMIN ),
-                "dbms.procedures", newSet( ADMIN ),
-                "dbms.listQueries", newSet( ADMIN ),
-                "dbms.security.createUser", newSet( ADMIN ),
-                "db.createLabel", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ));
-
-        String call = "CALL dbms.procedures";
-        assertListProceduresHasRoles( adminSubject, expected, call );
-        assertListProceduresHasRoles( schemaSubject, expected, call );
-        assertListProceduresHasRoles( writeSubject, expected, call );
-        assertListProceduresHasRoles( readSubject, expected, call );
-    }
-
-    @Test
-    public void shouldShowAllowedRolesWhenListingProceduresPublisherCreateToken() throws Throwable
-    {
-        configuredSetup( stringMap(
-                SecuritySettings.procedure_roles.name(), "test.numNodes:counter,user",
-                SecuritySettings.default_allowed.name(), "default",
-                SecuritySettings.allow_publisher_create_token.name(), "true") );
-
-        Map<String,Set<String>> expected = genericMap(
-                "test.staticReadProcedure", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.staticWriteProcedure", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ),
-                "test.staticSchemaProcedure", newSet( "default", ARCHITECT, ADMIN ),
-                "test.annotatedProcedure", newSet( "annotated", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.numNodes", newSet( "counter", "user", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "db.labels", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ),
+                "test.annotatedProcedure", newSet( "annotated", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
+                "test.numNodes", newSet( "counter", "user", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
+                "db.labels", newSet( "default", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
                 "dbms.security.changePassword", newSet( ADMIN ),
                 "dbms.procedures", newSet( ADMIN ),
                 "dbms.listQueries", newSet( ADMIN ),
@@ -287,9 +260,9 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 SecuritySettings.default_allowed.name(), "default" ) );
 
         Map<String,Set<String>> expected = genericMap(
-                "test.annotatedFunction", newSet( "annotated", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.allowedFunc", newSet( "counter", "user", READER, PUBLISHER, ARCHITECT, ADMIN ),
-                "test.nonAllowedFunc", newSet( "default", READER, PUBLISHER, ARCHITECT, ADMIN ) );
+                "test.annotatedFunction", newSet( "annotated", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
+                "test.allowedFunc", newSet( "counter", "user", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ),
+                "test.nonAllowedFunc", newSet( "default", READER, EDITOR, PUBLISHER, ARCHITECT, ADMIN ) );
 
         String call = "CALL dbms.functions";
         assertListProceduresHasRoles( adminSubject, expected, call );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredProceduresTestBase.java
@@ -242,7 +242,7 @@ public abstract class ConfiguredProceduresTestBase<S> extends ProcedureInteracti
                 "dbms.procedures", newSet( ADMIN ),
                 "dbms.listQueries", newSet( ADMIN ),
                 "dbms.security.createUser", newSet( ADMIN ),
-                "db.createLabel", newSet( "default", ARCHITECT, ADMIN ));
+                "db.createLabel", newSet( "default", PUBLISHER, ARCHITECT, ADMIN ));
 
         String call = "CALL dbms.procedures";
         assertListProceduresHasRoles( adminSubject, expected, call );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ProcedureInteractionTestBase.java
@@ -84,6 +84,7 @@ import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRol
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.ARCHITECT;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.READER;
+import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.EDITOR;
 
 public abstract class ProcedureInteractionTestBase<S>
 {
@@ -109,13 +110,14 @@ public abstract class ProcedureInteractionTestBase<S>
     S adminSubject;
     S schemaSubject;
     S writeSubject;
+    S editorSubject;
     S readSubject;
     S pwdSubject;
     S noneSubject;
 
     String[] initialUsers = { "adminSubject", "readSubject", "schemaSubject",
-        "writeSubject", "pwdSubject", "noneSubject", "neo4j" };
-    String[] initialRoles = { ADMIN, ARCHITECT, PUBLISHER, READER, EMPTY_ROLE };
+        "writeSubject", "editorSubject", "pwdSubject", "noneSubject", "neo4j" };
+    String[] initialRoles = { ADMIN, ARCHITECT, PUBLISHER, EDITOR, READER, EMPTY_ROLE };
 
     @Rule
     public final ThreadingRule threading = new ThreadingRule();
@@ -156,16 +158,19 @@ public abstract class ProcedureInteractionTestBase<S>
         userManager.newUser( "adminSubject", "abc", false );
         userManager.newUser( "schemaSubject", "abc", false );
         userManager.newUser( "writeSubject", "abc", false );
+        userManager.newUser( "editorSubject", "abc", false );
         userManager.newUser( "readSubject", "123", false );
         // Currently admin role is created by default
         userManager.addRoleToUser( ADMIN, "adminSubject" );
         userManager.addRoleToUser( ARCHITECT, "schemaSubject" );
         userManager.addRoleToUser( PUBLISHER, "writeSubject" );
+        userManager.addRoleToUser( EDITOR, "editorSubject" );
         userManager.addRoleToUser( READER, "readSubject" );
         userManager.newRole( EMPTY_ROLE );
         noneSubject = neo.login( "noneSubject", "abc" );
         pwdSubject = neo.login( "pwdSubject", "abc" );
         readSubject = neo.login( "readSubject", "123" );
+        editorSubject = neo.login( "editorSubject", "abc" );
         writeSubject = neo.login( "writeSubject", "abc" );
         schemaSubject = neo.login( "schemaSubject", "abc" );
         adminSubject = neo.login( "adminSubject", "abc" );
@@ -221,6 +226,17 @@ public abstract class ProcedureInteractionTestBase<S>
     void testFailWrite( S subject, String errMsg )
     {
         assertFail( subject, "CREATE (:Node)", errMsg );
+    }
+
+    void testSuccessfulTokenWrite( S subject )
+    {
+        assertEmpty( subject, "CALL db.createLabel('NewNodeName')" );
+    }
+
+    void testFailTokenWrite( S subject ) { testFailTokenWrite( subject, TOKEN_CREATE_OPS_NOT_ALLOWED ); }
+    void testFailTokenWrite( S subject, String errMsg )
+    {
+        assertFail( subject, "CALL db.createLabel('NewNodeName')", errMsg );
     }
 
     void testSuccessfulSchema( S subject )

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseAuthenticationIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseAuthenticationIT.java
@@ -66,10 +66,10 @@ public class EnterpriseAuthenticationIT extends AuthenticationIT
         assertThat( "Should have no errors", errors.size(), equalTo( 0 ) );
         ArrayNode results = (ArrayNode) response.get("results");
         ArrayNode data = (ArrayNode) results.get(0).get("data");
-        assertThat( "Should have 4 predefined roles", data.size(), equalTo( 4 ) );
+        assertThat( "Should have 5 predefined roles", data.size(), equalTo( 5 ) );
         Stream<String> values = data.findValues( "row" ).stream().map( row -> row.get(0).asText() );
         assertThat( "Expected specific roles", values.collect( Collectors.toList()),
-                hasItems( "admin", "architect", "publisher", "reader") );
+                hasItems( "admin", "architect", "publisher", "editor", "reader") );
 
     }
 


### PR DESCRIPTION
Added new role `Editor`, reverted `Publisher` role.
Removed setting to control if `Publisher` is allowed to create new tokens or not, instead `Publisher` is always allowed to create new tokens.
Added new role `Editor` that is allowed to read and write data but not allowed to create new tokens.
Procedures flagged with `Mode=WRITE` are always allowed to create new tokens, given that the user executing them is allowed.

changelog: Added new role `Editor`

* Allowed to read and write data but not create new tokens

Changed  role `Publisher`

* Allowed to read and write data and create new tokens
