### PR TITLE
Full pruning var expand

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
@@ -388,8 +388,6 @@ case class FullPruningVarLengthExpandPipe(source: Pipe,
   }
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
-    state.decorator.registerParentPipe(this)
-
     new FullyPruningIterator(input, state)
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.pipes
+
+import org.neo4j.collection.primitive.{Primitive, PrimitiveLongObjectMap}
+import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
+import org.neo4j.cypher.internal.frontend.v3_2.{InternalException, SemanticDirection}
+import org.neo4j.graphdb.{Node, Relationship}
+
+case class FullPruningVarLengthExpandPipe(source: Pipe,
+                                          fromName: String,
+                                          toName: String,
+                                          types: LazyTypes,
+                                          dir: SemanticDirection,
+                                          min: Int,
+                                          max: Int,
+                                          filteringStep: VarLengthPredicate = VarLengthPredicate.NONE)
+                                         (val id: Id = new Id)
+                                         (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with Pipe {
+  self =>
+
+  assert(min <= max)
+
+  /*
+  This algorithm has been implemented using a state machine. This Cypher statement shows the static connections between the states.
+
+  create (ln:State  {name: "LoadNext", loads: "The start node of the expansion.", checksRelationshipUniqueness: false}),
+         (pre:State {name: "PrePruning", loads: "The relationship iterator of the nodes before min length has been reached.", checksRelationshipUniqueness: true}),
+         (pru:State {name: "Pruning", loads: "The relationship iterator of the nodes after min length has been reached.", checksRelationshipUniqueness: true}),
+         (nil:State {name: "Empty", signals: "End of the line. No more expansions to be done."}),
+         (ln)-[:GOES_TO {if: "Input iterator is not empty, load next input row and the start node from it"}]->(pre),
+         (ln)-[:GOES_TO {if: "Input iterator is not empty"}]->(nil),
+         (nil)-[:GOES_TO]->(nil),
+         (pre)-[:GOES_TO {if: "Next step is still less than min"}]->(pre),
+         (pre)-[:GOES_TO {if: "Next step is min or greater"}]->(pru),
+         (pru)-[:GOES_TO {if: "Next step is still less than max"}]->(pru)
+
+   Missing from this picture are the dynamic connections between the states - both `pre` and `pru` have a `whenEmptied`
+   field that is followed once the loaded iterator has been emptied.
+ */
+
+  object Constants {
+    val VERY_BIG_VALUE:Int = 1000001
+  }
+
+  /**
+    * Performs DFS traversal, but omits traversing relationships that have been completely traversed (to the
+    * remaining depth) before.
+    *
+    * Pruning and full expand depths
+    * The full expand depth is an integer that denotes how deep a relationship has previously been explored. For
+    * example, a full expand depth of 2 would mean that all nodes that can be reached by following this relationship
+    * and maximally one more permitted relationship have already been visited. A relationship is permitted if is
+    * conforms to the var-length predicates (which is controlled at expand time), and the relationship is not already
+    * part of the current path.
+    *
+    * Before emitting a node (after relationship traversals), the PruningDFS updates the full expand depth of the
+    * incoming relationship on the previous node in the path. The full expand depth is computed as
+    *
+    *   1                 if the max path length is reached
+    *   A_VERY_BIG_VALUE  if the node has no relationships except the incoming one
+    *   d+1               if at or above minLength, or if the node has been emitted
+    *                       d is the minimum outgoing full expand depth
+    *   0                 otherwise
+    *
+    * Full expand depth always increase, so if a newly computed full expand depth is smaller than the previous value,
+    * the new depth is ignored.
+    *
+    * @param state                    The state to return to when this node is done
+    * @param node                     The current node
+    * @param path                     The path so far. Only the first pathLength elements are valid.
+    * @param pathLength               Length of the path so far
+    * @param queryState               The QueryState
+    * @param row                      The current row we are adding reachable nodes to
+    * @param expandMap                maps NodeID -> NodeState
+    * @param prevLocalRelIndex        index of the incoming relationship in the NodeState
+    * @param prevNodeState            The NodeState of the previous node in the path
+    *
+    * For this algorithm the incoming relationship is the one traversed to reach this
+    * node, while outgoing relationships are all other relationships connected to this
+    * node.
+    **/
+  class PruningDFS(state: FullPruneState,
+                   node: Node,
+                   val path: Array[Long],
+                   val pathLength: Int,
+                   val queryState: QueryState,
+                   row: ExecutionContext,
+                   expandMap: PrimitiveLongObjectMap[NodeState],
+                   prevLocalRelIndex: Int,
+                   prevNodeState: NodeState
+  ) extends CheckPath {
+
+    import NodeState.UNINITIALIZED
+
+    var relationshipCursor = 0
+    var nodeState: NodeState = UNINITIALIZED
+
+    def nextEndNode(): Node = {
+
+      initiate()
+
+      if (pathLength < self.max) {
+
+        nodeState.ensureExpanded(queryState, row, node)
+
+        while (hasRelationship) {
+          val currentRelIdx = nextRelationship()
+          if (!haveFullyExploredTheRemainingStepsBefore(currentRelIdx)) {
+            val rel = nodeState.rels(currentRelIdx)
+            val relId = rel.getId
+            if (!seenRelationshipInPath(relId)) {
+              val nextNode = rel.getOtherNode(node)
+              path(pathLength) = relId
+              val endNode = state.push( new PruningDFS(
+                                      state = state,
+                                      node = nextNode,
+                                      path = path,
+                                      pathLength = pathLength + 1,
+                                      queryState = queryState,
+                                      row = row,
+                                      expandMap = expandMap,
+                                      prevLocalRelIndex = currentRelIdx,
+                                      prevNodeState = nodeState
+                ) )
+              if (endNode != null)
+                return endNode
+              else
+                state.pop()
+            }
+          }
+        }
+      }
+
+      updatePrevFullExpandDepth()
+
+      if (!nodeState.isEmitted && pathLength >= self.min) {
+        nodeState.isEmitted = true
+        expandMap.put(node.getId, nodeState)
+        node
+      } else {
+        expandMap.put(node.getId, nodeState)
+        null
+      }
+    }
+
+    private def hasRelationship = relationshipCursor < nodeState.rels.length
+
+    private def nextRelationship() = {
+      val next = relationshipCursor
+      relationshipCursor += 1
+      next
+    }
+
+    private def haveFullyExploredTheRemainingStepsBefore(i: Int) = {
+      val stepsLeft = self.max - pathLength
+      nodeState.depths(i) >= stepsLeft
+    }
+
+    def updatePrevFullExpandDepth() = {
+      if ( pathLength > 0 ) {
+        val requiredStepsFromPrev = math.max(0, self.min - pathLength + 1)
+        if (requiredStepsFromPrev <= 1 || nodeState.isEmitted) {
+          prevNodeState.updateFullExpandDepth(prevLocalRelIndex, currentOutgoingFullExpandDepth() + 1)
+        }
+      }
+    }
+
+    private def currentOutgoingFullExpandDepth(): Int = {
+      assert(pathLength > 0)
+      if (pathLength == self.max) 0
+      else {
+        // The maximum amount of steps that have been fully explored is the minimum full expand depth of the
+        // outgoing relationships. The incoming relationship is not included, as that is the relationship that will be
+        // updated.
+        val incomingRelationship = path(pathLength - 1)
+        nodeState.minOutgoingDepth(incomingRelationship)
+      }
+    }
+
+    private def initiate() = {
+      nodeState = expandMap.get(node.getId)
+      if (nodeState == UNINITIALIZED) {
+        nodeState = new NodeState()
+      }
+    }
+  }
+
+  trait CheckPath {
+    def pathLength: Int
+
+    val path: Array[Long]
+
+    def seenRelationshipInPath(r: Long): Boolean = {
+      if (pathLength == 0) return false
+      var idx = 0
+      while (idx < pathLength) {
+        if (path(idx) == r) return true
+        idx += 1
+      }
+      false
+    }
+  }
+
+  object NodeState {
+    val UNINITIALIZED: NodeState = null
+
+    val NOOP = new NodeState() {
+      override def minOutgoingDepth(incomingRelId: Long): Int = 0
+      override def updateFullExpandDepth(relIndex:Int, depth:Int ) = {}
+    }
+  }
+
+  /**
+    * The state of expansion for one node
+    */
+  class NodeState() {
+    // All relationships that connect to this node, filtered by the var-length predicates
+    var rels: Array[Relationship] = _
+    // The fully expanded depth for each relationship in rels
+    var depths:Array[Byte] = _
+    // True if this node has been emitted before
+    var isEmitted = false
+
+    /**
+      * Computes the minimum outgoing full expanded depth.
+      *
+      * @param incomingRelId id of the incoming relationship, which is omitted from this computation
+      * @return the full expand depth
+      */
+    def minOutgoingDepth(incomingRelId: Long): Int = {
+      var max = Constants.VERY_BIG_VALUE
+      var i = 0
+      while (i < rels.length) {
+        if (rels(i).getId != incomingRelId) {
+          max = math.min(depths(i), max)
+        }
+        i += 1
+      }
+      max
+    }
+
+    def updateFullExpandDepth(relIndex:Int, depth:Int ): Unit = {
+      depths(relIndex) = depth.toByte
+    }
+
+    /**
+      * If not already done, list all relationships of a node, given the predicates of this pipe.
+      */
+    def ensureExpanded(queryState: QueryState, row: ExecutionContext, node: Node) = {
+      if ( rels == null ) {
+        val allRels = queryState.query.getRelationshipsForIds(node, dir, types.types(queryState.query))
+        rels = allRels.filter(r => {
+          filteringStep.filterRelationship(row, queryState)(r) &&
+            filteringStep.filterNode(row, queryState)(r.getOtherNode(node))
+        }).toArray
+        depths = new Array[Byte](rels.length)
+      }
+    }
+  }
+
+  /**
+    * The overall state of the full pruning var expand. Mostly manages stack of PruningDFS nodes.
+    */
+  class FullPruneState(queryState:QueryState ) {
+    var inputRow:ExecutionContext = _
+    val nodeState = new Array[PruningDFS](self.max + 1)
+    val path = new Array[Long](max)
+    var depth = -1
+
+    def startRow( inputRow:ExecutionContext ) = {
+      this.inputRow = inputRow
+      depth = -1
+    }
+    def canContinue: Boolean = inputRow != null
+    def next(): ExecutionContext = {
+      val endNode =
+        if (depth == -1) {
+          push( new PruningDFS(
+                                state = this,
+                                node = getNodeFromRow(inputRow),
+                                path = path,
+                                pathLength = 0,
+                                queryState = queryState,
+                                row = inputRow,
+                                expandMap = Primitive.longObjectMap[NodeState](),
+                                prevLocalRelIndex = -1,
+                                prevNodeState = NodeState.NOOP) )
+        } else {
+          var maybeEndNode: Node = null
+          while ( depth >= 0 && maybeEndNode == null ) {
+            maybeEndNode = nodeState(depth).nextEndNode()
+            if (maybeEndNode == null) pop()
+          }
+          maybeEndNode
+        }
+      if (endNode == null) {
+        inputRow = null
+        null
+      }
+      else inputRow.newWith(self.toName -> endNode)
+    }
+
+    def push( pruningDFS: PruningDFS ): Node = {
+      depth += 1
+      nodeState(depth) = pruningDFS
+      pruningDFS.nextEndNode()
+    }
+
+    def pop(): Unit = {
+      nodeState(depth) = null // not needed, but nice for debugging
+      depth -= 1
+    }
+
+    private def getNodeFromRow(row: ExecutionContext): Node =
+      row.getOrElse(fromName, throw new InternalException(s"Expected a node on `$fromName`")).asInstanceOf[Node]
+  }
+
+  class FullyPruningIterator(
+                       private val input: Iterator[ExecutionContext],
+                       val queryState: QueryState
+  ) extends Iterator[ExecutionContext] {
+
+    var outputRow:ExecutionContext = _
+    var fullPruneState:FullPruneState = new FullPruneState( queryState )
+    var hasPrefetched = false
+
+    override def hasNext = {
+      prefetch()
+      outputRow != null
+    }
+
+    override def next() = {
+      prefetch()
+      if (outputRow == null) {
+        // fail
+        Iterator.empty.next()
+      }
+      consumePrefetched()
+    }
+
+    def consumePrefetched() = {
+      val temp = outputRow
+      hasPrefetched = false
+      outputRow = null
+      temp
+    }
+
+    def prefetch(): Unit =
+      if (!hasPrefetched) {
+        outputRow = fetch()
+        hasPrefetched = true
+      }
+
+    def fetch(): ExecutionContext = {
+      while (fullPruneState.canContinue || input.nonEmpty) {
+        if (!fullPruneState.canContinue) {
+          fullPruneState.startRow(input.next())
+        } else {
+          val row = fullPruneState.next()
+          if (row != null) return row
+        }
+      }
+      null
+    }
+
+
+    private def getNodeFromRow(row: ExecutionContext): Node =
+      row.getOrElse(fromName, throw new InternalException(s"Expected a node on `$fromName`")).asInstanceOf[Node]
+  }
+
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    state.decorator.registerParentPipe(this)
+
+    new FullyPruningIterator(input, state)
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
@@ -147,7 +147,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
 
 
   /**
-    * Performs DFS travelsal, but omits traversing relationships that have been completely traversed (to the
+    * Performs DFS traversal, but omits traversing relationships that have been completely traversed (to the
     * remaining depth) before.
     *
     * Pruning and full expand depths

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
@@ -57,10 +57,6 @@ case class PruningVarLengthExpandPipe(source: Pipe,
    field that is followed once the loaded iterator has been emptied.
  */
 
-  object Constants {
-    val VERY_BIG_VALUE = 1000001
-  }
-
   sealed trait State {
     // Note that the ExecutionContext part here can be null.
     // This code is used in a hot spot, and avoiding object creation is important.
@@ -327,7 +323,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
       * @return the full expand depth
       */
     def minOutgoingDepth(incomingRelId: Long): Int = {
-      var min = Constants.VERY_BIG_VALUE
+      var min = Integer.MAX_VALUE >> 1 // we don't want it to overflow
       var i = 0
       while (i < rels.length) {
         if (rels(i).getId != incomingRelId)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -288,6 +288,10 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         val predicate = varLengthPredicate(predicates)
         PruningVarLengthExpandPipe(source, from, toName, LazyTypes(types), dir, minLength, maxLength, predicate)()
 
+      case FullPruningVarExpand(_, IdName(from), dir, types, IdName(toName), minLength, maxLength, predicates) =>
+        val predicate = varLengthPredicate(predicates)
+        FullPruningVarLengthExpandPipe(source, from, toName, LazyTypes(types), dir, minLength, maxLength, predicate)()
+
       case Sort(_, sortItems) =>
         SortPipe(source, sortItems.map(translateSortDescription))(id = id)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -229,6 +229,10 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
         val expandSpec = ExpandExpression(fromName, "", types.map(_.name), toName, dir, minLength = min, maxLength = Some(max))
         PlanDescriptionImpl(id, s"VarLengthExpand(Pruning)", children, Seq(expandSpec), variables)
 
+      case FullPruningVarExpand(_, IdName(fromName), dir, types, IdName(toName), min, max, predicates) =>
+        val expandSpec = ExpandExpression(fromName, "", types.map(_.name), toName, dir, minLength = min, maxLength = Some(max))
+        PlanDescriptionImpl(id, s"VarLengthExpand(FullPruning)", children, Seq(expandSpec), variables)
+
       case _: RemoveLabels =>
         PlanDescriptionImpl(id, "RemoveLabels", children, Seq.empty, variables)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/Expand.scala
@@ -76,6 +76,22 @@ case class PruningVarExpand(left: LogicalPlan,
   override def availableSymbols = left.availableSymbols + to
 }
 
+case class FullPruningVarExpand(left: LogicalPlan,
+                                from: IdName,
+                                dir: SemanticDirection,
+                                types: Seq[RelTypeName],
+                                to: IdName,
+                                minLength: Int,
+                                maxLength: Int,
+                                predicates: Seq[(Variable, Expression)] = Seq.empty)
+                               (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
+
+  override val lhs = Some(left)
+  override def rhs = None
+
+  override def availableSymbols = left.availableSymbols + to
+}
+
 sealed trait ExpansionMode
 case object ExpandAll extends ExpansionMode
 case object ExpandInto extends ExpansionMode

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -80,7 +80,12 @@ case object pruningVarExpander extends Rewriter {
 
         val innerRewriter = topDown(Rewriter.lift {
           case expand@VarExpand(lhs, fromId, dir, projectedDir, relTypes, toId, relId, length, _, predicates) if distinctSet(expand) =>
-            PruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
+            if (length.min >= 4 && length.max.get >= 5)
+              // These constants were selected by benchmarking on randomized graphs, with different
+              // degrees of interconnection.
+              FullPruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
+            else
+              PruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
         })
         plan.endoRewrite(innerRewriter)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipeTest.scala
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.pipes
+
+import org.neo4j.cypher.GraphDatabaseFunSuite
+import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_2.QueryStateHelper.queryStateFrom
+import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{Literal, Property, Variable}
+import org.neo4j.cypher.internal.compiler.v3_2.commands.predicates.{Equals, Predicate, True}
+import org.neo4j.cypher.internal.compiler.v3_2.commands.values.UnresolvedProperty
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.kernel.api.KernelTransaction.Type
+import org.neo4j.kernel.api.security.SecurityContext
+
+import scala.collection.immutable.IndexedSeq
+import scala.util.Random
+
+class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
+  val types = LazyTypes(Seq.empty[String])
+  implicit val pipeMonitor = mock[PipeMonitor]
+
+  test("node without any relationships produces empty result") {
+    val n1 = createNode()
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState) shouldBe empty
+    }
+  }
+
+  test("node with a single relationships produces a single output node") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2)
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList shouldBe List(Map("from" -> n1, "to" -> n2))
+    }
+  }
+
+  test("node with a single relationships produces a two output nodes if minLength is zero") {
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2)
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 0, 2, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList shouldBe List(
+        Map("from" -> n1, "to" -> n2),
+        Map("from" -> n1, "to" -> n1)
+      )
+    }
+  }
+
+  test("long path, take the middle of it") {
+
+    val nodes = (0 to 10) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes.head)))
+    val min = 3
+    val max = 5
+    val pipeUnderTest = createPipe(src, min, max, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).map(_.apply("to")).toSet should equal(
+        nodes.slice(min, max + 1).toSet // Slice is excluding the end, whereas ()-[*3..5]->() is including
+      )
+    }
+  }
+
+  test("self-loop in path is OK") {
+    /*
+    The only path in the graph starting from n1 that is two relationships long includes a self loop.
+    (n1)-[0]->(n1)-[1]->(n2) or (n1)-[1]->(n2)-[1]->(n1)
+     */
+    val n1 = createNode()
+    val n2 = createNode()
+    relate(n1, n2)
+    relate(n1, n1)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 2, 2, SemanticDirection.BOTH)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("fixed length with shortcut") {
+    /*
+    n1 - ---- - n2 - n3 - n4
+       - n1_2 -
+
+    Even though n1-n2 is traversed first, the length 4 path over n1_2 should be found
+     */
+    val n1 = createNode()
+    val n2 = createNode()
+    val n3 = createNode()
+    val n4 = createNode()
+    val n1_2 = createNode()
+
+    relate(n1, n1_2)
+    relate(n1_2, n2)
+
+    relate(n1, n2)
+    relate(n2, n3)
+    relate(n3, n4)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 4, 4, SemanticDirection.BOTH)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(
+        Set(
+          Map("from" -> n1, "to" -> n4)
+        )
+      )
+    }
+  }
+
+  test("fixed length with longer shortcut") {
+    /*
+    n1 - ----- - ----- - n2 - n3 - n4
+       - n1_2a - n1_2b -
+
+    Even though n1-n2 is traversed first, the length 4 path over n1_2 should be found
+     */
+    val n1 = createNode()
+    val n2 = createNode()
+    val n3 = createNode()
+    val n4 = createNode()
+    val n1_2a = createNode()
+    val n1_2b = createNode()
+
+    relate(n1, n1_2a)
+    relate(n1_2a, n1_2b)
+    relate(n1_2b, n2)
+
+    relate(n1, n2)
+    relate(n2, n3)
+    relate(n3, n4)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val pipeUnderTest = createPipe(src, 5, 5, SemanticDirection.BOTH)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(
+        Set(
+          Map("from" -> n1, "to" -> n4)
+        )
+      )
+    }
+  }
+
+  test("var-length with relationship predicate") {
+    /*
+    (n1)-[0 {k:1}]->(n2)-[1]->(n3)
+    MATCH (n1)-[r*1..2 {k:1}]-(n) RETURN DISTINCT n
+     */
+
+    val n1 = createNode()
+    val n2 = createNode()
+    val n3 = createNode()
+    relate(n1, n2, "k" -> 1)
+    relate(n2, n3, "k" -> 2)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val predicate = Equals(Property(Variable("r"), UnresolvedProperty("k")), Literal(1))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, predicate, True())
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("var-length with node predicate") {
+    /*
+    (n1)-[0]->(n2 {k:1})-[1]->(n3)
+    MATCH p = (n1)-[r*1..2]-(n) WHERE all(n IN nodes(p) | n.k=1) RETURN DISTINCT n
+     */
+
+    val n1 = createNode()
+    val n2 = createNode("k" -> 1)
+    val n3 = createNode()
+    relate(n1, n2)
+    relate(n2, n3)
+
+    val src = new FakePipe(Iterator(Map("from" -> n1)))
+    val predicate = Equals(Property(Variable("to"), UnresolvedProperty("k")), Literal(1))
+    val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, True(), predicate)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList should equal(
+        List(
+          Map("from" -> n1, "to" -> n2)
+        )
+      )
+    }
+  }
+
+  test("two ways to get to the same node - one inside and one outside the max") {
+    /*
+    (x)-[1]->()-[2]->()-[3]->()-[4]->(y)-[4]->(z)
+      \                              ^
+       \----------------------------/
+
+     */
+    val nodes = (0 to 5) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val n1 = nodes.head
+    val n4 = nodes(4)
+    val n5 = nodes(5)
+    relate(n1, n4)
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes.head)))
+    val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(nodes.tail.map(n => Map("from" -> n1, "to" -> n)).toSet)
+    }
+  }
+
+  test("multiple start nodes") {
+    val nodes = (0 to 10) map (_ => createNode())
+
+    nodes.tail.foldLeft(nodes.head) {
+      case (x: Node, y: Node) =>
+        relate(x, y)
+        y
+    }
+
+    val src = new FakePipe(Iterator(Map("from" -> nodes(1)), Map("from" -> nodes(5))))
+    val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
+
+    graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toSet should equal(Set(
+        Map("from" -> nodes(1), "to" -> nodes(2)),
+        Map("from" -> nodes(1), "to" -> nodes(3)),
+        Map("from" -> nodes(1), "to" -> nodes(4)),
+        Map("from" -> nodes(1), "to" -> nodes(5)),
+        Map("from" -> nodes(5), "to" -> nodes(6)),
+        Map("from" -> nodes(5), "to" -> nodes(7)),
+        Map("from" -> nodes(5), "to" -> nodes(8)),
+        Map("from" -> nodes(5), "to" -> nodes(9))
+      ))
+    }
+  }
+
+  private def setUpGraph(seed: Long, POPULATION: Int, friendCount: Int = 50): IndexedSeq[Node] = {
+    val r = new Random(seed)
+
+    var tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+    var count = 0
+
+    def checkAndSwitch() = {
+      count += 1
+      if (count == 1000) {
+        tx.success()
+        tx.close()
+        tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+        count = 0
+      }
+    }
+
+    val nodes = (0 to POPULATION) map { _ =>
+      checkAndSwitch()
+      createNode()
+    }
+
+    for {
+      n1 <- nodes
+      friends = r.nextInt(friendCount)
+      friendIdx <- 0 to friends
+      n2 = nodes(r.nextInt(POPULATION))
+    } {
+      checkAndSwitch()
+      relate(n1, n2)
+    }
+
+    tx.success()
+    tx.close()
+
+    nodes
+  }
+
+  private def testNode(startNode: Node, r: Random) = {
+    val min = r.nextInt(3)
+    val max = min + 1 + r.nextInt(3)
+    val sourcePipe = new FakePipe(Iterator(Map("from" -> startNode)))
+    val sourcePipe2 = new FakePipe(Iterator(Map("from" -> startNode)))
+    val pipeUnderTest = createPipe(sourcePipe, min, max, SemanticDirection.BOTH)
+    val pipe = VarLengthExpandPipe(sourcePipe2, "from", "r", "to", SemanticDirection.BOTH, SemanticDirection.BOTH, types, min, Some(max), nodeInScope = false)()
+    val comparison = DistinctPipe(pipe, Map("from" -> Variable("from"), "to" -> Variable("to")))()
+
+    val distinctExpand = graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      pipeUnderTest.createResults(queryState).toList
+    }
+
+    val distinctAfterVarLengthExpand = graph.withTx { tx =>
+      val queryState = queryStateFrom(graph, tx, Map.empty)
+      comparison.createResults(queryState).toList
+    }
+
+    val oldThing = distinctAfterVarLengthExpand.toSet
+    val newThing = distinctExpand.toSet
+    if (oldThing != newThing) {
+      val missingFromNew = oldThing -- newThing
+      val shouldNotBeInNew = newThing -- oldThing
+      var message =
+        s"""startNode: $startNode
+            |size of old result ${oldThing.size}
+            |size of new result ${newThing.size}
+            |min $min
+            |max $max
+            |""".stripMargin
+      if(missingFromNew.nonEmpty) {
+        message += s"missing from new result: ${missingFromNew.mkString(",")}\n"
+      }
+      if(shouldNotBeInNew.nonEmpty) {
+        message += s"should not be in new result: ${shouldNotBeInNew.mkString(",")}\n"
+      }
+
+      fail(message)
+    }
+  }
+
+  test("random and compare") {
+    // runs DistinctVarExpand and VarExpand side-by-side and checks that the reachable nodes are the same
+    val POPULATION: Int = 1 * 1000
+    val seed = System.currentTimeMillis()
+    val nodes = setUpGraph(seed, POPULATION, 20)
+    val r = new Random
+
+    val start = System.currentTimeMillis()
+
+    while(System.currentTimeMillis() - start < 10000) {
+      withClue("seed used: " + seed) {
+        testNode(nodes(r.nextInt(POPULATION)), r)
+      }
+    }
+  }
+
+  private def createPipe(src: FakePipe, min: Int, max: Int, outgoing: SemanticDirection) = {
+    FullPruningVarLengthExpandPipe(src, "from", "to", types, outgoing, min, max)()
+  }
+
+  private def createReferencePipe(src: FakePipe, min: Int, max: Int, outgoing: SemanticDirection) = {
+    PruningVarLengthExpandPipe(src, "from", "to", types, outgoing, min, max)()
+  }
+
+  private def createPipe(src: FakePipe,
+                         min: Int,
+                         max: Int,
+                         outgoing: SemanticDirection,
+                         relationshipPredicate: Predicate,
+                         nodePredicate: Predicate) = {
+    FullPruningVarLengthExpandPipe(src, "from", "to", types, outgoing, min, max, new VarLengthPredicate {
+      override def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean = {
+        row("to") = node
+        val result = nodePredicate.isTrue(row)(state)
+        row.remove("to")
+        result
+      }
+
+      override def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean = {
+        row("r") = rel
+        val result = relationshipPredicate.isTrue(row)(state)
+        row.remove("r")
+        result
+      }
+    })()
+  }
+}


### PR DESCRIPTION
New Cypher operator for improved handling of longer var-length expands with distinct start node / end node combinations. This new operator is called FullPruningVarExpand, and is planned for var-lengths above `4..5`. Above this length the FullPruningVarExpand gives improved execution times in most cases, with speed-ups of an order of magnitude or more on even longer var-lengths. 

changelog: Improved cypher execution speed on variable length queries where only the distinct pairs of start and end node are of interest. One query to benefit would be `MATCH (a)-[*4..5]->(b) RETURN DISTINCT a, b`.