### PR TITLE
Set additional headers to force web browsers to not cache html files

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/web/StaticContentFilter.java
@@ -44,7 +44,8 @@ public class StaticContentFilter implements Filter
         HttpServletResponse response = (HttpServletResponse) servletResponse;
         if ( request.getServletPath() != null && request.getServletPath().endsWith( ".html" ))
         {
-            response.addHeader( "Cache-Control", "no-cache" );
+            response.addHeader( "Cache-Control", "private, no-cache, no-store, proxy-revalidate, no-transform" );
+            response.addHeader( "Pragma", "no-cache" );
             response.addHeader( "Content-Security-Policy", "frame-ancestors 'none'" );
             response.addHeader( "X-Frame-Options", "DENY" );
         }

--- a/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/StaticContentFilterTest.java
@@ -45,7 +45,8 @@ public class StaticContentFilterTest
         new StaticContentFilter().doFilter( request, response, filterChain );
 
         // then
-        verify( response ).addHeader( "Cache-Control", "no-cache" );
+        verify( response ).addHeader( "Cache-Control", "private, no-cache, no-store, proxy-revalidate, no-transform" );
+        verify( response ).addHeader( "Pragma", "no-cache" );
         verify( response ).addHeader( "Content-Security-Policy", "frame-ancestors 'none'" );
         verify( response ).addHeader( "X-Frame-Options", "DENY" );
         verify( filterChain ).doFilter( request, response );


### PR DESCRIPTION
This solves the issue for some users where Neo4j Browser is updated but the user's web browser doesn't fetch the latest html from the server.