### PR TITLE
Autoparam and referentially identical identifiers

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
@@ -108,4 +108,21 @@ class ComparisonOperatorAcceptanceTest extends ExecutionEngineFunSuite with NewP
     result.toList should equal(List(Map("p" -> large)))
   }
 
+  test("should handle long chains of comparisons") {
+    executeScalarWithAllPlanners[Boolean]("RETURN 1 < 2 < 3 < 4 as val") shouldBe true
+    executeScalarWithAllPlanners[Boolean]("RETURN 1 < 3 < 2 < 4 as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 1 < 2 < 2 < 4 as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 1 < 2 <= 2 < 4 as val") shouldBe true
+
+    executeScalarWithAllPlanners[Boolean]("RETURN 1.0 < 2.1 < 3.2 < 4.2 as val") shouldBe true
+    executeScalarWithAllPlanners[Boolean]("RETURN 1.0 < 3.2 < 2.1 < 4.2 as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 1.0 < 2.1 < 2.1 < 4.2 as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 1.0 < 2.1 <= 2.1 < 4.2 as val") shouldBe true
+
+    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' < 'c' < 'd' as val") shouldBe true
+    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'c' < 'b' < 'd' as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' < 'b' < 'd' as val") shouldBe false
+    executeScalarWithAllPlanners[Boolean]("RETURN 'a' < 'b' <= 'b' < 'd' as val") shouldBe true
+  }
+
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
@@ -23,11 +23,11 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.PatternConverters._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.{InequalitySeekRangeWrapper, NestedPipeExpression, PrefixSeekRangeWrapper}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.ProjectedPath._
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression => CommandExpression, InequalitySeekRangeExpression, ProjectedPath}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{InequalitySeekRangeExpression, ProjectedPath, Expression => CommandExpression}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.TokenType._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.UnresolvedRelType
-import org.neo4j.cypher.internal.compiler.v2_3.commands.{expressions => commandexpressions, predicates, values => commandvalues}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.{predicates, expressions => commandexpressions, values => commandvalues}
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.ast.functions._
 import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/literalReplacement.scala
@@ -46,13 +46,15 @@ object literalReplacement {
     case ast.ContainerIndex(_, _: ast.StringLiteral) =>
       (acc, _) => acc
     case l: ast.StringLiteral =>
-      (acc, _) => acc + (l -> ast.Parameter(s"  AUTOSTRING${acc.size}")(l.position))
+      (acc, _) => if (acc.contains(l)) acc else acc + (l -> ast.Parameter(s"  AUTOSTRING${acc.size}")(l.position))
     case l: ast.IntegerLiteral =>
-      (acc, _) => acc + (l -> ast.Parameter(s"  AUTOINT${acc.size}")(l.position))
+      (acc, _) =>
+        if (acc.contains(l)) acc else
+        acc + (l -> ast.Parameter(s"  AUTOINT${acc.size}")(l.position))
     case l: ast.DoubleLiteral =>
-      (acc, _) => acc + (l -> ast.Parameter(s"  AUTODOUBLE${acc.size}")(l.position))
+      (acc, _) => if (acc.contains(l)) acc else acc + (l -> ast.Parameter(s"  AUTODOUBLE${acc.size}")(l.position))
     case l: ast.BooleanLiteral =>
-      (acc, _) => acc + (l -> ast.Parameter(s"  AUTOBOOL${acc.size}")(l.position))
+      (acc, _) => if (acc.contains(l)) acc else acc + (l -> ast.Parameter(s"  AUTOBOOL${acc.size}")(l.position))
   }
 
   def apply(term: ASTNode): (Rewriter, Map[String, Any]) = {

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ComparisonTest.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ComparisonTest.scala
@@ -39,4 +39,8 @@ class ComparisonTest extends ParserAstTest[ast.Expression] with Expressions {
   test("a > b > c") {
     yields(ands(gt(id("a"), id("b")), gt(id("b"), id("c"))))
   }
+
+  test("a > b > c > d") {
+    yields(ands(gt(id("a"), id("b")), gt(id("b"), id("c")), gt(id("c"), id("d"))))
+  }
 }


### PR DESCRIPTION
Expressions such as `a < b < c < d` is turned into
`a < b AND b < c AND c < d` in the parser but where the two `a`s, `b`s,
`c`s and `d`s are referentially equivalent. This caused issues with the
 auto parameterization which is backed by an identity map.

Note: In 3.2 there is a separate bug manifesting itself in the very same case. That bug is adressed in https://github.com/neo4j/neo4j/pull/9149, so that needs to go in before this is being forward merged to 3.2 in order for everything to go green.

Note also: The docs build failing is a known issue for all 2.3 builds.