### PR TITLE
Handle LocalDatabase restart breaking bolt connections

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactoryImpl.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactoryImpl.java
@@ -21,6 +21,7 @@ package org.neo4j.bolt.v1.runtime;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.graphdb.DependencyResolver;
@@ -49,8 +50,8 @@ public class BoltFactoryImpl extends LifecycleAdapter implements BoltFactory
 
     private QueryExecutionEngine queryExecutionEngine;
     private GraphDatabaseQueryService queryService;
-    private TransactionIdStore transactionIdStore;
     private AvailabilityGuard availabilityGuard;
+    private DependencyResolver dependencyResolver;
 
     public BoltFactoryImpl( GraphDatabaseAPI gds, UsageData usageData, LogService logging,
             ThreadToStatementContextBridge txBridge, Authentication authentication,
@@ -68,10 +69,9 @@ public class BoltFactoryImpl extends LifecycleAdapter implements BoltFactory
     @Override
     public void start() throws Throwable
     {
-        DependencyResolver dependencyResolver = gds.getDependencyResolver();
+        dependencyResolver = gds.getDependencyResolver();
         queryExecutionEngine = dependencyResolver.resolveDependency( QueryExecutionEngine.class );
         queryService = dependencyResolver.resolveDependency( GraphDatabaseQueryService.class );
-        transactionIdStore = dependencyResolver.resolveDependency( TransactionIdStore.class );
         availabilityGuard = dependencyResolver.resolveDependency( AvailabilityGuard.class );
     }
 
@@ -80,7 +80,6 @@ public class BoltFactoryImpl extends LifecycleAdapter implements BoltFactory
     {
         queryExecutionEngine = null;
         queryService = null;
-        transactionIdStore = null;
         availabilityGuard = null;
     }
 
@@ -98,7 +97,7 @@ public class BoltFactoryImpl extends LifecycleAdapter implements BoltFactory
         long bookmarkReadyTimeout = config.get( GraphDatabaseSettings.bookmark_ready_timeout );
         Duration txAwaitDuration = Duration.ofMillis( bookmarkReadyTimeout );
 
-        return new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
+        return new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine,
                 availabilityGuard, queryService, txAwaitDuration, clock );
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -22,6 +22,7 @@ package org.neo4j.bolt.v1.runtime;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.bolt.v1.runtime.TransactionStateMachine.BoltResultHandle;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
@@ -64,7 +65,6 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
     TransactionStateMachineSPI( GraphDatabaseAPI db,
                                 ThreadToStatementContextBridge txBridge,
                                 QueryExecutionEngine queryExecutionEngine,
-                                TransactionIdStore transactionIdStoreSupplier,
                                 AvailabilityGuard availabilityGuard,
                                 GraphDatabaseQueryService queryService,
                                 Duration txAwaitDuration,
@@ -73,7 +73,10 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
         this.db = db;
         this.txBridge = txBridge;
         this.queryExecutionEngine = queryExecutionEngine;
+
+        Supplier<TransactionIdStore> transactionIdStoreSupplier = db.getDependencyResolver().provideDependency( TransactionIdStore.class );
         this.transactionIdTracker = new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard, clock );
+
         this.contextFactory = Neo4jTransactionalContextFactory.create( queryService, locker );
         this.queryService = queryService;
         this.txAwaitDuration = txAwaitDuration;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltFactoryImplTest.java
@@ -98,8 +98,8 @@ public class BoltFactoryImplTest
         when( txIdStoreBeforeRestart.getLastClosedTransactionId() ).thenReturn( 42L );
         TransactionIdStore txIdStoreAfterRestart = mock( TransactionIdStore.class );
         when( txIdStoreAfterRestart.getLastClosedTransactionId() ).thenReturn( 4242L );
