### PR TITLE
Renamed `neo4j-admin version` to `neo4j-admin store-info`

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommandSection.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminCommandSection.java
@@ -54,6 +54,7 @@ public abstract class AdminCommandSection
 
     public final void printAllCommandsUnderSection( Consumer<String> output, List<AdminCommand.Provider> providers )
     {
+        output.accept( "" );
         output.accept( printable() );
         providers.sort( Comparator.comparing( AdminCommand.Provider::name ) );
         providers.forEach( provider -> provider.printSummary( s -> output.accept( "    " + s ) ) );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminCommandSectionTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/AdminCommandSectionTest.java
@@ -60,6 +60,7 @@ public class AdminCommandSectionTest
         generalSection.printAllCommandsUnderSection( out, providers );
 
         InOrder ordered = inOrder( out );
+        ordered.verify( out ).accept( "" );
         ordered.verify( out ).accept( "General" );
         ordered.verify( out ).accept( "    bam" );
         ordered.verify( out ).accept( "        A summary" );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -128,6 +128,7 @@ public class HelpCommandTest
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "available commands:%n" +
+                            "%n" +
                             "General%n" +
                             "    bar%n" +
                             "        null%n" +

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommand.java
@@ -40,15 +40,15 @@ import org.neo4j.kernel.internal.Version;
 
 import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.findSuccessor;
 
-public class VersionCommand implements AdminCommand
+public class StoreInfoCommand implements AdminCommand
 {
     private static final Arguments arguments = new Arguments()
             .withArgument( new MandatoryCanonicalPath( "store", "path-to-dir",
-                    "Path to database store to check version of." ) );
+                    "Path to database store." ) );
 
     private Consumer<String> out;
 
-    public VersionCommand( Consumer<String> out )
+    public StoreInfoCommand( Consumer<String> out )
     {
         this.out = out;
     }
@@ -69,17 +69,17 @@ public class VersionCommand implements AdminCommand
                             () -> new CommandFailed( String.format( "Could not find version metadata in store '%s'",
                                     storeDir ) ) );
 
-            final String fmt = "%-25s%s";
+            final String fmt = "%-30s%s";
             out.accept( String.format( fmt, "Store format version:", storeVersion ) );
 
             RecordFormats format = RecordFormatSelector.selectForVersion( storeVersion );
-            out.accept( String.format( fmt, "Introduced in version:", format.introductionVersion() ) );
+            out.accept( String.format( fmt, "Store format introduced in:", format.introductionVersion() ) );
 
             findSuccessor( format )
-                    .map( next -> String.format( fmt, "Superseded in version:", next.introductionVersion() ) )
+                    .map( next -> String.format( fmt, "Store format superseded in:", next.introductionVersion() ) )
                     .ifPresent( out );
 
-            out.accept( String.format( fmt, "Current version:", Version.getNeo4jVersion() ) );
+            //out.accept( String.format( fmt, "Current version:", Version.getNeo4jVersion() ) );
         }
         catch ( IOException e )
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/StoreInfoCommandProvider.java
@@ -27,26 +27,26 @@ import org.neo4j.commandline.admin.AdminCommandSection;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 
-public class VersionCommandProvider extends AdminCommand.Provider
+public class StoreInfoCommandProvider extends AdminCommand.Provider
 {
 
-    public VersionCommandProvider()
+    public StoreInfoCommandProvider()
     {
-        super( "version" );
+        super( "store-info" );
     }
 
     @Override
     @Nonnull
     public Arguments allArguments()
     {
-        return VersionCommand.arguments();
+        return StoreInfoCommand.arguments();
     }
 
     @Override
     @Nonnull
     public String summary()
     {
-        return "Check the version of a Neo4j database store.";
+        return "Prints information about a Neo4j database store.";
     }
 
     @Override
@@ -60,14 +60,14 @@ public class VersionCommandProvider extends AdminCommand.Provider
     @Nonnull
     public String description()
     {
-        return "Checks the version of a Neo4j database store. Note that this command expects a path to a store " +
-                "directory, for example --store=data/databases/graph.db.";
+        return "Prints information about a Neo4j database store, such as what version of Neo4j created it. Note that " +
+                "this command expects a path to a store directory, for example --store=data/databases/graph.db.";
     }
 
     @Override
     @Nonnull
     public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
-        return new VersionCommand( outsideWorld::stdOutLine );
+        return new StoreInfoCommand( outsideWorld::stdOutLine );
     }
 }

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -1,4 +1,4 @@
 org.neo4j.commandline.dbms.ImportCommandProvider
 org.neo4j.commandline.dbms.DumpCommandProvider
 org.neo4j.commandline.dbms.LoadCommandProvider
