### PR TITLE
add fallback for empty array

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -37,7 +37,7 @@ main() {
   build_classpath
   setup_java_opts
   export NEO4J_HOME NEO4J_CONF
-  exec "${JAVA_CMD}" -cp "${CLASSPATH}" "${JAVA_OPTS[@]}" -Dfile.encoding=UTF-8 "org.neo4j.commandline.admin.AdminTool" "$@"
+  exec "${JAVA_CMD}" -cp "${CLASSPATH}" "${JAVA_OPTS[@]:-}" -Dfile.encoding=UTF-8 "org.neo4j.commandline.admin.AdminTool" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
appears to be a difference across bash versions

null merge to 3.2