### PR TITLE
Add NODE KEY support to DbStructure

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeExistenceConstraintDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/schema_new/constaints/NodeExistenceConstraintDescriptor.java
@@ -21,9 +21,10 @@ package org.neo4j.kernel.api.schema_new.constaints;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.schema_new.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema_new.LabelSchemaSupplier;
 import org.neo4j.kernel.api.schema_new.SchemaUtil;
 
-public class NodeExistenceConstraintDescriptor extends ConstraintDescriptor
+public class NodeExistenceConstraintDescriptor extends ConstraintDescriptor implements LabelSchemaSupplier
 {
     private LabelSchemaDescriptor schema;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.schema_new.RelationTypeSchemaDescriptor;
 import org.neo4j.kernel.api.schema_new.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -48,6 +49,7 @@ public enum DbStructureArgumentFormatter implements ArgumentFormatter
             UniquenessConstraintDescriptor.class.getCanonicalName(),
             RelExistenceConstraintDescriptor.class.getCanonicalName(),
             NodeExistenceConstraintDescriptor.class.getCanonicalName(),
+            NodeKeyConstraintDescriptor.class.getCanonicalName(),
             LabelSchemaDescriptor.class.getCanonicalName(),
             SchemaDescriptorFactory.class.getCanonicalName(),
             NewIndexDescriptor.class.getCanonicalName(),
@@ -134,6 +136,14 @@ public enum DbStructureArgumentFormatter implements ArgumentFormatter
             int relTypeId = descriptor.getRelTypeId();
             builder.append( format( "ConstraintDescriptorFactory.existsForReltype( %d, %s )", relTypeId,
                     asString( descriptor.getPropertyIds() ) ) );
+        }
+        else if ( arg instanceof NodeKeyConstraintDescriptor )
+        {
+            NodeKeyConstraintDescriptor constraint = (NodeKeyConstraintDescriptor) arg;
+            int labelId = constraint.schema().getLabelId();
+            builder.append( format( "ConstraintDescriptorFactory.nodeKeyForLabel( %d, %s )",
+                    labelId,
+                    asString( constraint.schema().getPropertyIds() ) ) );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
@@ -34,6 +34,7 @@ public interface DbStructureLookup
     Iterator<Pair<String, String[]>> knownUniqueConstraints();
     Iterator<Pair<String, String[]>> knownNodePropertyExistenceConstraints();
     Iterator<Pair<String, String[]>> knownRelationshipPropertyExistenceConstraints();
+    Iterator<Pair<String, String[]>> knownNodeKeyConstraints();
 
     long nodesWithLabelCardinality( int labelId );
     long cardinalityByLabelsAndRelationshipType( int fromLabelId, int relTypeId, int toLabelId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.util.dbstructure;
 
 import org.neo4j.kernel.api.schema_new.constaints.NodeExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema_new.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.RelExistenceConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema_new.index.NewIndexDescriptor;
@@ -35,6 +36,7 @@ public interface DbStructureVisitor
     void visitNodePropertyExistenceConstraint( NodeExistenceConstraintDescriptor constraint, String userDescription );
     void visitRelationshipPropertyExistenceConstraint( RelExistenceConstraintDescriptor constraint,
             String userDescription );
+    void visitNodeKeyConstraint( NodeKeyConstraintDescriptor constraint, String userDescription );
 
     void visitAllNodesCount( long nodeCount );
     void visitNodeCount( int labelId, String labelName, long nodeCount );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatterTest.java
@@ -84,6 +84,13 @@ public class DbStructureArgumentFormatterTest
                 formatArgument( ConstraintDescriptorFactory.uniqueForLabel( 23, 42, 43 ) ) );
     }
 
+    @Test
+    public void shouldFormatNodeKeyConstraints()
+    {
+        assertEquals( "ConstraintDescriptorFactory.nodeKeyForLabel( 23, 42, 43 )",
+                formatArgument( ConstraintDescriptorFactory.nodeKeyForLabel( 23, 42, 43 ) ) );
+    }
+
     private String formatArgument( Object arg )
     {
         StringBuilder builder = new StringBuilder();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
@@ -46,6 +46,7 @@ public class DbStructureCollectorTest
         collector.visitRelationshipType( 2, "FRIEND" );
         collector.visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 1, 1 ), ":Person(name)", 1.0d, 1L );
         collector.visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 2, 1 ), ":City(name)" );
+        collector.visitNodeKeyConstraint( ConstraintDescriptorFactory.nodeKeyForLabel( 2, 1 ), ":City(name)" );
         collector.visitIndex( NewIndexDescriptorFactory.forLabel( 2, 2 ), ":City(income)", 0.2d, 1L );
         collector.visitAllNodesCount( 50 );
         collector.visitNodeCount( 1, "Person", 20 );
@@ -63,9 +64,15 @@ public class DbStructureCollectorTest
         assertEquals( asList( "Person" ),
                 Iterators.asList( Iterators.map( Pair::first, lookup.knownUniqueIndices() ) ) );
         assertArrayEquals( new String[]{"name"}, lookup.knownUniqueIndices().next().other() );
+
+        assertEquals( asList( "City" ),
+                Iterators.asList( Iterators.map( Pair::first, lookup.knownNodeKeyConstraints() ) ) );
+        assertArrayEquals( new String[]{"name"}, lookup.knownNodeKeyConstraints().next().other() );
+
         assertEquals( asList( "City" ),
                 Iterators.asList( Iterators.map( Pair::first, lookup.knownUniqueConstraints() ) ) );
         assertArrayEquals( new String[]{"name"}, lookup.knownUniqueConstraints().next().other() );
+
         assertEquals( asList( "City" ), Iterators.asList( Iterators.map( Pair::first, lookup.knownIndices() ) ) );
         assertArrayEquals( new String[]{"income"}, lookup.knownIndices().next().other() );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureInvocationTracingAcceptanceTest.java
@@ -132,10 +132,12 @@ public class DbStructureInvocationTracingAcceptanceTest
         visitor.apply( null ).visitRelationshipType( 0, "ACCEPTS" );
         visitor.apply( null ).visitRelationshipType( 1, "REJECTS" );
         visitor.apply( null ).visitIndex( NewIndexDescriptorFactory.forLabel( 0, 1 ), ":Person(age)", 0.5d, 1L );
-        visitor.apply( null )
-                .visitIndex( NewIndexDescriptorFactory.uniqueForLabel( 0, 0, 2 ), ":Person(name, lastName)", 0.5d, 1L );
-        visitor.apply( null )
-                .visitUniqueConstraint( ConstraintDescriptorFactory.uniqueForLabel( 1, 0 ), ":Party(name)" );
+        visitor.apply( null ).visitIndex(
+                        NewIndexDescriptorFactory.uniqueForLabel( 0, 0, 2 ), ":Person(name, lastName)", 0.5d, 1L );
+        visitor.apply( null ).visitUniqueConstraint(
+                        ConstraintDescriptorFactory.uniqueForLabel( 1, 0 ), ":Party(name)" );
+        visitor.apply( null ).visitNodeKeyConstraint(
+                        ConstraintDescriptorFactory.nodeKeyForLabel( 0, 1, 2 ), ":Person(name, lastName)" );
         visitor.apply( null ).visitAllNodesCount( 55 );
         visitor.apply( null ).visitNodeCount( 0, "Person", 50 );
         visitor.apply( null ).visitNodeCount( 0, "Party", 5 );


### PR DESCRIPTION
Because it was decided to add NODE KEY as a primary full stack constraint, we need to support it in DbStructure.