-org.neo4j.commandline.dbms.VersionCommandProvider
+org.neo4j.commandline.dbms.StoreInfoCommandProvider

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.STORE_VERSION;
 
-public class VersionCommandTest
+public class StoreInfoCommandTest
 {
     @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
@@ -65,7 +65,7 @@ public class VersionCommandTest
 
     private Path databaseDirectory;
     private ArgumentCaptor<String> outCaptor;
-    private VersionCommand command;
+    private StoreInfoCommand command;
     private Consumer<String> out;
 
     @Before
@@ -77,7 +77,7 @@ public class VersionCommandTest
 
         outCaptor = ArgumentCaptor.forClass( String.class );
         out = mock( Consumer.class );
-        command = new VersionCommand( out );
+        command = new StoreInfoCommand( out );
     }
 
     @Test
@@ -87,15 +87,16 @@ public class VersionCommandTest
         {
             PrintStream ps = new PrintStream( baos );
             Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
-            usage.printUsageForCommand( new VersionCommandProvider(), ps::println );
+            usage.printUsageForCommand( new StoreInfoCommandProvider(), ps::println );
 
-            assertEquals( String.format( "usage: neo4j-admin version --store=<path-to-dir>%n" +
+            assertEquals( String.format( "usage: neo4j-admin store-info --store=<path-to-dir>%n" +
                             "%n" +
-                            "Checks the version of a Neo4j database store. Note that this command expects a%n" +
-                            "path to a store directory, for example --store=data/databases/graph.db.%n" +
+                            "Prints information about a Neo4j database store, such as what version of Neo4j%n" +
+                            "created it. Note that this command expects a path to a store directory, for%n" +
+                            "example --store=data/databases/graph.db.%n" +
                             "%n" +
                             "options:%n" +
-                            "  --store=<path-to-dir>   Path to database store to check version of.%n" ),
+                            "  --store=<path-to-dir>   Path to database store.%n" ),
                     baos.toString() );
         }
     }
@@ -135,13 +136,12 @@ public class VersionCommandTest
 
         execute( databaseDirectory.toString() );
 
-        verify( out, times( 3 ) ).accept( outCaptor.capture() );
+        verify( out, times( 2 ) ).accept( outCaptor.capture() );
 
         assertEquals(
                 Arrays.asList(
-                        String.format( "Store format version:    %s", currentFormat.storeVersion() ),
-                        String.format( "Introduced in version:   %s", currentFormat.introductionVersion() ),
-                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
+                        String.format( "Store format version:         %s", currentFormat.storeVersion() ),
+                        String.format( "Store format introduced in:   %s", currentFormat.introductionVersion() ) ),
                 outCaptor.getAllValues() );
     }
 
@@ -152,14 +152,13 @@ public class VersionCommandTest
 
         execute( databaseDirectory.toString() );
 
-        verify( out, times( 4 ) ).accept( outCaptor.capture() );
+        verify( out, times( 3 ) ).accept( outCaptor.capture() );
 
         assertEquals(
                 Arrays.asList(
-                        "Store format version:    v0.A.5",
-                        "Introduced in version:   2.2.0",
-                        "Superseded in version:   2.3.0",
-                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
+                        "Store format version:         v0.A.5",
+                        "Store format introduced in:   2.2.0",
+                        "Store format superseded in:   2.3.0" ),
                 outCaptor.getAllValues() );
     }
 

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandEnterpriseTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.STORE_VERSION;
 
