### PR TITLE
throw exception if policy does not exist

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/LoadBalancingProcessor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/LoadBalancingProcessor.java
@@ -22,6 +22,8 @@ package org.neo4j.causalclustering.load_balancing;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+
 public interface LoadBalancingProcessor
 {
     /**
@@ -31,7 +33,7 @@ public interface LoadBalancingProcessor
      * @param context The client supplied context.
      * @return The result of invoking the procedure.
      */
-    Result run( Map<String,String> context );
+    Result run( Map<String,String> context ) throws ProcedureException;
 
     interface Result
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/ServerShufflingProcessor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/ServerShufflingProcessor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.neo4j.causalclustering.load_balancing.LoadBalancingProcessor;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 
 /**
  * Shuffles the servers of the delegate around so that every client
@@ -40,7 +41,7 @@ public class ServerShufflingProcessor implements LoadBalancingProcessor
     }
 
     @Override
-    public Result run( Map<String,String> context )
+    public Result run( Map<String,String> context ) throws ProcedureException
     {
         Result result = delegate.run( context );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/plugins/server_policies/ServerPoliciesPlugin.java
@@ -38,6 +38,7 @@ import org.neo4j.causalclustering.load_balancing.LoadBalancingPlugin;
 import org.neo4j.causalclustering.load_balancing.LoadBalancingResult;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.helpers.Service;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -95,13 +96,15 @@ public class ServerPoliciesPlugin implements LoadBalancingPlugin
     }
 
     @Override
-    public Result run( Map<String,String> context )
+    public Result run( Map<String,String> context ) throws ProcedureException
     {
+        Policy policy = policies.selectFor( context );
+
         CoreTopology coreTopology = topologyService.coreServers();
         ReadReplicaTopology rrTopology = topologyService.readReplicas();
 
         return new LoadBalancingResult( routeEndpoints( coreTopology ), writeEndpoints( coreTopology ),
-                readEndpoints( coreTopology, rrTopology, policies.selectFor( context ) ), timeToLive );
+                readEndpoints( coreTopology, rrTopology, policy ), timeToLive );
     }
 
     private List<Endpoint> routeEndpoints( CoreTopology cores )


### PR DESCRIPTION
The plugins can now throw procedure exceptions and the server policies
plugin will throw a ProcedureCallFailed if the supplied policy name
does not exist.