### PR TITLE
Do not sort property ids from schema descriptors as part of PropertyE…

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -71,23 +71,31 @@ class PropertyExistenceEnforcer
         this.relationshipConstraints = rels;
         for ( LabelSchemaDescriptor constraint : nodes )
         {
-            update( mandatoryNodePropertiesByLabel, constraint.getLabelId(), constraint.getPropertyIds() );
+            update( mandatoryNodePropertiesByLabel, constraint.getLabelId(), copyIds( constraint.getPropertyIds() ) );
         }
         for ( RelationTypeSchemaDescriptor constraint : rels )
         {
-            update( mandatoryRelationshipPropertiesByType, constraint.getRelTypeId(), constraint.getPropertyIds() );
+            update( mandatoryRelationshipPropertiesByType, constraint.getRelTypeId(),
+                    copyIds( constraint.getPropertyIds() ) );
         }
     }
 
     private static void update( PrimitiveIntObjectMap<int[]> map, int key, int[] values )
     {
-        Arrays.sort( values );
         int[] current = map.get( key );
         if ( current != null )
         {
             values = union( current, values );
         }
         map.put( key, values );
+    }
+
+    private static int[] copyIds( int[] propertyIds )
+    {
+        int[] values = new int[propertyIds.length];
+        System.arraycopy( propertyIds, 0, values, 0, propertyIds.length );
+        Arrays.sort( values );
+        return values;
     }
 
     TxStateVisitor decorate( TxStateVisitor visitor, ReadableTransactionState txState, StoreReadLayer storeLayer )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcer.java
@@ -71,26 +71,27 @@ class PropertyExistenceEnforcer
         this.relationshipConstraints = rels;
         for ( LabelSchemaDescriptor constraint : nodes )
         {
-            update( mandatoryNodePropertiesByLabel, constraint.getLabelId(), copyIds( constraint.getPropertyIds() ) );
+            update( mandatoryNodePropertiesByLabel, constraint.getLabelId(),
+                    copyAndSortPropertyIds( constraint.getPropertyIds() ) );
         }
         for ( RelationTypeSchemaDescriptor constraint : rels )
         {
             update( mandatoryRelationshipPropertiesByType, constraint.getRelTypeId(),
-                    copyIds( constraint.getPropertyIds() ) );
+                    copyAndSortPropertyIds( constraint.getPropertyIds() ) );
         }
     }
 
-    private static void update( PrimitiveIntObjectMap<int[]> map, int key, int[] values )
+    private static void update( PrimitiveIntObjectMap<int[]> map, int key, int[] sortedValues )
     {
         int[] current = map.get( key );
         if ( current != null )
         {
-            values = union( current, values );
+            sortedValues = union( current, sortedValues );
         }
-        map.put( key, values );
+        map.put( key, sortedValues );
     }
 
-    private static int[] copyIds( int[] propertyIds )
+    private static int[] copyAndSortPropertyIds( int[] propertyIds )
     {
         int[] values = new int[propertyIds.length];
         System.arraycopy( propertyIds, 0, values, 0, propertyIds.length );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.enterprise;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptor;
+import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
+import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
+import org.neo4j.kernel.api.schema.constaints.RelExistenceConstraintDescriptor;
+import org.neo4j.kernel.api.schema.constaints.UniquenessConstraintDescriptor;
+import org.neo4j.storageengine.api.StoreReadLayer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+public class PropertyExistenceEnforcerTest
+{
+
+    @Test
+    public void constraintPropertyIdsNotUpdatedByConstraintEnforcer() throws Exception
+    {
+        UniquenessConstraintDescriptor uniquenessConstraint = ConstraintDescriptorFactory.uniqueForLabel( 1, 1, 70, 8 );
+        NodeKeyConstraintDescriptor nodeKeyConstraint = ConstraintDescriptorFactory.nodeKeyForLabel( 2, 12, 7, 13 );
+        RelExistenceConstraintDescriptor relTypeConstraint =
+                ConstraintDescriptorFactory.existsForRelType( 3, 5, 13, 8 );
+        List<ConstraintDescriptor> descriptors =
+                Arrays.asList( uniquenessConstraint, nodeKeyConstraint, relTypeConstraint );
+
+        StoreReadLayer storeReadLayer = prepareStoreReadLayerMock( descriptors );
+
+        PropertyExistenceEnforcer.getOrCreatePropertyExistenceEnforcerFrom( storeReadLayer );
+
+        assertArrayEquals( "Property ids should remain untouched.", new int[]{1, 70, 8},
+                uniquenessConstraint.schema().getPropertyIds() );
+        assertArrayEquals( "Property ids should remain untouched.", new int[]{12, 7, 13},
+                nodeKeyConstraint.schema().getPropertyIds() );
+        assertArrayEquals( "Property ids should remain untouched.", new int[]{5, 13, 8},
+                relTypeConstraint.schema().getPropertyIds() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private StoreReadLayer prepareStoreReadLayerMock( List<ConstraintDescriptor> descriptors )
+    {
+        StoreReadLayer storeReadLayer = Mockito.mock( StoreReadLayer.class );
+        when( storeReadLayer.constraintsGetAll() ).thenReturn( descriptors.iterator() );
+        when( storeReadLayer.getOrCreateSchemaDependantState( eq( PropertyExistenceEnforcer.class ),
+                any( Function.class) ) ).thenAnswer( invocation ->
+        {
+            Function<StoreReadLayer, PropertyExistenceEnforcer> function = invocation.getArgumentAt( 1, Function.class );
+            return function.apply( storeReadLayer );
+        } );
+        return storeReadLayer;
+    }
+}

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.consistency.ConsistencyCheckTool;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+import org.neo4j.test.rule.SuppressOutput;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+
+public class CompositeConstraintIT
+{
+
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
+
+    @Test
+    public void compositeNodeKeyConstraintUpdate() throws Exception
+    {
+        File storeDir = testDirectory.graphDbDir();
+        GraphDatabaseService database = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+
+        Label label = Label.label( "label" );
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node node = database.createNode( label );
+            node.setProperty( "b", (short) 3 );
+            node.setProperty( "a", new double[]{0.6, 0.4, 0.2} );
+            transaction.success();
+        }
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            String query =
+                    format( "CREATE CONSTRAINT ON (n:%s) ASSERT (n.%s,n.%s) IS NODE KEY", label.name(), "a", "b" );
+            database.execute( query );
+            transaction.success();
+        }
+
+        awaitIndex( database );
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node node = database.createNode( label );
+            node.setProperty( "a", (short) 7 );
+            node.setProperty( "b", new double[]{0.7, 0.5, 0.3} );
+            transaction.success();
+        }
+        database.shutdown();
+
+        ConsistencyCheckService.Result consistencyCheckResult = checkDbConsistency( storeDir );
+        assertTrue( "Database is consistent", consistencyCheckResult.isSuccessful() );
+    }
+
+    private static ConsistencyCheckService.Result checkDbConsistency( File storeDir )
+            throws ConsistencyCheckTool.ToolFailureException, IOException
+    {
+        return ConsistencyCheckTool.runConsistencyCheckTool( new String[]{storeDir.getAbsolutePath()} );
+    }
+
+    private static void awaitIndex( GraphDatabaseService database )
+    {
+        try ( Transaction tx = database.beginTx() )
+        {
+            database.schema().awaitIndexesOnline( 2, TimeUnit.MINUTES );
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
…xistenceEnforcer creation.

Avoid sorting of property ids as part of enforcer creation since that will change
property ids order in index descriptor, descriptors hashcode that as a result can cause
incorrect index updates, inability to find an index with correct descriptor etc.