### PR TITLE
3.1 ratelimit source

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -27,6 +27,7 @@ import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.List;
@@ -242,8 +243,9 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         availableVersions.put(
                 (long) BoltProtocolV1.VERSION,
                 ( channel, isEncrypted ) -> {
+                    String source = ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
                     String descriptor = format( "\tclient%s\tserver%s", channel.remoteAddress(), channel.localAddress() );
-                    BoltWorker worker = workerFactory.newWorker( descriptor, channel::close );
+                    BoltWorker worker = workerFactory.newWorker( source, descriptor, channel::close );
                     return new BoltProtocolV1( worker, channel, logging );
                 }
         );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltFactory.java
@@ -29,10 +29,11 @@ public interface BoltFactory
     /**
      * Generate a new state machine.
      *
+     * @param source textual description of the source for rate limiting
      * @param connectionDescriptor textual description of the connection for logging purposes
      * @param onClose callback to call on shutdown of the state machine
      * @param clock used to keep track of execution times
      * @return new {@link BoltStateMachine} instance
      */
-    BoltStateMachine newMachine( String connectionDescriptor, Runnable onClose, Clock clock );
+    BoltStateMachine newMachine( String source, String connectionDescriptor, Runnable onClose, Clock clock );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachineSPI.java
@@ -25,7 +25,7 @@ import org.neo4j.bolt.security.auth.Authentication;
 import org.neo4j.bolt.security.auth.AuthenticationException;
 import org.neo4j.bolt.security.auth.AuthenticationResult;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
-import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.internal.Version;
 import org.neo4j.udc.UsageData;
