### PR TITLE
Never checkpoint GBPTree on close

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -735,8 +735,8 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
     /**
      * Closes this tree and its associated resources.
-     * NOTE: No {@link #checkpoint(IOLimiter) checkpoint} is performed. To make data persistent in store
-     * a checkpoint needs to be performed manually.
+     * <p>
+     * NOTE: No {@link #checkpoint(IOLimiter) checkpoint} is performed.
      *
      * @throws IOException on error closing resources.
      */
@@ -751,10 +751,10 @@ public class GBPTree<KEY,VALUE> implements Closeable
                 return;
             }
 
-            closed = true;
             // Force close on writer to not risk deadlock on pagedFile.close()
             writer.close();
             pagedFile.close();
+            closed = true;
         }
         finally
         {


### PR DESCRIPTION
Checkpoint will increment stable and unstable generation of tree,
making it impossible to recognise crash-pointers during the recovery
following the database crash.

Responsibility for checkpointing is completely left to the system
so GBPTree will only checkpoint when rest of system is checkpointing.

A checkpoint is always done as last step of a clean shutdown, which means NativeLabelScanStore (with underlying GBPTree) will always be flushed.

First attempt at this prevented checkpoint on close only when system
saw panic, but that did not guard for some failures during recovery
that did not trigger panic.