### PR TITLE
Fixes race between starting transaction and shutdown

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.rule;
+
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.function.Supplier;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+/**
+ * Very often when you want a {@link PageCacheRule} you also want {@link TestDirectory} and some {@link FileSystemRule}.
+ * This is tedious to write and apply in the correct order in every test doing this. This rule collects
+ * this threesome into one rule for convenience.
+ */
+public class PageCacheAndDependenciesRule implements TestRule
+{
+    private final RuleChain chain;
+    private final FileSystemRule<? extends FileSystemAbstraction> fs;
+    private final TestDirectory directory;
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    public PageCacheAndDependenciesRule()
+    {
+        this( () -> new EphemeralFileSystemRule() );
+    }
+
+    /**
+     * @param fsSupplier as {@link Supplier} to make it clear that it is this class that owns the created
+     * {@link FileSystemRule} instance.
+     */
+    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier )
+    {
+        this.fs = fsSupplier.get();
+        this.directory = TestDirectory.testDirectory( fs );
+        this.chain = RuleChain.outerRule( fs ).around( directory ).around( pageCacheRule );
+    }
+
+    @Override
+    public Statement apply( Statement base, Description description )
+    {
+        return chain.apply( base, description );
+    }
+
+    public FileSystemRule<? extends FileSystemAbstraction> fileSystemRule()
+    {
+        return fs;
+    }
+
+    public FileSystemAbstraction fileSystem()
+    {
+        return fs.get();
+    }
+
+    public TestDirectory directory()
+    {
+        return directory;
+    }
+
+    public PageCacheRule pageCacheRule()
+    {
+        return pageCacheRule;
+    }
+
+    public PageCache pageCache()
+    {
+        return pageCacheRule.getPageCache( fs );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -21,13 +21,14 @@ package org.neo4j.kernel;
 
 import java.time.Clock;
 
+import org.neo4j.kernel.AvailabilityGuard.AvailabilityRequirement;
 import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.time.Clocks;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
-import static org.neo4j.kernel.AvailabilityGuard.AvailabilityRequirement;
+
 import static org.neo4j.kernel.AvailabilityGuard.availabilityRequirement;
 
 /**
@@ -92,6 +93,6 @@ public class DatabaseAvailability implements Lifecycle
     public void shutdown()
             throws Throwable
     {
-        // TODO: Starting database. Make sure none can access it through lock or CAS
+        availabilityGuard.shutdown();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -93,6 +93,5 @@ public class DatabaseAvailability implements Lifecycle
     public void shutdown()
             throws Throwable
     {
-        availabilityGuard.shutdown();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -741,7 +741,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 availabilityGuard, tracers, storageEngine, procedures, transactionIdStore, clock, accessCapability ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, databaseHealth, transactionMonitor, procedures,
-                config );
+                config, availabilityGuard );
 
         kernel.registerTransactionHook( transactionEventHandlers );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -20,10 +20,13 @@
 package org.neo4j.kernel.impl.api;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.AvailabilityGuard.UnavailableException;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.TransactionHook;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction;
@@ -64,17 +67,22 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     private final DatabaseHealth health;
     private final TransactionMonitor transactionMonitor;
     private final Procedures procedures;
+    private final AvailabilityGuard availabilityGuard;
     private final long defaultTransactionTimeout;
+    private final long transactionStartTimeout;
 
     public Kernel( KernelTransactions transactionFactory, TransactionHooks hooks, DatabaseHealth health,
-            TransactionMonitor transactionMonitor, Procedures procedures, Config config )
+            TransactionMonitor transactionMonitor, Procedures procedures, Config config,
+            AvailabilityGuard availabilityGuard )
     {
         this.transactions = transactionFactory;
         this.hooks = hooks;
         this.health = health;
         this.transactionMonitor = transactionMonitor;
         this.procedures = procedures;
+        this.availabilityGuard = availabilityGuard;
         this.defaultTransactionTimeout = config.get( GraphDatabaseSettings.transaction_timeout ).toMillis();
+        this.transactionStartTimeout = config.get( GraphDatabaseSettings.transaction_start_timeout ).toMillis();
     }
 
     @Override
@@ -88,9 +96,21 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
             TransactionFailureException
     {
         health.assertHealthy( TransactionFailureException.class );
-        KernelTransaction transaction = transactions.newInstance( type, securityContext, timeout );
+
+        // Increment transaction monitor before checking the availability guard (which needs to be checked
+        // before starting the transaction). This is because the DatabaseAvailability does this in the other
+        // order, where it closes the availability guard and then awaits started transactions to finish.
         transactionMonitor.transactionStarted();
-        return transaction;
+        try
+        {
+            availabilityGuard.await( transactionStartTimeout );
+        }
+        catch ( UnavailableException e )
+        {
+            transactionMonitor.transactionFinished( false, false );
+            throw new TransactionFailureException( Status.Transaction.TransactionStartFailed, e, e.getMessage() );
+        }
+        return transactions.newInstance( type, securityContext, timeout );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 import org.neo4j.collection.pool.LinkedQueuePool;
 import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
-import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -301,10 +300,6 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
 
     private void assertRunning()
     {
-        if ( availabilityGuard.isShutdown() )
-        {
-            throw new DatabaseShutdownException();
-        }
         if ( stopped )
         {
             throw new IllegalStateException( "Can't start new transaction with stopped " + getClass() );
@@ -322,7 +317,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
 
     private class KernelTransactionImplementationFactory implements Factory<KernelTransactionImplementation>
     {
-        private Set<KernelTransactionImplementation> transactions;
+        private final Set<KernelTransactionImplementation> transactions;
 
         KernelTransactionImplementationFactory( Set<KernelTransactionImplementation> transactions )
         {
@@ -345,7 +340,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
 
     private class GlobalKernelTransactionPool extends LinkedQueuePool<KernelTransactionImplementation>
     {
-        private Set<KernelTransactionImplementation> transactions;
+        private final Set<KernelTransactionImplementation> transactions;
 
         GlobalKernelTransactionPool( Set<KernelTransactionImplementation> transactions,
                 Factory<KernelTransactionImplementation> factory )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import org.neo4j.collection.pool.LinkedQueuePool;
 import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
+import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -300,6 +301,10 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
 
     private void assertRunning()
     {
+        if ( availabilityGuard.isShutdown() )
+        {
+            throw new DatabaseShutdownException();
+        }
         if ( stopped )
         {
             throw new IllegalStateException( "Can't start new transaction with stopped " + getClass() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
@@ -50,11 +50,16 @@ public class CoreAPIAvailabilityGuard
         }
         catch ( AvailabilityGuard.UnavailableException e )
         {
-            if ( guard.isShutdown() )
-            {
-                throw new DatabaseShutdownException();
-            }
-            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage() );
+            throw convertUnavailabilityException( e );
         }
+    }
+
+    public RuntimeException convertUnavailabilityException( Exception e )
+    {
+        if ( guard.isShutdown() )
+        {
+            return new DatabaseShutdownException();
+        }
+        return new org.neo4j.graphdb.TransactionFailureException( e.getMessage(), e );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -155,7 +155,6 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
         try
         {
             msgLog.log( "Shutdown started" );
-            platform.availabilityGuard.shutdown();
             platform.life.shutdown();
         }
         catch ( LifecycleException throwable )
@@ -170,7 +169,6 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     {
         try
         {
-            availability.assertDatabaseAvailable();
             KernelTransaction kernelTx = dataSource.kernelAPI.get().newTransaction( type, securityContext, timeout );
             kernelTx.registerCloseListener(
                     (txId) -> dataSource.threadToTransactionBridge.unbindTransactionFromCurrentThread() );
@@ -179,7 +177,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
         }
         catch ( TransactionFailureException e )
         {
-            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage(), e );
+            throw availability.convertUnavailabilityException( e );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -154,6 +154,7 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     {
         try
         {
+            platform.availabilityGuard.shutdown();
             msgLog.log( "Shutdown started" );
             platform.life.shutdown();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -105,6 +105,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.storageengine.api.EntityType;
 
 import static java.lang.String.format;
+
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
 import static org.neo4j.helpers.collection.Iterators.emptyIterator;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -183,8 +183,7 @@ public class PlatformModule
         // Anyways please fix this.
         dependencies.satisfyDependency( dataSourceManager );
 
-        availabilityGuard = dependencies.satisfyDependency(
-                new AvailabilityGuard( clock, logging.getInternalLog( AvailabilityGuard.class ) ) );
+        availabilityGuard = dependencies.satisfyDependency( createAvailabilityGuard() );
 
         transactionMonitor = dependencies.satisfyDependency( createTransactionStats() );
 
@@ -198,6 +197,11 @@ public class PlatformModule
         dependencies.satisfyDependency( storeCopyCheckPointMutex );
 
         publishPlatformInfo( dependencies.resolveDependency( UsageData.class ) );
+    }
+
+    protected AvailabilityGuard createAvailabilityGuard()
+    {
+        return new AvailabilityGuard( clock, logging.getInternalLog( AvailabilityGuard.class ) );
     }
 
     protected SystemNanoClock createClock()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -186,7 +186,6 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
     {
         try
         {
-            availability.assertDatabaseAvailable();
             KernelTransaction kernelTx = sourceModule.kernelAPI.get().newTransaction( type, this.securityContext, timeout );
             kernelTx.registerCloseListener(
                     ( txId ) -> sourceModule.threadToTransactionBridge.unbindTransactionFromCurrentThread() );
@@ -195,7 +194,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
         }
         catch ( TransactionFailureException e )
         {
-            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage(), e );
+            throw availability.convertUnavailabilityException( e );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfiguration
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.AssertableLogProvider;
@@ -48,7 +49,6 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -86,9 +86,11 @@ public class NeoStoreDataSourceTest
         {
             DatabaseHealth databaseHealth = new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
                     NullLogProvider.getInstance().getLog( DatabaseHealth.class ) );
+            Dependencies dependencies = new Dependencies();
+            dependencies.satisfyDependency( databaseHealth );
 
             theDataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCacheRule.getPageCache( fs.get() ),
-                    stringMap(), databaseHealth );
+                    dependencies );
 
             databaseHealth.panic( new Throwable() );
 
@@ -110,7 +112,7 @@ public class NeoStoreDataSourceTest
     public void flushOfThePageCacheHappensOnlyOnceDuringShutdown() throws IOException
     {
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap() );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache );
 
         ds.init();
         ds.start();
@@ -125,12 +127,9 @@ public class NeoStoreDataSourceTest
     @Test
     public void flushOfThePageCacheOnShutdownHappensIfTheDbIsHealthy() throws IOException
     {
-        DatabaseHealth health = mock( DatabaseHealth.class );
-        when( health.isHealthy() ).thenReturn( true );
-
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
 
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap(), health );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache );
 
         ds.init();
         ds.start();
@@ -146,10 +145,11 @@ public class NeoStoreDataSourceTest
     {
         DatabaseHealth health = mock( DatabaseHealth.class );
         when( health.isHealthy() ).thenReturn( false );
-
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
 
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap(), health );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependency( health );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, dependencies );
 
         ds.init();
         ds.start();
@@ -224,10 +224,11 @@ public class NeoStoreDataSourceTest
         AssertableLogProvider logProvider = new AssertableLogProvider();
         SimpleLogService logService = new SimpleLogService( logProvider, logProvider );
         PageCache pageCache = pageCacheRule.getPageCache( fs.get() );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependencies( idGeneratorFactory, idTypeConfigurationProvider, config, logService );
 
-        NeoStoreDataSource dataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(), idGeneratorFactory,
-                idTypeConfigurationProvider,
-                pageCache, config, mock( DatabaseHealth.class ), logService );
+        NeoStoreDataSource dataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(),
+                pageCache, dependencies );
 
         try
         {
@@ -256,7 +257,9 @@ public class NeoStoreDataSourceTest
         IOException ex = new IOException( "boom!" );
         doThrow( ex ).when( databaseHealth )
                 .assertHealthy( IOException.class ); // <- this is a trick to simulate a failure during checkpointing
-        NeoStoreDataSource dataSource = dsRule.getDataSource( storeDir, fs, pageCache, emptyMap(), databaseHealth );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependencies( databaseHealth );
+        NeoStoreDataSource dataSource = dsRule.getDataSource( storeDir, fs, pageCache, dependencies );
         dataSource.start();
 
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
@@ -19,13 +19,21 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.mockito.InOrder;
 
 import java.io.File;
+import java.time.Clock;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.configuration.Config;
@@ -36,16 +44,34 @@ import org.neo4j.kernel.impl.factory.EditionModule;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.NullLog;
 import org.neo4j.test.ImpermanentGraphDatabase;
-
+import org.neo4j.test.rule.NeoStoreDataSourceRule;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
+import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.kernel.api.KernelTransaction.Type.explicit;
 
 public class KernelTest
 {
+    private final PageCacheAndDependenciesRule pageCacheRule = new PageCacheAndDependenciesRule();
+    private final NeoStoreDataSourceRule neoStoreRule = new NeoStoreDataSourceRule();
+
+    @Rule
+    public final RuleChain rules = RuleChain.outerRule( pageCacheRule ).around( neoStoreRule );
+
     @Test
     public void shouldNotAllowCreationOfConstraintsWhenInHA() throws Exception
     {
@@ -72,6 +98,29 @@ public class KernelTest
         db.shutdown();
     }
 
+    @Test
+    public void shouldIncrementTransactionMonitorBeforeCheckingDatabaseAvailability() throws Exception
+    {
+        // GIVEN
+        AvailabilityGuard availabilityGuard = spy( new AvailabilityGuard( Clock.systemUTC(), NullLog.getInstance() ) );
+        TransactionMonitor transactionMonitor = mock( TransactionMonitor.class );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependencies( availabilityGuard, transactionMonitor );
+        NeoStoreDataSource dataSource = neoStoreRule.getDataSource( pageCacheRule.directory().absolutePath(),
+                pageCacheRule.fileSystem(), pageCacheRule.pageCache(), dependencies );
+        dataSource.start();
+        KernelAPI kernel = dataSource.getKernel();
+
+        // WHEN
+        try ( KernelTransaction tx = kernel.newTransaction( explicit, AUTH_DISABLED ) )
+        {
+            // THEN
+            InOrder order = inOrder( transactionMonitor, availabilityGuard );
+            order.verify( transactionMonitor, times( 1 ) ).transactionStarted();
+            order.verify( availabilityGuard, times( 1 ) ).await( anyLong() );
+        }
+    }
+
     @SuppressWarnings("deprecation")
     class FakeHaDatabase extends ImpermanentGraphDatabase
     {
@@ -96,8 +145,8 @@ public class KernelTest
             new GraphDatabaseFacadeFactory( DatabaseInfo.COMMUNITY,  factory )
             {
                 @Override
-                protected PlatformModule createPlatform( File storeDir, Config config, Dependencies dependencies,
-                        GraphDatabaseFacade graphDatabaseFacade )
+                protected PlatformModule createPlatform( File storeDir, Config config,
+                        GraphDatabaseFacadeFactory.Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
                 {
                     return new ImpermanentPlatformModule( storeDir, config, databaseInfo, dependencies,
                             graphDatabaseFacade );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.security.AuthorizationExpiredException;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -73,8 +72,6 @@ import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.Race;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -94,6 +91,10 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.kernel.api.KernelTransaction.Type.explicit;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
@@ -410,15 +411,22 @@ public class KernelTransactionsTest
     }
 
     @Test
-    public void exceptionWhenStartingNewTransactionOnShutdownInstance() throws Throwable
+    public void shouldStartNewTransactionAfterGuardMarkedAsShutdown() throws Throwable
     {
+        // This is because the first thing thast happens when shutting down is that AvailabilityGuard gets
+        // marked as shut down. After that, transactions that just made it passed some layers in db.beginTx()
+        // or similar will have time to complete (other parts of shutdown will take care of that).
+
         KernelTransactions kernelTransactions = newKernelTransactions();
         SecurityContext securityContext = mock( SecurityContext.class );
 
         availabilityGuard.shutdown();
 
-        expectedException.expect( DatabaseShutdownException.class );
-        kernelTransactions.newInstance( KernelTransaction.Type.explicit, securityContext, 0L );
+        try ( KernelTransaction transaction =
+                kernelTransactions.newInstance( KernelTransaction.Type.explicit, securityContext, 0L ) )
+        {
+            assertNotNull( transaction );
+        }
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionCompletionAndShutdownRaceIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionCompletionAndShutdownRaceIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.DatabaseAvailability;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.logging.NullLog;
+import org.neo4j.test.Barrier;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactoryState;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.concurrent.OtherThreadRule;
+
+import static org.junit.Assert.assertNotNull;
+
+import static org.neo4j.helpers.collection.Iterables.single;
+
+/**
+ * In its essence this test is about a race in mainly {@link DatabaseAvailability} and
+ * {@link TransactionMonitor#transactionStarted()} where a transaction thread (starting the transaction)
+ * would race with shutdown ({@link DatabaseAvailability#stop()}) where a transaction would get passed
+ * the availability check, the shutdown would think that no transactions were running and start the shutdown,
+ * leaving the transaction executing straight in the middle of dead or dying components.
+ *
+ * This will still be the case for transactions that live longer than the shutdown timeout in
+ * {@link DatabaseAvailability#stop()}, but at least that's deterministic and configurable.
+ */
+public class TransactionCompletionAndShutdownRaceIT
+{
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory();
+    @Rule
+    public final OtherThreadRule<Void> transactor = new OtherThreadRule<>( "Transactor" );
+    @Rule
+    public final OtherThreadRule<Void> shutter = new OtherThreadRule<>( "Shutter" );
+
+    @Test
+    public void shouldAlwaysAwaitTransactionCompletionBeforeShuttingDown() throws Exception
+    {
+        // GIVEN
+        Barrier.Control barrier = new Barrier.Control();
+        AtomicBoolean barrierInstalled = new AtomicBoolean();
+        File storeDir = directory.absolutePath();
+        TestGraphDatabaseFactory dbFactory =
+                dbFactoryWithBarrierControlledTransactionStats( barrier, barrierInstalled );
+
+        {
+            GraphDatabaseService db = dbFactory.newImpermanentDatabase( storeDir );
+            barrierInstalled.set( true );
+
+            // WHEN
+            Future<Object> transactionFuture = transactor.execute( state -> doTransaction( db ) );
+            Future<Object> shutterFuture = shutter.execute( state -> doShutdown( db, barrier ) );
+
+            // THEN
+            shutterFuture.get();
+            transactionFuture.get();
+            barrierInstalled.set( false );
+        }
+
+        // Now assert that the node was created
+        GraphDatabaseService db = dbFactory.newImpermanentDatabase( storeDir );
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = single( db.getAllNodes() );
+            assertNotNull( node );
+            tx.success();
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private TestGraphDatabaseFactory dbFactoryWithBarrierControlledTransactionStats( Barrier.Control barrier,
+            AtomicBoolean barrierInstaller )
+    {
+        return new TestGraphDatabaseFactory()
+        {
+            @Override
+            protected GraphDatabaseFacadeFactory newTestGraphDatabaseFacadeFactory(
+                    File storeDir, Config config, TestGraphDatabaseFactoryState state )
+            {
+                return new TestGraphDatabaseFacadeFactory( state, true )
+                {
+                    @Override
+                    protected PlatformModule createPlatform( File storeDir, Config config, Dependencies dependencies,
+                            GraphDatabaseFacade graphDatabaseFacade )
+                    {
+                        return new TestGraphDatabaseFacadeFactory.TestDatabasePlatformModule(
+                                storeDir, config, databaseInfo, dependencies, graphDatabaseFacade )
+                        {
+                            @Override
+                            protected AvailabilityGuard createAvailabilityGuard()
+                            {
+                                return new AvailabilityGuard( clock, NullLog.getInstance() )
+                                {
+                                    @Override
+                                    public void require( AvailabilityRequirement requirement )
+                                    {
+                                        super.require( requirement );
+                                        if ( barrierInstaller.get() )
+                                        {
+                                            barrier.release();
+                                        }
+                                    }
+
+                                    @Override
+                                    public void await( long millis ) throws UnavailableException
+                                    {
+                                        super.await( millis );
+                                        if ( barrierInstaller.get() )
+                                        {
+                                            barrier.reached();
+                                        }
+                                    }
+                                };
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+
+    private Object doShutdown( GraphDatabaseService db, Barrier.Control barrier )
+    {
+        barrier.awaitUninterruptibly();
+        db.shutdown();
+        return null;
+    }
+
+    private Object doTransaction( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        return null;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -74,6 +74,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.kernel.impl.transaction.state.TransactionRecordState.PropertyReceiver;
 import org.neo4j.kernel.impl.util.ArrayMap;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -867,7 +868,9 @@ public class NeoStoresTest
 
     private void initializeStores( File storeDir, Map<String,String> additionalConfig ) throws IOException
     {
-        ds = dsRule.getDataSource( storeDir, fs.get(), pageCache, additionalConfig );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependency( Config.embeddedDefaults( additionalConfig ) );
+        ds = dsRule.getDataSource( storeDir, fs.get(), pageCache, dependencies );
         ds.init();
         ds.start();
 

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
+
 import javax.annotation.Nonnull;
 
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -204,7 +205,6 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
     protected GraphDatabaseBuilder.DatabaseCreator createImpermanentDatabaseCreator( final File storeDir,
             final TestGraphDatabaseFactoryState state )
     {
-
         return new GraphDatabaseBuilder.DatabaseCreator()
         {
             @Override
@@ -216,23 +216,29 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
             @Override
             public GraphDatabaseService newDatabase( @Nonnull Config config )
             {
-                return new TestGraphDatabaseFacadeFactory( state, true ).newFacade( storeDir, config,
+                return newTestGraphDatabaseFacadeFactory( storeDir, config, state ).newFacade( storeDir, config,
                         GraphDatabaseDependencies.newDependencies( state.databaseDependencies() ) );
             }
         };
     }
 
-    static class TestGraphDatabaseFacadeFactory extends GraphDatabaseFacadeFactory
+    protected GraphDatabaseFacadeFactory newTestGraphDatabaseFacadeFactory( File storeDir,
+            Config config, TestGraphDatabaseFactoryState state )
+    {
+        return new TestGraphDatabaseFacadeFactory( state, true );
+    }
+
+    protected static class TestGraphDatabaseFacadeFactory extends GraphDatabaseFacadeFactory
     {
         private final TestGraphDatabaseFactoryState state;
         private final boolean impermanent;
 
-        TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state, boolean impermanent )
+        protected TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state, boolean impermanent )
         {
             this( state, impermanent, DatabaseInfo.COMMUNITY, CommunityEditionModule::new );
         }
 
-        TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state, boolean impermanent,
+        protected TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state, boolean impermanent,
                 DatabaseInfo databaseInfo, Function<PlatformModule,EditionModule> editionFactory )
         {
             super(databaseInfo, editionFactory);
@@ -240,7 +246,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
             this.impermanent = impermanent;
         }
 
-        TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state )
+        protected TestGraphDatabaseFacadeFactory( TestGraphDatabaseFactoryState state )
         {
             this(state, false);
         }
@@ -252,15 +258,14 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
             return impermanent ?
                    new ImpermanentTestDatabasePlatformModule( storeDir, config.with( stringMap( ephemeral.name(), TRUE ) ),
                            dependencies, graphDatabaseFacade, this.databaseInfo ) :
-                   new TestDatabasePlatformModule( storeDir, config, dependencies, graphDatabaseFacade, this
-                           .databaseInfo );
+                   new TestDatabasePlatformModule( storeDir, config, this
+                           .databaseInfo, dependencies, graphDatabaseFacade );
         }
 
-        class TestDatabasePlatformModule extends PlatformModule
+        protected class TestDatabasePlatformModule extends PlatformModule
         {
-
-            TestDatabasePlatformModule( File storeDir, Config config, Dependencies dependencies,
-                    GraphDatabaseFacade graphDatabaseFacade, DatabaseInfo databaseInfo )
+            protected TestDatabasePlatformModule( File storeDir, Config config, DatabaseInfo databaseInfo,
+                    Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
             {
                 super( storeDir, config, databaseInfo, dependencies,
                         graphDatabaseFacade );
@@ -307,7 +312,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
             ImpermanentTestDatabasePlatformModule( File storeDir, Config config,
                     Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade, DatabaseInfo databaseInfo )
             {
-                super( storeDir, config, dependencies, graphDatabaseFacade, databaseInfo );
+                super( storeDir, config, databaseInfo, dependencies, graphDatabaseFacade );
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -20,8 +20,7 @@
 package org.neo4j.test.rule;
 
 import java.io.File;
-import java.util.Map;
-
+import java.util.function.Function;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -51,6 +50,7 @@ import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.logging.SimpleLogService;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.spi.SimpleKernelContext;
@@ -61,11 +61,13 @@ import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfiguration
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.internal.TransactionEventHandlers;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -84,36 +86,15 @@ public class NeoStoreDataSourceRule extends ExternalResource
 {
     private NeoStoreDataSource dataSource;
 
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            PageCache pageCache, Map<String,String> additionalConfig, DatabaseHealth databaseHealth )
+    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs, PageCache pageCache )
     {
-        CommunityIdTypeConfigurationProvider idTypeConfigurationProvider =
-                new CommunityIdTypeConfigurationProvider();
-        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
-        NullLogService logService = NullLogService.getInstance();
-        return getDataSource( storeDir, fs, idGeneratorFactory, idTypeConfigurationProvider, pageCache,
-                additionalConfig, databaseHealth, logService );
+        return getDataSource( storeDir, fs, pageCache, new Dependencies() );
     }
 
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            IdGeneratorFactory idGeneratorFactory, IdTypeConfigurationProvider idConfigurationProvider,
-            PageCache pageCache, Map<String, String> additionalConfig, DatabaseHealth databaseHealth,
-            LogService logService )
+    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs, PageCache pageCache,
+            DependencyResolver otherCustomOverriddenDependencies )
     {
-        return getDataSource( storeDir, fs, idGeneratorFactory, idConfigurationProvider, pageCache,
-                Config.embeddedDefaults( additionalConfig ), databaseHealth, logService );
-    }
-
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            IdGeneratorFactory idGeneratorFactory, IdTypeConfigurationProvider idConfigurationProvider,
-            PageCache pageCache, Config config, DatabaseHealth databaseHealth,
-            LogService logService )
-    {
-        if ( dataSource != null )
-        {
-            dataSource.stop();
-            dataSource.shutdown();
-        }
+        shutdownAnyRunning();
 
         StatementLocksFactory locksFactory = mock( StatementLocksFactory.class );
         StatementLocks statementLocks = mock( StatementLocks.class );
@@ -124,16 +105,34 @@ public class NeoStoreDataSourceRule extends ExternalResource
 
         JobScheduler jobScheduler = mock( JobScheduler.class, RETURNS_MOCKS );
         Monitors monitors = new Monitors();
+
+        Dependencies mutableDependencies = new Dependencies( otherCustomOverriddenDependencies );
+        Config config = dependency( mutableDependencies, Config.class, deps -> Config.empty() );
+        LogService logService = dependency( mutableDependencies, LogService.class,
+                deps -> new SimpleLogService( NullLogProvider.getInstance(), NullLogProvider.getInstance() ) );
+        IdGeneratorFactory idGeneratorFactory = dependency( mutableDependencies, IdGeneratorFactory.class,
+                deps -> new DefaultIdGeneratorFactory( fs ) );
+        IdTypeConfigurationProvider idConfigurationProvider = dependency( mutableDependencies,
+                IdTypeConfigurationProvider.class, deps -> new CommunityIdTypeConfigurationProvider() );
+        DatabaseHealth databaseHealth = dependency( mutableDependencies, DatabaseHealth.class,
+                deps -> new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
+                        NullLogProvider.getInstance().getLog( DatabaseHealth.class ) ) );
+        SystemNanoClock clock = dependency( mutableDependencies, SystemNanoClock.class, deps -> Clocks.nanoClock() );
+        TransactionMonitor transactionMonitor =
+                dependency( mutableDependencies, TransactionMonitor.class, deps -> new TransactionStats() );
+        AvailabilityGuard availabilityGuard = dependency( mutableDependencies, AvailabilityGuard.class,
+                deps -> new AvailabilityGuard( deps.resolveDependency( SystemNanoClock.class ),
+                        NullLog.getInstance() ) );
+
         LabelScanStoreProvider labelScanStoreProvider =
                 nativeLabelScanStoreProvider( storeDir, fs, pageCache, config, logService, monitors );
-        SystemNanoClock clock = Clocks.nanoClock();
         dataSource = new NeoStoreDataSource( storeDir, config, idGeneratorFactory, IdReuseEligibility.ALWAYS,
                 idConfigurationProvider,
                 logService, mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider( labelScanStoreProvider ), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locksFactory,
                 mock( SchemaWriteGuard.class ), mock( TransactionEventHandlers.class ), IndexingService.NO_MONITOR,
-                fs, mock( TransactionMonitor.class ), databaseHealth,
+                fs, transactionMonitor, databaseHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), null,
                 new CommunityCommitProcessFactory(), mock( InternalAutoIndexing.class ), pageCache,
@@ -141,10 +140,38 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
                 IOLimiter.unlimited(),
-                new AvailabilityGuard( clock, NullLog.getInstance() ), clock,
+                availabilityGuard, clock,
                 new CanWrite(), new StoreCopyCheckPointMutex() );
 
         return dataSource;
+    }
+
+    private <T> T dependency( Dependencies dependencies, Class<T> type,
+            Function<DependencyResolver,T> defaultSupplier )
+    {
+        try
+        {
+            return dependencies.resolveDependency( type );
+        }
+        catch ( IllegalArgumentException | UnsatisfiedDependencyException e )
+        {
+            return dependencies.satisfyDependency( defaultSupplier.apply( dependencies ) );
+        }
+    }
+
+    private void shutdownAnyRunning()
+    {
+        if ( dataSource != null )
+        {
+            dataSource.stop();
+            dataSource.shutdown();
+        }
+    }
+
+    @Override
+    protected void after( boolean successful ) throws Throwable
+    {
+        shutdownAnyRunning();
     }
 
     public static LabelScanStoreProvider nativeLabelScanStoreProvider( File storeDir, FileSystemAbstraction fs,
@@ -171,14 +198,6 @@ public class NeoStoreDataSourceRule extends ExternalResource
         {
             throw launderedException( e );
         }
-    }
-
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            PageCache pageCache, Map<String,String> additionalConfig )
-    {
-        DatabaseHealth databaseHealth = new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
-                NullLogProvider.getInstance().getLog( DatabaseHealth.class ) );
-        return getDataSource( storeDir, fs, pageCache, additionalConfig, databaseHealth );
     }
 
     private DependencyResolver dependencyResolverForNoIndexProvider( LabelScanStoreProvider labelScanStoreProvider )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -55,7 +55,6 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
@@ -156,7 +155,7 @@ public class TransactionLogCatchUpWriterTest
     {
         // create an empty store
         org.neo4j.kernel.impl.store.StoreId storeId;
-        NeoStoreDataSource ds = dsRule.getDataSource( storeDir, fs, pageCache, emptyMap() );
+        NeoStoreDataSource ds = dsRule.getDataSource( storeDir, fs, pageCache );
         try ( Lifespan ignored = new Lifespan( ds ) )
         {
             storeId = ds.getStoreId();


### PR DESCRIPTION
This was designed to work already, but there was a slight gap in that
armor. DatabaseAvailability is the among last components to register in
the database lifecycle and therefore one of the first to be stopped.
Stopping DatabaseAvailability will raise the availability guard and then
await all active transactions to be finished (with some configurable
timeout). Starting transactions also checked the availability guard
state and registered themselves as active.

The problem was that the active state wasn't registered until after the
availability guard had been checked and so this little window between
those calls was racing with that same window in DatabaseAvailability
potentially allowing a transaction to start without being aware that
database was shutting down and shutdown process being unaware of an
active transaction running concurrently. This could result in
unspecified exceptions being thrown due to transaction running inside
components which were shutting down or even had been shut down.

This commit tightens this gap by letting transaction starting register
itself as active before checking availability guard. This way
transactions starting concurrently with shutdown will deterministically
succeed or fail, all depending on whether they made it in before the
availability guard was raised for shutdown.

This still leaves the max timeout that DatabaseAvailability waits before
going ahead with the shut down anyway. But that is by default a timeout
reasonable for most setups and it's configurable.