### PR TITLE
Don't fail silently on native label scan store rebuild

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullStoreChangeStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/FullStoreChangeStream.java
@@ -20,9 +20,11 @@
 package org.neo4j.kernel.impl.api.scan;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 
 /**
  * Stream of changes used to rebuild a {@link LabelScanStore} from scratch.
@@ -32,4 +34,18 @@ public interface FullStoreChangeStream
     FullStoreChangeStream EMPTY = writer -> 0;
 
     long applyTo( LabelScanWriter writer ) throws IOException;
+
+    static FullStoreChangeStream asStream( final List<NodeLabelUpdate> existingData )
+    {
+        return writer ->
+        {
+            long count = 0;
+            for ( NodeLabelUpdate update : existingData )
+            {
+                writer.write( update );
+                count++;
+            }
+            return count;
+        };
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -55,7 +55,6 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelRange;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
-import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
 import org.neo4j.test.rule.RandomRule;
@@ -556,20 +555,6 @@ public abstract class LabelScanStoreTest
 
         life.start();
         assertTrue( monitor.initCalled );
-    }
-
-    protected FullStoreChangeStream asStream( final List<NodeLabelUpdate> existingData )
-    {
-        return writer ->
-        {
-            long count = 0;
-            for ( NodeLabelUpdate update : existingData )
-            {
-                writer.write( update );
-                count++;
-            }
-            return count;
-        };
     }
 
     private void scrambleIndexFilesAndRestart( List<NodeLabelUpdate> data,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -34,6 +34,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -42,7 +43,7 @@ import org.neo4j.test.rule.fs.FileSystemRule;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor.EMPTY;
+import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.EMPTY;
 import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
 
 public class NativeLabelScanStoreRebuildTest
@@ -75,7 +76,7 @@ public class NativeLabelScanStoreRebuildTest
         try
         {
             nativeLabelScanStore =
-                    new NativeLabelScanStore( pageCache, storeDir, THROWING_STREAM, false, EMPTY );
+                    new NativeLabelScanStore( pageCache, storeDir, THROWING_STREAM, false, new Monitors() );
 
             nativeLabelScanStore.init();
             nativeLabelScanStore.start();
@@ -92,7 +93,7 @@ public class NativeLabelScanStoreRebuildTest
         RecordingMonitor monitor = new RecordingMonitor();
 
         nativeLabelScanStore =
-                new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, false, monitor );
+                new NativeLabelScanStore( pageCache, storeDir, EMPTY, false, new Monitors() );
         nativeLabelScanStore.init();
         nativeLabelScanStore.start();
 
@@ -115,7 +116,7 @@ public class NativeLabelScanStoreRebuildTest
         try
         {
             nativeLabelScanStore =
-                    new NativeLabelScanStore( pageCache, storeDir, changeStream, false, EMPTY );
+                    new NativeLabelScanStore( pageCache, storeDir, changeStream, false, new Monitors() );
             nativeLabelScanStore.init();
 
             // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -91,9 +91,11 @@ public class NativeLabelScanStoreRebuildTest
 
         // when
         RecordingMonitor monitor = new RecordingMonitor();
+        Monitors monitors = new Monitors();
+        monitors.addMonitorListener( monitor );
 
         nativeLabelScanStore =
-                new NativeLabelScanStore( pageCache, storeDir, EMPTY, false, new Monitors() );
+                new NativeLabelScanStore( pageCache, storeDir, EMPTY, false, monitors );
         nativeLabelScanStore.init();
         nativeLabelScanStore.start();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.kernel.api.labelscan.LabelScanStore.Monitor.EMPTY;
+import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
+
+public class NativeLabelScanStoreRebuildTest
+{
+    private PageCacheRule pageCacheRule = new PageCacheRule();
+    private FileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    private TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( fileSystemRule ).around( pageCacheRule ).around( testDirectory );
+
+    private static final FullStoreChangeStream THROWING_STREAM = writer ->
+    {
+        throw new IllegalArgumentException();
+    };
+    private File storeDir;
+
+    @Before
+    public void setup()
+    {
+        storeDir = testDirectory.graphDbDir();
+    }
+
+    @Test
+    public void mustBeDirtyIfFailedDuringRebuild() throws Exception
+    {
+        // given
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
+        NativeLabelScanStore nativeLabelScanStore = null;
+        try
+        {
+            nativeLabelScanStore =
+                    new NativeLabelScanStore( pageCache, storeDir, THROWING_STREAM, false, EMPTY );
+
+            nativeLabelScanStore.init();
+            nativeLabelScanStore.start();
+        }
+        catch ( IllegalArgumentException e )
+        {
+            if ( nativeLabelScanStore != null )
+            {
+                nativeLabelScanStore.shutdown();
+            }
+        }
+
+        // when
+        RecordingMonitor monitor = new RecordingMonitor();
+
+        nativeLabelScanStore =
+                new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, false, monitor );
+        nativeLabelScanStore.init();
+        nativeLabelScanStore.start();
+
+        // then
+        assertTrue( monitor.notValid );
+        assertTrue( monitor.rebuilding );
+        assertTrue( monitor.rebuilt );
+        nativeLabelScanStore.shutdown();
+    }
+
+    @Test
+    public void shouldFailOnUnsortedLabelsFromFullStoreChangeStream() throws Exception
+    {
+        // given
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
+        List<NodeLabelUpdate> existingData = new ArrayList<>();
+        existingData.add( NodeLabelUpdate.labelChanges( 1, new long[0], new long[]{2, 1} ) );
+        FullStoreChangeStream changeStream = asStream( existingData );
+        NativeLabelScanStore nativeLabelScanStore = null;
+        try
+        {
+            nativeLabelScanStore =
+                    new NativeLabelScanStore( pageCache, storeDir, changeStream, false, EMPTY );
+            nativeLabelScanStore.init();
+
+            // when
+            nativeLabelScanStore.start();
+            fail( "Expected native label scan store to fail on " );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // then
+            assertThat( e.getMessage(), Matchers.containsString( "unsorted label" ) );
+            assertThat( e.getMessage(), Matchers.stringContainsInOrder( Iterables.asIterable( "2", "1" ) ) );
+        }
+        finally
+        {
+            if ( nativeLabelScanStore != null )
+            {
+                nativeLabelScanStore.shutdown();
+            }
+        }
+    }
+
+    private class RecordingMonitor implements LabelScanStore.Monitor
+    {
+        boolean notValid;
+        boolean rebuilding;
+        boolean rebuilt;
+
+        @Override
+        public void notValidIndex()
+        {
+            notValid = true;
+        }
+
+        @Override
+        public void rebuilding()
+        {
+            rebuilding = true;
+        }
+
+        @Override
+        public void rebuilt( long roughNodeCount )
+        {
+            rebuilt = true;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.rule.PageCacheRule;
 
+import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
+
 public class NativeLabelScanStoreTest extends LabelScanStoreTest
 {
     @Rule

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
@@ -38,9 +38,11 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.OperationalMode;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
 
 @RunWith( Parameterized.class )
 public class LuceneLabelScanStoreTest extends LabelScanStoreTest


### PR DESCRIPTION
Before, if failed to complete rebuild of native label scan store db startup
would crash. But on next startup it would act as if nothing is wrong and
no new rebuild would be triggered, effectively ending up with a completely
inconsistent label scan store.

Now we mark native label scan store as dirty before starting rebuild from full
node scan and mark it as clean once it finishes. If native label scan store is
dirty during startup a complete rebuild will be triggered.