### PR TITLE
Flushes page cache sequentially during some import stages

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -115,6 +115,17 @@ public interface Configuration
         return calculateMaxMemoryFromPercent( DEFAULT_MAX_MEMORY_PERCENT );
     }
 
+    /**
+     * @return whether or not to do sequential flushing of the page cache in the during stages which
+     * import nodes and relationships. Having this {@code true} will reduce random I/O and make most
+     * writes happen in this single background thread and will greatly benefit hardware which generally
+     * benefits from single sequential writer.
+     */
+    default boolean sequentialBackgroundFlushing()
+    {
+        return true;
+    }
+
     Configuration DEFAULT = new Configuration()
     {
     };
@@ -161,6 +172,12 @@ public interface Configuration
         public int movingAverageSize()
         {
             return defaults.movingAverageSize();
+        }
+
+        @Override
+        public boolean sequentialBackgroundFlushing()
+        {
+            return defaults.sequentialBackgroundFlushing();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -184,7 +184,9 @@ public class ParallelBatchImporter implements BatchImporter
             NodeStage nodeStage = new NodeStage( config, writeMonitor,
                     nodes, idMapper, idGenerator, neoStore, inputCache, neoStore.getLabelScanStore(),
                     storeUpdateMonitor, nodeRelationshipCache, memoryUsageStats );
+            neoStore.startFlushingPageCache();
             executeStage( nodeStage );
+            neoStore.stopFlushingPageCache();
             if ( idMapper.needsPreparation() )
             {
                 executeStage( new IdMapperPreparationStage( config, idMapper, cachedNodes,
@@ -327,7 +329,9 @@ public class ParallelBatchImporter implements BatchImporter
             RelationshipStage relationshipStage = new RelationshipStage( topic, config,
                     writeMonitor, typeFilter, relationships.iterator(), idMapper, neoStore,
                     nodeRelationshipCache, storeUpdateMonitor, nextRelationshipId );
+            neoStore.startFlushingPageCache();
             executeStage( relationshipStage );
+            neoStore.stopFlushingPageCache();
 
             int nodeTypes = thisIsTheOnlyRound ? NodeType.NODE_TYPE_ALL : NodeType.NODE_TYPE_DENSE;
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.io.pagecache.PageCache;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.helpers.Exceptions.launderedException;
+
+/**
+ * A dedicated thread which constantly call {@link PageCache#flushAndForce()} until a call to {@link #halt()} is made.
+ * Must be started manually by calling {@link #start()}.
+ */
+class PageCacheFlusher extends Thread
+{
+    private final PageCache pageCache;
+    private volatile boolean halted;
+    private volatile boolean done;
+    private volatile Throwable error;
+    private volatile Thread halter;
+
+    PageCacheFlusher( PageCache pageCache )
+    {
+        this.pageCache = pageCache;
+    }
+
+    @Override
+    public void run()
+    {
+        while ( !halted )
+        {
+            try
+            {
+                pageCache.flushAndForce();
+            }
+            catch ( Throwable e )
+            {
+                error = e;
+                break;
+            }
+        }
+        done = true;
+        Thread localHalter = halter;
+        if ( localHalter != null )
+        {
+            LockSupport.unpark( localHalter );
+        }
+    }
+
+    /**
+     * Halts this flusher, making it stop flushing. The current call to {@link PageCache#flushAndForce()}
+     * will complete before exiting this method call. If there was an error in the thread doing the flushes
+     * that exception will be thrown from this method as a {@link RuntimeException}.
+     */
+    void halt()
+    {
+        halter = Thread.currentThread();
+        halted = true;
+        while ( !done )
+        {
+            LockSupport.parkNanos( MILLISECONDS.toNanos( 100 ) );
+        }
+        if ( error != null )
+        {
+            throw launderedException( error );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.store;
+
+import org.junit.Rule;
+import org.junit.Test;
+import java.util.concurrent.Future;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.test.Barrier;
+import org.neo4j.test.rule.concurrent.OtherThreadRule;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class PageCacheFlusherTest
+{
+    @Rule
+    public final OtherThreadRule<Void> t2 = new OtherThreadRule<>();
+
+    @Test( timeout = 10_000 )
+    public void shouldWaitForCompletionInHalt() throws Exception
+    {
+        // GIVEN
+        PageCache pageCache = mock( PageCache.class );
+        Barrier.Control barrier = new Barrier.Control();
+        doAnswer( invocation -> {
+            barrier.reached();
+            return null;
+        } ).when( pageCache ).flushAndForce();
+        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
+        flusher.start();
+
+        // WHEN
+        barrier.await();
+        Future<Object> halt = t2.execute( state -> {
+            flusher.halt();
+            return null;
+        } );
+        t2.get().waitUntilWaiting( details -> details.isAt( PageCacheFlusher.class, "halt" ) );
+        barrier.release();
+
+        // THEN halt call exits normally after (confirmed) ongoing flushAndForce call completed.
+        halt.get();
+    }
+
+    @Test
+    public void shouldExitOnErrorInHalt() throws Exception
+    {
+        // GIVEN
+        PageCache pageCache = mock( PageCache.class );
+        RuntimeException failure = new RuntimeException();
+        doAnswer( invocation -> {
+            throw failure;
+        } ).when( pageCache ).flushAndForce();
+        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
+        flusher.start();
+
+        // WHEN
+        try
+        {
+            flusher.halt();
+        }
+        catch ( RuntimeException e )
+        {
+            // THEN
+            assertSame( failure, e );
+        }
+    }
+}


### PR DESCRIPTION
To get maximum sequential write I/O. Node and Relationship stages gets
a throughput improvement up to 2x or more, depending on hardware.