### PR TITLE
Use single shared instance of NullOutputStream across all modules

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
@@ -19,9 +19,10 @@
  */
 package org.neo4j.cypher
 
-import java.io.{OutputStream, PrintStream, PrintWriter, StringWriter}
+import java.io.{PrintStream, PrintWriter, StringWriter}
 
 import org.neo4j.graphdb.{NotFoundException, TransactionFailureException}
+import org.neo4j.io.NullOutputStream
 
 import scala.language.reflectiveCalls
 
@@ -134,7 +135,7 @@ class DeleteConcurrencyIT extends ExecutionEngineFunSuite {
 
   test("detach delete should be atomic") {
     val originalErr = System.err
-    System.setErr(new PrintStream( new OutputStream { override def write(b: Int){ } })) // let's not spam!
+    System.setErr(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM)) // let's not spam!
 
     try {
       val nodes = 10

--- a/community/io/src/main/java/org/neo4j/io/NullOutputStream.java
+++ b/community/io/src/main/java/org/neo4j/io/NullOutputStream.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class NullOutputStream extends OutputStream
+{
+    public static final OutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
+
+    private NullOutputStream()
+    {
+    }
+
+    @Override
+    public void write( int b ) throws IOException
+    {
+        //nothing
+    }
+
+    @Override
+    public void write( byte[] b ) throws IOException
+    {
+        // nothing
+    }
+
+    @Override
+    public void write( byte[] b, int off, int len ) throws IOException
+    {
+        // nothing
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.Function;
+
+import org.neo4j.io.NullOutputStream;
 
 /**
  * Common implementations of {@link Collector}
@@ -35,14 +36,7 @@ public class Collectors
 
     public static Collector silentBadCollector( int tolerance, int collect )
     {
-        return badCollector( new OutputStream()
-        {
-            @Override
-            public void write( int i ) throws IOException
-            {
-                // ignored
-            }
-        }, tolerance, collect );
+        return badCollector( NullOutputStream.NULL_OUTPUT_STREAM, tolerance, collect );
     }
 
     public static Collector badCollector( OutputStream out, int tolerance )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
@@ -25,7 +25,6 @@ import org.junit.rules.RuleChain;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -34,11 +33,11 @@ import java.util.function.Supplier;
 import org.neo4j.csv.reader.CharReadable;
 import org.neo4j.csv.reader.DataAfterQuoteException;
 import org.neo4j.csv.reader.Readables;
+import org.neo4j.io.NullOutputStream;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
@@ -53,7 +52,6 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.data;
@@ -91,7 +89,7 @@ public class ImportPanicIT
                 relationshipData(), defaultFormatRelationshipFileHeader(),
                 IdType.ACTUAL,
                 csvConfigurationWithLowBufferSize(),
-                new BadCollector( new NullOutputStream(), 0, 0 ),
+                new BadCollector( NullOutputStream.NULL_OUTPUT_STREAM, 0, 0 ),
                 Runtime.getRuntime().availableProcessors() );
 
         // WHEN
@@ -157,13 +155,5 @@ public class ImportPanicIT
             }
         }
         return file;
-    }
-
-    public class NullOutputStream extends OutputStream
-    {
-        @Override
-        public void write( int b ) throws IOException
-        {
-        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.io.NullOutputStream;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
@@ -207,7 +208,7 @@ public class BadCollectorTest
     public void shouldCollectUnlimitedNumberOfBadEntriesIfToldTo() throws Exception
     {
         // GIVEN
-        BadCollector collector = new BadCollector( new NullOutputStream(), UNLIMITED_TOLERANCE, COLLECT_ALL );
+        BadCollector collector = new BadCollector( NullOutputStream.NULL_OUTPUT_STREAM, UNLIMITED_TOLERANCE, COLLECT_ALL );
 
         // WHEN
         int count = 10_000;
@@ -257,13 +258,5 @@ public class BadCollectorTest
         fileSystem.mkdir( badDataPath.getParentFile() );
         fileSystem.create( badDataPath );
         return badDataPath;
-    }
-
-    private static class NullOutputStream extends OutputStream
-    {
-        @Override
-        public void write( int b ) throws IOException
-        {   // Don't
-        }
     }
 }

--- a/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
+++ b/community/logging/src/main/java/org/neo4j/logging/RotatingFileOutputStreamSupplier.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import org.neo4j.io.NullOutputStream;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
@@ -66,13 +67,7 @@ public class RotatingFileOutputStreamSupplier implements Supplier<OutputStream>,
     private static final LongSupplier DEFAULT_CURRENT_TIME_SUPPLIER = System::currentTimeMillis;
 
     // Used only in case no new output file can be created during rotation
-    private static final OutputStream nullStream = new OutputStream()
-    {
-        @Override
-        public void write( int i ) throws IOException
-        {
-        }
-    };
+    private static final OutputStream nullStream = NullOutputStream.NULL_OUTPUT_STREAM;
 
     private final LongSupplier currentTimeSupplier;
     private final FileSystemAbstraction fileSystem;

--- a/tools/src/main/java/org/neo4j/tools/console/input/ConsoleUtil.java
+++ b/tools/src/main/java/org/neo4j/tools/console/input/ConsoleUtil.java
@@ -24,54 +24,29 @@ import io.airlift.airline.Help;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.StringTokenizer;
 
+import org.neo4j.io.NullOutputStream;
 import org.neo4j.kernel.impl.util.Listener;
 
 import static org.neo4j.helpers.ArrayUtil.join;
 
 public class ConsoleUtil
 {
-    public static final Listener<PrintStream> NO_PROMPT = new Listener<PrintStream>()
-    {
-        @Override
-        public void receive( PrintStream out )
-        {   // Do nothing
-        }
+    public static final Listener<PrintStream> NO_PROMPT = out ->
+    {   // Do nothing
     };
 
     public static final Listener<PrintStream> staticPrompt( final String prompt )
     {
-        return new Listener<PrintStream>()
-        {
-            @Override
-            public void receive( PrintStream out )
-            {
-                out.print( prompt );
-            }
-        };
+        return out -> out.print( prompt );
     }
 
-    public static final OutputStream NULL_OUTPUT_STREAM = new OutputStream()
-    {
-        @Override
-        public void close(){}
-        @Override
-        public void flush(){}
-        @Override
-        public void write(byte[]b){}
-        @Override
-        public void write(byte[]b,int i,int l){}
-        @Override
-        public void write(int b){}
-    };
-
-    public static final PrintStream NULL_PRINT_STREAM = new PrintStream( NULL_OUTPUT_STREAM );
+    public static final PrintStream NULL_PRINT_STREAM = new PrintStream( NullOutputStream.NULL_OUTPUT_STREAM );
 
     public static String[] tokenizeStringWithQuotes( String string )
     {


### PR DESCRIPTION
Introduce NullOutputStream.
Remove custom null output stream implementations and update code to use single shared instance.