### PR TITLE
More scalable index logging

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelSchemaStateStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelSchemaStateStore.java
@@ -115,6 +115,6 @@ public class KernelSchemaStateStore implements UpdateableSchemaState
         finally {
             lock.writeLock().unlock();
         }
-        log.info( "Schema state store has been cleared." );
+        log.debug( "Schema state store has been cleared." );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -85,12 +85,6 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public void flush() throws IOException
-    {
-        getDelegate().flush();
-    }
-
-    @Override
     public Future<Void> close() throws IOException
     {
         return getDelegate().close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -78,11 +78,6 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
     }
 
     @Override
-    public void flush()
-    {
-    }
-
-    @Override
     public IndexDescriptor getDescriptor()
     {
         return descriptor;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -138,20 +138,6 @@ public class FlippableIndexProxy implements IndexProxy
         }
     }
 
-    @Override
-    public void flush() throws IOException
-    {
-        barge( lock.readLock() ); // see javadoc of this method (above) for rationale on why we use barge(...) here
-        try
-        {
-            delegate.flush();
-        }
-        finally
-        {
-            lock.readLock().unlock();
-        }
-    }
-
     /**
      * Acquire the {@code ReadLock} in an <i>unfair</i> way, without waiting for queued up writers.
      * <p/>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -92,8 +92,6 @@ public interface IndexProxy
 
     void force() throws IOException;
 
-    void flush() throws IOException;
-
     /**
      * @throws IndexNotFoundKernelException if the index isn't online yet.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -738,21 +738,6 @@ public class IndexingService extends LifecycleAdapter
         }
     }
 
-    public void flushAll()
-    {
-        for ( IndexProxy index : indexMapRef.getAllIndexProxies() )
-        {
-            try
-            {
-                index.flush();
-            }
-            catch ( IOException e )
-            {
-                throw new UnderlyingStorageException( "Unable to force " + index, e );
-            }
-        }
-    }
-
     private void closeAllIndexes()
     {
         Iterable<IndexProxy> indexesToStop = indexMapRef.clear();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -199,7 +199,7 @@ public class IndexingService extends LifecycleAdapter
             SchemaIndexProvider.Descriptor providerDescriptor = indexRule.getProviderDescriptor();
             SchemaIndexProvider provider = providerMap.apply( providerDescriptor );
             InternalIndexState initialState = provider.getInitialState( indexId );
-            log.info( indexStateInfo( "init", indexId, initialState, descriptor ) );
+            log.debug( indexStateInfo( "init", indexId, initialState, descriptor ) );
             boolean constraint = indexRule.isConstraintIndex();
 
             switch ( initialState )
@@ -233,8 +233,42 @@ public class IndexingService extends LifecycleAdapter
             }
             indexMap.putIndexProxy( indexId, indexProxy );
         }
+        logIndexStateSummary( "init" );
 
         indexMapRef.setIndexMap( indexMap );
+    }
+
+    private void logIndexStateSummary( String method )
+    {
+        int[] counts = new int[InternalIndexState.values().length];
+        for ( IndexRule indexRule : indexRules )
+        {
+            SchemaIndexProvider provider = providerMap.apply( indexRule.getProviderDescriptor() );
+            InternalIndexState state = provider.getInitialState( indexRule.getId() );
+            counts[state.ordinal()]++;
+        }
+
+        int mostIndex = -1;
+        for ( int i = 0; i < counts.length; i++ )
+        {
+            if ( mostIndex == -1 || counts[i] > counts[mostIndex] )
+            {
+                mostIndex = i;
+            }
+        }
+        InternalIndexState mostState = InternalIndexState.values()[mostIndex];
+        for ( IndexRule indexRule : indexRules )
+        {
+            long id = indexRule.getId();
+            SchemaIndexProvider provider = providerMap.apply( indexRule.getProviderDescriptor() );
+            InternalIndexState state = provider.getInitialState( id );
+            if ( mostState != state )
+            {
+                IndexDescriptor descriptor = new IndexDescriptor( indexRule.getLabel(), indexRule.getPropertyKey() );
+                log.info( indexStateInfo( method, id, state, descriptor ) );
+            }
+        }
+        log.info( format( "IndexingService.%s: indexes not specifically mentioned above are %s", method, mostState ) );
     }
 
     // Recovery semantics: This is to be called after init, and after the database has run recovery.
@@ -252,7 +286,7 @@ public class IndexingService extends LifecycleAdapter
         indexMap.foreachIndexProxy( ( indexId, proxy ) -> {
             InternalIndexState state = proxy.getState();
             IndexDescriptor descriptor = proxy.getDescriptor();
-            log.info( indexStateInfo( "start", indexId, state, descriptor ) );
+            log.debug( indexStateInfo( "start", indexId, state, descriptor ) );
             switch ( state )
             {
                 case ONLINE:
@@ -270,6 +304,7 @@ public class IndexingService extends LifecycleAdapter
                     throw new IllegalStateException( "Unknown state: " + state );
             }
         } );
+        logIndexStateSummary( "start" );
 
         // Drop placeholder proxies for indexes that need to be rebuilt
         dropRecoveringIndexes( indexMap, rebuildingDescriptors.keySet() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -136,12 +136,6 @@ public class OnlineIndexProxy implements IndexProxy
     }
 
     @Override
-    public void flush() throws IOException
-    {
-        accessor.flush();
-    }
-
-    @Override
     public Future<Void> close() throws IOException
     {
         accessor.close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -121,12 +121,6 @@ public class PopulatingIndexProxy implements IndexProxy
     }
 
     @Override
-    public void flush() throws IOException
-    {
-        // Ignored... this isn't controlled from the outside while we're populating the index.
-    }
-
-    @Override
     public Future<Void> close()
     {
         return job.cancel();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingControllerFactory.java
@@ -96,11 +96,11 @@ public class IndexSamplingControllerFactory
                 boolean result = storeView.indexSample( descriptor, register ).readSecond() == 0;
                 if ( result )
                 {
-                    log.warn( "Recovering index sampling for index %s", descriptor.userDescription( tokenNameLookup ) );
+                    log.debug( "Recovering index sampling for index %s",
+                            descriptor.userDescription( tokenNameLookup ) );
                 }
                 return result;
             }
         };
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/OnlineIndexSamplingJob.java
@@ -77,7 +77,7 @@ class OnlineIndexSamplingJob implements IndexSamplingJob
                         storeView.replaceIndexCounts( indexDescriptor, sample.uniqueValues(), sample.sampleSize(),
                                 sample.indexSize() );
                         durationLogger.markAsFinished();
-                        log.info(
+                        log.debug(
                                 format( "Sampled index %s with %d unique values in sample of avg size %d taken from " +
                                         "index containing %d entries",
                                         indexUserDescription, sample.uniqueValues(), sample.sampleSize(),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateStoreTest.java
@@ -58,12 +58,12 @@ public class KernelSchemaStateStoreTest
 
         // AND ALSO
         logProvider.assertExactly(
-                inLog( KernelSchemaStateStore.class ).info( "Schema state store has been cleared." )
+                inLog( KernelSchemaStateStore.class ).debug( "Schema state store has been cleared." )
         );
     }
 
     private KernelSchemaStateStore stateStore;
-    private AssertableLogProvider logProvider = new AssertableLogProvider();
+    private final AssertableLogProvider logProvider = new AssertableLogProvider();
 
     @Before
     public void before()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -66,11 +66,6 @@ public class IndexProxyAdapter implements IndexProxy
     }
 
     @Override
-    public void flush()
-    {
-    }
-
-    @Override
     public Future<Void> close()
     {
         return VOID;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -127,7 +127,7 @@ public class IndexStatisticsIT
     private void assertLogExistsForRecoveryOn( String labelAndProperty )
     {
         logProvider.assertAtLeastOnce(
-                inLog( IndexSamplingController.class ).warn( "Recovering index sampling for index %s", labelAndProperty )
+                inLog( IndexSamplingController.class ).debug( "Recovering index sampling for index %s", labelAndProperty )
         );
     }
 


### PR DESCRIPTION
Logging for indexing has been a bit verbose, but isn't a problem for scenarios where there are few indexes. Excessive logging includes:

- index state (ONLINE/POPULATING/FAILED) during init
- index state during start
- sampling recovery at startup
- sampling at runtime
- listing of index files during startup and log rotation

In scenarios with thousands of indexes the above logging quickly fills most of the `debug.log`, considering that the biggest one, the file listing, also gets logged on log file rotation. The excessive logging would quickly approach the critical log file rotation threshold to the point where the logging done while doing a log rotation would immediately cause log rotation itself.

Some of the logging is left as it was, although instead as DEBUG and some more scalable INFO logging is done to replace it for most users.