### PR TITLE
Consistency check for incremental backup

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/ConsistencyCheck.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/ConsistencyCheck.java
@@ -42,12 +42,6 @@ interface ConsistencyCheck
                 }
 
                 @Override
-                public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory, LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose ) throws ConsistencyCheckFailedException
-                {
-                    return true;
-                }
-
-                @Override
                 public boolean runFull( File storeDir, Config tuningConfiguration,
                         ProgressMonitorFactory progressFactory, LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose,
                         CheckConsistencyConfig checkConsistencyConfig )
@@ -64,13 +58,6 @@ interface ConsistencyCheck
                 public String name()
                 {
                     return "full";
-                }
-
-                @Override
-                public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory, LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose ) throws ConsistencyCheckFailedException
-                {
-                    return runFull( storeDir, tuningConfiguration, progressFactory, logProvider, fileSystem, pageCache,
-                            verbose, new CheckConsistencyConfig( tuningConfiguration ) );
                 }
 
                 @Override
@@ -93,11 +80,6 @@ interface ConsistencyCheck
             };
 
     String name();
-
-    @Deprecated
-    boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
-                     LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose )
-            throws ConsistencyCheckFailedException;
 
     boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
             LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose,
@@ -127,15 +109,6 @@ interface ConsistencyCheck
             public String name()
             {
                 return "full";
-            }
-
-            @Override
-            public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
-                    LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose )
-                    throws ConsistencyCheckFailedException
-            {
-                return runFull( storeDir, tuningConfiguration, progressFactory, logProvider, fileSystem, pageCache,
-                        verbose, new CheckConsistencyConfig( tuningConfiguration ) );
             }
 
             @Override

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -302,7 +302,7 @@ public class OnlineBackup
     public OnlineBackup incremental( String targetDirectory )
     {
         outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
-                timeoutMillis, defaultConfig() );
+                getConsistencyCheck( true ), timeoutMillis, defaultConfig() );
         return this;
     }
 
@@ -324,7 +324,7 @@ public class OnlineBackup
     public OnlineBackup incremental( String targetDirectory, boolean verification )
     {
         outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
-                timeoutMillis, defaultConfig() );
+                getConsistencyCheck( verification ), timeoutMillis, defaultConfig() );
         return this;
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -302,7 +302,7 @@ public class OnlineBackup
     public OnlineBackup incremental( String targetDirectory )
     {
         outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
-                getConsistencyCheck( true ), timeoutMillis, defaultConfig() );
+                getConsistencyCheck( false ), timeoutMillis, defaultConfig() );
         return this;
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -203,7 +203,7 @@ public class OnlineBackupCommand implements AdminCommand
             try
             {
                 backupService.doIncrementalBackup( address.getHost(), address.getPort(),
-                        destination, timeout, config );
+                        destination, ConsistencyCheck.NONE, timeout, config );
                 done = true;
             }
             catch ( Exception e )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupLabelIndexIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupLabelIndexIT.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import java.io.File;
 import java.util.HashSet;
@@ -43,7 +44,9 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.TestLabels;
 import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
+
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.backup.BackupServer.DEFAULT_PORT;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -53,11 +56,12 @@ public class BackupLabelIndexIT
 {
     private static final TestLabels LABEL = TestLabels.LABEL_ONE;
 
-    @Rule
-    public final RandomRule random = new RandomRule();
+    private final RandomRule random = new RandomRule();
+    private final TestDirectory directory = TestDirectory.testDirectory();
+    private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
 
     @Rule
-    public final TestDirectory directory = TestDirectory.testDirectory();
+    public final RuleChain ruleChain = RuleChain.outerRule( directory ).around( suppressOutput ).around( random );
 
     private File sourceDir;
     private File backupDir;
@@ -66,7 +70,7 @@ public class BackupLabelIndexIT
     private GraphDatabaseService backupDb;
 
     @Before
-    public void setupDirectoroes()
+    public void setupDirectories()
     {
         sourceDir = directory.absolutePath();
         backupDir = directory.directory( "backup" );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -1107,15 +1107,6 @@ public class BackupServiceIT
 
         @Override
         public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
-                LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose )
-                throws ConsistencyCheckFailedException
-        {
-            markAsChecked();
-            return ConsistencyCheck.FULL.runFull( storeDir, tuningConfiguration, progressFactory, logProvider, fileSystem, pageCache, verbose );
-        }
-
-        @Override
-        public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
                 LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose,
                 CheckConsistencyConfig checkConsistencyConfig ) throws ConsistencyCheckFailedException
         {
@@ -1128,7 +1119,7 @@ public class BackupServiceIT
             checked = true;
         }
 
