### PR TITLE
Avoids NPE in SystemDiagnostics on null ClassLoader URLs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/info/SystemDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/info/SystemDiagnostics.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.impl.util.OsBeanUtil;
 import org.neo4j.logging.Logger;
 
 import static java.net.NetworkInterface.getNetworkInterfaces;
+
 import static org.neo4j.helpers.Format.bytes;
 
 enum SystemDiagnostics implements DiagnosticsProvider
@@ -160,9 +161,21 @@ enum SystemDiagnostics implements DiagnosticsProvider
                 if ( loader instanceof URLClassLoader )
                 {
                     URLClassLoader urls = (URLClassLoader) loader;
-                    for ( URL url : urls.getURLs() )
-                        if ( "file".equalsIgnoreCase( url.getProtocol() ) )
-                            paths.put( url.toString(), pathValue( paths, "loader." + level, url.getPath() ) );
+                    URL[] classLoaderUrls = urls.getURLs();
+                    if ( classLoaderUrls != null )
+                    {
+                        for ( URL url : classLoaderUrls )
+                        {
+                            if ( "file".equalsIgnoreCase( url.getProtocol() ) )
+                            {
+                                paths.put( url.toString(), pathValue( paths, "loader." + level, url.getPath() ) );
+                            }
+                        }
+                    }
+                    else
+                    {
+                        paths.put( loader.toString(), "<ClassLoader unexpectedly has null URL array>" );
+                    }
                 }
                 loader = loader.getParent();
             }


### PR DESCRIPTION
This happened on an IBM JDK. Unexpected as it is there's no point failing
with NPE. Rather now this fact will be logged.