### PR TITLE
Backport to 3.1: Allow HeapSize to be set for neo4j-admin commands via env-variable

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -50,6 +50,8 @@ public class Usage
         output.accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         output.accept( "    NEO4J_HOME    Neo4j home directory." );
         output.accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
+        output.accept( "    HEAP_SIZE     Set size of JVM heap during command execution." );
+        output.accept( "                  Takes a number and a unit, for example 512m." );
         output.accept( "" );
         output.accept( "available commands:" );
         printCommandsUnderASegment( output );

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -44,6 +44,13 @@ public class Usage
     {
         output.accept( format( "usage: %s <command>", scriptName ) );
         output.accept( "" );
+        output.accept( "Manage your Neo4j instance." );
+        output.accept( "" );
+        output.accept( "environment variables:" );
+        output.accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
+        output.accept( "    NEO4J_HOME    Neo4j home directory." );
+        output.accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
+        output.accept( "" );
         output.accept( "available commands:" );
         printCommandsUnderASegment( output );
         output.accept( "" );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -94,6 +94,50 @@ public class HelpCommandTest
         }
     }
 
+    @Test
+    public void testAdminUsage() throws Exception
+    {
+        CommandLocator commandLocator = mock( CommandLocator.class );
+        ArrayList<AdminCommand.Provider> mockCommands = new ArrayList<AdminCommand.Provider>()
+        {{
+            add( mockCommand( "foo" ) );
+            add( mockCommand( "bar" ) );
+            add( mockCommand( "baz" ) );
+        }};
+        when( commandLocator.getAllProviders() ).thenReturn( mockCommands );
+
+        try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
+        {
+            PrintStream ps = new PrintStream( baos );
+
+            Usage usage = new Usage( "neo4j-admin", commandLocator );
+
+            HelpCommand helpCommand = new HelpCommand( usage, ps::println, commandLocator );
+
+            helpCommand.execute();
+
+            assertEquals( String.format( "usage: neo4j-admin <command>%n" +
+                            "%n" +
+                            "Manage your Neo4j instance.%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "%n" +
+                            "available commands:%n" +
+                            "    foo%n" +
+                            "        null%n" +
+                            "    bar%n" +
+                            "        null%n" +
+                            "    baz%n" +
+                            "        null%n" +
+                            "%n" +
+                            "Use neo4j-admin help <command> for more details.%n" ),
+                    baos.toString() );
+        }
+    }
+
     private AdminCommand.Provider mockCommand( String name )
     {
         AdminCommand.Provider commandProvider = mock( AdminCommand.Provider.class );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -124,13 +124,15 @@ public class HelpCommandTest
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "available commands:%n" +
-                            "    foo%n" +
-                            "        null%n" +
                             "    bar%n" +
                             "        null%n" +
                             "    baz%n" +
+                            "        null%n" +
+                            "    foo%n" +
                             "        null%n" +
                             "%n" +
                             "Use neo4j-admin help <command> for more details.%n" ),

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -41,25 +41,35 @@ public class Neo4jAdminUsageTest
         usageCmd.print( s -> sb.append( s ).append( "\n" ) );
 
         assertEquals("usage: neo4j-admin <command>\n" +
-                        "\n" + "available commands:\n" +
-                            "    backup\n" +
-                            "        Perform an online backup from a running Neo4j enterprise server.\n" +
-                            "    check-consistency\n" +
-                            "        Check the consistency of a database.\n" +
-                            "    dump\n" +
-                            "        Dump a database into a single-file archive.\n" +
-                            "    import\n" +
-                            "        Import from a collection of CSV files or a pre-3.0 database.\n" +
-                            "    load\n" +
-                            "        Load a database from an archive created with the dump command.\n" +
-                            "    restore\n" +
-                            "        Restore a backed up database.\n" +
-                            "    set-default-admin\n" +
-                            "        Sets the default admin user when no roles are present.\n" +
-                            "    set-initial-password\n" +
-                            "        Sets the initial password of the initial admin user ('neo4j').\n" +
-                            "    unbind\n" +
-                            "        Removes cluster state data for the specified database.\n" +
+                        "\n" +
+                        "Manage your Neo4j instance.\n" +
+                        "\n" +
+                        "environment variables:\n" +
+                        "    NEO4J_DEBUG   Set to anything to enable debug output.\n" +
+                        "    NEO4J_HOME    Neo4j home directory.\n" +
+                        "    NEO4J_CONF    Path to directory which contains neo4j.conf.\n" +
+                        "    HEAP_SIZE     Set size of JVM heap during command execution.\n" +
+                        "                  Takes a number and a unit, for example 512m.\n" +
+                        "\n" +
+                        "available commands:\n" +
+                        "    backup\n" +
+                        "        Perform an online backup from a running Neo4j enterprise server.\n" +
+                        "    check-consistency\n" +
+                        "        Check the consistency of a database.\n" +
+                        "    dump\n" +
+                        "        Dump a database into a single-file archive.\n" +
+                        "    import\n" +
+                        "        Import from a collection of CSV files or a pre-3.0 database.\n" +
+                        "    load\n" +
+                        "        Load a database from an archive created with the dump command.\n" +
+                        "    restore\n" +
+                        "        Restore a backed up database.\n" +
+                        "    set-default-admin\n" +
+                        "        Sets the default admin user when no roles are present.\n" +
+                        "    set-initial-password\n" +
+                        "        Sets the initial password of the initial admin user ('neo4j').\n" +
+                        "    unbind\n" +
+                        "        Removes cluster state data for the specified database.\n" +
                         "\n" +
                         "Use neo4j-admin help <command> for more details.\n",
                 sb.toString() );

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -23,12 +23,21 @@ set -o errexit -o nounset -o pipefail
 readonly NEO4J_BIN
 . "${NEO4J_BIN}/neo4j-shared.sh"
 
