### PR TITLE
Merge index listing methods

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -62,7 +62,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper)
     val propertyKeyId = tc.statement.readOperations().propertyKeyGetForName(propertyKey)
 
     // here we do not need to use getOnlineIndex method because uniqueness constraint creation is synchronous
-    Some(tc.statement.readOperations().uniqueIndexGetForLabelAndPropertyKey(SchemaDescriptorFactory.forLabel(labelId, propertyKeyId)))
+    Some(tc.statement.readOperations().indexGetForSchema(SchemaDescriptorFactory.forLabel(labelId, propertyKeyId)))
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -69,7 +69,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
     val propertyKeyId = tc.statement.readOperations().propertyKeyGetForName(propertyKey)
 
     // here we do not need to use getOnlineIndex method because uniqueness constraint creation is synchronous
-    Some(tc.statement.readOperations().uniqueIndexGetForLabelAndPropertyKey(SchemaDescriptorFactory.forLabel(labelId, propertyKeyId)))
+    Some(tc.statement.readOperations().indexGetForSchema(SchemaDescriptorFactory.forLabel(labelId, propertyKeyId)))
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -234,34 +234,19 @@ public interface ReadOperations
     /** Returns all indexes. */
     Iterator<NewIndexDescriptor> indexesGetAll();
 
