### PR TITLE
Correct query type for procedures

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.executionplan.procs
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.Literal
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{ExecutionPlan, InternalExecutionResult, ProcedureCallMode, READ_ONLY}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{ExecutionPlan, InternalExecutionResult, ProcedureCallMode}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{Counter, RuntimeJavaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.{ExternalCSVResource, QueryState}
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows, Signature}
@@ -77,8 +77,9 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
                                              notifications: Set[InternalNotification]) = {
     // close all statements
     taskCloser.close(success = true)
+    val callMode = ProcedureCallMode.fromAccessMode(signature.accessMode)
     val columns = signature.outputSignature.map(_.seq.map(_.name).toList).getOrElse(List.empty)
-    ExplainExecutionResult(columns, createNormalPlan, READ_ONLY, notifications)
+    ExplainExecutionResult(columns, createNormalPlan, callMode.queryType, notifications)
   }
 
   private def createProfiledExecutionResult(ctx: QueryContext, taskCloser: TaskCloser,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ProcedureCallProjection.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/ProcedureCallProjection.scala
@@ -32,4 +32,6 @@ case class ProcedureCallProjection(call: ResolvedCall) extends QueryHorizon {
     case _:ProcedureReadOnlyAccess => Some(LazyMode)
     case _ => Some(EagerMode)
   }
+
+  override def readOnly = call.containsNoUpdates
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -62,7 +62,7 @@ class PipeExecutionPlanBuilder(clock: Clock,
     }
 
     val periodicCommitInfo = periodicCommit.map(x => PeriodicCommitInfo(x.batchSize))
-    PipeInfo(topLevelPipe, plan.solved.exists(_.queryGraph.containsUpdates),
+    PipeInfo(topLevelPipe, !plan.solved.readOnly,
              periodicCommitInfo, fingerprint, context.plannerName)
   }
 

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
@@ -30,7 +30,7 @@ sealed trait PlannerQuery {
   val horizon: QueryHorizon
   val tail: Option[PlannerQuery]
 
-  def readOnly: Boolean = queryGraph.readOnly && tail.forall(_.readOnly)
+  def readOnly: Boolean = (queryGraph.readOnly && horizon.readOnly) && tail.forall(_.readOnly)
 
   def preferredStrictness: Option[StrictnessMode] =
     horizon.preferredStrictness orElse tail.flatMap(_.preferredStrictness)

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryHorizon.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryHorizon.scala
@@ -34,6 +34,8 @@ trait QueryHorizon {
     case id: Variable =>
       acc => (acc + IdName(id.name), Some(identity))
   }
+
+  def readOnly = true
 }
 
 final case class PassthroughAllHorizon() extends QueryHorizon {

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -47,6 +47,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Result;
@@ -524,6 +525,54 @@ public class ProcedureIT
         try ( Transaction tx = db.beginTx() )
         {
             assertEquals( 1, db.getAllNodes().stream().count() );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void readProceduresShouldPresentThemSelvesAsReadQueries() throws Throwable
+    {
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            Result result = db.execute( "EXPLAIN CALL org.neo4j.procedure.integrationTestMe()" );
+            assertEquals( result.getQueryExecutionType().queryType(), QueryExecutionType.QueryType.READ_ONLY);
+            tx.success();
+        }
+    }
+
+    @Test
+    public void readProceduresWithYieldShouldPresentThemSelvesAsReadQueries() throws Throwable
+    {
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            Result result = db.execute( "EXPLAIN CALL org.neo4j.procedure.integrationTestMe() YIELD someVal as v RETURN v" );
+            assertEquals( result.getQueryExecutionType().queryType(), QueryExecutionType.QueryType.READ_ONLY);
+            tx.success();
+        }
+    }
+
+    @Test
+    public void writeProceduresShouldPresentThemSelvesAsWriteQueries() throws Throwable
+    {
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            Result result = db.execute( "EXPLAIN CALL org.neo4j.procedure.createNode('n')" );
+            assertEquals( result.getQueryExecutionType().queryType(), QueryExecutionType.QueryType.READ_WRITE);
+            tx.success();
+        }
+    }
+
+    @Test
+    public void writeProceduresWithYieldShouldPresentThemSelvesAsWriteQueries() throws Throwable
+    {
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            Result result = db.execute( "EXPLAIN CALL org.neo4j.procedure.createNode('n') YIELD node as n RETURN n.prop" );
+            assertEquals( result.getQueryExecutionType().queryType(), QueryExecutionType.QueryType.READ_WRITE);
             tx.success();
         }
     }


### PR DESCRIPTION
For queries using procedures it should present the correct `QueryType`
and not assume that it is always `READ_ONLY`. The correct `QueryType`
is decided from the corresponding `mode` in the `@Procedure` annotation.