### PR TITLE
Avoid multiple attempt to open same index on log summary in IndexingService

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -190,7 +191,7 @@ public class IndexingService extends LifecycleAdapter
     {
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
 
-        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new HashMap<>();
+        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
         for ( IndexRule indexRule : indexRules )
         {
             IndexProxy indexProxy;
@@ -251,13 +252,14 @@ public class IndexingService extends LifecycleAdapter
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
 
         final Map<Long,RebuildingIndexDescriptor> rebuildingDescriptors = new HashMap<>();
-        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new HashMap<>();
+        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
 
         // Find all indexes that are not already online, do not require rebuilding, and create them
         indexMap.foreachIndexProxy( ( indexId, proxy ) -> {
             InternalIndexState state = proxy.getState();
             IndexDescriptor descriptor = proxy.getDescriptor();
-            indexStates.computeIfAbsent( state, internalIndexState -> new ArrayList<>() ).add( new IndexLogRecord(indexId, descriptor) );
+            indexStates.computeIfAbsent( state, internalIndexState -> new ArrayList<>() )
+                    .add( new IndexLogRecord( indexId, descriptor ) );
             log.debug( indexStateInfo( "start", indexId, state, descriptor ) );
             switch ( state )
             {
@@ -778,13 +780,13 @@ public class IndexingService extends LifecycleAdapter
         return samplingController;
     }
 
-    private void logIndexStateSummary( String method,  Map<InternalIndexState, List<IndexLogRecord>> indexStates )
+    private void logIndexStateSummary( String method, Map<InternalIndexState,List<IndexLogRecord>> indexStates )
     {
         int mostPopularStateCount = Integer.MIN_VALUE;
         InternalIndexState mostPopularState = null;
         for ( Map.Entry<InternalIndexState,List<IndexLogRecord>> indexStateEntry : indexStates.entrySet() )
         {
-            if (indexStateEntry.getValue().size() > mostPopularStateCount)
+            if ( indexStateEntry.getValue().size() > mostPopularStateCount )
             {
                 mostPopularState = indexStateEntry.getKey();
                 mostPopularStateCount = indexStateEntry.getValue().size();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -190,6 +190,7 @@ public class IndexingService extends LifecycleAdapter
     {
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
 
+        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new HashMap<>();
         for ( IndexRule indexRule : indexRules )
         {
             IndexProxy indexProxy;
@@ -199,6 +200,8 @@ public class IndexingService extends LifecycleAdapter
             SchemaIndexProvider.Descriptor providerDescriptor = indexRule.getProviderDescriptor();
             SchemaIndexProvider provider = providerMap.apply( providerDescriptor );
             InternalIndexState initialState = provider.getInitialState( indexId );
+            indexStates.computeIfAbsent( initialState, internalIndexState -> new ArrayList<>() ).add( new IndexLogRecord( indexId, descriptor ) );
+
             log.debug( indexStateInfo( "init", indexId, initialState, descriptor ) );
             boolean constraint = indexRule.isConstraintIndex();
 
@@ -233,42 +236,9 @@ public class IndexingService extends LifecycleAdapter
             }
             indexMap.putIndexProxy( indexId, indexProxy );
         }
-        logIndexStateSummary( "init" );
+        logIndexStateSummary( "init", indexStates );
 
         indexMapRef.setIndexMap( indexMap );
-    }
-
-    private void logIndexStateSummary( String method )
-    {
-        int[] counts = new int[InternalIndexState.values().length];
-        for ( IndexRule indexRule : indexRules )
-        {
-            SchemaIndexProvider provider = providerMap.apply( indexRule.getProviderDescriptor() );
-            InternalIndexState state = provider.getInitialState( indexRule.getId() );
-            counts[state.ordinal()]++;
-        }
-
-        int mostIndex = -1;
-        for ( int i = 0; i < counts.length; i++ )
-        {
-            if ( mostIndex == -1 || counts[i] > counts[mostIndex] )
-            {
-                mostIndex = i;
-            }
-        }
-        InternalIndexState mostState = InternalIndexState.values()[mostIndex];
-        for ( IndexRule indexRule : indexRules )
-        {
-            long id = indexRule.getId();
-            SchemaIndexProvider provider = providerMap.apply( indexRule.getProviderDescriptor() );
-            InternalIndexState state = provider.getInitialState( id );
-            if ( mostState != state )
-            {
-                IndexDescriptor descriptor = new IndexDescriptor( indexRule.getLabel(), indexRule.getPropertyKey() );
-                log.info( indexStateInfo( method, id, state, descriptor ) );
-            }
-        }
-        log.info( format( "IndexingService.%s: indexes not specifically mentioned above are %s", method, mostState ) );
     }
 
     // Recovery semantics: This is to be called after init, and after the database has run recovery.
@@ -281,11 +251,13 @@ public class IndexingService extends LifecycleAdapter
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
 
         final Map<Long,RebuildingIndexDescriptor> rebuildingDescriptors = new HashMap<>();
+        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new HashMap<>();
 
         // Find all indexes that are not already online, do not require rebuilding, and create them
         indexMap.foreachIndexProxy( ( indexId, proxy ) -> {
             InternalIndexState state = proxy.getState();
             IndexDescriptor descriptor = proxy.getDescriptor();
+            indexStates.computeIfAbsent( state, internalIndexState -> new ArrayList<>() ).add( new IndexLogRecord(indexId, descriptor) );
             log.debug( indexStateInfo( "start", indexId, state, descriptor ) );
             switch ( state )
             {
@@ -304,7 +276,7 @@ public class IndexingService extends LifecycleAdapter
                     throw new IllegalStateException( "Unknown state: " + state );
             }
         } );
-        logIndexStateSummary( "start" );
+        logIndexStateSummary( "start", indexStates );
 
         // Drop placeholder proxies for indexes that need to be rebuilt
         dropRecoveringIndexes( indexMap, rebuildingDescriptors.keySet() );
@@ -804,5 +776,52 @@ public class IndexingService extends LifecycleAdapter
     public IndexSamplingController getSamplingController()
     {
         return samplingController;
+    }
+
+    private void logIndexStateSummary( String method,  Map<InternalIndexState, List<IndexLogRecord>> indexStates )
+    {
+        int mostPopularStateCount = Integer.MIN_VALUE;
+        InternalIndexState mostPopularState = null;
+        for ( Map.Entry<InternalIndexState,List<IndexLogRecord>> indexStateEntry : indexStates.entrySet() )
+        {
+            if (indexStateEntry.getValue().size() > mostPopularStateCount)
+            {
+                mostPopularState = indexStateEntry.getKey();
+                mostPopularStateCount = indexStateEntry.getValue().size();
+            }
+        }
+        indexStates.remove( mostPopularState );
+        for ( Map.Entry<InternalIndexState,List<IndexLogRecord>> indexStateEntry : indexStates.entrySet() )
+        {
+            InternalIndexState state = indexStateEntry.getKey();
+            List<IndexLogRecord> logRecords = indexStateEntry.getValue();
+            for ( IndexLogRecord logRecord : logRecords )
+            {
+                log.info( indexStateInfo( method, logRecord.getIndexId(), state, logRecord.getDescriptor() ) );
+            }
+        }
+        log.info( format( "IndexingService.%s: indexes not specifically mentioned above are %s", method, mostPopularState ) );
+    }
+
+    private final class IndexLogRecord {
+
+        private final long indexId;
+        private final IndexDescriptor descriptor;
+
+        IndexLogRecord( long indexId, IndexDescriptor descriptor )
+        {
+            this.indexId = indexId;
+            this.descriptor = descriptor;
+        }
+
+        public long getIndexId()
+        {
+            return indexId;
+        }
+
+        public IndexDescriptor getDescriptor()
+        {
+            return descriptor;
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -20,9 +20,6 @@
 package org.neo4j.test;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
@@ -244,18 +241,5 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
                         GraphDatabaseDependencies.newDependencies( state.databaseDependencies() ) );
             }
         };
-    }
-
-    private Path tempFile( String name )
-    {
-        try
-        {
-            return Files.createTempFile( name, "tmp" );
-
-        }
-        catch ( IOException e )
-        {
-            throw new AssertionError( e );
-        }
     }
 }

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -647,16 +647,37 @@ public class AssertableLogProvider extends AbstractLogProvider<Log> implements T
     {
         synchronized (logCalls)
         {
-            for ( LogCall logCall : logCalls )
+            if ( containsMessage( partOfMessage ) )
             {
-                if ( logCall.message.contains( partOfMessage ) )
-                {
-                    return;
-                }
+                return;
             }
-            fail( format(
-                    "Expected at least one log statement containing '%s', but none found. Actual log calls were:\n%s", partOfMessage, serialize( logCalls.iterator() )
-            ) );
+            fail( format( "Expected at least one log statement containing '%s', but none found. Actual log calls were:\n%s",
+                    partOfMessage, serialize( logCalls.iterator() ) ) );
+        }
+    }
+
+    private boolean containsMessage( String partOfMessage )
+    {
+        for ( LogCall logCall : logCalls )
+        {
+            if ( logCall.message.contains( partOfMessage ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void assertNoMessagesContaining( String partOfMessage )
+    {
+        synchronized ( logCalls )
+        {
+            if ( containsMessage( partOfMessage ) )
+            {
+                fail( format(
+                        "Expected at least one log statement containing '%s', but none found. Actual log calls were:\n%s",
+                        partOfMessage, serialize( logCalls.iterator() ) ) );
+            }
         }
     }
 

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/index/StartOnExistingDbWithIndexIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/index/StartOnExistingDbWithIndexIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+public class StartOnExistingDbWithIndexIT
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void startStopDatabaseWithIndex() throws Exception
+    {
+        Label label = Label.label( "string" );
+        String property = "property";
+        AssertableLogProvider logProvider = new AssertableLogProvider( true );
+        GraphDatabaseService db = prepareDb( label, property, logProvider );
+        db.shutdown();
+        db = getDatabase( logProvider );
+        db.shutdown();
+
+        logProvider.assertNoMessagesContaining( "Failed to open index" );
+    }
+
+    private GraphDatabaseService prepareDb( Label label, String propertyName, LogProvider logProvider )
+    {
+        GraphDatabaseService db = getDatabase( logProvider );
+        try ( Transaction transaction = db.beginTx() )
+        {
+            db.schema().constraintFor( label ).assertPropertyIsUnique( propertyName ).create();
+            transaction.success();
+        }
+        waitIndexes( db );
+        return db;
+    }
+
+    private GraphDatabaseService getDatabase( LogProvider logProvider )
+    {
+        return new TestEnterpriseGraphDatabaseFactory()
+                .setInternalLogProvider( logProvider )
+                .newEmbeddedDatabase( testDirectory.graphDbDir() );
+    }
+
+    private void waitIndexes( GraphDatabaseService db )
+    {
+        try ( Transaction transaction = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 5, TimeUnit.SECONDS );
+            transaction.success();
+        }
+    }
+}


### PR DESCRIPTION
Collect indexes state to log summary during init and start of IndexService
to avoid multiple attempts and lucene failures to open same index multiple times on startup.