### PR TITLE
Unlocks byte arrays for Bolt/PackStream

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -132,9 +132,7 @@ public class Neo4jPack
             }
             else if ( obj instanceof byte[] )
             {
-                error = Optional.of(new Error( Status.Request.Invalid,
-                        "Byte array is not yet supported in Bolt"));
-                packNull();
+                pack( (byte[]) obj );
             }
             else if ( obj instanceof char[] )
             {
@@ -276,6 +274,8 @@ public class Neo4jPack
             PackType valType = peekNextType();
             switch ( valType )
             {
+                case BYTES:
+                    return unpackBytes();
                 case STRING:
                     return unpackString();
                 case INTEGER:

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
@@ -348,6 +348,23 @@ public class PackStreamTest
     }
 
     @Test
+    public void testCanPackAndUnpackBytes() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+        byte[] abcdefghij = "ABCDEFGHIJ".getBytes();
+
+        // When
+        PackStream.Packer packer = machine.packer();
+        packer.pack( abcdefghij );
+        packer.flush();
+
+        // Then
+        byte[] value = newUnpacker( machine.output() ).unpackBytes();
+        assertThat( value, equalTo( abcdefghij ) );
+    }
+
+    @Test
     public void testCanPackAndUnpackString() throws Throwable
     {
         // Given

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -381,36 +381,6 @@ public class TransportSessionIT
                 msgFailure( Status.Request.Invalid, "Point is not yet supported as a return type in Bolt" ) ) );
     }
 
-    @Test
-    public void shouldFailNicelyOnBinary() throws Throwable
-    {
-        //Given
-        GraphDatabaseService db = server.graphDatabaseService();
-        try ( Transaction tx = db.beginTx() )
-        {
-            Node node = db.createNode();
-            node.setProperty( "binary", new byte[]{(byte) 0xB0, 0x17} );
-            tx.success();
-        }
-
-        // When
-        client.connect( address )
-                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
-                .send( TransportTestUtil.chunk(
-                        init( "TestClient/1.1", emptyMap() ),
-                        run( "MATCH (n) RETURN n.binary" ),
-                        pullAll() ) );
-
-        // Then
-        assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyReceives(
-                msgSuccess(),
-                msgSuccess( allOf( hasEntry( is( "fields" ), equalTo( singletonList( "n.binary" ) ) ),
-                        hasKey( "result_available_after" ) ) ),
-                msgRecord( eqRecord( nullValue() ) ),
-                msgFailure( Status.Request.Invalid, "Byte array is not yet supported in Bolt" ) ) );
-    }
-
     private byte[] bytes( int... ints )
     {
         byte[] bytes = new byte[ints.length];


### PR DESCRIPTION
PackStream and 3/4 of the official drivers already have partial or complete support for a BYTES type. This PR unlocks the server to allow sending and receiving of byte[] values, a much-requested piece of functionality.

Awaiting confirmation from PM for inclusion. Can re-raise against 3.3 if required.