### PR TITLE
Add additional logging for store copy process on master

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -90,7 +90,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
                     monitors.newMonitor( StoreCopyServer.Monitor.class ), pageCache );
             LogicalTransactionStore logicalTransactionStore = logicalTransactionStoreSupplier.get();
             LogFileInformation logFileInformation = logFileInformationSupplier.get();
-            return new BackupImpl( copier, monitors, logicalTransactionStore, transactionIdStore, logFileInformation,
+            return new BackupImpl( copier, logicalTransactionStore, transactionIdStore, logFileInformation,
                     graphDatabaseAPI::storeId, logProvider );
         }, monitors, logProvider );
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/StoreCopyResponsePacker.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/StoreCopyResponsePacker.java
@@ -66,15 +66,16 @@ public class StoreCopyResponsePacker extends ResponsePacker
     @Override
     public <T> Response<T> packTransactionStreamResponse( RequestContext context, T response )
     {
+        final String packerIdentifier = Thread.currentThread().getName();
         final long toStartFrom = mandatoryStartTransactionId;
         final long toEndAt = transactionIdStore.getLastCommittedTransactionId();
         TransactionStream transactions = visitor -> {
             // Check so that it's even worth thinking about extracting any transactions at all
             if ( toStartFrom > BASE_TX_ID && toStartFrom <= toEndAt )
             {
-                monitor.startStreamingTransactions( toStartFrom );
+                monitor.startStreamingTransactions( toStartFrom, packerIdentifier );
                 extractTransactions( toStartFrom, filterVisitor( visitor, toEndAt ) );
-                monitor.finishStreamingTransactions( toEndAt );
+                monitor.finishStreamingTransactions( toEndAt, packerIdentifier );
             }
         };
         return new TransactionStreamResponse<>( response, storeId.get(), transactions, ResourceReleaser.NO_OP );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
@@ -30,7 +30,6 @@ import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.mockito.Matchers.any;
@@ -50,7 +49,7 @@ public class BackupImplTest
         when( storeCopyServer.flushStoresAndStreamStoreFiles( anyString(), any( StoreWriter.class ), anyBoolean() ) )
                 .thenReturn( RequestContext.EMPTY );
 
-        BackupImpl backup = new BackupImpl( storeCopyServer, new Monitors(), mock( LogicalTransactionStore.class ),
+        BackupImpl backup = new BackupImpl( storeCopyServer, mock( LogicalTransactionStore.class ),
                 mock( TransactionIdStore.class ), mock( LogFileInformation.class ), defaultStoreIdSupplier(),
                 NullLogProvider.getInstance() );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -24,6 +24,8 @@ import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -100,6 +102,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -108,28 +111,11 @@ import static org.neo4j.kernel.impl.storemigration.StoreFile.COUNTS_STORE_RIGHT;
 
 public class BackupServiceIT
 {
-    private static final class StoreSnoopingMonitor extends StoreCopyServer.Monitor.Adapter
-    {
-        private final Barrier barrier;
+    private final TestDirectory target = TestDirectory.testDirectory();
+    private final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
 
-        private StoreSnoopingMonitor( Barrier barrier )
-        {
-            this.barrier = barrier;
-        }
-
-        @Override
-        public void finishStreamingStoreFile( File storefile, String storeCopyIdentifier )
-        {
-            if ( storefile.getAbsolutePath().contains( NODE_STORE ) ||
-                 storefile.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
-            {
-                barrier.reached(); // multiple calls to this barrier will not block
-            }
-        }
-    }
-
-    @Rule
-    public final TestDirectory target = TestDirectory.testDirectory();
     private static final String NODE_STORE = StoreFactory.NODE_STORE_NAME;
     private static final String RELATIONSHIP_STORE = StoreFactory.RELATIONSHIP_STORE_NAME;
     private static final String BACKUP_HOST = "localhost";
@@ -139,15 +125,11 @@ public class BackupServiceIT
     private final IOLimiter limiter = IOLimiter.unlimited();
     private File storeDir;
     private File backupDir;
-    public int backupPort = 8200;
+    private int backupPort = 8200;
 
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
-
-    @Rule
-    public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
-    @Rule
-    public final PageCacheRule pageCacheRule = new PageCacheRule();
+    public RuleChain ruleChain = RuleChain.outerRule( target ).around( dbRule ).around( suppressOutput ).around(
+            pageCacheRule );
 
     @Before
     public void setup()
@@ -876,28 +858,33 @@ public class BackupServiceIT
                         new SimpleKernelContext( fileSystem, storeDir, DatabaseInfo.UNKNOWN, dependencies ),
                         DependenciesProxy.dependencies( dependencies, OnlineBackupExtensionFactory.Dependencies.class )
                 );
+        try
+        {
+            backup.start();
 
-        backup.start();
+            // when
+            backupService()
+                    .doFullBackup( BACKUP_HOST, backupPort, backupDir, ConsistencyCheck.NONE, withOnlineBackupDisabled,
+                            BackupClient.BIG_READ_TIMEOUT, false );
 
-        // when
-        backupService().doFullBackup( BACKUP_HOST, backupPort, backupDir, ConsistencyCheck.NONE,
-                withOnlineBackupDisabled, BackupClient.BIG_READ_TIMEOUT, false );
+            // then
+            verify( logger ).log( eq( "%s: Full backup started...") , Mockito.startsWith( "BackupServer" ) );
+            verify( logger ).log( eq( "%s: Full backup finished." ), Mockito.startsWith( "BackupServer" ) );
 
-        // then
-        verify( logger ).log( "Full backup started..." );
-        verify( logger ).log( "Full backup finished." );
+            // when
+            createAndIndexNode( dbRule, 2 );
 
-        // when
-        createAndIndexNode( dbRule, 2 );
+            backupService().doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir, ConsistencyCheck.NONE,
+                    withOnlineBackupDisabled, BackupClient.BIG_READ_TIMEOUT, false );
 
-        backupService().doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir,
-                ConsistencyCheck.NONE, withOnlineBackupDisabled, BackupClient.BIG_READ_TIMEOUT, false );
-
-        backup.stop();
-
-        // then
-        verify( logger ).log( "Incremental backup started..." );
-        verify( logger ).log( "Incremental backup finished." );
+            // then
+            verify( logger ).log( eq( "%s: Incremental backup started..."), Mockito.startsWith( "BackupServer" ) );
+            verify( logger ).log( eq( "%s: Incremental backup finished." ), Mockito.startsWith( "BackupServer" ) );
+        }
+        finally
+        {
+            backup.stop();
+        }
     }
 
     @Test
