### PR TITLE
UNWIND with list of nodes and MATCH

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -398,6 +398,14 @@ public abstract class CompiledConversionUtils
         {
             return ((Relationship) obj).getId();
         }
+        else if (obj instanceof NodeIdWrapper)
+        {
+            return ((NodeIdWrapper) obj).id();
+        }
+        else if (obj instanceof RelationshipIdWrapper)
+        {
+            return ((RelationshipIdWrapper) obj).id();
+        }
         else if (obj instanceof Long)
         {
             return (Long) obj;

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -175,7 +175,11 @@ public abstract class CompiledConversionUtils
 
     public static Object loadParameter( Object value )
     {
-        if ( value instanceof Node )
+        if (value == null)
+        {
+            return null;
+        }
+        else if ( value instanceof Node )
         {
             return new NodeIdWrapperImpl( ((Node) value).getId() );
         }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -384,4 +384,29 @@ public abstract class CompiledConversionUtils
         return value.id();
     }
 
+    public static long extractLong(Object obj)
+    {
+        if (obj == null)
+        {
+            return -1L;
+        }
+        if (obj instanceof Node)
+        {
+            return ((Node) obj).getId();
+        }
+        else if (obj instanceof Relationship)
+        {
+            return ((Relationship) obj).getId();
+        }
+        else if (obj instanceof Long)
+        {
+            return (Long) obj;
+        }
+        else
+        {
+            throw new IllegalArgumentException( format( "Can not be converted to long: %s", obj.getClass().getName() ) );
+
+        }
+    }
+
 }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -213,7 +213,7 @@ public abstract class CompiledConversionUtils
             }
             return copy;
         }
-        
+
         else
         {
             return value;

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -593,11 +593,11 @@ return p""")
     val res =
       executeWithAllPlannersAndRuntimesAndCompatibilityMode( """UNWIND {p1} AS n1
                                                                |UNWIND {p2} AS n2
-                                                               |MATCH (n1)<-[:PING_DAY]-(n2) RETURN 42""".stripMargin,
+                                                               |MATCH (n1)<-[:PING_DAY]-(n2) RETURN n1.prop, n2.prop""".stripMargin,
                                                              "p1" -> List(node1), "p2" -> List(node2))
 
     //Then