-public class VersionCommandEnterpriseTest
+public class StoreInfoCommandEnterpriseTest
 {
     @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
@@ -58,7 +58,7 @@ public class VersionCommandEnterpriseTest
 
     private Path databaseDirectory;
     private ArgumentCaptor<String> outCaptor;
-    private VersionCommand command;
+    private StoreInfoCommand command;
     private Consumer<String> out;
 
     @Before
@@ -69,7 +69,7 @@ public class VersionCommandEnterpriseTest
         Files.createDirectories( databaseDirectory );
         outCaptor = ArgumentCaptor.forClass( String.class );
         out = mock( Consumer.class );
-        command = new VersionCommand( out );
+        command = new StoreInfoCommand( out );
     }
 
     @Test
@@ -79,14 +79,13 @@ public class VersionCommandEnterpriseTest
 
         execute( databaseDirectory.toString() );
 
-        verify( out, times( 4 ) ).accept( outCaptor.capture() );
+        verify( out, times( 3 ) ).accept( outCaptor.capture() );
 
         assertEquals(
                 Arrays.asList(
-                        "Store format version:    vE.H.0",
-                        "Introduced in version:   3.0.0",
-                        "Superseded in version:   3.0.6",
-                        String.format( "Current version:         %s", Version.getNeo4jVersion() ) ),
+                        "Store format version:         vE.H.0",
+                        "Store format introduced in:   3.0.0",
+                        "Store format superseded in:   3.0.6" ),
                 outCaptor.getAllValues() );
     }
 

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -52,26 +52,31 @@ public class Neo4jAdminUsageTest
                         "                  Takes a number and a unit, for example 512m.\n" +
                         "\n" +
                         "available commands:\n" +
+                        "\n" +
                         "General\n" +
                         "    check-consistency\n" +
                         "        Check the consistency of a database.\n" +
                         "    import\n" +
                         "        Import from a collection of CSV files or a pre-3.0 database.\n" +
-                        "    version\n" +
-                        "        Check the version of a Neo4j database store.\n" +
+                        "    store-info\n" +
+                        "        Prints information about a Neo4j database store.\n" +
+                        "\n" +
                         "Authentication\n" +
                         "    set-default-admin\n" +
                         "        Sets the default admin user when no roles are present.\n" +
                         "    set-initial-password\n" +
                         "        Sets the initial password of the initial admin user ('neo4j').\n" +
+                        "\n" +
                         "Clustering\n" +
                         "    unbind\n" +
                         "        Removes cluster state data for the specified database.\n" +
+                        "\n" +
                         "Offline backup\n" +
                         "    dump\n" +
                         "        Dump a database into a single-file archive.\n" +
                         "    load\n" +
                         "        Load a database from an archive created with the dump command.\n" +
+                        "\n" +
                         "Online backup\n" +
                         "    backup\n" +
                         "        Perform an online backup from a running Neo4j enterprise server.\n" +


### PR DESCRIPTION
### Updated output

```
$ bin/neo4j-admin store-info --store=./data/databases/graph.db
Store format version:         v0.A.7
Store format introduced in:   3.0.0
```

Couple this with newly available `--version` argument and you have complete information.

### Updated help text

```
usage: neo4j-admin store-info --store=<path-to-dir>

Prints information about a Neo4j database store, such as what version of Neo4j
created it. Note that this command expects a path to a store directory, for
example --store=data/databases/graph.db.

options:
  --store=<path-to-dir>   Path to database store.
```

### Improved neo4j-admin help (newlines between sections)

```
usage: neo4j-admin <command>

Manage your Neo4j instance.

environment variables:
    NEO4J_CONF    Path to directory which contains neo4j.conf.
    NEO4J_DEBUG   Set to anything to enable debug output.
    NEO4J_HOME    Neo4j home directory.
    HEAP_SIZE     Set size of JVM heap during command execution.
                  Takes a number and a unit, for example 512m.

available commands:

General
    check-consistency
        Check the consistency of a database.
    help
        This help text, or help for the command specified in <command>.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    store-info
        Prints information about a Neo4j database store.

Authentication
    set-default-admin
        Sets the default admin user when no roles are present.
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').

Clustering
    unbind
        Removes cluster state data for the specified database.

Offline backup
    dump
        Dump a database into a single-file archive.
    load
        Load a database from an archive created with the dump command.

Online backup
    backup
        Perform an online backup from a running Neo4j enterprise server.
    restore
        Restore a backed up database.

Use neo4j-admin help <command> for more details.
```