@@ -33,6 +33,7 @@ import org.neo4j.udc.UsageDataKeys;
 
 class BoltStateMachineSPI implements BoltStateMachine.SPI
 {
+    private final String source;
     private final String connectionDescriptor;
     private final UsageData usageData;
     private final ErrorReporter errorReporter;
@@ -42,13 +43,15 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
 
     final TransactionStateMachine.SPI transactionSpi;
 
-    BoltStateMachineSPI( String connectionDescriptor,
+    BoltStateMachineSPI( String source,
+                         String connectionDescriptor,
                          UsageData usageData,
                          LogService logging,
                          Authentication authentication,
                          BoltConnectionTracker connectionTracker,
                          TransactionStateMachine.SPI transactionStateMachineSPI )
     {
+        this.source = source;
         this.connectionDescriptor = connectionDescriptor;
         this.usageData = usageData;
         this.errorReporter = new ErrorReporter( logging );
@@ -91,6 +94,7 @@ class BoltStateMachineSPI implements BoltStateMachine.SPI
     @Override
     public AuthenticationResult authenticate( Map<String,Object> authToken ) throws AuthenticationException
     {
+        authToken.put( AuthToken.SOURCE, source );
         return authentication.authenticate( authToken );
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
@@ -92,12 +92,12 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
     }
 
     @Override
-    public BoltStateMachine newMachine( String connectionDescriptor, Runnable onClose, Clock clock )
+    public BoltStateMachine newMachine( String source, String connectionDescriptor, Runnable onClose, Clock clock )
     {
         TransactionStateMachine.SPI transactionSPI =
                 new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
                         availabilityGuard, queryService, clock );
-        BoltStateMachine.SPI boltSPI = new BoltStateMachineSPI( connectionDescriptor, usageData,
+        BoltStateMachine.SPI boltSPI = new BoltStateMachineSPI( source, connectionDescriptor, usageData,
                 logging, authentication, connectionTracker, transactionSPI );
         return new BoltStateMachine( boltSPI, onClose, Clock.systemUTC() );
     }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
@@ -45,13 +45,13 @@ public class MonitoredWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( String connectionDescriptor, Runnable onClose )
+    public BoltWorker newWorker( String source, String connectionDescriptor, Runnable onClose )
     {
         if( monitors.hasListeners( SessionMonitor.class ) )
         {
-            return new MonitoredBoltWorker( monitor, delegate.newWorker( connectionDescriptor, onClose ), clock );
+            return new MonitoredBoltWorker( monitor, delegate.newWorker( source, connectionDescriptor, onClose ), clock );
         }
-        return delegate.newWorker( connectionDescriptor, onClose );
+        return delegate.newWorker( source, connectionDescriptor, onClose );
     }
 
     static class MonitoredBoltWorker implements BoltWorker

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/WorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/WorkerFactory.java
@@ -25,15 +25,16 @@ package org.neo4j.bolt.v1.runtime;
  */
 public interface WorkerFactory
 {
-    default BoltWorker newWorker( String connectionDescriptor )
+    default BoltWorker newWorker( String source, String connectionDescriptor )
     {
-        return newWorker( connectionDescriptor, null );
+        return newWorker( source, connectionDescriptor, null );
     }
 
     /**
+     * @param source               describes the source of the connection
      * @param connectionDescriptor describes the underlying medium (TCP, HTTP, ...)
      * @param onClose              callback for closing the underlying connection in case of protocol violation.
      * @return a new job queue
      */
-    BoltWorker newWorker( String connectionDescriptor, Runnable onClose );
+    BoltWorker newWorker( String source, String connectionDescriptor, Runnable onClose );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
@@ -57,9 +57,9 @@ public class ThreadedWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( String connectionDescriptor, Runnable onClose )
+    public BoltWorker newWorker( String source, String connectionDescriptor, Runnable onClose )
     {
-        BoltStateMachine machine = connector.newMachine( connectionDescriptor, onClose, Clock.systemUTC() );
+        BoltStateMachine machine = connector.newMachine( source, connectionDescriptor, onClose, Clock.systemUTC() );
         RunnableBoltWorker worker = new RunnableBoltWorker( machine, logging );
 
         scheduler.schedule( sessionWorker, worker, stringMap( THREAD_ID, machine.key() ) );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
@@ -76,7 +76,7 @@ public class ResetFuzzTest
     private final Neo4jJobScheduler scheduler = life.add(new Neo4jJobScheduler());
     private final BoltStateMachine machine = new BoltStateMachine( new FuzzStubSPI(), null, Clock.systemUTC() );
     private final ThreadedWorkerFactory sessions =
-            new ThreadedWorkerFactory( ( enc, closer, clock ) -> machine, scheduler, NullLogService.getInstance() );
+            new ThreadedWorkerFactory( ( src, enc, closer, clock ) -> machine, scheduler, NullLogService.getInstance() );
 
     private final List<List<RequestMessage>> sequences = asList(
             asList( run( "test", map() ), discardAll() ),
@@ -91,7 +91,7 @@ public class ResetFuzzTest
     {
         // given
         life.start();
-        BoltWorker boltWorker = sessions.newWorker( "<test>" );
+        BoltWorker boltWorker = sessions.newWorker( "127.0.0.1", "<test>" );
         boltWorker.enqueue( session -> session.init( "ResetFuzzTest/0.0", map(), nullResponseHandler() ) );
 
         BoltMessageRouter router = new BoltMessageRouter(

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionAuthIT.java
@@ -37,6 +37,7 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 public class BoltConnectionAuthIT
 {
     private static final String USER_AGENT = "BoltConnectionAuthIT/0.0";
+    private static final String SOURCE = "127.0.0.1";
 
     @Rule
     public SessionRule env = new SessionRule().withAuthEnabled( true );
@@ -46,7 +47,7 @@ public class BoltConnectionAuthIT
     {
         // Given it is important for client applications to programmatically
         // identify expired credentials as the cause of not being authenticated
-        BoltStateMachine machine = env.newMachine( "test" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "test" );
         BoltResponseRecorder recorder = new BoltResponseRecorder();
 
         // When
@@ -66,7 +67,7 @@ public class BoltConnectionAuthIT
     {
         // Given it is important for client applications to programmatically
         // identify expired credentials as the cause of not being authenticated
-        BoltStateMachine machine = env.newMachine( "test" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "test" );
         BoltResponseRecorder recorder = new BoltResponseRecorder();
         String version = "Neo4j/" + Version.getNeo4jVersion();
         // When
@@ -84,7 +85,7 @@ public class BoltConnectionAuthIT
     public void shouldCloseConnectionAfterAuthenticationFailure() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "test" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "test" );
 
         // When... then
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -101,7 +102,7 @@ public class BoltConnectionAuthIT
     @Test
     public void shouldBeAbleToActOnSessionWhenUpdatingCredentials() throws Throwable
     {
-        BoltStateMachine machine = env.newMachine( "test" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "test" );
         BoltResponseRecorder recorder = new BoltResponseRecorder();
 
         // when

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
@@ -55,6 +55,7 @@ public class BoltConnectionIT
 {
     private static final Map<String,Object> EMPTY_PARAMS = emptyMap();
     private static final String USER_AGENT = "BoltConnectionIT/0.0";
+    private static final String SOURCE = "127.0.0.1";
 
     @Rule
     public SessionRule env = new SessionRule();
@@ -63,7 +64,7 @@ public class BoltConnectionIT
     public void shouldCloseConnectionAckFailureBeforeInit() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -77,7 +78,7 @@ public class BoltConnectionIT
     public void shouldCloseConnectionResetBeforeInit() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -91,7 +92,7 @@ public class BoltConnectionIT
     public void shouldCloseConnectionOnRunBeforeInit() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -105,7 +106,7 @@ public class BoltConnectionIT
     public void shouldCloseConnectionOnDiscardAllBeforeInit() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -119,7 +120,7 @@ public class BoltConnectionIT
     public void shouldCloseConnectionOnPullAllBeforeInit() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
 
         // when
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -133,7 +134,7 @@ public class BoltConnectionIT
     public void shouldExecuteStatement() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -156,7 +157,7 @@ public class BoltConnectionIT
     public void shouldSucceedOn__run__pullAll__run() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -175,7 +176,7 @@ public class BoltConnectionIT
     public void shouldSucceedOn__run__discardAll__run() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -194,7 +195,7 @@ public class BoltConnectionIT
     public void shouldSucceedOn__run_BEGIN__pullAll__run_COMMIT__pullALL__run_COMMIT() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -220,7 +221,7 @@ public class BoltConnectionIT
     public void shouldFailOn__run__run() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran one statement
@@ -238,7 +239,7 @@ public class BoltConnectionIT
     public void shouldFailOn__pullAll__pullAll() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -257,7 +258,7 @@ public class BoltConnectionIT
     public void shouldFailOn__pullAll__discardAll() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -276,7 +277,7 @@ public class BoltConnectionIT
     public void shouldFailOn__discardAll__discardAll() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -295,7 +296,7 @@ public class BoltConnectionIT
     public void shouldFailOn__discardAll__pullAll() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And Given that I've ran and pulled one stream
@@ -314,7 +315,7 @@ public class BoltConnectionIT
     public void shouldHandleImplicitCommitFailure() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
         machine.run( "CREATE (n:Victim)-[:REL]->()", EMPTY_PARAMS, nullResponseHandler() );
         machine.discardAll( nullResponseHandler() );
@@ -341,7 +342,7 @@ public class BoltConnectionIT
         // and send a `ROLLBACK`, because that means that all failures in the
         // transaction, be they client-local or inside neo, can be handled the
         // same way by a driver.
-        BoltStateMachine machine = env.newMachine("bolt-test");
+        BoltStateMachine machine = env.newMachine( SOURCE, "bolt-test" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         machine.run( "BEGIN", EMPTY_PARAMS, nullResponseHandler() );
@@ -370,7 +371,7 @@ public class BoltConnectionIT
     public void shouldHandleFailureDuringResultPublishing() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         final CountDownLatch pullAllCallbackCalled = new CountDownLatch( 1 );
@@ -425,9 +426,9 @@ public class BoltConnectionIT
     public void shouldBeAbleToCleanlyRunMultipleSessionsInSingleThread() throws Throwable
     {
         // Given
-        BoltStateMachine firstMachine = env.newMachine( "<test>" );
+        BoltStateMachine firstMachine = env.newMachine( SOURCE, "<test>" );
         firstMachine.init( USER_AGENT, emptyMap(), null );
-        BoltStateMachine secondMachine = env.newMachine( "<test>" );
+        BoltStateMachine secondMachine = env.newMachine( SOURCE, "<test>" );
         secondMachine.init( USER_AGENT, emptyMap(), null );
 
         // And given I've started a transaction in one session
@@ -449,7 +450,7 @@ public class BoltConnectionIT
     public void shouldSupportUsingPeriodicCommitInSession() throws Exception
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
         Map<String, Object> params = new HashMap<>();
         params.put( "csvFileUrl", createLocalIrisData( machine ) );
@@ -496,7 +497,7 @@ public class BoltConnectionIT
     public void shouldNotSupportUsingPeriodicCommitInTransaction() throws Exception
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
         Map<String, Object> params = new HashMap<>();
         params.put( "csvFileUrl", createLocalIrisData( machine ) );
@@ -525,7 +526,7 @@ public class BoltConnectionIT
     public void shouldAllowNewTransactionAfterFailure() throws Throwable
     {
         // Given
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // And given I've started a transaction that failed

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/BoltConnectionIT.java
@@ -26,7 +26,6 @@ import org.neo4j.bolt.v1.runtime.BoltResponseHandler;
 import org.neo4j.bolt.testing.BoltResponseRecorder;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.Neo4jError;
-import org.neo4j.bolt.testing.NullResponseHandler;
 import org.neo4j.bolt.testing.RecordedBoltResponse;
 import org.neo4j.bolt.v1.runtime.spi.Record;
 import org.neo4j.bolt.v1.runtime.spi.BoltResult;
@@ -48,6 +47,7 @@ import static org.neo4j.bolt.testing.BoltMatchers.succeeded;
 import static org.neo4j.bolt.testing.NullResponseHandler.nullResponseHandler;
 import static org.neo4j.bolt.v1.messaging.BoltResponseMessage.SUCCESS;
 import static org.neo4j.bolt.testing.BoltMatchers.verifyKillsConnection;
+import static org.neo4j.bolt.v1.messaging.Neo4jPack.EMPTY_MAP;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
 @SuppressWarnings( "unchecked" )
@@ -135,7 +135,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -158,7 +158,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -177,7 +177,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -196,7 +196,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         BoltResponseRecorder recorder = new BoltResponseRecorder();
@@ -222,7 +222,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran one statement
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -240,7 +240,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -259,7 +259,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -278,7 +278,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -297,7 +297,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And Given that I've ran and pulled one stream
         machine.run( "RETURN 1", EMPTY_PARAMS, nullResponseHandler() );
@@ -316,7 +316,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
         machine.run( "CREATE (n:Victim)-[:REL]->()", EMPTY_PARAMS, nullResponseHandler() );
         machine.discardAll( nullResponseHandler() );
 
@@ -343,7 +343,7 @@ public class BoltConnectionIT
         // transaction, be they client-local or inside neo, can be handled the
         // same way by a driver.
         BoltStateMachine machine = env.newMachine( SOURCE, "bolt-test" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         machine.run( "BEGIN", EMPTY_PARAMS, nullResponseHandler() );
         machine.discardAll( nullResponseHandler() );
@@ -372,7 +372,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         final CountDownLatch pullAllCallbackCalled = new CountDownLatch( 1 );
         final AtomicReference<Neo4jError> error = new AtomicReference<>();
@@ -427,9 +427,9 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine firstMachine = env.newMachine( SOURCE, "<test>" );
-        firstMachine.init( USER_AGENT, emptyMap(), null );
+        firstMachine.init( USER_AGENT, EMPTY_MAP, null );
         BoltStateMachine secondMachine = env.newMachine( SOURCE, "<test>" );
-        secondMachine.init( USER_AGENT, emptyMap(), null );
+        secondMachine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And given I've started a transaction in one session
         runAndPull( firstMachine, "BEGIN" );
@@ -451,7 +451,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
         Map<String, Object> params = new HashMap<>();
         params.put( "csvFileUrl", createLocalIrisData( machine ) );
 
@@ -498,7 +498,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
         Map<String, Object> params = new HashMap<>();
         params.put( "csvFileUrl", createLocalIrisData( machine ) );
         runAndPull( machine, "BEGIN" );
@@ -527,7 +527,7 @@ public class BoltConnectionIT
     {
         // Given
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // And given I've started a transaction that failed
         runAndPull( machine, "BEGIN" );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -103,18 +103,18 @@ class SessionRule implements TestRule
         return new BasicAuthentication( authManager );
     }
 
-    BoltStateMachine newMachine( String connectionDescriptor )
+    BoltStateMachine newMachine( String source, String connectionDescriptor )
     {
-        return newMachine( connectionDescriptor, Clock.systemUTC() );
+        return newMachine( source, connectionDescriptor, Clock.systemUTC() );
     }
 
-    BoltStateMachine newMachine( String connectionDescriptor, Clock clock )
+    BoltStateMachine newMachine( String source, String connectionDescriptor, Clock clock )
     {
         if ( boltFactory == null )
         {
             throw new IllegalStateException( "Cannot access test environment before test is running." );
         }
-        BoltStateMachine connection = boltFactory.newMachine( connectionDescriptor, () -> {}, clock );
+        BoltStateMachine connection = boltFactory.newMachine( source, connectionDescriptor, () -> {}, clock );
         runningMachines.add( connection );
         return connection;
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
@@ -61,6 +61,7 @@ public class TransactionIT
 {
     private static final String USER_AGENT = "TransactionIT/0.0";
     private static final Pattern BOOKMARK_PATTERN = Pattern.compile( "neo4j:bookmark:v1:tx[0-9]+" );
+    private static final String SOURCE = "127.0.0.1";
 
     @Rule
     public SessionRule env = new SessionRule();
@@ -70,7 +71,7 @@ public class TransactionIT
     {
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -94,7 +95,7 @@ public class TransactionIT
     {
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -119,7 +120,7 @@ public class TransactionIT
         // Given
         BoltResponseRecorder runRecorder = new BoltResponseRecorder();
         BoltResponseRecorder pullAllRecorder = new BoltResponseRecorder();
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -136,7 +137,7 @@ public class TransactionIT
     {
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -163,7 +164,7 @@ public class TransactionIT
     {
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
-        BoltStateMachine machine = env.newMachine( "<test>" );
+        BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
         machine.init( USER_AGENT, emptyMap(), null );
 
         // When
@@ -203,7 +204,7 @@ public class TransactionIT
             @Override
             public void run()
             {
-                try ( BoltStateMachine machine = env.newMachine( "<write>" ) )
+                try ( BoltStateMachine machine = env.newMachine( SOURCE, "<write>" ) )
                 {
                     machine.init( USER_AGENT, emptyMap(), null );
                     latch.await();
@@ -219,7 +220,7 @@ public class TransactionIT
         thread.start();
 
         long dbVersionAfterWrite = dbVersion + 1;
-        try ( BoltStateMachine machine = env.newMachine( "<read>" ) )
+        try ( BoltStateMachine machine = env.newMachine( SOURCE, "<read>" ) )
         {
             BoltResponseRecorder recorder = new BoltResponseRecorder();
             machine.init( USER_AGENT, emptyMap(), null );
@@ -267,7 +268,7 @@ public class TransactionIT
             @Override
             public void run()
             {
-                try ( BoltStateMachine stateMachine = env.newMachine( "<write>" ) )
+                try ( BoltStateMachine stateMachine = env.newMachine( SOURCE, "<write>" ) )
                 {
                     machine[0] = stateMachine;
                     stateMachine.init( USER_AGENT, emptyMap(), null );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
@@ -55,7 +55,7 @@ import static org.neo4j.bolt.testing.BoltMatchers.succeededWithMetadata;
 import static org.neo4j.bolt.testing.BoltMatchers.succeededWithRecord;
 import static org.neo4j.bolt.testing.BoltMatchers.wasIgnored;
 import static org.neo4j.bolt.testing.NullResponseHandler.nullResponseHandler;
-
+import static org.neo4j.bolt.v1.messaging.Neo4jPack.EMPTY_MAP;
 
 public class TransactionIT
 {
@@ -72,7 +72,7 @@ public class TransactionIT
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         machine.run( "BEGIN", emptyMap(), recorder );
@@ -96,7 +96,7 @@ public class TransactionIT
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         machine.run( "BEGIN", emptyMap(), recorder );
@@ -121,7 +121,7 @@ public class TransactionIT
         BoltResponseRecorder runRecorder = new BoltResponseRecorder();
         BoltResponseRecorder pullAllRecorder = new BoltResponseRecorder();
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         machine.run( "ROLLBACK", emptyMap(), runRecorder );
@@ -138,7 +138,7 @@ public class TransactionIT
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         machine.run( "BEGIN", emptyMap(), recorder );
@@ -165,7 +165,7 @@ public class TransactionIT
         // Given
         BoltResponseRecorder recorder = new BoltResponseRecorder();
         BoltStateMachine machine = env.newMachine( SOURCE, "<test>" );
-        machine.init( USER_AGENT, emptyMap(), null );
+        machine.init( USER_AGENT, EMPTY_MAP, null );
 
         // When
         machine.run( "BEGIN", emptyMap(), recorder );
@@ -206,7 +206,7 @@ public class TransactionIT
             {
                 try ( BoltStateMachine machine = env.newMachine( SOURCE, "<write>" ) )
                 {
-                    machine.init( USER_AGENT, emptyMap(), null );
+                    machine.init( USER_AGENT, EMPTY_MAP, null );
                     latch.await();
                     machine.run( "MATCH (n:A) SET n.prop = 'two'", emptyMap(), nullResponseHandler() );
                     machine.pullAll( nullResponseHandler() );
@@ -223,7 +223,7 @@ public class TransactionIT
         try ( BoltStateMachine machine = env.newMachine( SOURCE, "<read>" ) )
         {
             BoltResponseRecorder recorder = new BoltResponseRecorder();
-            machine.init( USER_AGENT, emptyMap(), null );
+            machine.init( USER_AGENT, EMPTY_MAP, null );
             latch.release();
             final String bookmark = "neo4j:bookmark:v1:tx" + Long.toString( dbVersionAfterWrite );
             machine.run( "BEGIN", singletonMap( "bookmark", bookmark ), nullResponseHandler() );
@@ -271,7 +271,7 @@ public class TransactionIT
                 try ( BoltStateMachine stateMachine = env.newMachine( SOURCE, "<write>" ) )
                 {
                     machine[0] = stateMachine;
-                    stateMachine.init( USER_AGENT, emptyMap(), null );
+                    stateMachine.init( USER_AGENT, EMPTY_MAP, null );
                     String query = format( "USING PERIODIC COMMIT 10 LOAD CSV FROM 'http://localhost:%d' AS line " +
                                            "CREATE (n:A {id: line[0], square: line[1]}) " +
                                            "WITH count(*) as number " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -39,6 +39,7 @@ public interface AuthToken
     String NEW_CREDENTIALS = "new_credentials";
     String BASIC_SCHEME = "basic";
     String NATIVE_REALM = "native";
+    String SOURCE = "source";
 
     static String safeCast( String key, Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
@@ -84,28 +85,28 @@ public interface AuthToken
         return new InvalidAuthTokenException( format( "Unsupported authentication token%s", explanation ) );
     }
 
-    static Map<String,Object> newBasicAuthToken( String username, String password )
+    static Map<String,Object> newBasicAuthToken( String username, String password, String source )
     {
         return map( AuthToken.SCHEME_KEY, BASIC_SCHEME, AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS,
-                password );
+                password, AuthToken.SOURCE, source );
     }
 
-    static Map<String,Object> newBasicAuthToken( String username, String password, String realm )
+    static Map<String,Object> newBasicAuthToken( String username, String password, String source, String realm )
     {
         return map( AuthToken.SCHEME_KEY, BASIC_SCHEME, AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password,
-                AuthToken.REALM_KEY, realm );
+                AuthToken.REALM_KEY, realm, AuthToken.SOURCE, source );
     }
 
-    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String realm, String scheme )
+    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String source, String realm, String scheme )
     {
         return map( AuthToken.SCHEME_KEY, scheme, AuthToken.PRINCIPAL, principle, AuthToken.CREDENTIALS, credentials,
-                AuthToken.REALM_KEY, realm );
+                AuthToken.REALM_KEY, realm, AuthToken.SOURCE, source );
     }
 
-    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String realm, String scheme,
+    static Map<String,Object> newCustomAuthToken( String principle, String credentials, String source, String realm, String scheme,
             Map<String,Object> parameters )
     {
         return map( AuthToken.SCHEME_KEY, scheme, AuthToken.PRINCIPAL, principle, AuthToken.CREDENTIALS, credentials,
-                AuthToken.REALM_KEY, realm, AuthToken.PARAMETERS, parameters );
+                AuthToken.REALM_KEY, realm, AuthToken.PARAMETERS, parameters, AuthToken.SOURCE, source );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/security/AuthTokenTest.java
@@ -33,7 +33,7 @@ public class AuthTokenTest
     @Test
     public void shouldMakeBasicAuthToken() throws Exception
     {
-        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret" );
+        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret", "127.0.0.1" );
         assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
         assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
         assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
@@ -43,7 +43,7 @@ public class AuthTokenTest
     @Test
     public void shouldMakeBasicAuthTokenWithRealm() throws Exception
     {
-        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret", "my realm" );
+        Map<String, Object> token = AuthToken.newBasicAuthToken( "me", "my secret", "127.0.0.1", "my realm" );
         assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
         assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
         assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
@@ -53,7 +53,7 @@ public class AuthTokenTest
     @Test
     public void shouldMakeCustomAuthTokenAndBasicScheme() throws Exception
     {
-        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "basic" );
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "127.0.0.1", "my realm", "basic" );
         assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
         assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
         assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo(AuthToken.BASIC_SCHEME));
@@ -63,7 +63,7 @@ public class AuthTokenTest
     @Test
     public void shouldMakeCustomAuthTokenAndCustomcScheme() throws Exception
     {
-        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "my scheme" );
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "127.0.0.1", "my realm", "my scheme" );
         assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
         assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
         assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo("my scheme"));
@@ -73,7 +73,7 @@ public class AuthTokenTest
     @Test
     public void shouldMakeCustomAuthTokenAndCustomcSchemeWithParameters() throws Exception
     {
-        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "my realm", "my scheme", map("a", "A", "b", "B") );
+        Map<String, Object> token = AuthToken.newCustomAuthToken( "me", "my secret", "127.0.0.1", "my realm", "my scheme", map("a", "A", "b", "B") );
         assertThat("Should have correct username", token.get(AuthToken.PRINCIPAL), equalTo("me"));
         assertThat("Should have correct password", token.get(AuthToken.CREDENTIALS), equalTo("my secret"));
         assertThat("Should have correct scheme", token.get(AuthToken.SCHEME_KEY), equalTo("my scheme"));

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthenticationStrategy.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthenticationStrategy.java
@@ -29,5 +29,5 @@ public interface AuthenticationStrategy
     /**
      * Verify a user by password
      */
-    AuthenticationResult authenticate( User user, String password );
+    AuthenticationResult authenticate( User user, String password, String source );
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -115,12 +115,13 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
 
         String username = AuthToken.safeCast( AuthToken.PRINCIPAL, authToken );
         String password = AuthToken.safeCast( AuthToken.CREDENTIALS, authToken );
+        String source = AuthToken.safeCast( AuthToken.SOURCE, authToken );
 
         User user = userRepository.getUserByName( username );
         AuthenticationResult result = AuthenticationResult.FAILURE;
         if ( user != null )
         {
-            result = authStrategy.authenticate( user, password );
+            result = authStrategy.authenticate( user, password, source );
             if ( result == AuthenticationResult.SUCCESS && user.passwordChangeRequired() )
             {
                 result = AuthenticationResult.PASSWORD_CHANGE_REQUIRED;

--- a/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
@@ -49,6 +49,7 @@ import static org.neo4j.kernel.api.security.AuthenticationResult.PASSWORD_CHANGE
 import static org.neo4j.kernel.api.security.AuthenticationResult.SUCCESS;
 import static org.neo4j.kernel.api.security.AuthenticationResult.TOO_MANY_ATTEMPTS;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
+import static org.neo4j.server.security.auth.SecurityTestUtils.SOURCE;
 import static org.neo4j.test.assertion.Assert.assertException;
 
 public class BasicAuthManagerTest extends InitialUserTests
@@ -83,7 +84,7 @@ public class BasicAuthManagerTest extends InitialUserTests
         final User user = user1;
 
         // When
-        when( authStrategy.authenticate( user, "abc123" )).thenReturn( SUCCESS );
+        when( authStrategy.authenticate( user, "abc123", SOURCE )).thenReturn( SUCCESS );
 
         // Then
         assertLoginGivesResult( "jake", "abc123", SUCCESS );
@@ -99,7 +100,7 @@ public class BasicAuthManagerTest extends InitialUserTests
         final User user = user1;
 
         // When
-        when( authStrategy.authenticate( user, "abc123" )).thenReturn( TOO_MANY_ATTEMPTS );
+        when( authStrategy.authenticate( user, "abc123", SOURCE )).thenReturn( TOO_MANY_ATTEMPTS );
 
         // Then
         assertLoginGivesResult( "jake", "abc123", TOO_MANY_ATTEMPTS );
@@ -115,7 +116,7 @@ public class BasicAuthManagerTest extends InitialUserTests
         final User user = user1;
 
         // When
-        when( authStrategy.authenticate( user, "abc123" )).thenReturn( SUCCESS );
+        when( authStrategy.authenticate( user, "abc123", SOURCE )).thenReturn( SUCCESS );
 
         // Then
         assertLoginGivesResult( "jake", "abc123", PASSWORD_CHANGE_REQUIRED );

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
@@ -25,8 +25,15 @@ import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 
 public class SecurityTestUtils
 {
+    public static final String SOURCE = "127.0.0.1";
+
     public static Map<String,Object> authToken( String username, String password )
     {
-        return newBasicAuthToken( username, password );
+        return newBasicAuthToken( username, password, SOURCE );
+    }
+
+    public static Map<String,Object> authToken( String username, String password, String source )
+    {
+        return newBasicAuthToken( username, password, source );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
@@ -106,7 +106,7 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
 
         try
         {
-            SecurityContext securityContext = authenticate( username, password );
+            SecurityContext securityContext = authenticate( username, password, servletRequest.getRemoteAddr() );
             switch ( securityContext.subject().getAuthenticationResult() )
             {
             case PASSWORD_CHANGE_REQUIRED:
@@ -149,10 +149,10 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
         }
     }
 
-    private SecurityContext authenticate( String username, String password ) throws InvalidAuthTokenException
+    private SecurityContext authenticate( String username, String password, String source ) throws InvalidAuthTokenException
     {
         AuthManager authManager = authManagerSupplier.get();
-        Map<String,Object> authToken = newBasicAuthToken( username, password );
+        Map<String,Object> authToken = newBasicAuthToken( username, password, source );
         return authManager.login( authToken );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.neo4j.server.security.auth.SecurityTestUtils.SOURCE;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
 public class AuthorizationFilterTest
@@ -174,7 +175,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
         when( servletRequest.getRemoteAddr() ).thenReturn( "remote_ip_address" );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
+        when( authManager.login( authToken( "foo", "bar", "remote_ip_address" ) ) ).thenReturn( securityContext );
         when( securityContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
@@ -203,6 +204,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/user/foo" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
+        when( servletRequest.getRemoteAddr() ).thenReturn( SOURCE );
         when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
         when( securityContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
@@ -228,6 +230,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getRequestURL() ).thenReturn( new StringBuffer( "http://bar.baz:7474/db/data/" ) );
         when( servletRequest.getRequestURI() ).thenReturn( "/db/data/" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
+        when( servletRequest.getRemoteAddr() ).thenReturn( SOURCE );
         when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
         when( securityContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
@@ -255,6 +258,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
+        when( servletRequest.getRemoteAddr() ).thenReturn( SOURCE );
         when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
         when( securityContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
@@ -281,6 +285,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
+        when( servletRequest.getRemoteAddr() ).thenReturn( SOURCE );
         when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
         when( securityContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -47,15 +47,14 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.server.security.auth.SecurityTestUtils;
 import org.neo4j.server.security.enterprise.auth.EmbeddedInteraction;
-import org.neo4j.server.security.enterprise.auth.EnterpriseAuthAndUserManager;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -338,7 +337,7 @@ public class QueryLoggerIT
                 .newGraphDatabase();
 
         EnterpriseAuthManager authManager = database.getDependencyResolver().resolveDependency( EnterpriseAuthManager.class );
-        EnterpriseSecurityContext neo = authManager.login( AuthToken.newBasicAuthToken( "neo4j", "neo4j" ) );
+        EnterpriseSecurityContext neo = authManager.login( SecurityTestUtils.authToken( "neo4j", "neo4j" ) );
 
         String query = "CALL dbms.security.changePassword('abc123')";
         try ( InternalTransaction tx = database

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -382,10 +382,12 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
 
         String username;
         String password;
+        String source;
         try
         {
             username = AuthToken.safeCast( AuthToken.PRINCIPAL, shiroAuthToken.getAuthTokenMap() );
             password = AuthToken.safeCast( AuthToken.CREDENTIALS, shiroAuthToken.getAuthTokenMap() );
+            source = AuthToken.safeCast( AuthToken.SOURCE, shiroAuthToken.getAuthTokenMap() );
         }
         catch ( InvalidAuthTokenException e )
         {
@@ -398,7 +400,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
             throw new UnknownAccountException();
         }
 
-        AuthenticationResult result = authenticationStrategy.authenticate( user, password );
+        AuthenticationResult result = authenticationStrategy.authenticate( user, password, source );
 
         switch ( result )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -54,6 +54,11 @@ public class ShiroAuthToken implements AuthenticationToken
         return authToken.get( AuthToken.CREDENTIALS );
     }
 
+    public Object getSource()
+    {
+        return authToken.get( AuthToken.SOURCE );
+    }
+
     public String getScheme() throws InvalidAuthTokenException
     {
         return AuthToken.safeCast( AuthToken.SCHEME_KEY, authToken );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -118,7 +118,7 @@ class BoltInteraction implements NeoInteractionLevel<BoltInteraction.BoltSubject
     public InternalTransaction beginLocalTransactionAsUser( BoltSubject subject, KernelTransaction.Type txType )
             throws Throwable
     {
-        SecurityContext securityContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
+        SecurityContext securityContext = authManager.login( newBasicAuthToken( subject.username, subject.password, "127.0.0.1" ) );
         return getLocalGraph().beginTransaction( txType, securityContext );
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.Strings.escape;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.neo4j.server.security.auth.SecurityTestUtils.SOURCE;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 import static org.neo4j.test.assertion.Assert.assertException;
 
@@ -429,7 +430,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTests
         final User user = newUser( "jake", "abc123", false );
         users.create( user );
         manager.start();
-        when( authStrategy.authenticate( user, "abc123" ) ).thenReturn( AuthenticationResult.SUCCESS );
+        setMockAuthenticationStrategyResult( "jake", "abc123", AuthenticationResult.SUCCESS );
 
         // When
         userManager.activateUser( "jake", false );
@@ -721,7 +722,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTests
     private void setMockAuthenticationStrategyResult( String username, String password, AuthenticationResult result )
     {
         final User user = users.getUserByName( username );
-        when( authStrategy.authenticate( user, password ) ).thenReturn( result );
+        when( authStrategy.authenticate( user, password, SOURCE ) ).thenReturn( result );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+import org.neo4j.server.security.auth.SecurityTestUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -38,22 +39,22 @@ public class ShiroAuthTokenTest
     @Test
     public void shouldSupportBasicAuthToken() throws Exception
     {
-        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD ) );
-        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, SecurityTestUtils.SOURCE ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME, SecurityTestUtils.SOURCE );
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
-                        AuthToken.BASIC_SCHEME ) ) );
+                        AuthToken.BASIC_SCHEME, AuthToken.SOURCE, SecurityTestUtils.SOURCE ) ) );
         testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
     }
 
     @Test
     public void shouldSupportBasicAuthTokenWithWildcardRealm() throws Exception
     {
-        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, "*" ) );
-        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, SecurityTestUtils.SOURCE, "*" ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME, SecurityTestUtils.SOURCE );
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
-                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "*" ) ) );
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "*", AuthToken.SOURCE, SecurityTestUtils.SOURCE ) ) );
         testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
     }
 
@@ -61,11 +62,11 @@ public class ShiroAuthTokenTest
     public void shouldSupportBasicAuthTokenWithSpecificRealm() throws Exception
     {
         String realm = "ldap";
-        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, realm ) );
-        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, SecurityTestUtils.SOURCE, realm ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME, SecurityTestUtils.SOURCE );
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
-                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap" ) ) );
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap", AuthToken.SOURCE, SecurityTestUtils.SOURCE ) ) );
         testTokenSupportsRealm( token, true, realm );
         testTokenSupportsRealm( token, false, "unknown", "native" );
     }
@@ -75,11 +76,11 @@ public class ShiroAuthTokenTest
     {
         String realm = "ldap";
         ShiroAuthToken token =
-                new ShiroAuthToken( AuthToken.newCustomAuthToken( USERNAME, PASSWORD, realm, AuthToken.BASIC_SCHEME ) );
-        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+                new ShiroAuthToken( AuthToken.newCustomAuthToken( USERNAME, PASSWORD, SecurityTestUtils.SOURCE, realm, AuthToken.BASIC_SCHEME ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME, SecurityTestUtils.SOURCE );
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
-                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap" ) ) );
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap", AuthToken.SOURCE, SecurityTestUtils.SOURCE ) ) );
         testTokenSupportsRealm( token, true, realm );
         testTokenSupportsRealm( token, false, "unknown", "native" );
     }
@@ -91,12 +92,12 @@ public class ShiroAuthTokenTest
         Map<String,Object> params = map( "a", "A", "b", "B" );
         ShiroAuthToken token =
                 new ShiroAuthToken(
-                        AuthToken.newCustomAuthToken( USERNAME, PASSWORD, realm, AuthToken.BASIC_SCHEME, params ) );
-        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+                        AuthToken.newCustomAuthToken( USERNAME, PASSWORD, SecurityTestUtils.SOURCE, realm, AuthToken.BASIC_SCHEME, params ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME, SecurityTestUtils.SOURCE );
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
                         AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "ldap",
-                        "parameters", params ) ) );
+                        "parameters", params, AuthToken.SOURCE, SecurityTestUtils.SOURCE ) ) );
         testTokenSupportsRealm( token, true, realm );
         testTokenSupportsRealm( token, false, "unknown", "native" );
     }
@@ -110,11 +111,12 @@ public class ShiroAuthTokenTest
         }
     }
 
-    private void testBasicAuthToken( ShiroAuthToken token, String username, String password, String scheme )
+    private void testBasicAuthToken( ShiroAuthToken token, String username, String password, String scheme, String source )
             throws InvalidAuthTokenException
     {
         assertThat( "Token should have basic scheme", token.getScheme(), equalTo( scheme ) );
         assertThat( "Token have correct principal", token.getPrincipal(), equalTo( username ) );
         assertThat( "Token have correct credentials", token.getCredentials(), equalTo( password ) );
+        assertThat( "Token should have correct source", token.getSource(), equalTo( source ) );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
@@ -74,6 +74,6 @@ public class BoltInitChangePasswordTest
     private Map<String,Object> authToken( String username, String password, String newPassword )
     {
         return map( "principal", username, "credentials", password,
-                "new_credentials", newPassword, "scheme", "basic" );
+                "new_credentials", newPassword, "scheme", "basic", "source", "127.0.0.1" );
     }
 }

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
@@ -40,7 +40,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -49,6 +48,7 @@ import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.server.security.auth.SecurityTestUtils;
 import org.neo4j.server.security.enterprise.auth.EnterpriseAuthAndUserManager;
 import org.neo4j.server.security.enterprise.auth.EnterpriseUserManager;
 import org.neo4j.server.security.enterprise.auth.NeoInteractionLevel;
@@ -61,7 +61,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.BoltConnector.EncryptionLevel.OPTIONAL;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
-import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 
 abstract class AbstractRESTInteraction extends CommunityServerTestBase implements NeoInteractionLevel<RESTSubject>
 {
@@ -125,7 +124,7 @@ abstract class AbstractRESTInteraction extends CommunityServerTestBase implement
     public InternalTransaction beginLocalTransactionAsUser( RESTSubject subject, KernelTransaction.Type txType )
             throws Throwable
     {
-        SecurityContext securityContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
+        SecurityContext securityContext = authManager.login( SecurityTestUtils.authToken( subject.username, subject.password ) );
         return getLocalGraph().beginTransaction( txType, securityContext );
     }
 

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -78,7 +78,7 @@ public class BoltFailuresIT
     public void throwsWhenWorkerCreationFails()
     {
         WorkerFactory workerFactory = mock( WorkerFactory.class );
-        when( workerFactory.newWorker( anyString(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
+        when( workerFactory.newWorker( anyString(), anyString(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
 
         BoltKernelExtension extension = new BoltKernelExtensionWithWorkerFactory( workerFactory );
 


### PR DESCRIPTION
Rate limit authentication attempts per source instead of per user.
This solved an issue where it was possible to lock out a user from the server, just by attempting to log in with wrong credentials.

changelog: Limit authentication requests depending on their originating source