### PR TITLE
LOAD CSV WITH HEADERS from empty file

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import java.io.{File, PrintWriter}
-import java.net.{URLConnection, URLStreamHandler, URLStreamHandlerFactory, URL}
+import java.net.{URL, URLConnection, URLStreamHandler, URLStreamHandlerFactory}
 
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CreateTempFileTestSupport
@@ -459,6 +459,17 @@ class LoadCsvAcceptanceTest
 
     val result = execute(s"MATCH (n) WITH n, '$first' as prefix  LOAD CSV FROM prefix + n.prop AS line CREATE (a {name: line[0]}) RETURN a.name")
     assertStats(result, nodesCreated = 3, propertiesSet = 3)
+  }
+
+  test("empty headers file should not throw") {
+    val urls = csvUrls({ _ => {} })
+    for (url <- urls) {
+      val result = execute(
+        s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN count(*)"
+      )
+
+      result.toList should equal(List(Map("count(*)" -> 0)))
+    }
   }
 
   private def ensureNoIllegalCharsInWindowsFilePath(filename: String) = {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
@@ -106,7 +106,7 @@ case class LoadCSVPipe(source: Pipe,
       val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator)
       format match {
         case HasHeaders =>
-          val headers = iterator.next().toSeq // First row is headers
+          val headers = if (iterator.nonEmpty) iterator.next().toIndexedSeq else IndexedSeq.empty // First row is headers
           new IteratorWithHeaders(headers, context, iterator)
         case NoHeaders =>
           new IteratorWithoutHeaders(context, iterator)


### PR DESCRIPTION
When calling `LOAD CSV WITH HEADERS FROM $url` where `$url` is an empty
file we should not fail with a
`java.util.NoSuchElementException: next on empty iterator` but handle
it gracefully.

Note that the failing docs build is expected and is true for all 2.3 builds

changelog: Fixed an unnecessary error when loading an empty file using LOAD CSV WITH HEADERS