### PR TITLE
Aligns service availability log messages at startup

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -210,7 +210,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
             log.info( "Bolt Server extension loaded." );
             for ( ProtocolInitializer connector : connectors )
             {
-                logService.getUserLog( WorkerFactory.class ).info( "Bolt enabled on %s.", connector.address() );
+                logService.getUserLog( WorkerFactory.class ).info( "Bolt interface available at bolt://%s", connector.address() );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/helpers/SocketAddress.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/SocketAddress.java
@@ -58,7 +58,14 @@ public class SocketAddress
     @Override
     public String toString()
     {
-        return hostname + ":" + port;
+        if (hostname.contains(":"))
+        {
+            return "[" + hostname + "]:" + port;
+        }
+        else
+        {
+            return hostname + ":" + port;
+        }
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -318,7 +318,7 @@ public abstract class AbstractNeoServer implements NeoServer
         {
             setUpHttpLogging();
             webServer.start();
-            log.info( "Remote interface available at %s", baseUri() );
+            log.info( "HTTP interface available at %s", baseUri() );
         }
         catch ( Exception e )
         {

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -80,7 +80,7 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
                 info( NEO4J_IS_STARTING_MESSAGE ),
                 info( "Starting..." ),
                 info( "Started." ),
-                info( "Remote interface available at http://.+:7474/" ),
+                info( "HTTP interface available at http://.+:7474/" ),
                 info( "Stopping..." ),
                 info( "Stopped." )
         ) );


### PR DESCRIPTION
This also tweaks the `SocketAddress` representation to correctly display IPv6 addresses.