+setup_java_opts() {
+  JAVA_OPTS=()
+  if [[ -n "${HEAP_SIZE:-}" ]]; then
+    JAVA_OPTS+=("-Xmx${HEAP_SIZE}")
+    JAVA_OPTS+=("-Xms${HEAP_SIZE}")
+  fi
+}
+
 main() {
   setup_environment
   check_java
   build_classpath
+  setup_java_opts
   export NEO4J_HOME NEO4J_CONF
-  exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.commandline.admin.AdminTool" "$@"
+  exec "${JAVA_CMD}" -cp "${CLASSPATH}" "${JAVA_OPTS[@]}" -Dfile.encoding=UTF-8 "org.neo4j.commandline.admin.AdminTool" "$@"
 }
 
 main "$@"

--- a/packaging/standalone/src/tests/shell-scripts/test-admin-args.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-admin-args.sh
@@ -20,4 +20,10 @@ test_expect_success "should delegate unknown commands to the Java tool" "
   test_expect_java_arg 'org.neo4j.commandline.admin.AdminTool'
 "
 
+test_expect_success "should specify heap size when given" "
+  HEAP_SIZE=666m neo4j-home/bin/neo4j-admin backup &&
+  test_expect_java_arg '-Xms666m' &&
+  test_expect_java_arg '-Xmx666m'
+"
+
 test_done


### PR DESCRIPTION
should be a null merge to 3.2 since commit already exists there.

Original PR: https://github.com/neo4j/neo4j/pull/8956

New `neo4j-admin` help text includes environment variables as in 3.2:

```
usage: neo4j-admin <command>

Manage your Neo4j instance.

        environment variables:
        NEO4J_DEBUG   Set to anything to enable debug output.
        NEO4J_HOME    Neo4j home directory.
        NEO4J_CONF    Path to directory which contains neo4j.conf.
        HEAP_SIZE     Set size of JVM heap during command execution.
        Takes a number and a unit, for example 512m.

        available commands:
        backup
        Perform an online backup from a running Neo4j enterprise server.
        check-consistency
        Check the consistency of a database.
        dump
        Dump a database into a single-file archive.
        import
        Import from a collection of CSV files or a pre-3.0 database.
        load
        Load a database from an archive created with the dump command.
        restore
        Restore a backed up database.
        set-default-admin
        Sets the default admin user when no roles are present.
        set-initial-password
        Sets the initial password of the initial admin user ('neo4j').
        unbind
        Removes cluster state data for the specified database.

        Use neo4j-admin help <command> for more details.
```

changelog [3.1] `neo4j-admin` commands can now be given additional heap by specifying the `HEAP_SIZE` variable.
