### PR TITLE
changed default transaction log retention to 1 day in community edition

### DIFF
--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -127,7 +127,7 @@ dbms.connector.https.enabled=true
 #dbms.security.allow_csv_import_from_file_urls=true
 
 # Retention policy for transaction logs needed to perform recovery and backups.
-#dbms.tx_log.rotation.retention_policy=7 days
+dbms.tx_log.rotation.retention_policy=1 days
 
 # Enable a remote shell server which Neo4j Shell clients can log in to.
 #dbms.shell.enabled=true


### PR DESCRIPTION
This was probably overaggressive for community users. Which then leads
to public slack conversations about why is the size of my graph.db XXX
GB when I've only loaded X gig of data. And then how/when/why can I
clean out all the neostore.transaction* files. For community members,
for which neither HA or backup functionality is used and for which
this functionality requires said logs, keeping 7 days is
overaggressive.