-        public boolean isChecked()
+        boolean isChecked()
         {
             return checked;
         }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.com.storecopy.StoreUtil;
+import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
 import org.neo4j.cursor.IOCursor;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -48,6 +49,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.mockfs.UncloseableDelegatingFileSystemAbstraction;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -155,6 +157,27 @@ public class BackupServiceIT
     {
         return new BackupService( () -> new UncloseableDelegatingFileSystemAbstraction( fileSystemRule.get() ),
                 logProvider, new Monitors() );
+    }
+
+    @Test
+    public void performConsistencyCheckAfterIncrementalBackup()
+    {
+        defaultBackupPortHostParams();
+        Config defaultConfig = dbRule.getConfigCopy();
+
+        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        createAndIndexNode( db, 1 );
+
+        backupService().doFullBackup( BACKUP_HOST, backupPort, backupDir, ConsistencyCheck.NONE, defaultConfig,
+                BackupClient.BIG_READ_TIMEOUT, false );
+
+        createAndIndexNode( db, 1 );
+        TestFullConsistencyCheck consistencyCheck = new TestFullConsistencyCheck();
+        BackupService.BackupOutcome backupOutcome = backupService()
+                .doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort, backupDir, consistencyCheck,
+                        defaultConfig, BackupClient.BIG_READ_TIMEOUT, false );
+        assertTrue( "Consistency check invoked for incremental backup, ", consistencyCheck.isChecked() );
+        assertTrue( backupOutcome.isConsistent() );
     }
 
     @Test
@@ -647,7 +670,7 @@ public class BackupServiceIT
         try
         {
             backupService.doIncrementalBackup( BACKUP_HOST, backupPort, backupDir.getAbsoluteFile(),
-                    BackupClient.BIG_READ_TIMEOUT, defaultConfig );
+                    ConsistencyCheck.NONE, BackupClient.BIG_READ_TIMEOUT, defaultConfig );
             fail( "Should have thrown exception." );
         }
         // Then
@@ -1073,4 +1096,41 @@ public class BackupServiceIT
         }
     }
 
+    private static class TestFullConsistencyCheck implements ConsistencyCheck
+    {
+        private boolean checked = false;
+        @Override
+        public String name()
+        {
+            return "testFull";
+        }
+
+        @Override
+        public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
+                LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose )
+                throws ConsistencyCheckFailedException
+        {
+            markAsChecked();
+            return ConsistencyCheck.FULL.runFull( storeDir, tuningConfiguration, progressFactory, logProvider, fileSystem, pageCache, verbose );
+        }
+
+        @Override
+        public boolean runFull( File storeDir, Config tuningConfiguration, ProgressMonitorFactory progressFactory,
+                LogProvider logProvider, FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose,
+                CheckConsistencyConfig checkConsistencyConfig ) throws ConsistencyCheckFailedException
+        {
+            markAsChecked();
+            return ConsistencyCheck.FULL.runFull( storeDir, tuningConfiguration, progressFactory, logProvider, fileSystem, pageCache, verbose, checkConsistencyConfig );
+        }
+
+        private void markAsChecked()
+        {
+            checked = true;
+        }
+
+        public boolean isChecked()
+        {
+            return checked;
+        }
+    }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -225,7 +225,8 @@ public class OnlineBackupCommandTest
 
         execute( "--check-consistency=true", backupDir( dir.getParent() ), "--name=" + dir.getName() );
 
-        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ),
+                anyLong(), any() );
         verifyNoMoreInteractions( backupService );
         verify( consistencyCheckService ).runFullConsistencyCheck( any(), any(), any(), any(), any(),
                 anyBoolean(), eq( new File( "." ).getCanonicalFile() ), any( CheckConsistencyConfig.class ) );
