### PR TITLE
Invalid handling of composite index

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -468,7 +468,8 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
       IdempotentResult(transactionalContext.statement.schemaWriteOperations().indexCreate( descriptor ))
     } catch {
       case _: AlreadyIndexedException =>
-        val indexDescriptor = transactionalContext.statement.readOperations().indexGetForSchema (SchemaDescriptorFactory.forLabel(descriptor.getLabelId, descriptor.getPropertyId));
+        val indexDescriptor = transactionalContext.statement.readOperations().indexGetForSchema (
+          SchemaDescriptorFactory.forLabel(descriptor.getLabelId, descriptor.getPropertyIds:_*))
         if(transactionalContext.statement.readOperations().indexGetState(indexDescriptor) == InternalIndexState.FAILED)
           throw new FailedIndexException(indexDescriptor.userDescription(tokenNameLookup))
         IdempotentResult(indexDescriptor, wasCreated = false)

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelException.java
@@ -19,25 +19,27 @@
  */
 package org.neo4j.kernel.api.exceptions.index;
 
+import java.util.Arrays;
+
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 
 public class IndexPopulationFailedKernelException extends KernelException
 {
-    private static final String FORMAT_MESSAGE = "Failed to populate index for %s [labelId: %d, propertyKeyId %s]";
+    private static final String FORMAT_MESSAGE = "Failed to populate index for %s [labelId: %d, properties %s]";
 
     public IndexPopulationFailedKernelException( LabelSchemaDescriptor descriptor, String indexUserDescription,
             Throwable cause )
     {
         super( Status.Schema.IndexCreationFailed, cause, FORMAT_MESSAGE, indexUserDescription,
-                descriptor.getLabelId(), descriptor.getPropertyId() );
+                descriptor.getLabelId(), Arrays.toString( descriptor.getPropertyIds() ) );
     }
 
     public IndexPopulationFailedKernelException( LabelSchemaDescriptor descriptor, String indexUserDescription,
             String message )
     {
         super( Status.Schema.IndexCreationFailed, FORMAT_MESSAGE + ", due to " + message,
-                indexUserDescription, descriptor.getLabelId(), descriptor.getPropertyId() );
+                indexUserDescription, descriptor.getLabelId(), Arrays.toString( descriptor.getPropertyIds() ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelExceptionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/exceptions/index/IndexPopulationFailedKernelExceptionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.index;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndexPopulationFailedKernelExceptionTest
+{
+
+    @Test
+    public void shouldHandleMultiplePropertiesInConstructor1()
+    {
+        // Given
+        LabelSchemaDescriptor descriptor = new LabelSchemaDescriptor( 0, 42, 43, 44 );
+        TokenNameLookup lookup = mock( TokenNameLookup.class );
+        when( lookup.labelGetName( 0 ) ).thenReturn( "L" );
+        when( lookup.propertyKeyGetName( 42 ) ).thenReturn( "FOO" );
+        when( lookup.propertyKeyGetName( 43 ) ).thenReturn( "BAR" );
+        when( lookup.propertyKeyGetName( 44 ) ).thenReturn( "BAZ" );
+
+        // When
+        IndexPopulationFailedKernelException index =
+                new IndexPopulationFailedKernelException( descriptor, "INDEX", new RuntimeException(  ));
+
+        // Then
+        assertThat(index.getUserMessage( lookup ), equalTo(
+                "Failed to populate index for INDEX [labelId: 0, properties [42, 43, 44]]"));
+    }
+
+    @Test
+    public void shouldHandleMultiplePropertiesInConstructor2()
+    {
+        // Given
+        LabelSchemaDescriptor descriptor = new LabelSchemaDescriptor( 0, 42, 43, 44 );
+        TokenNameLookup lookup = mock( TokenNameLookup.class );
+        when( lookup.labelGetName( 0 ) ).thenReturn( "L" );
+        when( lookup.propertyKeyGetName( 42 ) ).thenReturn( "FOO" );
+        when( lookup.propertyKeyGetName( 43 ) ).thenReturn( "BAR" );
+        when( lookup.propertyKeyGetName( 44 ) ).thenReturn( "BAZ" );
+
+        // When
+        IndexPopulationFailedKernelException index =
+                new IndexPopulationFailedKernelException( descriptor, "INDEX", "an act of pure evil occurred");
+
+        // Then
+        assertThat(index.getUserMessage( lookup ), equalTo(
+                "Failed to populate index for INDEX [labelId: 0, properties [42, 43, 44]], due to an act of pure evil occurred"));
+    }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -274,6 +274,12 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with NewPlann
     result should useIndex(":L(foo,bar,baz")
   }
 
+  test("should not fail on multiple attempts to create a composite index") {
+    // Given
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE INDEX ON :Person(firstname, lastname)")
+    executeWithCostPlannerAndInterpretedRuntimeOnly("CREATE INDEX ON :Person(firstname, lastname)")
+  }
+
   case class haveIndexes(expectedIndexes: String*) extends Matcher[GraphDatabaseQueryService] {
     def apply(graph: GraphDatabaseQueryService): MatchResult = {
       graph.inTx {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -214,7 +214,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
                   "A constraint cannot be created until the index has been dropped.")
   }
 
-  test("should give appropriate error message when there is already a constraint") {
+  test("should give appropriate error message when there is already a NODE KEY constraint") {
     // Given
     exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS NODE KEY")
 


### PR DESCRIPTION
There were several instances where we assumed a single property when creating error messages and exceptions. There was also a more severe error where multiple attempts to create a composite index, e.g.
```
CREATE INDEX ON :Person(firstname, lastname)
CREATE INDEX ON :Person(firstname, lastname)
```
ended up in an error instead with a non-sensical error message instead of being idempotent.