@@ -1053,6 +1040,26 @@ public class BackupServiceIT
     private DbRepresentation getDbRepresentation()
     {
         return DbRepresentation.of( storeDir );
+    }
+
+    private static final class StoreSnoopingMonitor extends StoreCopyServer.Monitor.Adapter
+    {
+        private final Barrier barrier;
+
+        private StoreSnoopingMonitor( Barrier barrier )
+        {
+            this.barrier = barrier;
+        }
+
+        @Override
+        public void finishStreamingStoreFile( File storefile, String storeCopyIdentifier )
+        {
+            if ( storefile.getAbsolutePath().contains( NODE_STORE ) ||
+                    storefile.getAbsolutePath().contains( RELATIONSHIP_STORE ) )
+            {
+                barrier.reached(); // multiple calls to this barrier will not block
+            }
+        }
     }
 
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -103,7 +103,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.storemigration.StoreFile.COUNTS_STORE_LEFT;
 import static org.neo4j.kernel.impl.storemigration.StoreFile.COUNTS_STORE_RIGHT;
 
@@ -119,7 +118,7 @@ public class BackupServiceIT
         }
 
         @Override
-        public void finishStreamingStoreFile( File storefile )
+        public void finishStreamingStoreFile( File storefile, String storeCopyIdentifier )
         {
             if ( storefile.getAbsolutePath().contains( NODE_STORE ) ||
                  storefile.getAbsolutePath().contains( RELATIONSHIP_STORE ) )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -89,8 +89,8 @@ import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
 import org.neo4j.kernel.ha.cluster.SimpleHighAvailabilityMemberContext;
 import org.neo4j.kernel.ha.cluster.SwitchToMaster;
 import org.neo4j.kernel.ha.cluster.SwitchToSlave;
-import org.neo4j.kernel.ha.cluster.SwitchToSlaveCopyThenBranch;
 import org.neo4j.kernel.ha.cluster.SwitchToSlaveBranchThenCopy;
+import org.neo4j.kernel.ha.cluster.SwitchToSlaveCopyThenBranch;
 import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
 import org.neo4j.kernel.ha.cluster.member.HighAvailabilitySlaves;
 import org.neo4j.kernel.ha.cluster.member.ObservedClusterMembers;
@@ -174,7 +174,6 @@ import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
-
 import static org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache.TransactionMetadata;
 
 /**
@@ -419,7 +418,8 @@ public class HighlyAvailableEditionModule
                         platformModule.dependencies.resolveDependency( TransactionIdStore.class ),
                         platformModule.dependencies.resolveDependency( LogicalTransactionStore.class ),
                         platformModule.dependencies.resolveDependency( NeoStoreDataSource.class ),
-                        platformModule.dependencies.resolveDependency( PageCache.class ) );
+                        platformModule.dependencies.resolveDependency( PageCache.class ),
+                        logging.getInternalLogProvider() );
 
         final Factory<ConversationSPI> conversationSPIFactory =
                 () -> new DefaultConversationSPI( lockManager, platformModule.jobScheduler );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.RETURNS_MOCKS;
@@ -62,7 +63,7 @@ public class DefaultMasterImplSPITest
                 mock( PropertyKeyTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ),
                 mock( IdGeneratorFactory.class ), mock( TransactionCommitProcess.class ), checkPointer,
                 mock( TransactionIdStore.class ), mock( LogicalTransactionStore.class ),
-                dataSource, mock( PageCache.class ) );
+                dataSource, mock( PageCache.class ), NullLogProvider.getInstance() );
 
         master.flushStoresAndStreamStoreFiles( mock( StoreWriter.class ) );
 


### PR DESCRIPTION
Introduce additional logging for store copy from master.
Track start/stop of store copy, files copy, transaction streaming start and finish.
Include thread name into the logs to be able to track parallel full backups,
and full store copies.