### PR TITLE
Use last transaction log position for checkpoint that generated during upgrade

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigratorCheckPointer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigratorCheckPointer.java
@@ -50,12 +50,13 @@ public class StoreMigratorCheckPointer
      * <p>
      * It will create the file with header containing the log version and lastCommittedTx given as arguments
      *
-     * @param logVersion the log version to open
+     * @param lastClosedTransactionLogPosition last closed transaction log position
      * @param lastCommittedTx the last committed tx id
      */
-    public void checkPoint( long logVersion, long lastCommittedTx ) throws IOException
+    public void checkPoint( LogPosition lastClosedTransactionLogPosition, long lastCommittedTx ) throws IOException
     {
         PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, fileSystem );
+        long logVersion = lastClosedTransactionLogPosition.getLogVersion();
         File logFileForVersion = logFiles.getLogFileForVersion( logVersion );
         if ( !fileSystem.fileExists( logFileForVersion ) )
         {
@@ -74,7 +75,7 @@ public class StoreMigratorCheckPointer
                           new PositionAwarePhysicalFlushableChannel( storeChannel ) )
             {
                 TransactionLogWriter writer = new TransactionLogWriter( new LogEntryWriter( channel ) );
-                writer.checkPoint( new LogPosition( logVersion, offset ) );
+                writer.checkPoint( lastClosedTransactionLogPosition );
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -95,7 +95,6 @@ public class StoreMigratorTest
         TransactionId expected = new TransactionId( txId, checksum, timestamp );
 
         // ... and files
-        PageCache pageCache = pageCacheRule.getPageCache( fs );
         File storeDir = directory.graphDbDir();
         File neoStore = new File( storeDir, DEFAULT_NAME );
         neoStore.createNewFile();
@@ -129,8 +128,6 @@ public class StoreMigratorTest
         TransactionId expected = new TransactionId( txId, checksum, timestamp );
 
         // ... and files
-        PageCache pageCache = pageCacheRule.getPageCache( fs );
-
         File storeDir = directory.graphDbDir();
         File neoStore = new File( storeDir, DEFAULT_NAME );
         neoStore.createNewFile();
@@ -156,7 +153,6 @@ public class StoreMigratorTest
     {
         // given
         long txId = 42;
-        PageCache pageCache = pageCacheRule.getPageCache( fs );
         File storeDir = directory.graphDbDir();
         File neoStore = new File( storeDir, DEFAULT_NAME );
         neoStore.createNewFile();
@@ -186,7 +182,6 @@ public class StoreMigratorTest
     {
         // given
         long txId = 1;
-        PageCache pageCache = pageCacheRule.getPageCache( fs );
         File storeDir = directory.graphDbDir();
         File neoStore = new File( storeDir, DEFAULT_NAME );
         neoStore.createNewFile();
@@ -263,7 +258,6 @@ public class StoreMigratorTest
 
         assertEquals( writtenLogPosition, readLogPosition );
     }
-
     private StoreMigrator newStoreMigrator()
     {
         return new StoreMigrator( fs, pageCache,


### PR DESCRIPTION
Use Last transaction log position for checkpoint and for last transaction metadata store fields.
LOG_POSITION field can provide logVersion that is bigger then any existing log
and that will generate checkpoint that have higher log version then subsequent checkpoint that will use
last committed transaction log version.