### PR TITLE
Change UNWIND to accept non-lists

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/helpers/ListSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/helpers/ListSupport.scala
@@ -84,6 +84,8 @@ trait ListSupport {
     if (z == null) Iterable() else Iterable(z)
   }
 
+  def makeTraversableNull(z: Any): Iterable[Any] = if (isList(z)) { castToIterable(z) } else Iterable(z)
+
   protected def castToIterable: PartialFunction[Any, Iterable[Any]] = {
     case x: Array[_]        => x
     case x: Map[_, _]       => Iterable(x)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipe.scala
@@ -62,7 +62,7 @@ case class UnwindPipe(source: Pipe, collection: Expression, variable: String)
       } else {
         if (input.hasNext) {
           context = input.next()
-          unwindIterator = makeTraversable(collection(context)(state)).iterator
+          unwindIterator = makeTraversableNull(collection(context)(state)).iterator
           prefetch()
         }
       }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Clause.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Clause.scala
@@ -288,10 +288,7 @@ case class Unwind(expression: Expression, variable: Variable)(val position: Inpu
 
   override def semanticCheck =
     expression.semanticCheck(Expression.SemanticContext.Results) chain
-      expression.expectType(CTList(CTAny).covariant) ifOkChain {
-      val possibleInnerTypes: TypeGenerator = expression.types(_).unwrapLists
-      variable.declare(possibleInnerTypes)
-    }
+      variable.declare(CTAny.covariant)
 }
 
 abstract class CallClause extends Clause {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -20,6 +20,49 @@
 
 Feature: UnwindAcceptance
 
+  Scenario Outline: Unwind on non-lists
+    Given any graph
+    When executing query:
+      """
+      UNWIND <nonList> AS var
+      RETURN var
+      """
+    Then the result should be:
+      | var       |
+      | <nonList> |
+    And no side effects
+
+    Examples:
+      | nonList |
+      | 1       |
+      | 'foo'   |
+      | {k: 1}  |
+      | true    |
+
+  Scenario: Unwind treats null as normal value
+    Given any graph
+    When executing query:
+      """
+      UNWIND null AS var
+      RETURN var
+      """
+    Then the result should be:
+      | var  |
+      | null |
+    And no side effects
+
+  Scenario: Unwind on empty list eliminates cardinality
+    Given any graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3] AS int
+      UNWIND [] AS var
+      RETURN var, int
+      """
+    Then the result should be:
+      | var | int |
+    And no side effects
+
   Scenario: Flat type support in list literal
     Given an empty graph
     And having executed:


### PR DESCRIPTION
- UNWIND in interpreted runtime now treats `null` as a single-element list