### PR TITLE
Use getDegree instead of expansion

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriter.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriter.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
 import org.neo4j.cypher.internal.compiler.v3_2.ast.NestedPlanExpression
 import org.neo4j.cypher.internal.frontend.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.helpers.calculateUsingGetDegree
 
 case object getDegreeRewriter extends Rewriter {
 
@@ -51,12 +52,5 @@ case object getDegreeRewriter extends Rewriter {
     case func@FunctionInvocation(_, _, _, IndexedSeq(PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(None, List(), None), RelationshipPattern(None, types, None, None, dir), NodePattern(Some(node), List(), None))))))
       if func.function == functions.Exists =>
       GreaterThan(calculateUsingGetDegree(func, node, types, dir.reversed), SignedDecimalIntegerLiteral("0")(func.position))(func.position)
-  }
-
-  private def calculateUsingGetDegree(func: FunctionInvocation, node: Variable, types: Seq[RelTypeName], dir: SemanticDirection): Expression = {
-    types
-      .map(typ => GetDegree(node.copyId, Some(typ), dir)(typ.position))
-      .reduceOption[Expression](Add(_, _)(func.position))
-      .getOrElse(GetDegree(node, None, dir)(func.position))
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -411,11 +411,8 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     // Then inner pattern query graph
     val relName = "  UNNAMED20"
     val nodeName = "  UNNAMED23"
-    val exp: PatternExpression = PatternExpression(RelationshipsPattern(RelationshipChain(
-      NodePattern(Some(Variable("a")(pos)), Seq(), None) _,
-      RelationshipPattern(Some(Variable(relName)(pos)), Seq.empty, None, None, OUTGOING) _,
-      NodePattern(Some(Variable(nodeName)(pos)), Seq(), None) _
-    ) _) _)
+    val exp = GreaterThan(GetDegree(varFor("a"),None,OUTGOING) _,
+                          SignedDecimalIntegerLiteral("0") _) _
     val predicate= Predicate(Set(IdName("a")), exp)
     val selections = Selections(Set(predicate))
 
@@ -463,11 +460,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     // Then inner pattern query graph
     val relName = "  UNNAMED35"
     val nodeName = "  UNNAMED38"
-    val exp1: PatternExpression = PatternExpression(RelationshipsPattern(RelationshipChain(
-      NodePattern(Some(Variable("a")(pos)), Seq(), None) _,
-      RelationshipPattern(Some(Variable(relName)(pos)), Seq.empty, None, None, OUTGOING) _,
-      NodePattern(Some(Variable(nodeName)(pos)), Seq(), None) _
-    ) _) _)
+    val exp1 = GreaterThan(GetDegree(varFor("a"),None,OUTGOING) _, SignedDecimalIntegerLiteral("0") _) _
     val exp2: Expression = In(
       Property(Variable("a")_, PropertyKeyName("prop")_)_,
       ListLiteral(Seq(SignedDecimalIntegerLiteral("42")_))_
@@ -486,11 +479,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     // Then inner pattern query graph
     val relName = "  UNNAMED20"
     val nodeName = "  UNNAMED23"
-    val exp1: PatternExpression = PatternExpression(RelationshipsPattern(RelationshipChain(
-      NodePattern(Some(Variable("a")(pos)), Seq(), None) _,
-      RelationshipPattern(Some(Variable(relName)(pos)), Seq.empty, None, None, OUTGOING) _,
-      NodePattern(Some(Variable(nodeName)(pos)), Seq(), None) _
-    ) _) _)
+    val exp1 = GreaterThan(GetDegree(varFor("a"),None,OUTGOING) _, SignedDecimalIntegerLiteral("0") _) _
     val exp2: Expression = In(
       Property(Variable("a")_, PropertyKeyName("prop")_)_,
       ListLiteral(Seq(SignedDecimalIntegerLiteral("42")_))_
@@ -509,11 +498,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     // Then inner pattern query graph
     val relName = "  UNNAMED36"
     val nodeName = "  UNNAMED39"
-    val exp1: PatternExpression = PatternExpression(RelationshipsPattern(RelationshipChain(
-      NodePattern(Some(Variable("a")(pos)), Seq(), None) _,
-      RelationshipPattern(Some(Variable(relName)(pos)), Seq.empty, None, None, OUTGOING) _,
-      NodePattern(Some(Variable(nodeName)(pos)), Seq(), None) _
-    ) _) _)
+    val exp1 = GreaterThan(GetDegree(varFor("a"),None,OUTGOING)_, SignedDecimalIntegerLiteral("0")_)_
     val exp2: Expression = In(
       Property(Variable("a")_, PropertyKeyName("prop")_)_,
       ListLiteral(Seq(SignedDecimalIntegerLiteral("42")_))_

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriterTest.scala
@@ -1,0 +1,29 @@
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
+
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.ast.functions.Exists
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+
+class getDegreeRewriterTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  test("Rewrite exists( (a)-[:FOO]->() ) to GetDegree( (a)-[:FOO]->() ) > 0") {
+    val incoming = Exists.asInvocation(
+      PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(Some(varFor("a")), Seq.empty, None)(pos),
+                                                               RelationshipPattern(None, Seq(RelTypeName("FOO")(pos)), None, None, SemanticDirection.OUTGOING)(pos),
+                                                               NodePattern(None, Seq.empty, None)(pos))(pos))(pos)))(pos)
+    val expected = GreaterThan(GetDegree(varFor("a"), Some(RelTypeName("FOO")(pos)), SemanticDirection.OUTGOING)(pos), SignedDecimalIntegerLiteral("0")(pos))(pos)
+
+    getDegreeRewriter(incoming) should equal(expected)
+  }
+
+  test("Rewrite exists( ()-[:FOO]->(a) ) to GetDegree( (a)<-[:FOO]-() ) > 0") {
+    val incoming = Exists.asInvocation(
+      PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(None, Seq.empty, None)(pos),
+                                                               RelationshipPattern(None, Seq(RelTypeName("FOO")(pos)), None, None, SemanticDirection.OUTGOING)(pos),
+                                                               NodePattern(Some(varFor("a")), Seq.empty, None)(pos))(pos))(pos)))(pos)
+    val expected = GreaterThan(GetDegree(varFor("a"), Some(RelTypeName("FOO")(pos)), SemanticDirection.INCOMING)(pos), SignedDecimalIntegerLiteral("0")(pos))(pos)
+
+    getDegreeRewriter(incoming) should equal(expected)
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/getDegreeRewriterTest.scala
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
 
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/calculateUsingGetDegree.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/helpers/calculateUsingGetDegree.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v3_2.helpers
+
+import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
+
+/*
+ * Calculates how to transform a pattern (a)-[:R1:R2...]->() to getDegree call
+ * of that very pattern.
+ */
+object calculateUsingGetDegree {
+
+  def apply(expr: Expression, node: Variable, types: Seq[RelTypeName], dir: SemanticDirection): Expression = {
+      types
+        .map(typ => GetDegree(node.copyId, Some(typ), dir)(typ.position))
+        .reduceOption[Expression](Add(_, _)(expr.position))
+        .getOrElse(GetDegree(node, None, dir)(expr.position))
+    }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -316,7 +316,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
 
     val result = executeWithAllPlannersAndCompatibilityMode("MATCH (n:A) WHERE (n)-[:HAS]->() RETURN n")
 
-    val argumentPLan = result.executionPlanDescription().cd("Argument")
+    val argumentPLan = result.executionPlanDescription().cd("NodeByLabelScan")
     val estimatedRows = argumentPLan.arguments.collect { case n: EstimatedRows => n }.head
     estimatedRows should equal(EstimatedRows(3.0))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -107,14 +107,11 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = profileWithAllPlanners("match (n) where (n)-[:FOO]->() return *")
 
     //THEN
-    assertRows(1)(result)("SemiApply")
-    assertDbHits(0)(result)("SemiApply")
+    assertRows(1)(result)("Filter")
+    assertDbHits(4)(result)("Filter")
 
     assertRows(2)(result)("AllNodesScan")
     assertDbHits(3)(result)("AllNodesScan")
-
-    assertRows(0)(result)("Expand(All)")
-    assertDbHits(2)(result)("Expand(All)")
   }
 
   test("match (n:A)-->(x:B) return *") {
@@ -153,14 +150,11 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = profileWithAllPlanners("match (n) where not (n)-[:FOO]->() return *")
 
     //THEN
-    assertRows(1)(result)("AntiSemiApply")
-    assertDbHits(0)(result)("AntiSemiApply")
+    assertRows(1)(result)("Filter")
+    assertDbHits(4)(result)("Filter")
 
     assertRows(2)(result)("AllNodesScan")
     assertDbHits(3)(result)("AllNodesScan")
-
-    assertRows(0)(result)("Expand(All)")
-    assertDbHits(2)(result)("Expand(All)")
   }
 
   test("unfinished profiler complains [using MATCH]") {


### PR DESCRIPTION
In cases such as `exists((a)-[:R]->()` and `WHERE (a)-[:R]->()` it is more efficient to use
the count store to check the degree of node `a` instead of doing a full expansion.  This PR adds rewriters to basically rewrite the above queries to use `getDegree((a)-[:R]->()) > 0` instead.