### PR TITLE
Only check uniqueness constraints on actual changes

### DIFF
--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryInvalidationIT.java
@@ -32,7 +32,6 @@ import org.neo4j.cypher.internal.frontend.v3_1.ast.Query;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -51,15 +50,8 @@ public class QueryInvalidationIT
 
     @Rule
     public final DatabaseRule db = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig( GraphDatabaseSettings.query_statistics_divergence_threshold, "0.5" );
-            builder.setConfig( GraphDatabaseSettings.cypher_min_replan_interval, "1s" );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.query_statistics_divergence_threshold, "0.5" )
+            .withSetting( GraphDatabaseSettings.cypher_min_replan_interval, "1s" );
 
     @Test
     public void shouldRePlanAfterDataChangesFromAnEmptyDatabase() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexManager;
@@ -53,13 +52,7 @@ public class TransactionRepresentationCommitProcessIT
 
     @Rule
     public final DatabaseRule db = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            builder.setConfig( GraphDatabaseSettings.check_point_interval_time, "10ms" );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.check_point_interval_time, "10ms" );
 
     @Test( timeout = 15000 )
     public void commitDuringContinuousCheckpointing() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
@@ -86,17 +85,9 @@ public class IndexStatisticsTest
 
     @Rule
     public DatabaseRule dbRule = new EmbeddedDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            // make sure we don't sample in these tests
-            builder.setConfig( GraphDatabaseSettings.index_background_sampling_enabled, "false" );
-            builder.setConfig( GraphDatabaseSettings.multi_threaded_schema_index_population_enabled,
+            .withSetting( GraphDatabaseSettings.index_background_sampling_enabled, "false" )
+            .withSetting( GraphDatabaseSettings.multi_threaded_schema_index_population_enabled,
                     multiThreadedPopulationEnabled + "" );
-        }
-    };
 
     private GraphDatabaseService db;
     private ThreadToStatementContextBridge bridge;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
@@ -28,7 +28,6 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.test.Race;
@@ -42,14 +41,7 @@ public class NeoStoresIT
 {
     @ClassRule
     public static final DatabaseRule db = new EmbeddedDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig(  GraphDatabaseSettings.dense_node_threshold, "1");
-        }
-    };
+            .withSetting(  GraphDatabaseSettings.dense_node_threshold, "1");
 
     private static final RelationshipType FRIEND = RelationshipType.withName( "FRIEND" );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipChainPointerChasingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipChainPointerChasingTest.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.rule.DatabaseRule;
@@ -55,13 +54,7 @@ public class RelationshipChainPointerChasingTest
 
     @Rule
     public final DatabaseRule db = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            builder.setConfig( GraphDatabaseSettings.dense_node_threshold, String.valueOf( THRESHOLD ) );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.dense_node_threshold, String.valueOf( THRESHOLD ) );
 
     @Test
     public void shouldChaseTheLivingRelationships() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreIT.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -42,13 +41,7 @@ public class RelationshipGroupStoreIT
 
     @Rule
     public final DatabaseRule db = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            builder.setConfig( GraphDatabaseSettings.dense_node_threshold, "1" );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.dense_node_threshold, "1" );
 
     @Test
     public void shouldCreateAllTheseRelationshipTypes() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.locking.NoOpClient;
@@ -64,13 +63,7 @@ public class RelationshipCreatorTest
     private static final int DENSE_NODE_THRESHOLD = 5;
     @Rule
     public final DatabaseRule dbRule = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            builder.setConfig( GraphDatabaseSettings.dense_node_threshold, String.valueOf( DENSE_NODE_THRESHOLD ) );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.dense_node_threshold, String.valueOf( DENSE_NODE_THRESHOLD ) );
     private IdGeneratorFactory idGeneratorFactory;
 
     @Before