-        when( dependencyResolver.resolveDependency( TransactionIdStore.class ) )
-                .thenReturn( txIdStoreBeforeRestart ).thenReturn( txIdStoreAfterRestart );
+        when( dependencyResolver.provideDependency( TransactionIdStore.class ) )
+                .thenReturn( () -> txIdStoreBeforeRestart ).thenReturn( () -> txIdStoreAfterRestart );
 
         BoltFactoryImpl boltFactory = newBoltFactory( db );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/txtracking/TransactionIdTrackerTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.txtracking;
 import org.junit.Test;
 
 import java.time.Clock;
+import java.util.function.Supplier;
 
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -38,13 +39,15 @@ import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_I
 
 public class TransactionIdTrackerTest
 {
-    private final TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+    private final Supplier<TransactionIdStore> transactionIdStoreSupplier = mock( Supplier.class );
     private final AvailabilityGuard availabilityGuard = mock( AvailabilityGuard.class );
 
     @Test( timeout = 500 )
     public void shouldAlwaysReturnIfTheRequestVersionIsBaseTxIdOrLess() throws Exception
     {
         // given
+        TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+        when(transactionIdStoreSupplier.get()).thenReturn( transactionIdStore );
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( -1L );
         when( availabilityGuard.isAvailable() ).thenReturn( true );
         TransactionIdTracker transactionIdTracker = createTracker();
@@ -60,7 +63,10 @@ public class TransactionIdTrackerTest
     {
         // given
         long version = 5L;
-        when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
+        TransactionIdStore transactionIdStore = mock(TransactionIdStore.class);
+        when( transactionIdStoreSupplier.get() ).thenReturn( transactionIdStore );
+        when( transactionIdStore.getLastClosedTransactionId()).thenReturn( version );
+
         when( availabilityGuard.isAvailable() ).thenReturn( true );
         TransactionIdTracker transactionIdTracker = createTracker();
 
@@ -75,6 +81,8 @@ public class TransactionIdTrackerTest
     {
         // given
         long version = 5L;
+        TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+        when(transactionIdStoreSupplier.get()).thenReturn( transactionIdStore );
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
         when( availabilityGuard.isAvailable() ).thenReturn( true );
         TransactionIdTracker transactionIdTracker = createTracker();
@@ -97,6 +105,8 @@ public class TransactionIdTrackerTest
     {
         // given
         long version = 5L;
+        TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
+        when(transactionIdStoreSupplier.get()).thenReturn( transactionIdStore );
         when( transactionIdStore.getLastClosedTransactionId() ).thenReturn( version );
         when( availabilityGuard.isAvailable() ).thenReturn( false );
         TransactionIdTracker transactionIdTracker = createTracker();
@@ -116,6 +126,6 @@ public class TransactionIdTrackerTest
 
     private TransactionIdTracker createTracker()
     {
-        return new TransactionIdTracker( transactionIdStore, availabilityGuard, Clock.systemUTC() );
+        return new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard, Clock.systemUTC() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
@@ -462,8 +463,8 @@ public class ReadReplicaReplicationIT
 
     private TransactionIdTracker transactionIdTracker( GraphDatabaseAPI database )
     {
-        TransactionIdStore transactionIdStore =
-                database.getDependencyResolver().resolveDependency( TransactionIdStore.class );
+        Supplier<TransactionIdStore> transactionIdStore =
+                database.getDependencyResolver().provideDependency( TransactionIdStore.class );
         AvailabilityGuard availabilityGuard =
                 database.getDependencyResolver().resolveDependency( AvailabilityGuard.class );
         return new TransactionIdTracker( transactionIdStore, availabilityGuard, Clock.systemUTC() );

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
       <dependency>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver</artifactId>
-        <version>1.1.0-M06</version>
+        <version>1.2.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This happens because TransactionIdStore doesn't get refreshed after a store copy.

* Introduce CANCELLED state so that polling process doesn't get restarted unless we explicitly want to restart it
* Pass around a supplier of TransactionIdStore and resolve it in TransactionIdTracker
* Bumped drivers to 1.2