### PR TITLE
Predicates on shortest path and optional match

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/QueryGraph.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/QueryGraph.scala
@@ -217,8 +217,9 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
         val shortestPaths = shortestPathPatterns.filter {
           p => coveredIds.contains(p.rel.nodes._1) && coveredIds.contains(p.rel.nodes._2)
         }
-        val shortestPathIds = shortestPaths.flatMap(p => p.name)
-        val predicates = selections.predicates.filter(_.dependencies.subsetOf(coveredIds ++ argumentIds ++ shortestPathIds))
+        val shortestPathIds = shortestPaths.flatMap(p => Set(p.rel.name) ++ p.name)
+        val allIds = coveredIds ++ argumentIds ++ shortestPathIds
+        val predicates = selections.predicates.filter(_.dependencies.subsetOf(allIds))
         val filteredHints = hints.filter(h => h.variables.forall(variable => coveredIds.contains(IdName(variable.name))))
         qg.
           withSelections(Selections(predicates)).

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/steps/planShortestPaths.scala
@@ -57,7 +57,8 @@ case object planShortestPaths {
       planShortestPathsWithFallback(inner, shortestPaths, predicates, safePredicates, needFallbackPredicates, queryGraph)
     }
     else {
-      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates, false, context.errorIfShortestPathHasCommonNodesAtRuntime  )
+      context.logicalPlanProducer.planShortestPath(inner, shortestPaths, predicates, withFallBack = false,
+                                                   disallowSameNode = context.errorIfShortestPathHasCommonNodesAtRuntime  )
     }
   }
 
@@ -82,7 +83,8 @@ case object planShortestPaths {
     // Plan FindShortestPaths within an Apply with an Optional so we get null rows when
     // the graph algorithm does not find anything (left-hand-side)
     val lhsArgument = lpp.planArgumentRowFrom(inner)
-    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, true, context.errorIfShortestPathHasCommonNodesAtRuntime)
+    val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, withFallBack = true,
+                                     disallowSameNode = context.errorIfShortestPathHasCommonNodesAtRuntime)
     val lhsOption = lpp.planOptional(lhsSp, Set.empty)
     val lhs = lpp.planApply(inner, lhsOption)
 


### PR DESCRIPTION
When combining `OPTIONAL MATCH` and `shortestPath` with predicates we
forgot to keep track of the relationship name of the shortest path pattern,
causing the cost planner to choke on such queries.