### PR TITLE
Handle Ands with single value

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/SimplifyPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/SimplifyPredicatesTest.scala
@@ -57,4 +57,12 @@ class SimplifyPredicatesTest extends CypherFunSuite with PredicateTestSupport {
   test("P or P and P or Q  iff  P or Q") {
     ands(ors(P, P), ors(P, Q)) <=> ands(P, ors(P, Q))
   }
+
+  test("ANDS with only one TRUE") {
+    ands(TRUE) <=> TRUE
+  }
+
+  test("ORS with only one FALSE") {
+    ors(FALSE) <=> FALSE
+  }
 }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/CNFNormalizer.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_2.ast.rewriters
 
-import org.neo4j.cypher.internal.frontend.v3_2.ast._
-import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, Condition}
-import org.neo4j.cypher.internal.frontend.v3_2.{AstRewritingMonitor, Rewriter, bottomUp, inSequence, topDown}
 import org.neo4j.cypher.internal.frontend.v3_2.Foldable._
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.ast.functions.Exists
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, Condition}
+import org.neo4j.cypher.internal.frontend.v3_2.{AstRewritingMonitor, Rewriter, bottomUp, inSequence, topDown}
 
 case object CNFNormalizer extends StatementRewriter {
 
@@ -120,12 +120,12 @@ object simplifyPredicates extends Rewriter {
 
   private val step: Rewriter = Rewriter.lift {
     case Not(Not(exp))                    => exp
+    case p@Ands(exps) if exps.size == 1   => exps.head
+    case p@Ors(exps) if exps.size == 1    => exps.head
     case p@Ands(exps) if exps.contains(T) => Ands(exps.filterNot(T == _))(p.position)
     case p@Ors(exps) if exps.contains(F)  => Ors(exps.filterNot(F == _))(p.position)
     case p@Ors(exps) if exps.contains(T)  => True()(p.position)
     case p@Ands(exps) if exps.contains(F) => False()(p.position)
-    case p@Ands(exps) if exps.size == 1   => exps.head
-    case p@Ors(exps) if exps.size == 1    => exps.head
   }
 
   private val instance = fixedPoint(bottomUp(step))


### PR DESCRIPTION
In 3.2 we have added more folding of constants, e.g. `1 < 2 < 3` is now
folded as `Ands(TRUE)`. This triggered a bug in `CNFNormalizer` caused
by the order of `case` statements.