### PR TITLE
Print paths in use as part of startup script

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -211,7 +211,33 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
+EOF
+}
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -278,10 +278,12 @@ main() {
 
   case "${1:-}" in
     console)
+      print_configurable_paths
       do_console
       ;;
 
     start)
+      print_configurable_paths
       do_start
       ;;
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -278,11 +278,13 @@ main() {
 
   case "${1:-}" in
     console)
+      print_active_database
       print_configurable_paths
       do_console
       ;;
 
     start)
+      print_active_database
       print_configurable_paths
       do_start
       ;;

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -187,7 +187,33 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
+EOF
+}
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
@@ -187,7 +187,33 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
+EOF
+}
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
@@ -187,7 +187,33 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
+EOF
+}
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
@@ -183,14 +183,14 @@ _setup_configurable_paths() {
 print_configurable_paths() {
   cat <<EOF
 Directories in use:
-  Home:         ${NEO4J_HOME}
-  Config:       ${NEO4J_CONF}
-  Logs:         ${NEO4J_LOGS}
-  Plugins:      ${NEO4J_PLUGINS}
-  Import:       ${NEO4J_IMPORT}
-  Data:         ${NEO4J_DATA}
-  Certificates: ${NEO4J_CERTS}
-  Run:          ${NEO4J_RUN}
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
 EOF
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
@@ -193,3 +193,7 @@ Directories in use:
   Run:          ${NEO4J_RUN}
 EOF
 }
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
+}

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
@@ -175,5 +175,21 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-import}")
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  Home:         ${NEO4J_HOME}
+  Config:       ${NEO4J_CONF}
+  Logs:         ${NEO4J_LOGS}
+  Plugins:      ${NEO4J_PLUGINS}
+  Import:       ${NEO4J_IMPORT}
+  Data:         ${NEO4J_DATA}
+  Certificates: ${NEO4J_CERTS}
+  Run:          ${NEO4J_RUN}
+EOF
 }

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
@@ -175,8 +175,14 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-import}")
   NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
   readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
@@ -187,7 +187,33 @@ _setup_configurable_paths() {
   NEO4J_LOGS=$(resolve_path "${dbms_directories_logs:-logs}")
   NEO4J_PLUGINS=$(resolve_path "${dbms_directories_plugins:-plugins}")
   NEO4J_RUN=$(resolve_path "${dbms_directories_run:-run}")
-  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN
+  NEO4J_CERTS=$(resolve_path "${dbms_directories_certificates:-certificates}")
+
+  if [ -z "${dbms_directories_import:-}" ]; then
+    NEO4J_IMPORT="NOT SET"
+  else
+    NEO4J_IMPORT=$(resolve_path "${dbms_directories_import:-}")
+  fi
+
+  readonly NEO4J_DATA NEO4J_LIB NEO4J_LOGS NEO4J_PLUGINS NEO4J_RUN NEO4J_IMPORT NEO4J_CERTS
+}
+
+print_configurable_paths() {
+  cat <<EOF
+Directories in use:
+  home:         ${NEO4J_HOME}
+  config:       ${NEO4J_CONF}
+  logs:         ${NEO4J_LOGS}
+  plugins:      ${NEO4J_PLUGINS}
+  import:       ${NEO4J_IMPORT}
+  data:         ${NEO4J_DATA}
+  certificates: ${NEO4J_CERTS}
+  run:          ${NEO4J_RUN}
+EOF
+}
+
+print_active_database() {
+  echo "Active database: ${dbms_active_database:-graph.db}"
 }
 
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.m4
@@ -273,10 +273,14 @@ main() {
 
   case "${1:-}" in
     console)
+      print_active_database
+      print_configurable_paths
       do_console
       ;;
 
     start)
+      print_active_database
+      print_configurable_paths
       do_start
       ;;
 

--- a/packaging/standalone/src/tests/shell-scripts/test-config.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-config.sh
@@ -120,4 +120,10 @@ test_expect_success "should write paths in use" "
   test_expect_stdout_matching '  Run:          $(neo4j_home)/ruun' run_daemon
 "
 
+test_expect_success "should write active database" "
+  clear_config &&
+  set_config 'dbms.active_database' 'bigdata' neo4j.conf &&
+  test_expect_stdout_matching 'Active database: bigdata' run_daemon
+"
+
 test_done

--- a/packaging/standalone/src/tests/shell-scripts/test-config.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-config.sh
@@ -110,14 +110,14 @@ test_expect_success "should write paths in use" "
   set_config 'dbms.directories.certificates' '/certs/bob' neo4j.conf &&
   set_config 'dbms.directories.run' 'ruun' neo4j.conf &&
   set_config 'dbms.directories.logs' 'loogs' neo4j.conf &&