-    /** Returns the constraint index for the given labelId and propertyKey. */
-    NewIndexDescriptor uniqueIndexGetForLabelAndPropertyKey( LabelSchemaDescriptor descriptor )
-            throws SchemaRuleNotFoundException, DuplicateSchemaRuleException;
-
-    /** Get all constraint indexes for a label. */
-    Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( int labelId );
-
-    /** Returns all constraint indexes. */
-    Iterator<NewIndexDescriptor> uniqueIndexesGetAll();
-
-    /** Retrieve the state of an index.
-     * @param descriptor*/
+    /** Retrieve the state of an index. */
     InternalIndexState indexGetState( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Retrieve the population progress of an index.
-     * @param descriptor*/
+    /** Retrieve the population progress of an index. */
     PopulationProgress indexGetPopulationProgress( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Get the index size.
-     * @param descriptor*/
+    /** Get the index size. */
     long indexSize( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Calculate the index unique values percentage (range: {@code 0.0} exclusive to {@code 1.0} inclusive).
-     * @param descriptor*/
+    /** Calculate the index unique values percentage (range: {@code 0.0} exclusive to {@code 1.0} inclusive). */
     double indexUniqueValuesSelectivity( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    /** Returns the failure description of a failed index.
-     * @param descriptor*/
+    /** Returns the failure description of a failed index. */
     String indexGetFailure( NewIndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/index/NewIndexDescriptor.java
@@ -19,14 +19,19 @@
  */
 package org.neo4j.kernel.api.schema_new.index;
 
+import java.util.Iterator;
+import java.util.List;
 import java.util.function.Predicate;
 
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.LabelSchemaSupplier;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
 import static java.lang.String.format;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.GENERAL;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.UNIQUE;
 
 /**
  * Internal representation of a graph index, including the schema unit it targets (eg. label-property combination)
@@ -142,5 +147,21 @@ public class NewIndexDescriptor implements LabelSchemaSupplier
     public String toString()
     {
         return userDescription( SchemaUtil.idTokenNameLookup );
+    }
+
+    /**
+     * Sorts indexes by type, returning first GENERAL indexes, followed by UNIQUE. Implementation is not suitable in
+     * hot path.
+     *
+     * @param indexes Indexes to sort
+     * @return sorted indexes
+     */
+    public static Iterator<NewIndexDescriptor> sortByType( Iterator<NewIndexDescriptor> indexes )
+    {
+        List<NewIndexDescriptor> materialized = Iterators.asList( indexes );
+        return Iterators.concat(
+                Iterators.filter( GENERAL, materialized.iterator() ),
+                Iterators.filter( UNIQUE, materialized.iterator() ) );
+
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.builtinprocs;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -47,7 +46,7 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import static org.neo4j.helpers.collection.Iterators.asList;
-import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.UNIQUE;
 import static org.neo4j.procedure.Mode.READ;
 
 @SuppressWarnings( {"unused", "WeakerAccess"} )
@@ -102,9 +101,6 @@ public class BuiltInProcedures
             TokenNameLookup tokens = new StatementTokenNameLookup( operations );
 
             List<NewIndexDescriptor> indexes = asList( operations.indexesGetAll() );
-
-            Set<NewIndexDescriptor> uniqueIndexes = asSet( operations.uniqueIndexesGetAll() );
-            indexes.addAll( uniqueIndexes );
             indexes.sort( Comparator.comparing( a -> a.userDescription( tokens ) ) );
 
             ArrayList<IndexResult> result = new ArrayList<>();
@@ -113,7 +109,7 @@ public class BuiltInProcedures
                 try
                 {
                     String type;
-                    if ( uniqueIndexes.contains( index ) )
+                    if ( index.type() == UNIQUE )
                     {
                         type = IndexType.NODE_UNIQUE_PROPERTY.typeName();
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -42,11 +42,12 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
-import org.neo4j.kernel.api.schema_new.constaints.ConstraintBoundary;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.impl.coreapi.schema.PropertyNameUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.GENERAL;
 
 public class SchemaProcedure
 {
@@ -85,9 +86,12 @@ public class SchemaProcedure
                     while ( indexDescriptorIterator.hasNext() )
                     {
                         NewIndexDescriptor index = indexDescriptorIterator.next();
-                        String[] propertyNames = PropertyNameUtils.getPropertyKeys(
-                                                    statementTokenNameLookup, index.schema().getPropertyIds() );
-                        indexes.add( String.join( ",", propertyNames ) );
+                        if ( index.type() == GENERAL )
+                        {
+                            String[] propertyNames = PropertyNameUtils.getPropertyKeys(
+                                                        statementTokenNameLookup, index.schema().getPropertyIds() );
+                            indexes.add( String.join( ",", propertyNames ) );
+                        }
                     }
                     properties.put( "indexes", indexes );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -125,7 +125,7 @@ public class DataIntegrityValidatingStatementOperations implements
         try
         {
             NewIndexDescriptor existingIndex =
-                    schemaReadDelegate.indexGetForLabelAndPropertyKey( state, index.schema() );
+                    schemaReadDelegate.indexGetForSchema( state, index.schema() );
 
             if ( existingIndex == null )
             {
@@ -223,7 +223,7 @@ public class DataIntegrityValidatingStatementOperations implements
             LabelSchemaDescriptor descriptor )
             throws AlreadyIndexedException, AlreadyConstrainedException
     {
-        NewIndexDescriptor existingIndex = schemaReadDelegate.indexGetForLabelAndPropertyKey( state, descriptor );
+        NewIndexDescriptor existingIndex = schemaReadDelegate.indexGetForSchema( state, descriptor );
         if ( existingIndex != null )
         {
             if ( existingIndex.type() == UNIQUE )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -184,11 +184,11 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public NewIndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, LabelSchemaDescriptor descriptor )
+    public NewIndexDescriptor indexGetForSchema( KernelStatement state, LabelSchemaDescriptor descriptor )
     {
         acquireSharedSchemaLock( state );
         state.assertOpen();
-        return schemaReadDelegate.indexGetForLabelAndPropertyKey( state, descriptor );
+        return schemaReadDelegate.indexGetForSchema( state, descriptor );
     }
 
     @Override
@@ -249,22 +249,6 @@ public class LockingStatementOperations implements
         acquireSharedSchemaLock( state );
         state.assertOpen();
         return schemaReadDelegate.indexGetCommittedId( state, index );
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId )
-    {
-        acquireSharedSchemaLock( state );
-        state.assertOpen();
-        return schemaReadDelegate.uniqueIndexesGetForLabel( state, labelId );
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> uniqueIndexesGetAll( KernelStatement state )
-    {
-        acquireSharedSchemaLock( state );
-        state.assertOpen();
-        return schemaReadDelegate.uniqueIndexesGetAll( state );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -60,7 +60,6 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
-import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.exceptions.schema.RepeatedPropertyInCompositeSchemaException;
@@ -575,7 +574,7 @@ public class OperationsFacade
             throws SchemaRuleNotFoundException
     {
         statement.assertOpen();
-        NewIndexDescriptor indexDescriptor = schemaRead().indexGetForLabelAndPropertyKey( statement, descriptor );
+        NewIndexDescriptor indexDescriptor = schemaRead().indexGetForSchema( statement, descriptor );
         if ( indexDescriptor == null )
         {
             throw new SchemaRuleNotFoundException( SchemaRule.Kind.INDEX_RULE, descriptor );
@@ -598,55 +597,10 @@ public class OperationsFacade
     }
 
     @Override
-    public NewIndexDescriptor uniqueIndexGetForLabelAndPropertyKey( LabelSchemaDescriptor descriptor )
-            throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
-
-    {
-        NewIndexDescriptor result = null;
-        Iterator<NewIndexDescriptor> indexes = uniqueIndexesGetForLabel( descriptor.getLabelId() );
-        while ( indexes.hasNext() )
-        {
-            NewIndexDescriptor index = indexes.next();
-            if ( index.schema().equals( descriptor ) )
-            {
-                if ( null == result )
-                {
-                    result = index;
-                }
-                else
-                {
-                    throw new DuplicateSchemaRuleException( SchemaRule.Kind.CONSTRAINT_INDEX_RULE, index.schema() );
-                }
-            }
-        }
-
-        if ( null == result )
-        {
-            throw new SchemaRuleNotFoundException( SchemaRule.Kind.CONSTRAINT_INDEX_RULE, descriptor );
-        }
-
-        return result;
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( int labelId )
-    {
-        statement.assertOpen();
-        return schemaRead().uniqueIndexesGetForLabel( statement, labelId );
-    }
-
-    @Override
     public Long indexGetOwningUniquenessConstraintId( NewIndexDescriptor index ) throws SchemaRuleNotFoundException
     {
         statement.assertOpen();
         return schemaRead().indexGetOwningUniquenessConstraintId( statement, index );
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> uniqueIndexesGetAll()
-    {
-        statement.assertOpen();
-        return schemaRead().uniqueIndexesGetAll( statement );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -115,7 +115,6 @@ import static org.neo4j.helpers.collection.Iterators.iterator;
 import static org.neo4j.helpers.collection.Iterators.singleOrNull;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
 import static org.neo4j.kernel.api.properties.DefinedProperty.NO_SUCH_PROPERTY;
-import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.ANY;
 import static org.neo4j.kernel.impl.api.state.IndexTxStateUpdater.LabelChangeType.ADDED_LABEL;
 import static org.neo4j.kernel.impl.api.state.IndexTxStateUpdater.LabelChangeType.REMOVED_LABEL;
 import static org.neo4j.kernel.impl.util.Cursors.count;
@@ -736,7 +735,7 @@ public class StateHandlingStatementOperations implements
         {
             rules = filter(
                     SchemaDescriptor.equalTo( descriptor ),
-                    state.txState().indexDiffSetsByLabel( descriptor.getLabelId(), ANY ).apply( rules ) );
+                    state.txState().indexDiffSetsByLabel( descriptor.getLabelId() ).apply( rules ) );
         }
         return singleOrNull( rules );
     }
@@ -749,7 +748,7 @@ public class StateHandlingStatementOperations implements
         if ( state.hasTxStateWithChanges() )
         {
             if ( checkIndexState( descriptor,
-                    state.txState().indexDiffSetsByLabel( descriptor.schema().getLabelId(), ANY ) ) )
+                    state.txState().indexDiffSetsByLabel( descriptor.schema().getLabelId() ) ) )
             {
                 return InternalIndexState.POPULATING;
             }
@@ -766,7 +765,7 @@ public class StateHandlingStatementOperations implements
         if ( state.hasTxStateWithChanges() )
         {
             if ( checkIndexState( descriptor,
-                    state.txState().indexDiffSetsByLabel( descriptor.schema().getLabelId(), ANY ) ) )
+                    state.txState().indexDiffSetsByLabel( descriptor.schema().getLabelId() ) ) )
             {
                 return PopulationProgress.NONE;
             }
@@ -795,7 +794,7 @@ public class StateHandlingStatementOperations implements
     {
         if ( state.hasTxStateWithChanges() )
         {
-            return state.txState().indexDiffSetsByLabel( labelId, ANY )
+            return state.txState().indexDiffSetsByLabel( labelId )
                                         .apply( storeLayer.indexesGetForLabel( labelId ) );
         }
         return storeLayer.indexesGetForLabel( labelId );
@@ -806,7 +805,7 @@ public class StateHandlingStatementOperations implements
     {
         if ( state.hasTxStateWithChanges() )
         {
-            return state.txState().indexChanges( ANY ).apply( storeLayer.indexesGetAll() );
+            return state.txState().indexChanges().apply( storeLayer.indexesGetAll() );
         }
 
         return storeLayer.indexesGetAll();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RemoveOrphanConstraintIndexesOnStartup.java
@@ -28,6 +28,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.Iterators.loop;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.UNIQUE;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 
 /**
@@ -51,9 +52,10 @@ public class RemoveOrphanConstraintIndexesOnStartup
         try ( KernelTransaction transaction = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = transaction.acquireStatement() )
         {
-            for ( NewIndexDescriptor index : loop( statement.readOperations().uniqueIndexesGetAll() ) )
+            for ( NewIndexDescriptor index : loop( statement.readOperations().indexesGetAll() ) )
             {
-                if ( statement.readOperations().indexGetOwningUniquenessConstraintId( index ) == null )
+                if ( index.type() == UNIQUE &&
+                     statement.readOperations().indexGetOwningUniquenessConstraintId( index ) == null )
                 {
                     log.info( "Removing orphan constraint index: " + index );
                     statement.schemaWriteOperations().uniqueIndexDrop( index );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
@@ -37,7 +37,7 @@ public interface SchemaReadOperations
     /**
      * Returns the descriptor for the given labelId and propertyKey.
      */
-    NewIndexDescriptor indexGetForLabelAndPropertyKey( KernelStatement state, LabelSchemaDescriptor descriptor );
+    NewIndexDescriptor indexGetForSchema( KernelStatement state, LabelSchemaDescriptor descriptor );
 
     /**
      * Get all indexes for a label.
@@ -48,16 +48,6 @@ public interface SchemaReadOperations
      * Returns all indexes.
      */
     Iterator<NewIndexDescriptor> indexesGetAll( KernelStatement state );
-
-    /**
-     * Get all constraint indexes for a label.
-     */
-    Iterator<NewIndexDescriptor> uniqueIndexesGetForLabel( KernelStatement state, int labelId );
-
-    /**
-     * Returns all constraint indexes.
-     */
-    Iterator<NewIndexDescriptor> uniqueIndexesGetAll( KernelStatement state );
 
     /**
      * Retrieve the state of an index.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdater.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
-import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
@@ -72,10 +71,7 @@ public class IndexTxStateUpdater
         PrimitiveIntSet nodePropertyIds = Primitive.intSet();
         nodePropertyIds.addAll( readOps.nodeGetPropertyKeys( state, node ).iterator() );
 
-        Iterator<NewIndexDescriptor> indexes =
-                Iterators.concat(
-                        storeReadLayer.indexesGetForLabel( labelId ),
-                        storeReadLayer.uniquenessIndexesGetForLabel( labelId ) );
+        Iterator<NewIndexDescriptor> indexes = storeReadLayer.indexesGetForLabel( labelId );
 
         while ( indexes.hasNext() )
         {
@@ -108,7 +104,7 @@ public class IndexTxStateUpdater
     {
         assert noSchemaChangedInTx( state );
         Iterator<NewIndexDescriptor> indexes =
-                storeReadLayer.indexesAndUniqueIndexesRelatedToProperty( after.propertyKeyId() );
+                storeReadLayer.indexesGetRelatedToProperty( after.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, after.propertyKeyId(),
                 index ->
                 {
@@ -124,7 +120,7 @@ public class IndexTxStateUpdater
     {
         assert noSchemaChangedInTx( state );
         Iterator<NewIndexDescriptor> indexes =
-                storeReadLayer.indexesAndUniqueIndexesRelatedToProperty( before.propertyKeyId() );
+                storeReadLayer.indexesGetRelatedToProperty( before.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
                 index ->
                 {
@@ -140,7 +136,7 @@ public class IndexTxStateUpdater
         assert noSchemaChangedInTx( state );
         assert before.propertyKeyId() == after.propertyKeyId();
         Iterator<NewIndexDescriptor> indexes =
-                storeReadLayer.indexesAndUniqueIndexesRelatedToProperty( before.propertyKeyId() );
+                storeReadLayer.indexesGetRelatedToProperty( before.propertyKeyId() );
         nodeIndexMatcher.onMatchingSchema( state, indexes, node, before.propertyKeyId(),
                 index ->
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -816,16 +816,15 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     }
 
     @Override
-    public ReadableDiffSets<NewIndexDescriptor> indexDiffSetsByLabel( int labelId, NewIndexDescriptor.Filter indexType )
+    public ReadableDiffSets<NewIndexDescriptor> indexDiffSetsByLabel( int labelId )
     {
-        return indexChangesDiffSets().filterAdded( index ->
-                SchemaDescriptorPredicates.hasLabel( index, labelId ) && indexType.test( index ) );
+        return indexChangesDiffSets().filterAdded( SchemaDescriptorPredicates.hasLabel( labelId ) );
     }
 
     @Override
-    public ReadableDiffSets<NewIndexDescriptor> indexChanges( NewIndexDescriptor.Filter indexType )
+    public ReadableDiffSets<NewIndexDescriptor> indexChanges()
     {
-        return ReadableDiffSets.Empty.ifNull( indexChanges ).filterAdded( indexType );
+        return ReadableDiffSets.Empty.ifNull( indexChanges );
     }
 
     private DiffSets<NewIndexDescriptor> indexChangesDiffSets()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -184,7 +184,7 @@ public class StorageLayer implements StoreReadLayer
     }
 
     @Override
-    public NewIndexDescriptor indexGetForLabelAndPropertyKey( LabelSchemaDescriptor descriptor )
+    public NewIndexDescriptor indexGetForSchema( LabelSchemaDescriptor descriptor )
     {
         return schemaCache.indexDescriptor( descriptor );
     }
@@ -192,32 +192,17 @@ public class StorageLayer implements StoreReadLayer
     @Override
     public Iterator<NewIndexDescriptor> indexesGetForLabel( int labelId )
     {
-        return toIndexDescriptors( filter( rule -> hasLabel( rule, labelId ) && !rule.canSupportUniqueConstraint(),
-                schemaCache.indexRules() ) );
+        return toIndexDescriptors( filter( hasLabel( labelId ), schemaCache.indexRules() ) );
     }
 
     @Override
     public Iterator<NewIndexDescriptor> indexesGetAll()
     {
-        return toIndexDescriptors( filter( rule -> !rule.canSupportUniqueConstraint(), schemaCache.indexRules() ) );
+        return toIndexDescriptors( schemaCache.indexRules() );
     }
 
     @Override
-    public Iterator<NewIndexDescriptor> uniquenessIndexesGetForLabel( int labelId )
-    {
-        Predicate<IndexRule> indexRulePredicate =
-                rule -> hasLabel( rule, labelId ) && rule.canSupportUniqueConstraint();
-        return toIndexDescriptors( filter( indexRulePredicate, schemaCache.indexRules() ) );
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> uniquenessIndexesGetAll()
-    {
-        return toIndexDescriptors( filter( IndexRule::canSupportUniqueConstraint, schemaCache.indexRules() ) );
-    }
-
-    @Override
-    public Iterator<NewIndexDescriptor> indexesAndUniqueIndexesRelatedToProperty( int propertyId )
+    public Iterator<NewIndexDescriptor> indexesGetRelatedToProperty( int propertyId )
     {
         return schemaCache.indexesByProperty( propertyId );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorageLayer.java
@@ -192,7 +192,7 @@ public class StorageLayer implements StoreReadLayer
     @Override
     public Iterator<NewIndexDescriptor> indexesGetForLabel( int labelId )
     {
-        return toIndexDescriptors( filter( hasLabel( labelId ), schemaCache.indexRules() ) );
+        return schemaCache.indexDescriptorsForLabel( labelId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptorFactory;
 
 import static java.lang.String.format;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.GENERAL;
 
 public enum DbStructureArgumentFormatter implements ArgumentFormatter
 {
@@ -101,8 +102,9 @@ public enum DbStructureArgumentFormatter implements ArgumentFormatter
         {
             NewIndexDescriptor descriptor = (NewIndexDescriptor) arg;
             int labelId = descriptor.schema().getLabelId();
-            builder.append( format( "NewIndexDescriptorFactory.forLabel( %d, %s )", labelId,
-                    asString( descriptor.schema().getPropertyIds() ) ) );
+            String methodName = descriptor.type() == GENERAL ? "forLabel" : "uniqueForLabel";
+            builder.append( format( "NewIndexDescriptorFactory.%s( %d, %s )", methodName,
+                    labelId, asString( descriptor.schema().getPropertyIds() ) ) );
         }
         else if ( arg instanceof LabelSchemaDescriptor )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
 
 import static java.lang.String.format;
+import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Type.UNIQUE;
 
 public class DbStructureCollector implements DbStructureVisitor
 {
@@ -168,16 +169,11 @@ public class DbStructureCollector implements DbStructureVisitor
     }
 
     @Override
-    public void visitIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long
-            size )
+    public void visitIndex( NewIndexDescriptor descriptor, String userDescription,
+                            double uniqueValuesPercentage, long size )
     {
-        regularIndices.putIndex( descriptor.schema(), userDescription, uniqueValuesPercentage, size );
-    }
-
-    @Override
-    public void visitUniqueIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size )
-    {
-        uniqueIndices.putIndex( descriptor.schema(), userDescription, uniqueValuesPercentage, size );
+        IndexDescriptorMap indices = descriptor.type() == UNIQUE ? uniqueIndices : regularIndices;
+        indices.putIndex( descriptor.schema(), userDescription, uniqueValuesPercentage, size );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -31,8 +31,6 @@ public interface DbStructureVisitor
     void visitRelationshipType( int relTypeId, String relTypeName );
 
     void visitIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
-    void visitUniqueIndex( NewIndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage,
-                           long size );
     void visitUniqueConstraint( UniquenessConstraintDescriptor constraint, String userDescription );
     void visitNodePropertyExistenceConstraint( NodeExistenceConstraintDescriptor constraint, String userDescription );
     void visitRelationshipPropertyExistenceConstraint( RelExistenceConstraintDescriptor constraint,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -134,30 +134,17 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
         TokenNameLookup nameLookup = new StatementTokenNameLookup( read );
 
         showIndices( visitor, read, nameLookup );
-        showUniqueIndices( visitor, read, nameLookup );
         showUniqueConstraints( visitor, read, nameLookup );
     }
 
     private void showIndices( DbStructureVisitor visitor, ReadOperations read, TokenNameLookup nameLookup ) throws IndexNotFoundKernelException
     {
-        for ( NewIndexDescriptor descriptor : loop( read.indexesGetAll() ) )
+        for ( NewIndexDescriptor descriptor : loop( NewIndexDescriptor.sortByType( read.indexesGetAll() ) ) )
         {
             String userDescription = descriptor.schema().userDescription( nameLookup );
             double uniqueValuesPercentage = read.indexUniqueValuesSelectivity( descriptor );
             long size = read.indexSize( descriptor );
             visitor.visitIndex( descriptor, userDescription , uniqueValuesPercentage, size );
-        }
-    }
-
-    private void showUniqueIndices( DbStructureVisitor visitor, ReadOperations read, TokenNameLookup nameLookup ) throws IndexNotFoundKernelException
-
-    {
-        for ( NewIndexDescriptor descriptor : loop( read.uniqueIndexesGetAll() ) )
-        {
-            String userDescription = descriptor.schema().userDescription( nameLookup );
-            double uniqueValuesPercentage = read.indexUniqueValuesSelectivity( descriptor );
-            long size = read.indexSize( descriptor );
-            visitor.visitUniqueIndex( descriptor, userDescription, uniqueValuesPercentage, size );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreReadLayer.java
@@ -67,20 +67,9 @@ public interface StoreReadLayer
     Iterator<NewIndexDescriptor> indexesGetAll();
 
     /**
-     * @param labelId label to list indexes related to uniqueness constraints for.
-     * @return {@link NewIndexDescriptor} related to uniqueness constraints associated with the given {@code labelId}.
-     */
-    Iterator<NewIndexDescriptor> uniquenessIndexesGetForLabel( int labelId );
-
-    /**
-     * @return all {@link NewIndexDescriptor} related to uniqueness constraints.
-     */
-    Iterator<NewIndexDescriptor> uniquenessIndexesGetAll();
-
-    /**
      * Returns all indexes (including unique) related to a property.
      */
-    Iterator<NewIndexDescriptor> indexesAndUniqueIndexesRelatedToProperty( int propertyId );
+    Iterator<NewIndexDescriptor> indexesGetRelatedToProperty( int propertyId );
 
     /**
      * @param index {@link NewIndexDescriptor} to get related uniqueness constraint for.
@@ -145,10 +134,10 @@ public interface StoreReadLayer
     /**
      * Looks for a stored index by given {@code descriptor}
      *
-     * @param descriptor a description of the node .
-     * @return {@link NewIndexDescriptor} for matching index, or {@code null} if not found. TODO should throw exception.
+     * @param descriptor a description of the index.
+     * @return {@link NewIndexDescriptor} for matching index, or {@code null} if not found.
      */
-    NewIndexDescriptor indexGetForLabelAndPropertyKey( LabelSchemaDescriptor descriptor );
+    NewIndexDescriptor indexGetForSchema( LabelSchemaDescriptor descriptor );
 
     /**
      * Returns state of a stored index.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -108,9 +108,9 @@ public interface ReadableTransactionState
 
     // SCHEMA RELATED
 
-    ReadableDiffSets<NewIndexDescriptor> indexDiffSetsByLabel( int labelId, NewIndexDescriptor.Filter indexType );
+    ReadableDiffSets<NewIndexDescriptor> indexDiffSetsByLabel( int labelId );
 
-    ReadableDiffSets<NewIndexDescriptor> indexChanges( NewIndexDescriptor.Filter indexType );
+    ReadableDiffSets<NewIndexDescriptor> indexChanges();
 
     Iterable<NewIndexDescriptor> constraintIndexesCreatedInTx();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -320,8 +320,8 @@ public class BuiltInProceduresTest
         when( read.propertyKeyGetAllTokens() ).thenAnswer( asTokens( propKeys ) );
         when( read.labelsGetAllTokens() ).thenAnswer( asTokens( labels ) );
         when( read.relationshipTypesGetAllTokens() ).thenAnswer( asTokens( relTypes ) );
-        when( read.indexesGetAll() ).thenAnswer( ( i ) -> indexes.iterator() );
-        when( read.uniqueIndexesGetAll() ).thenAnswer( ( i ) -> uniqueIndexes.iterator() );
+        when( read.indexesGetAll() ).thenAnswer(
+                ( i ) -> Iterators.concat( indexes.iterator(), uniqueIndexes.iterator() ) );
         when( read.constraintsGetAll() ).thenAnswer( ( i ) -> constraints.iterator() );
         when( read.proceduresGetAll() ).thenReturn( procs.getAllProcedures() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperationsTest.java
@@ -81,7 +81,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowReAddingIndex() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( index );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( index );
 
         // WHEN
         try
@@ -102,7 +102,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowAddingIndexWhenConstraintIndexExists() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -123,7 +123,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowDroppingIndexThatDoesNotExist() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( null );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( null );
 
         // WHEN
         try
@@ -144,7 +144,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowDroppingIndexWhenConstraintIndexExists() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -165,7 +165,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowDroppingConstraintIndexThatDoesNotExists() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try
@@ -186,7 +186,7 @@ public class DataIntegrityValidatingStatementOperationsTest
     public void shouldDisallowDroppingConstraintIndexThatIsReallyJustRegularIndex() throws Exception
     {
         // GIVEN
-        when( innerRead.indexGetForLabelAndPropertyKey( state, descriptor ) ).thenReturn( uniqueIndex );
+        when( innerRead.indexGetForSchema( state, descriptor ) ).thenReturn( uniqueIndex );
 
         // WHEN
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
@@ -68,7 +68,7 @@ public class OperationsFacadeTest
     }
 
     @Test
-    public void testThrowExceptionWhenIndexNotFoundByLabelAndProperty() throws SchemaRuleNotFoundException
+    public void testThrowExceptionWhenIndexNotFound() throws SchemaRuleNotFoundException
     {
         setupSchemaReadOperations();
 
@@ -79,41 +79,6 @@ public class OperationsFacadeTest
                 "No index was found for :Label1(Prop1)." ) );
 
         operationsFacade.indexGetForSchema( descriptor );
-    }
-
-    @Test
-    public void testThrowExceptionWhenDuplicateUniqueIndexFound()
-            throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
-    {
-        SchemaReadOperations readOperations = setupSchemaReadOperations();
-        NewIndexDescriptor index = NewIndexDescriptorFactory.forSchema( descriptor );
-        Mockito.when( readOperations
-                .uniqueIndexesGetForLabel( Mockito.any( KernelStatement.class ), Mockito.eq( descriptor.getLabelId() ) ) )
-                .thenReturn( Iterators.iterator( index, index ) );
-        TokenNameLookup tokenNameLookup = getDefaultTokenNameLookup();
-
-        expectedException.expect( DuplicateSchemaRuleException.class );
-        expectedException.expect( new KernelExceptionUserMessageMatcher<>( tokenNameLookup,
-                "Multiple constraint indexs found for :Label1(Prop1)." ) );
-
-        operationsFacade.uniqueIndexGetForLabelAndPropertyKey( descriptor );
-    }
-
-    @Test
-    public void testThrowExceptionWhenUniqueIndexNotFound()
-            throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
-    {
-        SchemaReadOperations readOperations = setupSchemaReadOperations();
-        TokenNameLookup tokenNameLookup = getDefaultTokenNameLookup();
-        Mockito.when( readOperations
-                .uniqueIndexesGetForLabel( Mockito.any( KernelStatement.class ), anyInt() ) )
-                .thenReturn( Iterators.emptyIterator() );
-
-        expectedException.expect( SchemaRuleNotFoundException.class );
-        expectedException.expect( new KernelExceptionUserMessageMatcher<>( tokenNameLookup,
-                "No constraint index was found for :Label1(Prop1)." ) );
-
-        operationsFacade.uniqueIndexGetForLabelAndPropertyKey( descriptor );
     }
 
     private SchemaReadOperations setupSchemaReadOperations()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -250,8 +250,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
         Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
         LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( labelId, propertyIds );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        NewIndexDescriptor result =
-                statement.readOperations().uniqueIndexGetForLabelAndPropertyKey( descriptor );
+        NewIndexDescriptor result = statement.readOperations().indexGetForSchema( descriptor );
         commit();
         return result;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -300,8 +300,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         ReadOperations readOps = statement.readOperations();
         int person = readOps.labelGetForName( "Person" );
         int propId = readOps.propertyKeyGetForName( "id" );
-        NewIndexDescriptor idx = readOps
-                .uniqueIndexGetForLabelAndPropertyKey( SchemaDescriptorFactory.forLabel( person, propId ) );
+        NewIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
 
         // when
         createLabeledNode( statement, "Item", "id", 2 );
@@ -327,8 +326,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         ReadOperations readOps = statement.readOperations();
         int person = readOps.labelGetForName( "Person" );
         int propId = readOps.propertyKeyGetForName( "id" );
-        NewIndexDescriptor idx = readOps
-                .uniqueIndexGetForLabelAndPropertyKey( SchemaDescriptorFactory.forLabel( person, propId ) );
+        NewIndexDescriptor idx = readOps.indexGetForSchema( SchemaDescriptorFactory.forLabel( person, propId ) );
 
         // when
         createLabeledNode( statement, "Person", "id", 2 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -89,9 +89,9 @@ public class IndexQueryTransactionStateTest
         when( store.indexGetState( newIndexDescriptor ) ).thenReturn( InternalIndexState.ONLINE );
         when( store.indexesGetForLabel( labelId ) ).then( answerAsIteratorFrom( indexes ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( indexes ) );
-        when( store.indexesAndUniqueIndexesRelatedToProperty( propertyKeyId ) ).then( answerAsIteratorFrom( indexes ) );
+        when( store.indexesGetRelatedToProperty( propertyKeyId ) ).then( answerAsIteratorFrom( indexes ) );
         when( store.constraintsGetForLabel( labelId ) ).thenReturn( Collections.emptyIterator() );
-        when( store.indexGetForLabelAndPropertyKey( newIndexDescriptor.schema() ) ).thenReturn( newIndexDescriptor );
+        when( store.indexGetForSchema( newIndexDescriptor.schema() ) ).thenReturn( newIndexDescriptor );
 
         statement = mock( StoreStatement.class );
         when( state.getStoreStatement() ).thenReturn( statement );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
@@ -52,8 +52,6 @@ import static org.neo4j.helpers.collection.Iterators.filter;
 import static org.neo4j.kernel.api.properties.Property.property;
 import static org.neo4j.kernel.api.schema_new.SchemaDescriptorPredicates.hasLabel;
 import static org.neo4j.kernel.api.schema_new.SchemaDescriptorPredicates.hasProperty;
-import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.GENERAL;
-import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.UNIQUE;
 import static org.neo4j.kernel.impl.api.state.IndexTxStateUpdater.LabelChangeType.ADDED_LABEL;
 import static org.neo4j.kernel.impl.api.state.IndexTxStateUpdater.LabelChangeType.REMOVED_LABEL;
 
@@ -89,18 +87,14 @@ public class IndexTxStateUpdaterTest
         when( state.txState() ).thenReturn( txState );
 
         StoreReadLayer storeReadLayer = mock( StoreReadLayer.class );
-        when( storeReadLayer.indexesGetAll() ).thenAnswer(
-                x -> filter( GENERAL, indexes.iterator() ) );
-        when( storeReadLayer.uniquenessIndexesGetAll() ).thenAnswer(
-                x -> filter( UNIQUE, indexes.iterator() ) );
+        when( storeReadLayer.indexesGetAll() ).thenAnswer( x -> indexes.iterator() );
+        when( storeReadLayer.indexesGetForLabel(anyInt() ) )
+                .thenAnswer(
+                    x -> filter( hasLabel( (Integer)x.getArguments()[0] ), indexes.iterator() ) );
 
-        when( storeReadLayer.indexesGetForLabel( anyInt() ) ).thenAnswer(
-                x -> filter( GENERAL, filter( hasLabel( (Integer)x.getArguments()[0] ), indexes.iterator() ) ) );
-        when( storeReadLayer.uniquenessIndexesGetForLabel( anyInt() ) ).thenAnswer(
-                x -> filter( UNIQUE, filter( hasLabel( (Integer)x.getArguments()[0] ), indexes.iterator() ) ) );
-
-        when( storeReadLayer.indexesAndUniqueIndexesRelatedToProperty( anyInt() ) ).thenAnswer(
-                x -> filter( hasProperty( (Integer)x.getArguments()[0] ), indexes.iterator() ) );
+        when( storeReadLayer.indexesGetRelatedToProperty( anyInt() ) )
+                .thenAnswer(
+                    x -> filter( hasProperty( (Integer)x.getArguments()[0] ), indexes.iterator() ) );
 
         PrimitiveIntSet labels = Primitive.intSet();
         labels.add( labelId1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -68,13 +68,13 @@ public class SchemaTransactionStateTest
             StateHandlingStatementOperations txContext, KernelStatement state, int labelId, int propertyKey )
     {
         LabelSchemaDescriptor schemaDescriptor = SchemaDescriptorFactory.forLabel( labelId, propertyKey );
-        return txContext.indexGetForLabelAndPropertyKey( state, schemaDescriptor );
+        return txContext.indexGetForSchema( state, schemaDescriptor );
     }
 
     private static NewIndexDescriptor indexGetForLabelAndPropertyKey( StoreReadLayer store, int labelId,
             int propertyKey )
     {
-        return store.indexGetForLabelAndPropertyKey( SchemaDescriptorFactory.forLabel( labelId, propertyKey ) );
+        return store.indexGetForSchema( SchemaDescriptorFactory.forLabel( labelId, propertyKey ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -70,7 +70,6 @@ import static org.neo4j.helpers.collection.Pair.of;
 import static org.neo4j.kernel.api.properties.Property.booleanProperty;
 import static org.neo4j.kernel.api.properties.Property.numberProperty;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
-import static org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor.Filter.GENERAL;
 import static org.neo4j.kernel.impl.api.state.StubCursors.cursor;
 import static org.neo4j.kernel.impl.api.state.StubCursors.relationship;
 
@@ -176,7 +175,7 @@ public class TxStateTest
 
         // THEN
         assertEquals( asSet( indexOn_1_1 ),
-                state.indexDiffSetsByLabel( indexOn_1_1.schema().getLabelId(), GENERAL ).getAdded() );
+                state.indexDiffSetsByLabel( indexOn_1_1.schema().getLabelId() ).getAdded() );
     }
 
     @Test
@@ -186,7 +185,7 @@ public class TxStateTest
         state.indexRuleDoAdd( indexOn_1_1 );
 
         // THEN
-        assertEquals( asSet( indexOn_1_1 ), state.indexChanges( GENERAL ).getAdded() );
+        assertEquals( asSet( indexOn_1_1 ), state.indexChanges().getAdded() );
     }
 
     // endregion

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/CineastsDbStructure.java
@@ -81,7 +81,7 @@ implements Visitable<DbStructureVisitor>
         visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 1, 5 ), ":Person(name)", 1.0d, 49845L );
         visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 3, 5 ), ":Actor(name)", 1.0d, 44689L );
         visitor.visitIndex( NewIndexDescriptorFactory.forLabel( 4, 5 ), ":Director(name)", 1.0d, 6010L );
-        visitor.visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 2, 3 ), ":User(login)", 1.0d, 45L );
+        visitor.visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 2, 3 ), ":User(login)", 1.0d, 45L );
         visitor.visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 2, 3 ),
                 "CONSTRAINT ON ( " + "user:User ) ASSERT user.login IS UNIQUE" );
         visitor.visitAllNodesCount( 63042L );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
@@ -44,7 +44,7 @@ public class DbStructureCollectorTest
         collector.visitPropertyKey( 2, "income" );
         collector.visitRelationshipType( 1, "LIVES_IN" );
         collector.visitRelationshipType( 2, "FRIEND" );
-        collector.visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 1, 1 ), ":Person(name)", 1.0d, 1L );
+        collector.visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 1, 1 ), ":Person(name)", 1.0d, 1L );
         collector.visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 2, 1 ), ":City(name)" );
         collector.visitIndex( NewIndexDescriptorFactory.forLabel( 2, 2 ), ":City(income)", 0.2d, 1L );
         collector.visitAllNodesCount( 50 );
@@ -91,8 +91,7 @@ public class DbStructureCollectorTest
         collector.visitPropertyKey( 5, "area" );
         collector.visitRelationshipType( 1, "LIVES_IN" );
         collector.visitRelationshipType( 2, "FRIEND" );
-        collector
-                .visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 1, 1, 3 ), ":Person(name, lastName)", 1.0d, 1L );
+        collector.visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 1, 1, 3 ), ":Person(name, lastName)", 1.0d, 1L );
         collector.visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 2, 1, 5 ), ":City(name, area)" );
         collector.visitIndex( NewIndexDescriptorFactory.forLabel( 2, 2, 4 ), ":City(income, tax)", 0.2d, 1L );
         collector.visitAllNodesCount( 50 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
@@ -133,7 +133,7 @@ public class DbStructureInvocationTracingAcceptanceTest
         visitor.apply( null ).visitRelationshipType( 1, "REJECTS" );
         visitor.apply( null ).visitIndex( NewIndexDescriptorFactory.forLabel( 0, 1 ), ":Person(age)", 0.5d, 1L );
         visitor.apply( null )
-                .visitUniqueIndex( NewIndexDescriptorFactory.forLabel( 0, 0, 2 ), ":Person(name, lastName)", 0.5d, 1L );
+                .visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 0, 0, 2 ), ":Person(name, lastName)", 0.5d, 1L );
         visitor.apply( null )
                 .visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 1, 0 ), ":Party(name)" );
         visitor.apply( null ).visitAllNodesCount( 55 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuideTest.java
@@ -148,7 +148,7 @@ public class GraphDbStructureGuideTest
         accept( visitor );
 
         // THEN
-        verify( visitor ).visitUniqueIndex( descriptor, ":Person(name)", 1.0d, 0L );
+        verify( visitor ).visitIndex( descriptor, ":Person(name)", 1.0d, 0L );
         verify( visitor ).visitUniqueConstraint( constraint, "CONSTRAINT ON ( person:Person ) ASSERT person.name IS " +
                 "UNIQUE" );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -326,7 +326,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
         // then
         {
             ReadOperations statement = readOperationsInNewTransaction();
-            assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( statement.uniqueIndexesGetAll() ) );
+            assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( statement.indexesGetAll() ) );
             commit();
         }
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -180,7 +180,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( asSet( uniqueIndex ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( asSet( uniqueIndex ), asSet( readOperations.indexesGetAll() ) );
     }
 
     @Test
@@ -189,15 +189,14 @@ public class UniquenessConstraintCreationIT
         // given
         Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ),
-                asSet( statement.readOperations().uniqueIndexesGetAll() ) );
+        assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );
 
         // when
         rollback();
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.indexesGetAll() ) );
         commit();
     }
 
@@ -267,8 +266,7 @@ public class UniquenessConstraintCreationIT
         Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
         UniquenessConstraintDescriptor constraint =
                 statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
-        assertEquals( asSet( uniqueIndex ),
-                asSet( statement.readOperations().uniqueIndexesGetAll() ) );
+        assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );
         commit();
 
         // when
@@ -278,7 +276,7 @@ public class UniquenessConstraintCreationIT
 
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.uniqueIndexesGetAll() ) );
+        assertEquals( emptySetOf( NewIndexDescriptor.class ), asSet( readOperations.indexesGetAll() ) );
         commit();
     }
 

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -452,7 +452,7 @@ public class StoreUpgradeIntegrationTest
         try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() );
               Statement statement = tx.acquireStatement() )
         {
-            Iterator<NewIndexDescriptor> indexes = getAllIndexes( db );
+            Iterator<NewIndexDescriptor> indexes = NewIndexDescriptor.sortByType( getAllIndexes( db ) );
             DoubleLongRegister register = Registers.newDoubleLongRegister();
             for ( int i = 0; indexes.hasNext(); i++ )
             {

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -478,10 +478,7 @@ public class StoreUpgradeIntegrationTest
             ThreadToStatementContextBridge bridge = db.getDependencyResolver()
                     .resolveDependency( ThreadToStatementContextBridge.class );
             Statement statement = bridge.get();
-            return Iterators.concat(
-                    statement.readOperations().indexesGetAll(),
-                    statement.readOperations().uniqueIndexesGetAll()
-            );
+            return statement.readOperations().indexesGetAll();
         }
     }
 


### PR DESCRIPTION
This PR accomplished two things:

1) Merged index listing methods
In hot paths we need all indexes regardless of whether they're general or unique. It's therefor better to have one method return both types, and filter in the slow paths; than to concatenate in the hot paths as currently done.

2) Faster index lookup by label in schema cache
As some customers have a lot of indexes, we should be faster at this to not slow down label updates.