-    res.toList should equal(List(Map("42" -> 42)))
+    res.toList should equal(List(Map("n1.prop" -> 1, "n2.prop" -> 2)))
   }
 
   /**

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -580,6 +580,26 @@ return p""")
     res.toList should equal(List(Map("c" -> 2)))
   }
 
+  test("should handle unwind followed by expand into on a list of nodes in both runtimes") {
+    // Given
+    val node1 = createNode("prop" -> 1)
+    val node2 = createLabeledNode(Map("prop" -> 2), "Ping")
+    relate(node2, node1, "PING_DAY")
+    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
+    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
+    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
+
+    // When
+    val res =
+      executeWithAllPlannersAndRuntimesAndCompatibilityMode( """UNWIND {p1} AS n1
+                                                               |UNWIND {p2} AS n2
+                                                               |MATCH (n1)<-[:PING_DAY]-(n2) RETURN 42""".stripMargin,
+                                                             "p1" -> List(node1), "p2" -> List(node2))
+
+    //Then
+    res.toList should equal(List(Map("42" -> 42)))
+  }
+
   /**
    * Append variable to keys and transform value arrays to lists
    */

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -563,6 +563,23 @@ return p""")
     resultWithAlias.close()
   }
 
+  test("should handle unwind on a list of nodes in both runtimes") {
+    // Given
+    val node1 = createNode()
+    val node2 = createNode()
+    relate(createLabeledNode("Ping"), node1, "PING_DAY")
+    relate(createLabeledNode("Ping"), node2, "PING_DAY")
+    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
+    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
+
+    // When
+    val res =
+      executeWithAllPlannersAndRuntimesAndCompatibilityMode("UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c", "p" -> List(node1, node2))
+
+    //Then
+    res.toList should equal(List(Map("c" -> 2)))
+  }
+
   /**
    * Append variable to keys and transform value arrays to lists
    */

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -36,9 +36,9 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, dir)
+      generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, fromVar.codeGenType, dir)
     else
-      generator.nodeGetRelationshipsWithDirectionAndTypes(iterVar, fromVar.name, dir, types.keys.toIndexedSeq)
+      generator.nodeGetRelationshipsWithDirectionAndTypes(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq)
     generator.incrementDbHits()
   }
 
@@ -46,6 +46,10 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
                              (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
+  }
+
+  def foo[E](generator: MethodStructure[E]) = fromVar.codeGenType match {
+    case c if c.isPrimitive => generator.loadVariable(fromVar.name)
   }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextRelationship(iterVar)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -36,9 +36,9 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.connectingRelationships(iterVar, fromVar.name, dir, toVar.name)
+      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, toVar.name, toVar.codeGenType)
     else
-      generator.connectingRelationships(iterVar, fromVar.name, dir, types.keys.toIndexedSeq, toVar.name)
+      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq, toVar.name, toVar.codeGenType)
     generator.incrementDbHits()
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProperty.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProperty.scala
@@ -50,20 +50,20 @@ case class NodeProperty(token: Option[Int], propName: String, nodeIdVar: Variabl
 
   override def propertyByName[E](body: MethodStructure[E], localName: String) =
     if (nodeIdVar.nullable)
-      body.ifNotStatement(body.isNull(nodeIdVar.name, CodeGenType.primitiveNode)) {ifBody =>
-        ifBody.nodeGetPropertyForVar(nodeIdVar.name, propKeyVar, localName)
+      body.ifNotStatement(body.isNull(nodeIdVar.name, nodeIdVar.codeGenType)) {ifBody =>
+        ifBody.nodeGetPropertyForVar(nodeIdVar.name, nodeIdVar.codeGenType, propKeyVar, localName)
       }
     else
-      body.nodeGetPropertyForVar(nodeIdVar.name, propKeyVar, localName)
+      body.nodeGetPropertyForVar(nodeIdVar.name, nodeIdVar.codeGenType, propKeyVar, localName)
 
   //TODO will probably need to send in type so that nodes can be unboxed
   override def propertyById[E](body: MethodStructure[E], localName: String) =
     if (nodeIdVar.nullable)
-      body.ifNotStatement(body.isNull(nodeIdVar.name, CodeGenType.primitiveNode)) {ifBody =>
-        ifBody.nodeGetPropertyById(nodeIdVar.name, token.get, localName)
+      body.ifNotStatement(body.isNull(nodeIdVar.name, nodeIdVar.codeGenType)) {ifBody =>
+        ifBody.nodeGetPropertyById(nodeIdVar.name, nodeIdVar.codeGenType, token.get, localName)
       }
     else
-      body.nodeGetPropertyById(nodeIdVar.name, token.get, localName)
+      body.nodeGetPropertyById(nodeIdVar.name, nodeIdVar.codeGenType, token.get, localName)
 
   override def codeGenType(implicit context: CodeGenContext) = CodeGenType.Any
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -147,8 +147,8 @@ trait MethodStructure[E] {
   def lookupLabelIdE(labelName: String): E
   def lookupRelationshipTypeId(typeIdVar: String, typeName: String): Unit
   def lookupRelationshipTypeIdE(typeName: String): E
-  def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, direction: SemanticDirection): Unit
-  def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, direction: SemanticDirection, typeVars: Seq[String]): Unit
+  def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection): Unit
+  def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection, typeVars: Seq[String]): Unit
   def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, toNode:String)
   def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, types: Seq[String], toNode: String)
   def nextNode(targetVar: String, iterVar: String): Unit

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -128,7 +128,7 @@ trait MethodStructure[E] {
   def unbox(expression:E, codeGenType: CodeGenType): E
   def toFloat(expression:E): E
 
-  // parameters
+  // parameters, and external data loading
   def expectParameter(key: String, variableName: String, codeGenType: CodeGenType): Unit
 
   // map

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -149,8 +149,8 @@ trait MethodStructure[E] {
   def lookupRelationshipTypeIdE(typeName: String): E
   def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection): Unit
   def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection, typeVars: Seq[String]): Unit
-  def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, toNode:String)
-  def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, types: Seq[String], toNode: String)
+  def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, toNode:String, toNodeType: CodeGenType)
+  def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, types: Seq[String], toNode: String, toNodeType: CodeGenType)
   def nextNode(targetVar: String, iterVar: String): Unit
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -156,8 +156,8 @@ trait MethodStructure[E] {
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit
   def hasNextNode(iterVar: String): E
   def hasNextRelationship(iterVar: String): E
-  def nodeGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
-  def nodeGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
+  def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
+  def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit
   def nodeIdSeek(nodeIdVar: String, expression: E, codeGenType: CodeGenType)(block: MethodStructure[E] => Unit): Unit
   def relationshipGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
   def relationshipGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -443,22 +443,22 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     }
   }
 
-  override def connectingRelationships(iterVar: String, fromNode: String, direction: SemanticDirection,
-                                       toNode: String) = {
+  override def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, direction: SemanticDirection,
+                                       toNode: String, toNodeType: CodeGenType) = {
     val local = generator.declare(typeRef[RelationshipIterator], iterVar)
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
       body.assign(local, invoke(Methods.allConnectingRelationships,
-                                readOperations, body.load(fromNode), dir(direction),
-                                body.load(toNode)))
+                                readOperations, forceLong(fromNode, fromNodeType), dir(direction),
+                               forceLong(toNode, toNodeType)))
     }
   }
 
-  override def connectingRelationships(iterVar: String, fromNode: String, direction: SemanticDirection,
-                                       typeVars: Seq[String], toNode: String) = {
+  override def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, direction: SemanticDirection,
+                                       typeVars: Seq[String], toNode: String, toNodeType: CodeGenType) = {
     val local = generator.declare(typeRef[RelationshipIterator], iterVar)
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
-      body.assign(local, invoke(Methods.connectingRelationships, readOperations, body.load(fromNode), dir(direction),
-                                body.load(toNode),
+      body.assign(local, invoke(Methods.connectingRelationships, readOperations, forceLong(fromNode, fromNodeType), dir(direction),
+                                forceLong(toNode, toNodeType),
                                 newArray(typeRef[Int], typeVars.map(body.load): _*)))
     }
   }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -281,7 +281,8 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
         invoke(cast(typeRef[NodeIdWrapper], generator.load(nodeIdVar)), nodeId))
 
   override def node(nodeIdVar: String, codeGenType: CodeGenType) =
-    generator.load(nodeIdVar)
+    if (codeGenType.isPrimitive) generator.load(nodeIdVar)
+    else invoke(cast(typeRef[NodeIdWrapper], generator.load(nodeIdVar)), nodeId)
 
   override def nullablePrimitive(varName: String, codeGenType: CodeGenType, onSuccess: Expression) = codeGenType match {
     case CypherCodeGenType(CTNode, LongType) | CypherCodeGenType(CTRelationship, LongType) =>
@@ -1297,17 +1298,17 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     locals += (name -> generator.declare(typeRef[Boolean], name))
   }
 
-  override def nodeGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String) = {
+  override def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String) = {
     val local = locals(propValueVar)
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
-      body.assign(local, invoke(readOperations, nodeGetProperty, body.load(nodeIdVar), body.load(propIdVar)))
+      body.assign(local, invoke(readOperations, nodeGetProperty, forceLong(nodeVar, nodeVarType), body.load(propIdVar)))
     }
   }
 
-  override def nodeGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String) = {
+  override def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String) = {
     val local = locals(propValueVar)
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
-      body.assign(local, invoke(readOperations, nodeGetProperty, body.load(nodeIdVar), constant(propId)))
+      body.assign(local, invoke(readOperations, nodeGetProperty, forceLong(nodeVar, nodeVarType), constant(propId)))
     }
   }
 

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
@@ -125,7 +125,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         Operation("look up rel type", _.lookupRelationshipTypeId("foo", "bar")),
         Operation("all relationships for node", (m) => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
-          m.nodeGetRelationshipsWithDirection("foo", "node", SemanticDirection.OUTGOING)
+          m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
         }),
         Operation("has label", m => {
           m.lookupLabelId("label", "A")
@@ -164,12 +164,12 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.lookupRelationshipTypeId("a", "A")
           m.lookupRelationshipTypeId("b", "B")
-          m.nodeGetRelationshipsWithDirectionAndTypes("foo", "node", SemanticDirection.OUTGOING, Seq("a", "b"))
+          m.nodeGetRelationshipsWithDirectionAndTypes("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING, Seq("a", "b"))
         }),
         Operation("next relationship", (m) => {
           m.createRelExtractor("r")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
-          m.nodeGetRelationshipsWithDirection("foo", "node", SemanticDirection.OUTGOING)
+          m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
           m.nextRelationshipAndNode("nextNode", "foo", SemanticDirection.OUTGOING, "node", "r")
         }),
     Operation("expand into", (m) => {
@@ -200,7 +200,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       m.allNodesScan("nodeIter")
       m.whileLoop(m.hasNextNode("nodeIter")) { b1 =>
         b1.nextNode("node", "nodeIter")
-        b1.nodeGetRelationshipsWithDirection("relIter", "node", SemanticDirection.OUTGOING)
+        b1.nodeGetRelationshipsWithDirection("relIter", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
         b1.whileLoop(b1.hasNextRelationship("relIter")) { b2 =>
           b2.nextRelationshipAndNode("nextNode", "relIter", SemanticDirection.OUTGOING, "node", "r")
         }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
@@ -137,12 +137,12 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           m.lookupPropertyKey("prop", "prop")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
-          m.nodeGetPropertyForVar("node", "prop", "propVar")
+          m.nodeGetPropertyForVar("node", CodeGenType.primitiveNode, "prop", "propVar")
         }),
         Operation("property by id for node", m => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
-          m.nodeGetPropertyById("node", 13, "propVar")
+          m.nodeGetPropertyById("node", CodeGenType.primitiveNode, 13, "propVar")
         }),
         Operation("property by name for relationship", m => {
           m.lookupPropertyKey("prop", "prop")
@@ -153,7 +153,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         Operation("property by id for relationship", m => {
           m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
-          m.nodeGetPropertyById("rel", 13, "propVar")
+          m.nodeGetPropertyById("rel", CodeGenType.primitiveNode, 13, "propVar")
         }),
         Operation("rel type", m => {
           m.createRelExtractor("bar")


### PR DESCRIPTION
The compile runtime is not handling `UNWIND {p} AS p MATCH (p)...` where `{p}` contains a list of nodes. Such queries currently fails in compilation with type errors and falls back on the compiled runtime. This PR fixes that. It also changes so that whatever data is loaded via UNWIND never leaks `Node` and `Relationship` into the generated code.