-  test_expect_stdout_matching '  Home:         $(neo4j_home)' run_daemon &&
-  test_expect_stdout_matching '  Config:       $(neo4j_home)/conf' run_daemon &&
-  test_expect_stdout_matching '  Data:         /data/bob' run_daemon &&
-  test_expect_stdout_matching '  Import:       /import/bob' run_daemon &&
-  test_expect_stdout_matching '  Plugins:      /plugins/bob' run_daemon &&
-  test_expect_stdout_matching '  Certificates: /certs/bob' run_daemon &&
-  test_expect_stdout_matching '  Logs:         $(neo4j_home)/loogs' run_daemon &&
-  test_expect_stdout_matching '  Run:          $(neo4j_home)/ruun' run_daemon
+  test_expect_stdout_matching '  home:         $(neo4j_home)' run_daemon &&
+  test_expect_stdout_matching '  config:       $(neo4j_home)/conf' run_daemon &&
+  test_expect_stdout_matching '  data:         /data/bob' run_daemon &&
+  test_expect_stdout_matching '  import:       /import/bob' run_daemon &&
+  test_expect_stdout_matching '  plugins:      /plugins/bob' run_daemon &&
+  test_expect_stdout_matching '  certificates: /certs/bob' run_daemon &&
+  test_expect_stdout_matching '  logs:         $(neo4j_home)/loogs' run_daemon &&
+  test_expect_stdout_matching '  run:          $(neo4j_home)/ruun' run_daemon
 "
 
 test_expect_success "should write active database" "

--- a/packaging/standalone/src/tests/shell-scripts/test-config.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-config.sh
@@ -100,4 +100,24 @@ test_expect_success "can configure log directory outside neo4j-root" "
   test_expect_file_matching 'stdout from java' '$(pwd)/other-log-dir/neo4j.log'
 "
 
+test_expect_success "should write paths in use" "
+  clear_config &&
+  mkdir '$(neo4j_home)/loogs' &&
+  mkdir '$(neo4j_home)/ruun' &&
+  set_config 'dbms.directories.data' '/data/bob' neo4j.conf &&
+  set_config 'dbms.directories.import' '/import/bob' neo4j.conf &&
+  set_config 'dbms.directories.plugins' '/plugins/bob' neo4j.conf &&
+  set_config 'dbms.directories.certificates' '/certs/bob' neo4j.conf &&
+  set_config 'dbms.directories.run' 'ruun' neo4j.conf &&
+  set_config 'dbms.directories.logs' 'loogs' neo4j.conf &&
+  test_expect_stdout_matching '  Home:         $(neo4j_home)' run_daemon &&
+  test_expect_stdout_matching '  Config:       $(neo4j_home)/conf' run_daemon &&
+  test_expect_stdout_matching '  Data:         /data/bob' run_daemon &&
+  test_expect_stdout_matching '  Import:       /import/bob' run_daemon &&
+  test_expect_stdout_matching '  Plugins:      /plugins/bob' run_daemon &&
+  test_expect_stdout_matching '  Certificates: /certs/bob' run_daemon &&
+  test_expect_stdout_matching '  Logs:         $(neo4j_home)/loogs' run_daemon &&
+  test_expect_stdout_matching '  Run:          $(neo4j_home)/ruun' run_daemon
+"
+
 test_done


### PR DESCRIPTION
Example output when starting neo4j (default config, tarball):


### Console
```
$ bin/neo4j console                            
Active database: graph.db                                                               
Directories in use:                                                                                                
  Home:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT
  Config:       /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/conf
  Logs:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/logs
  Plugins:      /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/plugins
  Import:       /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/import
  Data:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/data
  Certificates: /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/certificates
  Run:          /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/run
Starting Neo4j.
WARNING: Max 1024 open files allowed, minimum of 40000 recommended. See the Neo4j manual.
2017-03-24 16:21:05.527+0000 INFO  Starting...
...
```

### Start
```
$ bin/neo4j start
Active database: graph.db
Directories in use:
  Home:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT
  Config:       /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/conf
  Logs:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/logs
  Plugins:      /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/plugins
  Import:       /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/import
  Data:         /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/data
  Certificates: /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/certificates
  Run:          /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/run
Starting Neo4j.
WARNING: Max 1024 open files allowed, minimum of 40000 recommended. See the Neo4j manual.
Started neo4j (pid 26044). It is available at http://localhost:7474/
There may be a short delay until the server is ready.
See /home/jonas/work/neo4j/packaging/standalone/target/neo4j-enterprise-3.2.0-SNAPSHOT/logs/neo4j.log for current status.
```