### PR TITLE
Cleanup: Don't use unnecessary default interface implementations

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -138,20 +138,40 @@ public class GBPTree<KEY,VALUE> implements Closeable
      */
     public interface Monitor
     {
+        class Adaptor implements Monitor
+        {
+            @Override
+            public void checkpointCompleted()
+            {   // no-op
+            }
+
+            @Override
+            public void noStoreFile()
+            {   // no-op
+            }
+
+            @Override
+            public void cleanupFinished( long numberOfPagesVisited, long numberOfCleanedCrashPointers,
+                    long durationMillis )
+            {   // no-op
+            }
+
+            @Override
+            public void startupState( boolean clean )
+            {   // no-op
+            }
+        }
+
         /**
          * Called when a {@link GBPTree#checkpoint(IOLimiter)} has been completed, but right before
          * {@link GBPTree#writer() writers} are re-enabled.
          */
-        default void checkpointCompleted()
-        {   // no-op by default
-        }
+        void checkpointCompleted();
 
         /**
          * Called when the tree was started on no existing store file and so will be created.
          */
-        default void noStoreFile()
-        {   // no-op by default
-        }
+        void noStoreFile();
 
         /**
          * Called after recovery has completed and cleaning has been done.
@@ -160,27 +180,20 @@ public class GBPTree<KEY,VALUE> implements Closeable
          * @param numberOfCleanedCrashPointers number of cleaned crashed pointers.
          * @param durationMillis time spent cleaning.
          */
-        default void cleanupFinished( long numberOfPagesVisited, long numberOfCleanedCrashPointers,
-                long durationMillis )
-        {   // no-op by default
-        }
+        void cleanupFinished( long numberOfPagesVisited, long numberOfCleanedCrashPointers, long durationMillis );
 
         /**
          * Report tree state on startup.
          *
          * @param clean true if tree was clean on startup.
          */
-        default void startupState( boolean clean )
-        {   // no-op by default
-        }
+        void startupState( boolean clean );
     }
 
     /**
      * No-op {@link Monitor}.
      */
-    public static final Monitor NO_MONITOR = new Monitor()
-    {   // does nothing
-    };
+    public static final Monitor NO_MONITOR = new Monitor.Adaptor();
 
     /**
      * No-op header reader.

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -1132,7 +1132,7 @@ public class GBPTreeTest
         }
     }
 
-    private static class CheckpointControlledMonitor implements Monitor
+    private static class CheckpointControlledMonitor extends Monitor.Adaptor
     {
         private final Barrier.Control barrier = new Barrier.Control();
         private volatile boolean enabled;
@@ -1147,7 +1147,7 @@ public class GBPTreeTest
         }
     }
 
-    private static class CheckpointCounter implements Monitor
+    private static class CheckpointCounter extends Monitor.Adaptor
     {
         private int count;
 
@@ -1178,7 +1178,7 @@ public class GBPTreeTest
         }
     }
 
-    private static class MonitorDirty implements Monitor
+    private static class MonitorDirty extends Monitor.Adaptor
     {
         private boolean called;
         private boolean cleanOnStart;
@@ -1204,7 +1204,7 @@ public class GBPTreeTest
         }
     }
 
-    private static class MonitorCleanup implements Monitor
+    private static class MonitorCleanup extends Monitor.Adaptor
     {
         private boolean cleanupCalled;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleCleanupMonitor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleCleanupMonitor.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.index.internal.gbptree;
 
-class SimpleCleanupMonitor implements GBPTree.Monitor
+class SimpleCleanupMonitor extends GBPTree.Monitor.Adaptor
 {
     boolean cleanupFinished;
     long numberOfPagesVisited;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LabelScanStore.java
@@ -37,37 +37,59 @@ public interface LabelScanStore extends Lifecycle
 {
     interface Monitor
     {
-        Monitor EMPTY = new Monitor()
-        {   // empty
-        };
+        Monitor EMPTY = new Monitor.Adaptor();
 
-        default void init()
-        {   // empty
+        class Adaptor implements Monitor
+        {
+            @Override
+            public void init()
+            {   // empty
+            }
+
+            @Override
+            public void noIndex()
+            {   // empty
+            }
+
+            @Override
+            public void lockedIndex( Exception e )
+            {   // empty
+            }
+
+            @Override
+            public void notValidIndex()
+            {   // empty
+            }
+
+            @Override
+            public void rebuilding()
+            {   // empty
+            }
+
+            @Override
+            public void rebuilt( long roughNodeCount )
+            {   // empty
+            }
+
+            @Override
+            public void recoveryCompleted( Map<String,Object> data )
+            {   // empty
+            }
         }
 
-        default void noIndex()
-        {   // empty
-        }
+        void init();
 
-        default void lockedIndex( Exception e )
-        {   // empty
-        }
+        void noIndex();
 
-        default void notValidIndex()
-        {   // empty
-        }
+        void lockedIndex( Exception e );
 
-        default void rebuilding()
-        {   // empty
-        }
+        void notValidIndex();
 
-        default void rebuilt( long roughNodeCount )
-        {   // empty
-        }
+        void rebuilding();
 
-        default void recoveryCompleted( Map<String,Object> data )
-        {   // empty
-        }
+        void rebuilt( long roughNodeCount );
+
+        void recoveryCompleted( Map<String,Object> data );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/LoggingMonitor.java
@@ -29,7 +29,7 @@ import static java.lang.String.format;
 /**
  * Logs about important events about {@link LabelScanStore} {@link Monitor}.
  */
-public class LoggingMonitor implements Monitor
+public class LoggingMonitor extends Monitor.Adaptor
 {
     private final Log log;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -355,7 +355,7 @@ public class NativeLabelScanStore implements LabelScanStore
 
     private GBPTree.Monitor treeMonitor()
     {
-        return new GBPTree.Monitor()
+        return new GBPTree.Monitor.Adaptor()
         {
             @Override
             public void cleanupFinished( long numberOfPagesVisited, long numberOfCleanedCrashPointers,

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -594,7 +594,7 @@ public abstract class LabelScanStoreTest
         }
     }
 
-    private static class TrackingMonitor implements LabelScanStore.Monitor
+    private static class TrackingMonitor extends LabelScanStore.Monitor.Adaptor
     {
         boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled;
         boolean corruptedIndex = false;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -140,7 +140,7 @@ public class NativeLabelScanStoreRebuildTest
         }
     }
 
-    private class RecordingMonitor implements LabelScanStore.Monitor
+    private class RecordingMonitor extends LabelScanStore.Monitor.Adaptor
     {
         boolean notValid;
         boolean rebuilding;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
@@ -158,7 +158,7 @@ public abstract class LabelScanStoreHaIT
         life.shutdown();
     }
 
-    private static class TestMonitor implements LabelScanStore.Monitor
+    private static class TestMonitor extends LabelScanStore.Monitor.Adaptor
     {
         private volatile int callsTo_init;
         private volatile int timesRebuiltWithData;


### PR DESCRIPTION
In GBPTree and NativeLabelScanStore