### PR TITLE
Add tests for shouldRetry on parents of closed linked cursors

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2796,6 +2796,65 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
     }
 
     @Test
+    public void shouldRetryOnWriteParentOfClosedLinkedCursorMustNotThrow() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        configureStandardPageCache();
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            //noinspection unused
+            try ( PageCursor linked = cursor.openLinkedCursor( 1 ) )
+            {
+                assertTrue( linked.next() );
+            }
+            assertFalse( cursor.shouldRetry() );
+        }
+    }
+
+    @Test
+    public void shouldRetryOnReadParentOfClosedLinkedCursorMustNotThrow() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        configureStandardPageCache();
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            try ( PageCursor linked = cursor.openLinkedCursor( 1 ) )
+            {
+                assertTrue( linked.next() );
+            }
+            cursor.shouldRetry();
+        }
+    }
+
+    @Test
+    public void shouldRetryOnReadParentOnDirtyPageOfClosedLinkedCursorMustNotThrow() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        configureStandardPageCache();
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor reader = pf.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( reader.next() );
+            try ( PageCursor writer = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+            {
+                assertTrue( writer.next() );
+            }
+            try ( PageCursor linked = reader.openLinkedCursor( 1 ) )
+            {
+                assertTrue( linked.next() );
+            }
+            assertTrue( reader.shouldRetry() ) ;
+        }
+    }
+
+    @Test
     public void pageCursorCloseShouldNotReturnAlreadyClosedLinkedCursorToPool() throws Exception
     {
         File file = file( "a" );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2805,12 +2805,11 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
               PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
         {
             assertTrue( cursor.next() );
-            //noinspection unused
             try ( PageCursor linked = cursor.openLinkedCursor( 1 ) )
             {
                 assertTrue( linked.next() );
             }
-            assertFalse( cursor.shouldRetry() );
+            cursor.shouldRetry();
         }
     }
 


### PR DESCRIPTION
This is a scenario that shows up in the GBPTree usage, but wasn't yet covered by the page cache tests. Well, it is now.