### PR TITLE
Fix bug, native label scan store missing entry 0,0

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -247,7 +247,7 @@ public class NativeLabelScanStore implements LabelScanStore
         int highestLabelId = -1;
         try ( RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor = index.seek(
                 new LabelScanKey().set( Integer.MAX_VALUE, Long.MAX_VALUE ),
-                new LabelScanKey().set( 0, 0 ) ) )
+                new LabelScanKey().set( 0, -1 ) ) )
         {
             if ( cursor.next() )
             {


### PR DESCRIPTION
When searching for allNodeLabelRanges, native label scan store
would miss entry with labelId 0 and nodeId 0 if it was the only
entry because it did not calculate highestLabelId correctly.