### PR TITLE
GBPTree writer fail fast if hitting tree node with valid successor

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -937,7 +937,6 @@ public class GBPTree<KEY,VALUE> implements Closeable
         private long stableGeneration;
         private long unstableGeneration;
 
-
         SingleWriter( InternalTreeLogic<KEY,VALUE> treeLogic )
         {
             this.structurePropagation = new StructurePropagation<>( layout.newKey(), layout.newKey(), layout.newKey() );

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -27,6 +27,7 @@ import org.neo4j.io.pagecache.PageCursor;
 
 import static org.neo4j.index.internal.gbptree.KeySearch.isHit;
 import static org.neo4j.index.internal.gbptree.KeySearch.positionOf;
+import static org.neo4j.index.internal.gbptree.PointerChecking.assertNoSuccessor;
 import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.BUBBLE;
 import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.REPLACE;
 import static org.neo4j.index.internal.gbptree.StructurePropagation.UPDATE_MID_CHILD;
@@ -301,6 +302,8 @@ class InternalTreeLogic<KEY,VALUE>
 
             TreeNode.goTo( cursor, "child", childId );
             level.treeNodeId = cursor.getCurrentPageId();
+
+            assertNoSuccessor( cursor, stableGeneration, unstableGeneration );
         }
 
         assert TreeNode.isLeaf( cursor ) : "Ended up on a tree node which isn't a leaf after moving cursor towards " +

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
@@ -28,9 +28,8 @@ class PointerChecking
 {
     static final String WRITER_TRAVERSE_OLD_STATE_MESSAGE =
                     "Writer traversed to a tree node that has a valid successor, " +
-                    "meaning writer will not act on latest version of the tree. This is not allowed. " +
                     "This is most likely due to failure to checkpoint the tree before shutdown and/or tree state " +
-                    "being out of date. Make a safety copy of tree file and delete.";
+                    "being out of date.";
 
     /**
      * Checks a read pointer for success/failure and throws appropriate exception with failure information

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
@@ -26,6 +26,12 @@ import org.neo4j.io.pagecache.PageCursor;
  */
 class PointerChecking
 {
+    static final String WRITER_TRAVERSE_OLD_STATE_MESSAGE =
+                    "Writer traversed to a tree node that has a valid successor, " +
+                    "meaning writer will not act on latest version of the tree. This is not allowed. " +
+                    "This is most likely due to failure to checkpoint the tree before shutdown and/or tree state " +
+                    "being out of date. Make a safety copy of tree file and delete.";
+
     /**
      * Checks a read pointer for success/failure and throws appropriate exception with failure information
      * if failure. Must be called after a consistent read from page cache (after {@link PageCursor#shouldRetry()}.
@@ -45,6 +51,22 @@ class PointerChecking
         {
             throw new TreeInconsistencyException( "Pointer to id " + result + " not allowed. Minimum node id allowed is " +
                     IdSpace.MIN_TREE_NODE_ID );
+        }
+    }
+
+    /**
+     * Assert cursor rest on a node that does not have a valid (not crashed) successor.
+     *
+     * @param cursor PageCursor resting on a tree node.
+     * @param stableGeneration Current stable generation of tree.
+     * @param unstableGeneration Current unstable generation of tree.
+     */
+    static void assertNoSuccessor( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    {
+        long successor = TreeNode.successor( cursor, stableGeneration, unstableGeneration );
+        if ( TreeNode.isNode( successor ) )
+        {
+            throw new TreeInconsistencyException( WRITER_TRAVERSE_OLD_STATE_MESSAGE );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/PhysicalToLogicalLabelChanges.java
@@ -21,17 +21,17 @@ package org.neo4j.kernel.impl.index.labelscan;
 
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 
-public class PhysicalToLogicalLabelChanges
+class PhysicalToLogicalLabelChanges
 {
     /**
-     * Converts physical before/after state to logical add/remove state. This conversion
-     * reuses the existing long[] arrays in {@link NodeLabelUpdate}, merely shuffles numbers
-     * around and possible terminates them with -1 because the logical change set will be
+     * Converts physical before/after state to logical remove/add state. This conversion reuses the existing
+     * long[] arrays in {@link NodeLabelUpdate}, 'before' is used for removals and 'after' is used for adds,
+     * by shuffling numbers around and possible terminates them with -1 because the logical change set will be
      * equally big or smaller than the physical change set.
      *
      * @param update {@link NodeLabelUpdate} containing physical before/after state.
      */
-    public static void convertToAdditionsAndRemovals( NodeLabelUpdate update )
+    static void convertToAdditionsAndRemovals( NodeLabelUpdate update )
     {
         int beforeLength = update.getLabelsBefore().length;
         int afterLength = update.getLabelsAfter().length;


### PR DESCRIPTION
If writer reach a tree node with a valid successor it means that the
tree is not consistent in one out of three ways:
1. Tree state point to a root that is outdated (has a successor)
2. Child pointer in parent does not point to latest successor of child.
3. Sibling pointer does not point to latest successor of sibling.