### PR TITLE
Register LoggingLogFileMonitor only once in NeoStoreDataSource.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -408,11 +408,13 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
 
         this.commitProcessFactory = commitProcessFactory;
         this.pageCache = pageCache;
+        this.monitors.addMonitorListener( new LoggingLogFileMonitor( msgLog ) );
     }
 
     @Override
     public void init()
-    {   // We do our own internal life management:
+    {
+        // We do our own internal life management:
         // start() does life.init() and life.start(),
         // stop() does life.stop() and life.shutdown().
     }
@@ -430,10 +432,6 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         dependencies.satisfyDependency( lockService );
         dependencies.satisfyDependency( indexConfigStore );
         life.add( indexConfigStore );
-
-        // Monitor listeners
-        LoggingLogFileMonitor loggingLogMonitor = new LoggingLogFileMonitor( msgLog );
-        monitors.addMonitorListener( loggingLogMonitor );
 
         life.add( new Delegate( Lifecycles.multiple( indexProviders.values() ) ) );
 


### PR DESCRIPTION
Previously listener was register on each component start, now that will be only once.