### PR TITLE
Fix cast error in 3.1 compatibility

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/SchemaDescriptorTranslation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/SchemaDescriptorTranslation.scala
@@ -30,25 +30,25 @@ trait SchemaDescriptorTranslation {
 
   implicit def kernelToCypher(index: KernelIndexDescriptor): SchemaTypes.IndexDescriptor =
     if (index.schema().getPropertyIds.length == 1)
-      SchemaTypes.IndexDescriptor(index.schema().getLabelId, index.schema().getPropertyIds()(0))
+      SchemaTypes.IndexDescriptor(index.schema().getLabelId, index.schema().getPropertyId)
     else
       throw new UnsupportedOperationException("Cypher 2.3 does not support composite indexes")
 
   implicit def kernelToCypher(index: UniquenessConstraintDescriptor): SchemaTypes.UniquenessConstraint =
     if (index.schema().getPropertyIds.length == 1)
-      SchemaTypes.UniquenessConstraint(index.schema().getLabelId, index.schema().getPropertyIds()(0))
+      SchemaTypes.UniquenessConstraint(index.schema().getLabelId, index.schema().getPropertyId)
     else
       throw new UnsupportedOperationException("Cypher 2.3 does not support composite constraints")
 
   implicit def kernelToCypher(index: NodeExistenceConstraintDescriptor): SchemaTypes.NodePropertyExistenceConstraint =
     if (index.schema().getPropertyIds.length == 1)
-      SchemaTypes.NodePropertyExistenceConstraint(index.schema().getLabelId, index.schema().getPropertyIds()(0))
+      SchemaTypes.NodePropertyExistenceConstraint(index.schema().getLabelId, index.schema().getPropertyId)
     else
       throw new UnsupportedOperationException("Cypher 2.3 does not support composite constraints")
 
   implicit def kernelToCypher(index: RelExistenceConstraintDescriptor): SchemaTypes.RelationshipPropertyExistenceConstraint =
     if (index.schema().getPropertyIds.length == 1)
-      SchemaTypes.RelationshipPropertyExistenceConstraint(index.schema().getRelTypeId, index.schema().getPropertyIds()(0))
+      SchemaTypes.RelationshipPropertyExistenceConstraint(index.schema().getRelTypeId, index.schema().getPropertyId)
     else
       throw new UnsupportedOperationException("Cypher 2.3 does not support composite constraints")
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/SchemaDescriptorTranslation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/SchemaDescriptorTranslation.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.spi.v3_1
 
 import org.neo4j.cypher.internal.compiler.v3_1.spi.SchemaTypes
 import org.neo4j.kernel.api.schema_new.SchemaDescriptor
-import org.neo4j.kernel.api.schema_new.constaints.{ConstraintDescriptorFactory, UniquenessConstraintDescriptor => KernelUniquenessConstraint}
+import org.neo4j.kernel.api.schema_new.constaints.{ConstraintDescriptorFactory, NodeExistenceConstraintDescriptor, RelExistenceConstraintDescriptor, UniquenessConstraintDescriptor => KernelUniquenessConstraint}
 import org.neo4j.kernel.api.schema_new.index.{NewIndexDescriptorFactory, NewIndexDescriptor => KernelIndexDescriptor}
 
 trait SchemaDescriptorTranslation {
@@ -39,6 +39,16 @@ trait SchemaDescriptorTranslation {
   implicit def toCypher(constraint: KernelUniquenessConstraint): SchemaTypes.UniquenessConstraint = {
     assertSingleProperty(constraint.schema())
     SchemaTypes.UniquenessConstraint(constraint.schema().getLabelId, constraint.schema().getPropertyId)
+  }
+
+  implicit def toCypher(constraint: NodeExistenceConstraintDescriptor): SchemaTypes.NodePropertyExistenceConstraint = {
+    assertSingleProperty(constraint.schema())
+    SchemaTypes.NodePropertyExistenceConstraint(constraint.schema().getLabelId, constraint.schema().getPropertyId)
+  }
+
+  implicit def toCypher(constraint: RelExistenceConstraintDescriptor): SchemaTypes.RelationshipPropertyExistenceConstraint = {
+    assertSingleProperty(constraint.schema())
+    SchemaTypes.RelationshipPropertyExistenceConstraint(constraint.schema().getRelTypeId, constraint.schema().getPropertyId)
   }
 
   def assertSingleProperty(schema: SchemaDescriptor):Unit =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -90,7 +90,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
       SchemaDescriptorFactory.forLabel(labelId, propertyKeyId)
     ).asScala.collectFirst {
         case constraint: ConstraintDescriptor if constraint.`type`() == ConstraintDescriptor.Type.UNIQUE =>
-          ConstraintBoundary.map( constraint ).asInstanceOf[UniquenessConstraint]
+          SchemaTypes.UniquenessConstraint(labelId, propertyKeyId)
     }
   } catch {
     case _: KernelException => None


### PR DESCRIPTION
Stuff went too fast. This PR resolved a mistake in 3.1 cypher compatibility related to existence constraints.