### PR TITLE
Fall back to interpreted queries if the compiler fails

### DIFF
--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
@@ -49,7 +49,12 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
       case res: ProduceResult =>
         val idMap = LogicalPlanIdentificationBuilder(plan)
 
-        val query: CodeStructureResult[GeneratedQuery] = generateQuery(plan, semanticTable, idMap, res.columns, conf)
+        val query: CodeStructureResult[GeneratedQuery] = try {
+          generateQuery(plan, semanticTable, idMap, res.columns, conf)
+        } catch {
+          case e: CantCompileQueryException => throw e
+          case e: Exception => throw new CantCompileQueryException(cause = e)
+        }
 
         val fp = planContext.statistics match {
           case igs: InstrumentedGraphStatistics =>


### PR DESCRIPTION
Handles any exception from the compiler by falling back to the interpreter.