@@ -240,7 +241,8 @@ public class OnlineBackupCommandTest
 
         execute( "--check-consistency=false", backupDir( dir.getParent() ), "--name=" + dir.getName() );
 
-        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ),
+                anyLong(), any() );
         verifyNoMoreInteractions( backupService );
         verifyNoMoreInteractions( consistencyCheckService );
     }
@@ -328,7 +330,8 @@ public class OnlineBackupCommandTest
 
         execute( backupDir( dir.getParent() ), "--name=" + dir.getName() );
 
-        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ),
+                anyLong(), any() );
         verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
         verify( outsideWorld ).stdOutLine( "Doing consistency check..." );
         verifyNoMoreInteractions( backupService );
@@ -342,13 +345,15 @@ public class OnlineBackupCommandTest
         File dir = testDirectory.directory( "ccInc" );
         when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
         when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{ dir } );
-        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ), anyLong(), any()
+        ) )
                 .thenThrow( new RuntimeException( "nah-ah" ) );
 
         execute( "--cc-report-dir=" + dir.getParent(), backupDir( dir.getParent() ),
                 "--name=" + dir.getName() );
 
-        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ),
+                anyLong(), any() );
         verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
         verify( outsideWorld ).stdErrLine( "Incremental backup failed: nah-ah" );
         verify( outsideWorld ).stdErrLine( "Old backup renamed to 'ccInc.err.1'." );
@@ -366,7 +371,8 @@ public class OnlineBackupCommandTest
         File dir = testDirectory.directory( "ccInc" );
         when( mockFs.isDirectory( eq( dir.getParentFile() ) ) ).thenReturn( true );
         when( mockFs.listFiles( eq( dir ) ) ).thenReturn( new File[]{ dir } );
-        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ), anyLong(), any()
+        ) )
                 .thenThrow( new RuntimeException( "nah-ah" ) );
 
         doThrow( new IOException( "kaboom" ) ).when( mockFs ).renameFile( any(), any() );
@@ -422,7 +428,8 @@ public class OnlineBackupCommandTest
     {
         File dir = testDirectory.directory( "ccInc" );
         assertTrue( new File( dir, "afile" ).createNewFile() );
-        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ), anyLong(), any()
+        ) )
                 .thenThrow( new RuntimeException( "nah-ah" ) );
 
         expected.expectMessage( "Backup failed: nah-ah" );
@@ -444,13 +451,15 @@ public class OnlineBackupCommandTest
         {
             when( mockFs.fileExists( eq( new File( dir.getParentFile(), "ccInc.err." + i ) ) ) ).thenReturn( true );
         }
-        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ), anyLong(), any()
+        ) )
                 .thenThrow( new RuntimeException( "nah-ah" ) );
 
         execute( "--cc-report-dir=" + dir.getParent(), backupDir( dir.getParent() ),
                 "--name=" + dir.getName() );
 
-        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() );
+        verify( backupService ).doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ),
+                anyLong(), any() );
         verify( outsideWorld ).stdOutLine( "Destination is not empty, doing incremental backup..." );
         verify( outsideWorld ).stdErrLine( "Incremental backup failed: nah-ah" );
         verify( outsideWorld ).stdErrLine( "Old backup renamed to 'ccInc.err.50'." );
@@ -472,7 +481,8 @@ public class OnlineBackupCommandTest
         {
             when( mockFs.fileExists( eq( new File( dir.getParentFile(), "ccInc.err." + i ) ) ) ).thenReturn( true );
         }
-        when( backupService.doIncrementalBackup( any(), anyInt(), any(), anyLong(), any() ) )
+        when( backupService.doIncrementalBackup( any(), anyInt(), any(), eq( ConsistencyCheck.NONE ), anyLong(), any()
+        ) )
                 .thenThrow( new RuntimeException( "nah-ah" ) );
 
         expected.expect( CommandFailed.class );


### PR DESCRIPTION
Allow to perform consistency check of incremental backup for backup commands that use OnlineBackup API: check will be performed if user requested verification of created backup, by specifying `verification = true` in appropriate incremental backup call.