### PR TITLE
Allow skip bad entries logging during import

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -179,7 +179,7 @@ public class ImportTool
                         + "about relationships refering to missing nodes. Format errors in input data are "
                         + "still treated as errors" ),
         SKIP_BAD_ENTRIES_LOGGING ("skip-bad-entries-logging", Boolean.FALSE,
-                "<true/false>", "Whether or not log bad entries detected during import."),
+                "<true/false>", "Whether or not to skip logging bad entries detected during import."),
         SKIP_BAD_RELATIONSHIPS( "skip-bad-relationships", Boolean.TRUE,
                 "<true/false>",
                 "Whether or not to skip importing relationships that refers to missing node ids, i.e. either "

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -913,6 +913,36 @@ public class ImportToolTest
     }
 
     @Test
+    public void skipLoggingOfBadEntries() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = asList( "a", "b", "c" );
+        Configuration config = Configuration.COMMAS;
+        File nodeData = nodeData( true, config, nodeIds, TRUE );
+        List<RelationshipDataLine> relationships = Arrays.asList(
+                // header                                   line 1 of file1
+                relationship( "a", "b", "TYPE", "aa" ), //          line 2 of file1
+                relationship( "c", "bogus", "TYPE", "bb" ), //      line 3 of file1
+                relationship( "b", "c", "KNOWS", "cc" ), //         line 1 of file2
+                relationship( "c", "a", "KNOWS", "dd" ), //         line 2 of file2
+                relationship( "missing", "a", "KNOWS", "ee" ) ); // line 3 of file2
+        File relationshipData1 = relationshipData( true, config, relationships.iterator(), lines( 0, 2 ), true );
+        File relationshipData2 = relationshipData( false, config, relationships.iterator(), lines( 2, 5 ), true );
+
+        // WHEN importing data where some relationships refer to missing nodes
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", nodeData.getAbsolutePath(),
+                "--bad-tolerance", "2",
+                "--skip-bad-entries-logging", "true",
+                "--relationships", relationshipData1.getAbsolutePath() + MULTI_FILE_DELIMITER +
+                        relationshipData2.getAbsolutePath() );
+
+        assertFalse( badFile().exists() );
+        verifyRelationships( relationships );
+    }
+
+    @Test
     public void shouldFailIfTooManyBadRelationships() throws Exception
     {
         // GIVEN

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -30,7 +30,6 @@ import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.DuplicateInputId
 import static java.lang.String.format;
 import static java.util.Arrays.copyOf;
 import static java.util.Arrays.sort;
-
 import static org.neo4j.helpers.Exceptions.withMessage;
 
 public class BadCollector implements Collector
@@ -56,6 +55,7 @@ public class BadCollector implements Collector
     private final int collect;
     private long[] leftOverDuplicateNodeIds = new long[10];
     private int leftOverDuplicateNodeIdsCursor;
+    private final boolean logBadEntries;
 
     // volatile since one importer thread calls collect(), where this value is incremented and later the "main"
     // thread calls badEntries() to get a count.
@@ -64,50 +64,28 @@ public class BadCollector implements Collector
 
     public BadCollector( OutputStream out, int tolerance, int collect )
     {
+        this(out, tolerance, collect, false);
+    }
+
+    public BadCollector( OutputStream out, int tolerance, int collect, boolean skipBadEntriesLogging )
+    {
         this.out = new PrintStream( out );
         this.tolerance = tolerance;
         this.collect = collect;
+        this.logBadEntries = !skipBadEntriesLogging;
     }
 
     @Override
     public void collectBadRelationship( final InputRelationship relationship, final Object specificValue )
     {
-        checkTolerance( BAD_RELATIONSHIPS, new ProblemReporter()
-        {
-            private final String message = format( "%s refering to missing node %s", relationship, specificValue );
-
-            @Override
-            public String message()
-            {
-                return message;
-            }
-
-            @Override
-            public InputException exception()
-            {
-                return new InputException( message );
-            }
-        } );
+        checkTolerance( BAD_RELATIONSHIPS, new RelationshipsProblemReporter( relationship, specificValue ) );
     }
 
     @Override
     public void collectDuplicateNode( final Object id, long actualId, final String group,
             final String firstSource, final String otherSource )
     {
-        checkTolerance( DUPLICATE_NODES, new ProblemReporter()
-        {
-            @Override
-            public String message()
-            {
-                return DuplicateInputIdException.message( id, group, firstSource, otherSource );
-            }
-
-            @Override
-            public InputException exception()
-            {
-                return new DuplicateInputIdException( id, group, firstSource, otherSource );
-            }
-        } );
+        checkTolerance( DUPLICATE_NODES, new NodesProblemReporter( id, group, firstSource, otherSource ) );
 
         if ( leftOverDuplicateNodeIdsCursor == leftOverDuplicateNodeIds.length )
         {
@@ -119,23 +97,7 @@ public class BadCollector implements Collector
     @Override
     public void collectExtraColumns( final String source, final long row, final String value )
     {
-        checkTolerance( EXTRA_COLUMNS, new ProblemReporter()
-        {
-            private final String message = format( "Extra column not present in header on line %d in %s with value %s",
-                    row, source, value );
-
-            @Override
-            public String message()
-            {
-                return message;
-            }
-
-            @Override
-            public InputException exception()
-            {
-                return new InputException( message );
-            }
-        } );
+        checkTolerance( EXTRA_COLUMNS, new ExtraColumnsProblemReporter( row, source, value ) );
     }
 
     @Override
@@ -168,17 +130,116 @@ public class BadCollector implements Collector
         boolean collect = collects( bit );
         if ( collect )
         {
-            out.println( report.message() );
+            if ( logBadEntries )
+            {
+                out.println( report.message() );
+            }
             badEntries++;
         }
 
         if ( !collect || (tolerance != BadCollector.UNLIMITED_TOLERANCE && badEntries > tolerance) )
         {
             InputException exception = report.exception();
-            throw collect
-                    ? withMessage( exception, format( "Too many bad entries %d, where last one was: %s", badEntries,
-                            exception.getMessage() ) )
-                    : exception;
+            throw collect ? withMessage( exception, format( "Too many bad entries %d, where last one was: %s",
+                    badEntries, exception.getMessage() ) ) : exception;
+        }
+    }
+
+    private static class RelationshipsProblemReporter implements ProblemReporter
+    {
+        private String message;
+        private final InputRelationship relationship;
+        private final Object specificValue;
+
+        RelationshipsProblemReporter( InputRelationship relationship, Object specificValue )
+        {
+            this.relationship = relationship;
+            this.specificValue = specificValue;
+        }
+
+        @Override
+        public String message()
+        {
+            return getReportMessage();
+        }
+
+        @Override
+        public InputException exception()
+        {
+            return new InputException( getReportMessage() );
+        }
+
+        private String getReportMessage()
+        {
+            if ( message == null )
+            {
+                message = format( "%s refering to missing node %s", relationship, specificValue );
+            }
+            return message;
+        }
+    }
+
+    private static class NodesProblemReporter implements ProblemReporter
+    {
+        private final Object id;
+        private final String group;
+        private final String firstSource;
+        private final String otherSource;
+
+        NodesProblemReporter( Object id, String group, String firstSource, String otherSource )
+        {
+            this.id = id;
+            this.group = group;
+            this.firstSource = firstSource;
+            this.otherSource = otherSource;
+        }
+
+        @Override
+        public String message()
+        {
+            return DuplicateInputIdException.message( id, group, firstSource, otherSource );
+        }
+
+        @Override
+        public InputException exception()
+        {
+            return new DuplicateInputIdException( id, group, firstSource, otherSource );
+        }
+    }
+
+    private static class ExtraColumnsProblemReporter implements ProblemReporter
+    {
+        private String message;
+        private final long row;
+        private final String source;
+        private final String value;
+
+        ExtraColumnsProblemReporter( long row, String source, String value )
+        {
+            this.row = row;
+            this.source = source;
+            this.value = value;
+        }
+
+        @Override
+        public String message()
+        {
+            return getReportMessage();
+        }
+
+        @Override
+        public InputException exception()
+        {
+            return new InputException( getReportMessage() );
+        }
+
+        private String getReportMessage()
+        {
+            if ( message == null )
+            {
+                message = format( "Extra column not present in header on line %d in %s with value %s", row, source, value );
+            }
+            return message;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
@@ -42,17 +42,22 @@ public class Collectors
             {
                 // ignored
             }
-        }, tolerance, collect );
+        }, tolerance, collect, true );
     }
 
     public static Collector badCollector( OutputStream out, int tolerance )
     {
-        return badCollector( out, tolerance, BadCollector.COLLECT_ALL );
+        return badCollector( out, tolerance, BadCollector.COLLECT_ALL, false );
     }
 
     public static Collector badCollector( OutputStream out, int tolerance, int collect )
     {
-        return new BadCollector( out, tolerance, collect );
+        return new BadCollector( out, tolerance, collect, false );
+    }
+
+    public static Collector badCollector( OutputStream out, int tolerance, int collect, boolean skipBadEntriesLogging )
+    {
+        return new BadCollector( out, tolerance, collect, skipBadEntriesLogging );
     }
 
     public static Function<OutputStream,Collector> badCollector( final int tolerance )
@@ -62,7 +67,7 @@ public class Collectors
 
     public static Function<OutputStream,Collector> badCollector( final int tolerance, final int collect )
     {
-        return out -> badCollector( out, tolerance, collect );
+        return out -> badCollector( out, tolerance, collect, false );
     }
 
     public static int collect( boolean skipBadRelationships, boolean skipDuplicateNodes, boolean ignoreExtraColumns )


### PR DESCRIPTION
Introduce new import tool option: `skip-bad-entries-logging` that will allow to skip logging of all bad entries.
Default value of new option: false