### PR TITLE
Don't explicitly close the file system in RotatingFileOutputStreamSupplierTest

### DIFF
--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.logging;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,12 +109,6 @@ public class RotatingFileOutputStreamSupplierTest
         archiveLogFile7 = new File( logDir, "logfile.log.7" );
         archiveLogFile8 = new File( logDir, "logfile.log.8" );
         archiveLogFile9 = new File( logDir, "logfile.log.9" );
-    }
-
-    @After
-    public void tearDown() throws Exception
-    {
-        fileSystem.close();
     }
 
     @Test


### PR DESCRIPTION
Because the `TestDirectory` will do it for us.
This fixes a test flakiness where the two would race with each other in the `shouldNotUpdateOutputStreamWhenClosedDuringRotation` test.