### PR TITLE
Do not delay loading additional properties for IndexEntryUpdates

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -69,6 +70,12 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     public NewIndexDescriptor getDescriptor()
     {
         return getDelegate().getDescriptor();
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return getDelegate().schema();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -83,6 +84,12 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
     public NewIndexDescriptor getDescriptor()
     {
         return descriptor;
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return descriptor.schema();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.updater.DelegatingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
@@ -216,6 +217,20 @@ public class FlippableIndexProxy implements IndexProxy
         try
         {
             return delegate.getDescriptor();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        lock.readLock().lock();
+        try
+        {
+            return delegate.schema();
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.LabelSchemaSupplier;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -57,7 +59,7 @@ import org.neo4j.storageengine.api.schema.PopulationProgress;
  *
  * @see ContractCheckingIndexProxy
  */
-public interface IndexProxy
+public interface IndexProxy extends LabelSchemaSupplier
 {
     void start() throws IOException;
 
@@ -77,6 +79,8 @@ public interface IndexProxy
     Future<Void> close() throws IOException;
 
     NewIndexDescriptor getDescriptor();
+
+    LabelSchemaDescriptor schema();
 
     SchemaIndexProvider.Descriptor getProviderDescriptor();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -84,7 +84,7 @@ import static org.neo4j.kernel.impl.util.JobScheduler.Groups.indexPopulation;
  * If, however, it is {@link org.neo4j.kernel.api.index.InternalIndexState#ONLINE}, the index provider is required to
  * also guarantee that the index had been flushed to disk.
  */
-public class IndexingService extends LifecycleAdapter
+public class IndexingService extends LifecycleAdapter implements IndexingUpdateService
 {
     private final IndexSamplingController samplingController;
     private final IndexProxyCreator indexProxyCreator;
@@ -405,6 +405,7 @@ public class IndexingService extends LifecycleAdapter
      * @throws IOException potentially thrown from index updating.
      * @throws IndexEntryConflictException potentially thrown from index updating.
      */
+    @Override
     public void apply( IndexUpdates updates ) throws IOException, IndexEntryConflictException
     {
         if ( state == State.NOT_STARTED )
@@ -438,6 +439,12 @@ public class IndexingService extends LifecycleAdapter
                 }
             }
         }
+    }
+
+    @Override
+    public void loadAdditionalProperties( NodeUpdates nodeUpdates )
+    {
+        nodeUpdates.loadAdditionalProperties( indexMapRef.getAllIndexProxies(), storeView );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -433,7 +433,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
             for ( NodeUpdates update : updates )
             {
                 for ( IndexEntryUpdate<IndexUpdaterMap.IndexUpdaterWithSchema> indexUpdate :
-                        update.forIndexKeys( updaterMap.updaters(), storeView ) )
+                        update.forIndexKeys( updaterMap.updaters() ) )
                 {
                     indexUpdate.indexKey().process( indexUpdate );
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingUpdateService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingUpdateService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.impl.transaction.state.IndexUpdates;
+
+public interface IndexingUpdateService
+{
+    /**
+     * Apply updates to the relevant indexes.
+     */
+    void apply( IndexUpdates updates ) throws IOException, IndexEntryConflictException;
+
+    /**
+     * Load eventual additional properties depending on the set of active indexes. This has to happen earlier than
+     * the actual application of the updates to the indexes, so that the properties reflect the exact state of the
+     * transaction.
+     */
+    void loadAdditionalProperties( NodeUpdates nodeUpdates );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
@@ -189,6 +189,25 @@ public class NodeUpdates implements PropertyLoader.PropertyLoadSink
         return gatherUpdatesForPotentials( potentiallyRelevant );
     }
 
+    public <INDEX_KEY extends LabelSchemaSupplier> void loadAdditionalProperties(
+            Iterable<INDEX_KEY> indexKeys, PropertyLoader propertyLoader )
+    {
+        PrimitiveIntSet additionalPropertiesToLoad = Primitive.intSet();
+
+        for ( INDEX_KEY indexKey : indexKeys )
+        {
+            if ( atLeastOneRelevantChange( indexKey ) )
+            {
+                gatherPropsToLoad( indexKey.schema(), additionalPropertiesToLoad );
+            }
+        }
+
+        if ( !additionalPropertiesToLoad.isEmpty() )
+        {
+            loadProperties( propertyLoader, additionalPropertiesToLoad );
+        }
+    }
+
     private <INDEX_KEY extends LabelSchemaSupplier> Iterable<IndexEntryUpdate<INDEX_KEY>> gatherUpdatesForPotentials(
             Iterable<INDEX_KEY> potentiallyRelevant )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/OnlineIndexProxy.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -114,6 +115,12 @@ public class OnlineIndexProxy implements IndexProxy
     public NewIndexDescriptor getDescriptor()
     {
         return descriptor;
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return descriptor.schema();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
@@ -96,6 +97,12 @@ public class PopulatingIndexProxy implements IndexProxy
     public NewIndexDescriptor getDescriptor()
     {
         return descriptor;
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
+    {
+        return descriptor.schema();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionApplierFacade;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.IndexingServiceFactory;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.api.store.StorageLayer;
@@ -155,7 +156,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     private final LockService lockService;
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync;
     private final CommandReaderFactory commandReaderFactory;
-    private final WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync;
+    private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync;
     private final NeoStoreIndexStoreView indexStoreView;
     private final LegacyIndexProviderLookup legacyIndexProviderLookup;
     private final PropertyPhysicalToLogicalConverter indexUpdatesConverter;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -94,7 +94,6 @@ import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
 import org.neo4j.kernel.impl.transaction.state.Loaders;
 import org.neo4j.kernel.impl.transaction.state.PropertyCreator;
 import org.neo4j.kernel.impl.transaction.state.PropertyDeleter;
-import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.kernel.impl.transaction.state.PropertyTraverser;
 import org.neo4j.kernel.impl.transaction.state.RecordChangeSet;
 import org.neo4j.kernel.impl.transaction.state.RelationshipCreator;
@@ -381,7 +380,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
         // Schema index application
         appliers.add( new IndexBatchTransactionApplier( indexingService, labelScanStoreSync, indexUpdatesSync,
-                neoStores.getNodeStore(), new PropertyLoader( neoStores ),
+                neoStores.getNodeStore(),
                 indexUpdatesConverter, mode ) );
 
         // Legacy index application

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.BatchTransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.NodePropertyCommandsExtractor;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.store.NodeLabels;
@@ -58,7 +59,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
 {
     private final IndexingService indexingService;
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync;
-    private final WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync;
+    private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync;
     private final SingleTransactionApplier transactionApplier;
     private final PropertyPhysicalToLogicalConverter indexUpdateConverter;
 
@@ -67,7 +68,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
 
     public IndexBatchTransactionApplier( IndexingService indexingService,
             WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync,
-            WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync,
+            WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync,
             NodeStore nodeStore, PropertyLoader propertyLoader,
             PropertyPhysicalToLogicalConverter indexUpdateConverter,
             TransactionApplicationMode mode )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
@@ -44,7 +44,6 @@ import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.state.IndexUpdates;
 import org.neo4j.kernel.impl.transaction.state.OnlineIndexUpdates;
-import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.kernel.impl.transaction.state.RecoveryIndexUpdates;
 import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
@@ -69,7 +68,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
     public IndexBatchTransactionApplier( IndexingService indexingService,
             WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync,
             WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync,
-            NodeStore nodeStore, PropertyLoader propertyLoader,
+            NodeStore nodeStore,
             PropertyPhysicalToLogicalConverter indexUpdateConverter,
             TransactionApplicationMode mode )
     {
@@ -77,7 +76,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
         this.labelScanStoreSync = labelScanStoreSync;
         this.indexUpdatesSync = indexUpdatesSync;
         this.indexUpdateConverter = indexUpdateConverter;
-        this.transactionApplier = new SingleTransactionApplier( nodeStore, propertyLoader, mode );
+        this.transactionApplier = new SingleTransactionApplier( nodeStore, mode );
     }
 
     @Override
@@ -130,15 +129,13 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
     private class SingleTransactionApplier extends TransactionApplier.Adapter
     {
         private final NodeStore nodeStore;
-        private final PropertyLoader propertyLoader;
         private final TransactionApplicationMode mode;
         private final NodePropertyCommandsExtractor indexUpdatesExtractor = new NodePropertyCommandsExtractor();
         private List<IndexRule> createdIndexes;
 
-        SingleTransactionApplier( NodeStore nodeStore, PropertyLoader propertyLoader, TransactionApplicationMode mode )
+        SingleTransactionApplier( NodeStore nodeStore, TransactionApplicationMode mode )
         {
             this.nodeStore = nodeStore;
-            this.propertyLoader = propertyLoader;
             this.mode = mode;
         }
 
@@ -174,7 +171,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
         private IndexUpdates createIndexUpdates()
         {
             return mode == TransactionApplicationMode.RECOVERY ? new RecoveryIndexUpdates() :
-                new OnlineIndexUpdates( nodeStore, propertyLoader, indexUpdateConverter );
+                new OnlineIndexUpdates( nodeStore, indexingService, indexUpdateConverter );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexUpdatesWork.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexUpdatesWork.java
@@ -29,8 +29,8 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.concurrent.Work;
 import org.neo4j.helpers.collection.NestingIterator;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.NodeUpdates;
-import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
@@ -39,7 +39,7 @@ import org.neo4j.kernel.impl.transaction.state.IndexUpdates;
 /**
  * Combines {@link IndexUpdates} from multiple transactions into one bigger job.
  */
-public class IndexUpdatesWork implements Work<IndexingService,IndexUpdatesWork>
+public class IndexUpdatesWork implements Work<IndexingUpdateService,IndexUpdatesWork>
 {
     private final List<IndexUpdates> updates = new ArrayList<>();
 
@@ -56,7 +56,7 @@ public class IndexUpdatesWork implements Work<IndexingService,IndexUpdatesWork>
     }
 
     @Override
-    public void apply( IndexingService material )
+    public void apply( IndexingUpdateService material )
     {
         try
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.api.index.updater.SwallowingIndexUpdater;
 import org.neo4j.storageengine.api.schema.IndexReader;
@@ -77,6 +78,12 @@ public class IndexProxyAdapter implements IndexProxy
 
     @Override
     public NewIndexDescriptor getDescriptor()
+    {
+        return null;
+    }
+
+    @Override
+    public LabelSchemaDescriptor schema()
     {
         return null;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
@@ -37,7 +37,6 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
-import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 
 import static org.junit.Assert.assertEquals;
@@ -62,7 +61,7 @@ public class IndexBatchTransactionApplierTest
         TransactionToApply tx = mock( TransactionToApply.class );
         PropertyStore propertyStore = mock( PropertyStore.class );
         try ( IndexBatchTransactionApplier applier = new IndexBatchTransactionApplier( indexing, labelScanSync,
-                indexUpdatesSync, mock( NodeStore.class ), mock( PropertyLoader.class ),
+                indexUpdatesSync, mock( NodeStore.class ),
                 new PropertyPhysicalToLogicalConverter( propertyStore ),
                 TransactionApplicationMode.INTERNAL ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.NodeStore;
@@ -57,7 +58,7 @@ public class IndexBatchTransactionApplierTest
         LabelScanWriter writer = new OrderVerifyingLabelScanWriter( 10, 15, 20 );
         WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanSync =
                 spy( new WorkSync<>( singletonProvider( writer ) ) );
-        WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexing );
+        WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexing );
         TransactionToApply tx = mock( TransactionToApply.class );
         PropertyStore propertyStore = mock( PropertyStore.class );
         try ( IndexBatchTransactionApplier applier = new IndexBatchTransactionApplier( indexing, labelScanSync,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
@@ -72,7 +72,6 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyKeyTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipTypeTokenCommand;
-import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.storageengine.api.Token;
 
 import static org.junit.Assert.assertFalse;
@@ -926,7 +925,7 @@ public class NeoStoreTransactionApplierTest
     private BatchTransactionApplier newIndexApplier()
     {
         return new IndexBatchTransactionApplier( indexingService, labelScanStoreSynchronizer,
-                indexUpdatesSync, nodeStore, new PropertyLoader( neoStores ),
+                indexUpdatesSync, nodeStore,
                 new PropertyPhysicalToLogicalConverter( propertyStore ), INTERNAL );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.api.BatchTransactionApplier;
 import org.neo4j.kernel.impl.api.BatchTransactionApplierFacade;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
@@ -114,7 +115,7 @@ public class NeoStoreTransactionApplierTest
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork>
             labelScanStoreSynchronizer = new WorkSync<>( labelScanStore );
     private final TransactionToApply transactionToApply = mock( TransactionToApply.class );
-    private final WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexingService );
+    private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexingService );
 
     @Before
     public void setup()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
@@ -40,7 +40,6 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 
 import static java.util.Collections.singleton;
@@ -97,7 +96,7 @@ public class NeoTransactionIndexApplierTest
         PropertyStore propertyStore = mock( PropertyStore.class );
         return new IndexBatchTransactionApplier( indexingService,
                 labelScanStoreSynchronizer, indexUpdatesSync, mock( NodeStore.class ),
-                mock(PropertyLoader.class ), new PropertyPhysicalToLogicalConverter( propertyStore ),
+                new PropertyPhysicalToLogicalConverter( propertyStore ),
                 TransactionApplicationMode.INTERNAL );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
@@ -59,7 +60,7 @@ public class NeoTransactionIndexApplierTest
     private final Collection<DynamicRecord> emptyDynamicRecords = Collections.emptySet();
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSynchronizer =
             new WorkSync<>( labelScanStore );
-    private final WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexingService );
+    private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexingService );
     private final TransactionToApply transactionToApply = mock( TransactionToApply.class );
 
     @Before

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
@@ -89,7 +89,7 @@ public class SchemaRuleCommandTest
     private final PropertyStore propertyStore = mock( PropertyStore.class );
     private final IndexBatchTransactionApplier indexApplier = new IndexBatchTransactionApplier( indexes,
             labelScanStoreSynchronizer, indexUpdatesSync, mock( NodeStore.class ),
-            mock( PropertyLoader.class ), new PropertyPhysicalToLogicalConverter( propertyStore ),
+            new PropertyPhysicalToLogicalConverter( propertyStore ),
             TransactionApplicationMode.INTERNAL );
     private final PhysicalLogCommandReaderV2_2 reader = new PhysicalLogCommandReaderV2_2();
     private final IndexRule rule = IndexRule.indexRule( id, NewIndexDescriptorFactory.forLabel( labelId, propertyKey ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 import org.neo4j.kernel.impl.api.BatchTransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -84,7 +85,7 @@ public class SchemaRuleCommandTest
             mock( CacheAccessBackDoor.class ), LockService.NO_LOCK_SERVICE );
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSynchronizer =
             new WorkSync<>( labelScanStore );
-    private final WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexes );
+    private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync = new WorkSync<>( indexes );
     private final PropertyStore propertyStore = mock( PropertyStore.class );
     private final IndexBatchTransactionApplier indexApplier = new IndexBatchTransactionApplier( indexes,
             labelScanStoreSynchronizer, indexUpdatesSync, mock( NodeStore.class ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.NodeUpdates;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.BatchTransactionApplier;
@@ -1218,7 +1219,7 @@ public class TransactionRecordStateTest
         transaction.accept( extractor );
 
         OnlineIndexUpdates lazyIndexUpdates = new OnlineIndexUpdates( neoStores.getNodeStore(),
-                new PropertyLoader( neoStores ),
+                mock( IndexingUpdateService.class ),
                 new PropertyPhysicalToLogicalConverter( neoStores.getPropertyStore() ) );
         lazyIndexUpdates.feed( extractor.propertyCommandsByNodeIds(), extractor.nodeCommandsById() );
         return lazyIndexUpdates;


### PR DESCRIPTION
This fixes the store corruption issue that is blocking alpha07, confirmed locally.

I did not go all the way cleaning these changes up, will clean some more in a separate PR if the issue is solved.