### PR TITLE
Faster composite lucene population

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
@@ -47,11 +47,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.StringHelper;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
@@ -264,7 +260,7 @@ public class LuceneDocumentStructure
         private final Field idField;
         private final Field idValueField;
 
-        private final Map<String,Field> valueFields = new HashMap<>();
+        private Field[] reusableValueFields = new Field[0];
 
         private DocWithId()
         {
@@ -284,10 +280,15 @@ public class LuceneDocumentStructure
         private void setValues( Object... values )
         {
             removeAllValueFields();
+            int neededLength = values.length * ValueEncoding.values().length;
+            if ( reusableValueFields.length < neededLength )
+            {
+                reusableValueFields = new Field[neededLength];
+            }
+
             for ( int i = 0; i < values.length; i++ )
             {
-                ValueEncoding encoding = ValueEncoding.forValue( values[i] );
-                Field reusableField = getFieldWithValue( i, encoding, values[i] );
+                Field reusableField = getFieldWithValue( i, values[i] );
                 document.add( reusableField );
             }
         }
@@ -306,14 +307,16 @@ public class LuceneDocumentStructure
             }
         }
 
-        private Field getFieldWithValue( int propertyNumber, ValueEncoding encoding, Object value )
+        private Field getFieldWithValue( int propertyNumber, Object value )
         {
+            ValueEncoding encoding = ValueEncoding.forValue( value );
+            int reuseId = propertyNumber * ValueEncoding.values().length + encoding.ordinal();
             String key = encoding.key( propertyNumber );
-            Field reusableField = valueFields.get( key );
+            Field reusableField = reusableValueFields[reuseId];
             if ( reusableField == null )
             {
                 reusableField = encoding.encodeField( key, value );
-                valueFields.put( key, reusableField );
+                reusableValueFields[reuseId] = reusableField;
             }
             else
             {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
@@ -87,10 +87,16 @@ public class LuceneDocumentStructure
 
     public static String encodedStringValuesForSampling( Object... values )
     {
-        return Arrays.stream( values ).map( s -> {
-            ValueEncoding encoding = ValueEncoding.forValue( s );
-            return encoding.encodeField( encoding.key(), s ).stringValue();
-        } ).collect( Collectors.joining( DELIMITER ) );
+        StringBuilder sb = new StringBuilder();
+        String sep = "";
+        for ( Object value : values )
+        {
+            sb.append( sep );
+            sep = DELIMITER;
+            ValueEncoding encoding = ValueEncoding.forValue( value );
+            sb.append( encoding.encodeField( encoding.key(), value ).stringValue() );
+        }
+        return sb.toString();
     }
 
     public static MatchAllDocsQuery newScanQuery()


### PR DESCRIPTION
Following the composite index work, a performance regression was seen in index population. This PR halves the size of that regression by implementing faster versions of 
 * how strings are encoded for value sampling
 * how thread local lucene `Field` objects are tracked and reused 

The slowdown is improved from 1.23x to 1.11x for small_string values, and from 1.18x to 1.05x for long values.