--- a/community/kernel/src/test/java/org/neo4j/test/ConfigBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ConfigBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.graphdb.config.Setting;
+
+/**
+ * Convenience for building config for a test database.
+ * In particular this is class is useful when parameterizing a test with different configurations.
+ * <p>
+ * Usage:
+ * <pre><code>
+ *  import static org.neo4j.test.ConfigBuilder.configure;
+ *
+ * {@literal @}{@link org.junit.runner.RunWith RunWith}({@link org.junit.runners.Parameterized Parameterized.class})
+ *  public class SomeTest
+ *  {
+ *     {@literal @}{@link org.junit.runners.Parameterized.Parameters Parameterized.Parameters}( name = "{0}" )
+ *      public static Iterable&lt;Object[]&gt; configurations()
+ *      {
+ *          return Arrays.asList(
+ *              // First set of configuration
+ *              {@link #configure(Setting, String) configure}( {@link
+ *              org.neo4j.graphdb.factory.GraphDatabaseSettings#query_cache_size
+ *              GraphDatabaseSettings.query_cache_size}, "42" ).{@link #asParameters() asParameters}(),
+ *              // Second set of configuration
+ *              {@link #configure(Setting, String) configure}( {@link
+ *              org.neo4j.graphdb.factory.GraphDatabaseSettings#query_cache_size
+ *              GraphDatabaseSettings.query_cache_size}, "12" )
+ *                   .{@link #and(Setting, String) and}( {@link
+ *                   org.neo4j.graphdb.factory.GraphDatabaseSettings#cypher_min_replan_interval
+ *                   GraphDatabaseSettings.cypher_min_replan_interval}, "5000" ).{@link #asParameters() asParameters}()
+ *          );
+ *      }
+ *
+ *      public final{@literal @}Rule {@link org.neo4j.test.rule.DatabaseRule DatabaseRule} db;
+ *
+ *      public SomeTest( ConfigBuilder config )
+ *      {
+ *          this.db = new {@link org.neo4j.test.rule.ImpermanentDatabaseRule
+ *          ImpermanentDatabaseRule}().{@link org.neo4j.test.rule.DatabaseRule#withConfiguration(Map)
+ *          withConfiguration}( config.{@link #configuration() configuration}() );
+ *      }
+ *  }
+ * </code></pre>
+ */
+public final class ConfigBuilder
+{
+    public static ConfigBuilder configure( Setting<?> key, String value )
+    {
+        Map<Setting<?>,String> config = new HashMap<>();
+        config.put( key, value );
+        return new ConfigBuilder( config );
+    }
+
+    private final Map<Setting<?>,String> config;
+
+    private ConfigBuilder( Map<Setting<?>,String> config )
+    {
+        this.config = config;
+    }
+
+    public Map<Setting<?>,String> configuration()
+    {
+        return Collections.unmodifiableMap( config );
+    }
+
+    public ConfigBuilder and( Setting<?> key, String value )
+    {
+        Map<Setting<?>,String> config = new HashMap<>( this.config );
+        config.put( key, value );
+        return new ConfigBuilder( config );
+    }
+
+    public Object[] asParameters()
+    {
+        return new Object[] {this};
+    }
+
+    @Override
+    public String toString()
+    {
+        return config.toString();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -22,6 +22,7 @@ package org.neo4j.test.rule;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -67,6 +68,7 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     private String storeDir;
     private Supplier<Statement> statementSupplier;
     private boolean startEagerly = true;
+    private Map<Setting<?>, String> config;
 
     /**
      * Means the database will be started on first {@link #getGraphDatabaseAPI()}}
@@ -296,6 +298,13 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
         // Override to configure the database
 
         // Adjusted defaults for testing
+        if ( config != null )
+        {
+            for ( Map.Entry<Setting<?>,String> setting : config.entrySet() )
+            {
+                builder.setConfig( setting.getKey(), setting.getValue() );
+            }
+        }
     }
 
     public GraphDatabaseBuilder setConfig( Setting<?> setting, String value )
@@ -326,6 +335,26 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
             storeDir = database.getStoreDir();
             statementSupplier = resolveDependency( ThreadToStatementContextBridge.class );
         }
+    }
+
+    public DatabaseRule withSetting( Setting<?> key, String value )
+    {
+        if ( this.config == null )
+        {
+            this.config = new HashMap<>();
+        }
+        this.config.put( key, value );
+        return this;
+    }
+
+    public DatabaseRule withConfiguration( Map<Setting<?>,String> configuration )
+    {
+        if ( this.config == null )
+        {
+            this.config = new HashMap<>();
+        }
+        this.config.putAll( configuration );
+        return this;
     }
 
     public interface RestartAction

--- a/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/concurrent/ThreadingRule.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.test.rule.concurrent;
 
-import org.junit.rules.ExternalResource;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -29,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import org.junit.rules.ExternalResource;
 
 import org.neo4j.function.Predicates;
 import org.neo4j.function.ThrowingFunction;
@@ -66,27 +70,76 @@ public class ThreadingRule extends ExternalResource
 
     public <FROM, TO, EX extends Exception> Future<TO> execute( ThrowingFunction<FROM,TO,EX> function, FROM parameter )
     {
-        return executor.submit( task( Barrier.NONE, function, parameter, (t) -> {} ) );
+        final Consumer<Thread> threadConsumer = (t) -> {};
+        return executor.submit( task( Barrier.NONE, function, function.toString(), parameter, threadConsumer ) );
+    }
+
+    public <FROM, TO, EX extends Exception> List<Future<TO>> multiple( int threads, ThrowingFunction<FROM,TO,EX> function, FROM parameter )
+    {
+        List<Future<TO>> result = new ArrayList<>( threads );
+        for ( int i = 0; i < threads; i++ )
+        {
+            result.add( executor.submit( task(
+                    Barrier.NONE, function, function.toString() + ":task=" + i, parameter, ( t ) -> {} ) ) );
+        }
+        return result;
+    }
+
+    public static <T> List<T> await( Iterable<Future<T>> futures ) throws InterruptedException, ExecutionException
+    {
+        List<T> result = futures instanceof Collection
+                ? new ArrayList<>( ((Collection) futures).size() )
+                : new ArrayList<>();
+        List<Throwable> failures = null;
+        for ( Future<T> future : futures )
+        {
+            try
+            {
+                result.add( future.get() );
+            }
+            catch ( ExecutionException e )
+            {
+                if ( failures == null )
+                {
+                    failures = new ArrayList<>();
+                }
+                failures.add( e.getCause() );
+            }
+        }
+        if ( failures != null )
+        {
+            if ( failures.size() == 1 )
+            {
+                throw new ExecutionException( failures.get( 0 ) );
+            }
+            ExecutionException exception = new ExecutionException( null );
+            for ( Throwable failure : failures )
+            {
+                exception.addSuppressed( failure );
+            }
+            throw exception;
+        }
+        return result;
     }
 
     public <FROM, TO, EX extends Exception> Future<TO> executeAndAwait(
             ThrowingFunction<FROM,TO,EX> function, FROM parameter, Predicate<Thread> threadCondition,
             long timeout, TimeUnit unit ) throws TimeoutException, InterruptedException
     {
-        ConcurrentTransfer<Thread> threadTransfer = new ConcurrentTransfer<>();
-        Future<TO> future = executor.submit( task( Barrier.NONE, function, parameter, threadTransfer ) );
-        Predicates.await( threadTransfer, threadCondition, timeout, unit );
+        ConcurrentTransfer<Thread> transfer = new ConcurrentTransfer<>();
+        Future<TO> future = executor.submit( task( Barrier.NONE, function, function.toString(), parameter, transfer ) );
+        Predicates.await( transfer, threadCondition, timeout, unit );
         return future;
     }
 
     private static <FROM, TO, EX extends Exception> Callable<TO> task(
-            final Barrier barrier, final ThrowingFunction<FROM,TO,EX> function, final FROM parameter,
+            final Barrier barrier, final ThrowingFunction<FROM,TO,EX> function, final String name, final FROM parameter,
             final Consumer<Thread> threadConsumer )
     {
         return () -> {
             Thread thread = Thread.currentThread();
-            String name = thread.getName();
-            thread.setName( function.toString() );
+            String previousName = thread.getName();
+            thread.setName( name );
             threadConsumer.accept( thread );
             barrier.reached();
             try
@@ -95,7 +148,7 @@ public class ThreadingRule extends ExternalResource
             }
             finally
             {
-                thread.setName( name );
+                thread.setName( previousName );
             }
         };
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/AutoIndexOperationsTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/AutoIndexOperationsTest.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.ReadableRelationshipIndex;
@@ -41,15 +40,8 @@ public class AutoIndexOperationsTest
 {
     @Rule
     public final DatabaseRule db = new EmbeddedDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig( GraphDatabaseSettings.relationship_keys_indexable, "Type" );
-            builder.setConfig( GraphDatabaseSettings.relationship_auto_indexing, "true" );
-        }
-    };
+            .withSetting( GraphDatabaseSettings.relationship_keys_indexable, "Type" )
+            .withSetting( GraphDatabaseSettings.relationship_auto_indexing, "true" );
 
     @Test
     public void shouldNotSeeDeletedRelationshipWhenQueryingWithStartAndEndNode()

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/IdReuseTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/IdReuseTest.java
@@ -31,13 +31,12 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.rule.EnterpriseDatabaseRule;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
 import org.neo4j.kernel.impl.store.id.IdType;
-import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EnterpriseDatabaseRule;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -47,15 +46,8 @@ import static org.junit.Assert.assertThat;
 public class IdReuseTest
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EnterpriseDatabaseRule()
-    {
-        @Override
-        protected void configure(GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE + "," + IdType.RELATIONSHIP );
-        }
-    };
+    public DatabaseRule dbRule = new EnterpriseDatabaseRule()
+            .withSetting( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE + "," + IdType.RELATIONSHIP );
 
     @Test
     public void shouldReuseNodeIdsFromRolledBackTransaction() throws Exception

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/RelationshipIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/store/id/RelationshipIdReuseStressIT.java
@@ -44,31 +44,22 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
 import org.neo4j.kernel.impl.store.id.IdType;
-import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EnterpriseDatabaseRule;
 
 import static org.junit.Assert.assertThat;
 
 public class RelationshipIdReuseStressIT
 {
-
     @Rule
-    public EmbeddedDatabaseRule embeddedDatabase = new EnterpriseDatabaseRule()
-    {
-        @Override
-        protected void configure(GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.RELATIONSHIP.name() );
-        }
-    };
+    public DatabaseRule embeddedDatabase = new EnterpriseDatabaseRule()
+            .withSetting( EnterpriseEditionSettings.idTypesToReuse, IdType.RELATIONSHIP.name() );
 
     private ExecutorService executorService = Executors.newCachedThreadPool();
 
@@ -183,13 +174,13 @@ public class RelationshipIdReuseStressIT
         return TestRelationshipTypes.values()[ThreadLocalRandom.current().nextInt( TestRelationshipTypes.values().length )];
     }
 
-    private Node getRandomCityNode( EmbeddedDatabaseRule embeddedDatabase, Label cityLabel )
+    private Node getRandomCityNode( DatabaseRule embeddedDatabase, Label cityLabel )
     {
         return embeddedDatabase.
                 findNode( cityLabel, NAME_PROPERTY, "city" + (ThreadLocalRandom.current().nextInt( 1, NUMBER_OF_CITIES + 1 )) );
     }
 
-    private Node getRandomBandNode( EmbeddedDatabaseRule embeddedDatabase, Label bandLabel )
+    private Node getRandomBandNode( DatabaseRule embeddedDatabase, Label bandLabel )
     {
         return embeddedDatabase.
                 findNode( bandLabel, NAME_PROPERTY, "band" + (ThreadLocalRandom.current().nextInt( 1, NUMBER_OF_BANDS + 1 )) );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/store/id/NodeIdReuseStressIT.java
@@ -29,7 +29,6 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
@@ -38,7 +37,7 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.Race;
-import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EnterpriseDatabaseRule;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -53,15 +52,8 @@ public class NodeIdReuseStressIT
     private static final int OPERATIONS_COUNT = 10_000;
 
     @Rule
-    public EmbeddedDatabaseRule db = new EnterpriseDatabaseRule()
-    {
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            builder.setConfig( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE.name() );
-        }
-    };
+    public DatabaseRule db = new EnterpriseDatabaseRule()
+            .withSetting( EnterpriseEditionSettings.idTypesToReuse, IdType.NODE.name() );
 
     @Before
     public void verifyParams() throws Exception

--- a/enterprise/kernel/src/test/java/org/neo4j/locking/MergeLockConcurrencyTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/locking/MergeLockConcurrencyTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.locking;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.function.ThrowingFunction;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.ConfigBuilder;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+import org.neo4j.test.rule.concurrent.ThreadingRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterators.single;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.lock_manager;
+import static org.neo4j.test.ConfigBuilder.configure;
+import static org.neo4j.test.rule.concurrent.ThreadingRule.await;
+
+@RunWith( Parameterized.class )
+public class MergeLockConcurrencyTest
+{
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final ThreadingRule threads = new ThreadingRule();
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Iterable<Object[]> configurations()
+    {
+        return Arrays.asList(
+                configure( lock_manager, "community" ).asParameters(),
+                configure( lock_manager, "forseti" ).asParameters()
+        );
+    }
+
+    public MergeLockConcurrencyTest( ConfigBuilder config )
+    {
+        db.withConfiguration( config.configuration() );
+    }
+
+    @Test
+    public void shouldNotDeadlockOnMergeFollowedByPropertyAssignment() throws Exception
+    {
+        withConstraint( mergeThen( this::reassignProperties ) );
+    }
+
+    @Test
+    public void shouldNotDeadlockOnMergeFollowedByLabelReAddition() throws Exception
+    {
+        withConstraint( mergeThen( this::reassignLabels ) );
+    }
+
+    private void withConstraint( ThrowingFunction<CyclicBarrier,Node,Exception> action ) throws Exception
+    {
+        // given
+        db.execute( "CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.bar IS UNIQUE" );
+        CyclicBarrier barrier = new CyclicBarrier( 2 );
+        Node node = mergeNode();
+
+        // when
+        List<Node> result = await( threads.multiple( barrier.getParties(), action, barrier ) );
+
+        // then
+        assertEquals( "size of result", 2, result.size() );
+        assertEquals( node, result.get( 0 ) );
+        assertEquals( node, result.get( 1 ) );
+    }
+
+    private ThrowingFunction<CyclicBarrier,Node,Exception> mergeThen(
+            ThrowingConsumer<Node,? extends Exception> action )
+    {
+        return barrier ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = mergeNode();
+
+                barrier.await();
+
+                action.accept( node );
+
+                tx.success();
+                return node;
+            }
+        };
+    }
+
+    private Node mergeNode()
+    {
+        return (Node) single( db.execute( "MERGE (foo:Foo{bar:'baz'}) RETURN foo" ) ).get( "foo" );
+    }
+
+    private void reassignProperties( Node node )
+    {
+        for ( Map.Entry<String,Object> property : node.getAllProperties().entrySet() )
+        {
+            node.setProperty( property.getKey(), property.getValue() );
+        }
+    }
+
+    private void reassignLabels( Node node )
+    {
+        for ( Label label : node.getLabels() )
+        {
+            node.addLabel( label );
+        }
+    }
+}


### PR DESCRIPTION
Skip checking if a property is re-assigned to the same value.
Skip checking if a label is added that already was assigned.

This avoids a deadlock scenario between concurrent MERGE queries, where the MERGE was followed by re-assignment of the same property. This is quite a common pattern, especially to bulk-re-assign all expected properties of the node.

Example query: `MERGE (user:User{id:$user.id}) SET user = $user` (where there is a uniqueness constraint on `(user:User) / user.id`