### PR TITLE
Cache the PropertyExistanceEnforcer

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.store;
 
 import java.util.Iterator;
+import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -608,6 +609,12 @@ public class StorageLayer implements StoreReadLayer
         RelationshipGroupRecord relationshipGroupRecord = relationshipGroupStore.newRecord();
         return countRelationshipsInGroup( groupId, direction, relType, nodeId, relationshipRecord,
                 relationshipGroupRecord, storeStatement.recordCursors() );
+    }
+
+    @Override
+    public <T> T getOrCreateSchemaDependantState( Class<T> type, Function<StoreReadLayer,T> factory )
+    {
+        return schemaCache.getOrCreateDependantState( type, factory, this );
     }
 
     private void visitNode( StorageStatement statement, NodeItem nodeItem, DegreeVisitor visitor )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -322,7 +322,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
                     txStateVisitor, storeLayer, storageStatement, txState, countsRecordState );
             try ( TxStateVisitor visitor = txStateVisitor )
             {
-                txState.accept( txStateVisitor );
+                txState.accept( visitor );
             }
 
             // Convert record state into commands

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -20,6 +20,7 @@
 package org.neo4j.storageengine.api;
 
 import java.util.Iterator;
+import java.util.function.Function;
 import java.util.function.IntPredicate;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
@@ -384,4 +385,6 @@ public interface StoreReadLayer
 
     int degreeRelationshipsInGroup( StorageStatement storeStatement, long id, long groupId, Direction direction,
             Integer relType );
