### PR TITLE
Unrecurse JavaConversionSupport.makeENFXSafe

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/JavaConversionSupport.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/JavaConversionSupport.scala
@@ -54,7 +54,7 @@ object JavaConversionSupport {
     // Init
     private def fetchNext(): Option[T] = {
       _next = None
-      while ( _next.isEmpty && hasMore() ) {
+      while (_next.isEmpty && hasMore()) {
         try {
           _next = Some(f(more()))
         } catch {
@@ -62,7 +62,6 @@ object JavaConversionSupport {
           case _: EntityNotFoundException => // IGNORE
         }
       }
-
       _next
     }
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/JavaConversionSupport.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/JavaConversionSupport.scala
@@ -53,14 +53,13 @@ object JavaConversionSupport {
 
     // Init
     private def fetchNext(): Option[T] = {
-      if (!hasMore())
-        _next = None
-      else {
+      _next = None
+      while ( _next.isEmpty && hasMore() ) {
         try {
           _next = Some(f(more()))
         } catch {
-          case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => fetchNext()
-          case _: EntityNotFoundException => fetchNext()
+          case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => // IGNORE
+          case _: EntityNotFoundException => // IGNORE
         }
       }
 


### PR DESCRIPTION
A user observed a StackOverflow here after having misconfigured his store files. While this was a user fault, the stack overflow masked the cause and is generally not needed. Here is a fix.