+
+    <T> T getOrCreateSchemaDependantState( Class<T> type, Function<StoreReadLayer, T> factory );
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveSortedArraySet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveSortedArraySet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive;
+
+import java.util.Arrays;
+
+public class PrimitiveSortedArraySet
+{
+    /**
+     * Merges two sets of integers represented as sorted arrays.
+     *
+     * @param lhs
+     *         a set of integers, represented as a sorted array.
+     * @param rhs
+     *         a set of integers, represented as a sorted array.
+     * @return a set of integers, represented as a sorted array.
+     */
+    public static int[] mergeSortedSet( int[] lhs, int[] rhs )
+    {
+        if ( lhs.length < rhs.length )
+        {
+            return mergeSortedSet( rhs, lhs );
+        }
+        int[] merged = null;
+        int m = 0;
+        for ( int l = 0, r = 0; l < lhs.length && r < rhs.length; )
+        {
+            while ( l < lhs.length && lhs[l] < rhs[r] )
+            {
+                if ( merged != null )
+                {
+                    merged[m++] = lhs[l];
+                }
+                l++;
+            }
+            if ( l == lhs.length )
+            {
+                if ( merged == null )
+                {
+                    merged = Arrays.copyOf( lhs, lhs.length + rhs.length - r );
+                    m = l;
+                }
+                System.arraycopy( rhs, r, merged, m, rhs.length - r );
+                m += rhs.length - r;
+                break;
+            }
+            if ( lhs[l] > rhs[r] )
+            {
+                if ( merged == null )
+                {
+                    merged = Arrays.copyOf( lhs, lhs.length + rhs.length - r );
+                    m = l;
+                }
+                merged[m++] = rhs[r++];
+            }
+            else // i.e. ( lhs[l] == rhs[r] )
+            {
+                if ( merged != null )
+                {
+                    merged[m++] = lhs[l];
+                }
+                l++;
+                r++;
+            }
+        }
+        if ( merged == null )
+        {
+            return lhs;
+        }
+        if ( merged.length < m )
+        {
+            merged = Arrays.copyOf( merged, m );
+        }
+        return merged;
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveSortedArraySetTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveSortedArraySetTest.java
@@ -5,19 +5,19 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.enterprise;
+package org.neo4j.collection.primitive;
 
 import java.util.Arrays;
 
@@ -27,10 +27,10 @@ import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertSame;
-import static org.neo4j.kernel.impl.enterprise.PropertyExistenceEnforcer.merge;
+import static org.neo4j.collection.primitive.PrimitiveSortedArraySet.mergeSortedSet;
 
 @RunWith( Parameterized.class )
-public class PropertyExistenceEnforcerMergeTest
+public class PrimitiveSortedArraySetTest
 {
     @Parameterized.Parameters( name = "{0}" )
     public static Iterable<Object[]> parameters()
@@ -53,7 +53,7 @@ public class PropertyExistenceEnforcerMergeTest
     private final int[] rhs;
     private final int[] expected;
 
-    public PropertyExistenceEnforcerMergeTest( Input input )
+    public PrimitiveSortedArraySetTest( Input input )
     {
         this.lhs = input.lhs;
         this.rhs = input.rhs;
@@ -63,7 +63,7 @@ public class PropertyExistenceEnforcerMergeTest
     @Test
     public void testMerge() throws Exception
     {
-        int[] actual = merge( lhs, rhs );
+        int[] actual = mergeSortedSet( lhs, rhs );
         if ( lhs == expected || rhs == expected )
         {
             assertSame( expected, actual );

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseConstraintSemantics.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.kernel.impl.enterprise;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.BiPredicate;
 
 import org.neo4j.cursor.Cursor;
@@ -31,7 +29,6 @@ import org.neo4j.kernel.api.exceptions.schema.NodePropertyExistenceException;
 import org.neo4j.kernel.api.exceptions.schema.RelationshipPropertyExistenceException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
-import org.neo4j.kernel.api.schema_new.SchemaProcessor;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
@@ -43,6 +40,7 @@ import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.storageengine.api.txstate.TxStateVisitor;
 
 import static org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException.Phase.VERIFICATION;
+import static org.neo4j.kernel.impl.enterprise.PropertyExistenceEnforcer.getOrCreatePropertyExistenceEnforcerFrom;
 
 public class EnterpriseConstraintSemantics extends StandardConstraintSemantics
 {
@@ -135,48 +133,16 @@ public class EnterpriseConstraintSemantics extends StandardConstraintSemantics
     public TxStateVisitor decorateTxStateVisitor( StoreReadLayer storeLayer, ReadableTransactionState txState,
             TxStateVisitor visitor )
     {
-        ExistenceConstraintCollector collector = new ExistenceConstraintCollector();
-        Iterator<ConstraintDescriptor> constraints = storeLayer.constraintsGetAll();
-        while ( constraints.hasNext() )
+        if ( !txState.hasDataChanges() )
         {
-            collector.addIfRelevant( constraints.next() );
+            // If there are no data changes, there is no need to enforce constraints. Since there is no need to
+            // enforce constraints, there is no need to build up the state required to be able to enforce constraints.
+            // In fact, it might even be counter productive to build up that state, since if there are no data changes
+            // there would be schema changes instead, and in that case we would throw away the schema-dependant state
+            // we just built when the schema changing transaction commits.
+            return visitor;
         }
-
-        if ( collector.hasExistenceConstraints() )
-        {
-            return new PropertyExistenceEnforcer( visitor, txState, storeLayer, collector.labelExists, collector.relTypeExists );
-        }
-        return visitor;
-    }
-
-    private static class ExistenceConstraintCollector implements SchemaProcessor
-    {
-        final List<LabelSchemaDescriptor> labelExists = new ArrayList<>();
-        final List<RelationTypeSchemaDescriptor> relTypeExists = new ArrayList<>();
-
-        void addIfRelevant( ConstraintDescriptor constraint )
-        {
-            if ( constraint.enforcesPropertyExistence() )
-            {
-                constraint.schema().processWith( this );
-            }
-        }
-
-        @Override
-        public void processSpecific( LabelSchemaDescriptor schema )
-        {
-            labelExists.add( schema );
-        }
-
-        @Override
-        public void processSpecific( RelationTypeSchemaDescriptor schema )
-        {
-            relTypeExists.add( schema );
-        }
-
-        boolean hasExistenceConstraints()
-        {
-            return labelExists.size() > 0 || relTypeExists.size() > 0;
-        }
+        return getOrCreatePropertyExistenceEnforcerFrom( storeLayer )
+                .decorate( visitor, txState, storeLayer );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -19,11 +19,16 @@
  */
 package org.neo4j.kernel.impl.enterprise;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntIterator;
+import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
@@ -31,6 +36,8 @@ import org.neo4j.kernel.api.exceptions.schema.NodePropertyExistenceException;
 import org.neo4j.kernel.api.exceptions.schema.RelationshipPropertyExistenceException;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.SchemaProcessor;
+import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -42,191 +49,407 @@ import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.storageengine.api.txstate.TxStateVisitor;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException.Phase.VALIDATION;
 
-class PropertyExistenceEnforcer extends TxStateVisitor.Delegator
+class PropertyExistenceEnforcer
 {
-    private final StoreReadLayer storeLayer;
-    private final ReadableTransactionState txState;
-    private final List<LabelSchemaDescriptor> labelExistenceConstraints;
-    private final List<RelationTypeSchemaDescriptor> relTypeExistenceConstraints;
-
-    private final PrimitiveIntSet propertyKeyIds = Primitive.intSet();
-
-    private StorageStatement storageStatement;
-
-    PropertyExistenceEnforcer( TxStateVisitor next, ReadableTransactionState txState, StoreReadLayer storeLayer,
-            List<LabelSchemaDescriptor> labelExistenceConstraints,
-            List<RelationTypeSchemaDescriptor> relTypeExistenceConstraints )
+    static PropertyExistenceEnforcer getOrCreatePropertyExistenceEnforcerFrom( StoreReadLayer storeLayer )
     {
-        super( next );
-        this.txState = txState;
-        this.storeLayer = storeLayer;
-        this.labelExistenceConstraints = labelExistenceConstraints;
-        this.relTypeExistenceConstraints = relTypeExistenceConstraints;
+        return storeLayer.getOrCreateSchemaDependantState( PropertyExistenceEnforcer.class, FACTORY );
     }
 
-    @Override
-    public void visitNodePropertyChanges( long id, Iterator<StorageProperty> added, Iterator<StorageProperty> changed,
-            Iterator<Integer> removed ) throws ConstraintValidationException
-    {
-        validateNode( id );
-        super.visitNodePropertyChanges( id, added, changed, removed );
-    }
+    private final List<LabelSchemaDescriptor> nodeConstraints;
+    private final List<RelationTypeSchemaDescriptor> relationshipConstraints;
+    private final PrimitiveIntObjectMap<int[]> mandatoryNodePropertiesByLabel = Primitive.intObjectMap();
+    private final PrimitiveIntObjectMap<int[]> mandatoryRelationshipPropertiesByType = Primitive.intObjectMap();
 
-    @Override
-    public void visitNodeLabelChanges( long id, Set<Integer> added, Set<Integer> removed )
-            throws ConstraintValidationException
+    private PropertyExistenceEnforcer( List<LabelSchemaDescriptor> nodes, List<RelationTypeSchemaDescriptor> rels )
     {
-        validateNode( id );
-        super.visitNodeLabelChanges( id, added, removed );
-    }
-
-    @Override
-    public void visitCreatedRelationship( long id, int type, long startNode, long endNode )
-            throws ConstraintValidationException
-    {
-        validateRelationship( id );
-        super.visitCreatedRelationship( id, type, startNode, endNode );
-    }
-
-    @Override
-    public void visitRelPropertyChanges( long id, Iterator<StorageProperty> added, Iterator<StorageProperty> changed,
-            Iterator<Integer> removed ) throws ConstraintValidationException
-    {
-        validateRelationship( id );
-        super.visitRelPropertyChanges( id, added, changed, removed );
-    }
-
-    private void validateNode( long nodeId ) throws NodePropertyExistenceException
-    {
-        if ( labelExistenceConstraints.isEmpty() )
+        this.nodeConstraints = nodes;
+        this.relationshipConstraints = rels;
+        for ( LabelSchemaDescriptor constraint : nodes )
         {
-            return;
+            update( mandatoryNodePropertiesByLabel, constraint.getLabelId(), constraint.getPropertyIds() );
+        }
+        for ( RelationTypeSchemaDescriptor constraint : rels )
+        {
+            update( mandatoryRelationshipPropertiesByType, constraint.getRelTypeId(), constraint.getPropertyIds() );
+        }
+    }
+
+    private static void update( PrimitiveIntObjectMap<int[]> map, int key, int[] values )
+    {
+        Arrays.sort( values );
+        int[] current = map.get( key );
+        if ( current != null )
+        {
+            values = merge( current, values );
+        }
+        map.put( key, values );
+    }
+
+    TxStateVisitor decorate( TxStateVisitor visitor, ReadableTransactionState txState, StoreReadLayer storeLayer )
+    {
+        return new Decorator( visitor, txState, storeLayer );
+    }
+
+    private static final PropertyExistenceEnforcer NO_CONSTRAINTS = new PropertyExistenceEnforcer(
+            emptyList(), emptyList() )
+    {
+        @Override
+        TxStateVisitor decorate( TxStateVisitor visitor, ReadableTransactionState txState, StoreReadLayer storeLayer )
+        {
+            return visitor;
+        }
+    };
+    private static final Function<StoreReadLayer,PropertyExistenceEnforcer> FACTORY = storeLayer ->
+    {
+        List<LabelSchemaDescriptor> nodes = new ArrayList<>();
+        List<RelationTypeSchemaDescriptor> relationships = new ArrayList<>();
+        for ( Iterator<ConstraintDescriptor> constraints = storeLayer.constraintsGetAll(); constraints.hasNext(); )
+        {
+            ConstraintDescriptor constraint = constraints.next();
+            if ( constraint.enforcesPropertyExistence() )
+            {
+                constraint.schema().processWith( new SchemaProcessor()
+                {
+                    @Override
+                    public void processSpecific( LabelSchemaDescriptor schema )
+                    {
+                        nodes.add( schema );
+                    }
+
+                    @Override
+                    public void processSpecific( RelationTypeSchemaDescriptor schema )
+                    {
+                        relationships.add( schema );
+                    }
+                } );
+            }
+        }
+        if ( nodes.isEmpty() && relationships.isEmpty() )
+        {
+            return NO_CONSTRAINTS;
+        }
+        return new PropertyExistenceEnforcer( nodes, relationships );
+    };
+
+    private class Decorator extends TxStateVisitor.Delegator
+    {
+        private final ReadableTransactionState txState;
+        private final StoreReadLayer storeLayer;
+        private final PrimitiveIntSet propertyKeyIds = Primitive.intSet();
+        private StorageStatement storageStatement;
+
+        Decorator( TxStateVisitor next, ReadableTransactionState txState, StoreReadLayer storeLayer )
+        {
+            super( next );
+            this.txState = txState;
+            this.storeLayer = storeLayer;
         }
 
-        try ( Cursor<NodeItem> node = nodeCursor( nodeId ) )
+        @Override
+        public void visitNodePropertyChanges(
+                long id, Iterator<StorageProperty> added, Iterator<StorageProperty> changed,
+                Iterator<Integer> removed ) throws ConstraintValidationException
         {
-            if ( node.next() )
+            validateNode( id );
+            super.visitNodePropertyChanges( id, added, changed, removed );
+        }
+
+        @Override
+        public void visitNodeLabelChanges( long id, Set<Integer> added, Set<Integer> removed )
+                throws ConstraintValidationException
+        {
+            validateNode( id );
+            super.visitNodeLabelChanges( id, added, removed );
+        }
+
+        @Override
+        public void visitCreatedRelationship( long id, int type, long startNode, long endNode )
+                throws ConstraintValidationException
+        {
+            validateRelationship( id );
+            super.visitCreatedRelationship( id, type, startNode, endNode );
+        }
+
+        @Override
+        public void visitRelPropertyChanges(
+                long id, Iterator<StorageProperty> added, Iterator<StorageProperty> changed,
+                Iterator<Integer> removed ) throws ConstraintValidationException
+        {
+            validateRelationship( id );
+            super.visitRelPropertyChanges( id, added, changed, removed );
+        }
+
+        @Override
+        public void close()
+        {
+            super.close();
+            if ( storageStatement != null )
             {
-                PrimitiveIntSet labelIds = node.get().labels();
+                storageStatement.close();
+            }
+        }
 
-                propertyKeyIds.clear();
-                try ( Cursor<PropertyItem> properties = properties( node.get() ) )
+        private void validateNode( long nodeId ) throws NodePropertyExistenceException
+        {
+            if ( mandatoryNodePropertiesByLabel.isEmpty() )
+            {
+                return;
+            }
+
+            PrimitiveIntSet labelIds;
+            try ( Cursor<NodeItem> node = node( nodeId ) )
+            {
+                if ( node.next() )
                 {
-                    while ( properties.next() )
+                    labelIds = node.get().labels();
+                    if ( labelIds.isEmpty() )
                     {
-                        propertyKeyIds.add( properties.get().propertyKeyId() );
+                        return;
                     }
-                }
-
-                for ( LabelSchemaDescriptor descriptor : labelExistenceConstraints )
-                {
-                    if ( labelIds.contains( descriptor.getLabelId() ) )
+                    propertyKeyIds.clear();
+                    try ( Cursor<PropertyItem> properties = properties( node.get() ) )
                     {
-                        for ( int propertyId : descriptor.getPropertyIds() )
+                        while ( properties.next() )
                         {
-                            validateNodeProperty( nodeId, propertyId, descriptor );
+                            propertyKeyIds.add( properties.get().propertyKeyId() );
                         }
                     }
                 }
+                else
+                {
+                    throw new IllegalStateException( format( "Node %d with changes should exist.", nodeId ) );
+                }
             }
-            else
+
+            validateNodeProperties( nodeId, labelIds, propertyKeyIds );
+        }
+
+        private void validateRelationship( long id ) throws RelationshipPropertyExistenceException
+        {
+            if ( mandatoryRelationshipPropertiesByType.isEmpty() )
             {
-                throw new IllegalStateException( format( "Node %d with changes should exist.", nodeId ) );
+                return;
             }
+
+            int relationshipType;
+            int[] required;
+            try ( Cursor<RelationshipItem> relationship = relationship( id ) )
+            {
+                if ( relationship.next() )
+                {
+                    relationshipType = relationship.get().type();
+                    required = mandatoryRelationshipPropertiesByType.get( relationshipType );
+                    if ( required == null )
+                    {
+                        return;
+                    }
+                    propertyKeyIds.clear();
+                    try ( Cursor<PropertyItem> properties = properties( relationship.get() ) )
+                    {
+                        while ( properties.next() )
+                        {
+                            propertyKeyIds.add( properties.get().propertyKeyId() );
+                        }
+                    }
+                }
+                else
+                {
+                    throw new IllegalStateException( format( "Relationship %d with changes should exist.", id ) );
+                }
+            }
+
+            for ( int mandatory : required )
+            {
+                if ( !propertyKeyIds.contains( mandatory ) )
+                {
+                    failRelationship( id, relationshipType, mandatory );
+                }
+            }
+        }
+
+        private Cursor<NodeItem> node( long id )
+        {
+            Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id );
+            return txState.augmentSingleNodeCursor( cursor, id );
+        }
+
+        private Cursor<RelationshipItem> relationship( long id )
+        {
+            Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id );
+            return txState.augmentSingleRelationshipCursor( cursor, id );
+        }
+
+        private Cursor<PropertyItem> properties( NodeItem node )
+        {
+            Lock lock = node.lock();
+            Cursor<PropertyItem> cursor = storeStatement().acquirePropertyCursor( node.nextPropertyId(), lock );
+            return txState.augmentPropertyCursor( cursor, txState.getNodeState( node.id() ) );
+        }
+
+        private Cursor<PropertyItem> properties( RelationshipItem relationship )
+        {
+            Lock lock = relationship.lock();
+            Cursor<PropertyItem> cursor = storeStatement().acquirePropertyCursor( relationship.nextPropertyId(), lock );
+            return txState.augmentPropertyCursor( cursor, txState.getRelationshipState( relationship.id() ) );
+        }
+
+        private StorageStatement storeStatement()
+        {
+            return storageStatement == null ? storageStatement = storeLayer.newStatement() : storageStatement;
         }
     }
 
-    private void validateNodeProperty( long nodeId, int propertyKey, LabelSchemaDescriptor descriptor )
+    private void validateNodeProperties( long id, PrimitiveIntSet labelIds, PrimitiveIntSet propertyKeyIds )
             throws NodePropertyExistenceException
     {
-        if ( !propertyKeyIds.contains( propertyKey ) )
+        if ( labelIds.size() > mandatoryNodePropertiesByLabel.size() )
         {
-            throw new NodePropertyExistenceException( descriptor, ConstraintValidationException.Phase.VALIDATION, nodeId );
-        }
-    }
-
-    private Cursor<NodeItem> nodeCursor( long id )
-    {
-        Cursor<NodeItem> cursor = storeStatement().acquireSingleNodeCursor( id );
-        return txState.augmentSingleNodeCursor( cursor, id );
-    }
-
-    private Cursor<PropertyItem> properties( NodeItem node )
-    {
-        Lock lock = node.lock();
-        Cursor<PropertyItem> cursor = storeStatement().acquirePropertyCursor( node.nextPropertyId(), lock );
-        return txState.augmentPropertyCursor( cursor, txState.getNodeState( node.id() ) );
-    }
-
-    private StorageStatement storeStatement()
-    {
-        return storageStatement == null ? storageStatement = storeLayer.newStatement() : storageStatement;
-    }
-
-    @Override
-    public void close()
-    {
-        super.close();
-        if ( storageStatement != null )
-        {
-            storageStatement.close();
-        }
-    }
-
-    private void validateRelationship( long id ) throws RelationshipPropertyExistenceException
-    {
-        if ( relTypeExistenceConstraints.isEmpty() )
-        {
-            return;
-        }
-
-        try ( Cursor<RelationshipItem> relationship = relationshipCursor( id ) )
-        {
-            if ( relationship.next() )
+            for ( PrimitiveIntIterator labels = mandatoryNodePropertiesByLabel.iterator(); labels.hasNext(); )
             {
-                // Iterate all constraints and find property existence constraints that match relationship type
-                propertyKeyIds.clear();
-                try ( Cursor<PropertyItem> properties = properties( relationship.get() ) )
+                int label = labels.next();
+                if ( labelIds.contains( label ) )
                 {
-                    while ( properties.next() )
-                    {
-                        propertyKeyIds.add( properties.get().propertyKeyId() );
-                    }
-                }
-
-                for ( RelationTypeSchemaDescriptor descriptor : relTypeExistenceConstraints )
-                {
-                    if ( relationship.get().type() == descriptor.getRelTypeId() )
-                    {
-                        for ( int propertyId : descriptor.getPropertyIds() )
-                        {
-                            if ( !propertyKeyIds.contains( propertyId ) )
-                            {
-                                throw new RelationshipPropertyExistenceException( descriptor,
-                                        ConstraintValidationException.Phase.VALIDATION, id );
-                            }
-                        }
-                    }
+                    validateNodeProperties( id, label, mandatoryNodePropertiesByLabel.get( label ), propertyKeyIds );
                 }
             }
-            else
+        }
+        else
+        {
+            for ( PrimitiveIntIterator labels = labelIds.iterator(); labels.hasNext(); )
             {
-                throw new IllegalStateException( format( "Relationship %d with changes should exist.", id ) );
+                int label = labels.next();
+                int[] keys = mandatoryNodePropertiesByLabel.get( label );
+                if ( keys != null )
+                {
+                    validateNodeProperties( id, label, keys, propertyKeyIds );
+                }
+            }
+        }
+    }
+
+    private void validateNodeProperties( long id, int label, int[] requiredKeys, PrimitiveIntSet propertyKeyIds )
+            throws NodePropertyExistenceException
+    {
+        for ( int key : requiredKeys )
+        {
+            if ( !propertyKeyIds.contains( key ) )
+            {
+                failNode( id, label, key );
             }
         }
     }
 
-    private Cursor<RelationshipItem> relationshipCursor( long id )
+    private void failNode( long id, int label, int propertyKey )
+            throws NodePropertyExistenceException
     {
-        Cursor<RelationshipItem> cursor = storeStatement().acquireSingleRelationshipCursor( id );
-        return txState.augmentSingleRelationshipCursor( cursor, id );
+        for ( LabelSchemaDescriptor constraint : nodeConstraints )
+        {
+            if ( constraint.getLabelId() == label && contains( constraint.getPropertyIds(), propertyKey ) )
+            {
+                throw new NodePropertyExistenceException( constraint, VALIDATION, id );
+            }
+        }
+        throw new IllegalStateException( format(
+                "Node constraint for label=%d, propertyKey=%d should exist.",
+                label, propertyKey ) );
     }
 
-    private Cursor<PropertyItem> properties( RelationshipItem relationship )
+    private void failRelationship( long id, int relationshipType, int propertyKey )
+            throws RelationshipPropertyExistenceException
     {
-        Lock lock = relationship.lock();
-        Cursor<PropertyItem> cursor = storeStatement().acquirePropertyCursor( relationship.nextPropertyId(), lock );
-        return txState.augmentPropertyCursor( cursor, txState.getRelationshipState( relationship.id() ) );
+        for ( RelationTypeSchemaDescriptor constraint : relationshipConstraints )
+        {
+            if ( constraint.getRelTypeId() == relationshipType && contains( constraint.getPropertyIds(), propertyKey ) )
+            {
+                throw new RelationshipPropertyExistenceException( constraint, VALIDATION, id );
+            }
+        }
+        throw new IllegalStateException( format(
+                "Relationship constraint for relationshipType=%d, propertyKey=%d should exist.",
+                relationshipType, propertyKey ) );
+    }
+
+    /**
+     * Merges two sets of integers represented as sorted arrays.
+     *
+     * @param lhs
+     *         a set of integers, represented as a sorted array.
+     * @param rhs
+     *         a set of integers, represented as a sorted array.
+     * @return a set of integers, represented as a sorted array.
+     */
+    static int[] merge( int[] lhs, int[] rhs )
+    {
+        if ( lhs.length < rhs.length )
+        {
+            return merge( rhs, lhs );
+        }
+        int[] merged = null;
+        int m = 0;
+        for ( int l = 0, r = 0; l < lhs.length && r < rhs.length; )
+        {
+            while ( l < lhs.length && lhs[l] < rhs[r] )
+            {
+                if ( merged != null )
+                {
+                    merged[m++] = lhs[l];
+                }
+                l++;
+            }
+            if ( l == lhs.length )
+            {
+                if ( merged == null )
+                {
+                    merged = Arrays.copyOf( lhs, lhs.length + rhs.length - r );
+                    m = l;
+                }
+                System.arraycopy( rhs, r, merged, m, rhs.length - r );
+                m += rhs.length - r;
+                break;
+            }
+            if ( lhs[l] > rhs[r] )
+            {
+                if ( merged == null )
+                {
+                    merged = Arrays.copyOf( lhs, lhs.length + rhs.length - r );
+                    m = l;
+                }
+                merged[m++] = rhs[r++];
+            }
+            else // i.e. ( lhs[l] == rhs[r] )
+            {
+                if ( merged != null )
+                {
+                    merged[m++] = lhs[l];
+                }
+                l++;
+                r++;
+            }
+        }
+        if ( merged == null )
+        {
+            return lhs;
+        }
+        if ( merged.length < m )
+        {
+            merged = Arrays.copyOf( merged, m );
+        }
+        return merged;
+    }
+
+    private boolean contains( int[] list, int value )
+    {
+        for ( int x : list )
+        {
+            if ( value == x )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerMergeTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerMergeTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.enterprise;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertSame;
+import static org.neo4j.kernel.impl.enterprise.PropertyExistenceEnforcer.merge;
+
+@RunWith( Parameterized.class )
+public class PropertyExistenceEnforcerMergeTest
+{
+    @Parameterized.Parameters( name = "{0}" )
+    public static Iterable<Object[]> parameters()
+    {
+        return Arrays.asList(
+                lhs( 1, 2, 3 ).rhs( 1, 2, 3 ).expectLhs(),
+                lhs( 1, 2, 3 ).rhs( 1 ).expectLhs(),
+                lhs( 1, 2, 3 ).rhs( 2 ).expectLhs(),
+                lhs( 1, 2, 3 ).rhs( 3 ).expectLhs(),
+                lhs( 1 ).rhs( 1, 2, 3 ).expectRhs(),
+                lhs( 2 ).rhs( 1, 2, 3 ).expectRhs(),
+                lhs( 3 ).rhs( 1, 2, 3 ).expectRhs(),
+                lhs( 1, 2, 3 ).rhs( 4, 5, 6 ).expect( 1, 2, 3, 4, 5, 6 ),
+                lhs( 1, 3, 5 ).rhs( 2, 4, 6 ).expect( 1, 2, 3, 4, 5, 6 ),
+                lhs( 1, 2, 3, 5 ).rhs( 2, 4, 6 ).expect( 1, 2, 3, 4, 5, 6 )
+        );
+    }
+
+    private final int[] lhs;
+    private final int[] rhs;
+    private final int[] expected;
+
+    public PropertyExistenceEnforcerMergeTest( Input input )
+    {
+        this.lhs = input.lhs;
+        this.rhs = input.rhs;
+        this.expected = input.expected;
+    }
+
+    @Test
+    public void testMerge() throws Exception
+    {
+        int[] actual = merge( lhs, rhs );
+        if ( lhs == expected || rhs == expected )
+        {
+            assertSame( expected, actual );
+        }
+        else
+        {
+            assertArrayEquals( expected, actual );
+        }
+    }
+
+    private static Input.Lhs lhs( int... lhs )
+    {
+        return new Input.Lhs( lhs );
+    }
+
+    static class Input
+    {
+        final int[] lhs;
+        final int[] rhs;
+        final int[] expected;
+
+        Input( int[] lhs, int[] rhs, int[] expected )
+        {
+            this.lhs = lhs;
+            this.rhs = rhs;
+            this.expected = expected;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format(
+                    "{lhs=%s, rhs=%s, expected=%s}",
+                    Arrays.toString( lhs ),
+                    Arrays.toString( rhs ),
+                    Arrays.toString( expected ) );
+        }
+
+        static class Lhs
+        {
+            final int[] lhs;
+
+            Lhs( int[] lhs )
+            {
+                this.lhs = lhs;
+            }
+
+            Rhs rhs( int... rhs )
+            {
+                return new Rhs( lhs, rhs );
+            }
+        }
+
+        static class Rhs
+        {
+            final int[] lhs;
+            final int[] rhs;
+
+            Rhs( int[] lhs, int[] rhs )
+            {
+
+                this.lhs = lhs;
+                this.rhs = rhs;
+            }
+
+            Object[] expect( int... expected )
+            {
+                return new Object[] {new Input( lhs, rhs, expected )};
+            }
+
+            Object[] expectLhs()
+            {
+                return new Object[] {new Input( lhs, rhs, lhs )};
+            }
+
+            Object[] expectRhs()
+            {
+                return new Object[] {new Input( lhs, rhs, rhs )};
+            }
+        }
+    }
+}


### PR DESCRIPTION
Only create new instances of PropertyExistanceEnforcer when needed after the schema has changed.

In addition to that we now only apply the PropertyExistanceEnforcer if there are data changes.