### PR TITLE
fix long recovery leading to oom in in-flight map

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightMap.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightMap.java
@@ -27,6 +27,22 @@ import static java.lang.String.format;
 public class InFlightMap<V>
 {
     private final SortedMap<Long,V> map = new ConcurrentSkipListMap<>();
+    private volatile boolean enabled;
+
+    public InFlightMap()
+    {
+        this ( false );
+    }
+
+    public InFlightMap( boolean enabled )
+    {
+        this.enabled = enabled;
+    }
+
+    public void enable()
+    {
+        this.enabled = true;
+    }
 
     /**
      * Adds a new mapping.
@@ -37,6 +53,11 @@ public class InFlightMap<V>
      */
     public void put( Long key, V value )
     {
+        if ( !enabled )
+        {
+            return;
+        }
+
         V previousValue = map.putIfAbsent( key, value );
 
         if ( previousValue != null )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreLife.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreLife.java
@@ -81,7 +81,7 @@ public class CoreLife implements Lifecycle
         localDatabase.start();
         coreStateMachines.installCommitProcess( localDatabase.getCommitProcess() );
         applicationProcess.start();
-        raftMachine.startTimers();
+        raftMachine.postRecoveryActions();
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -78,14 +78,13 @@ public class RaftMachineBuilder
             new InMemoryStateStorage<>( new RaftMembershipState() );
     private Monitors monitors = new Monitors();
     private CommitListener commitListener = commitIndex -> {};
-    private final InFlightMap<RaftLogEntry> inFlightMap;
+    private InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>();
 
     public RaftMachineBuilder( MemberId member, int expectedClusterSize, RaftGroup.Builder memberSetBuilder )
     {
         this.member = member;
         this.expectedClusterSize = expectedClusterSize;
         this.memberSetBuilder = memberSetBuilder;
-        inFlightMap = new InFlightMap<>();
     }
 
     public RaftMachine build()
@@ -159,6 +158,12 @@ public class RaftMachineBuilder
     public RaftMachineBuilder raftLog( RaftLog raftLog )
     {
         this.raftLog = raftLog;
+        return this;
+    }
+
+    public RaftMachineBuilder inFlightMap( InFlightMap<RaftLogEntry> inFlightMap )
+    {
+        this.inFlightMap = inFlightMap;
         return this;
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftTestFixture.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftTestFixture.java
@@ -91,7 +91,7 @@ public class RaftTestFixture
         {
             member.raftLog().append( new RaftLogEntry(0, new MemberIdSet(asSet( members ))) );
             member.raftInstance().installCoreState( new RaftCoreState( new MembershipEntry( 0,  asSet( members )) ) );
-            member.raftInstance().startTimers();
+            member.raftInstance().postRecoveryActions();
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/Fixture.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/Fixture.java
@@ -106,7 +106,7 @@ public class Fixture
         {
             raft.raftLog().append( new RaftLogEntry(0, new MemberIdSet(asSet( members ))) );
             raft.raftMachine().installCoreState( new RaftCoreState( new MembershipEntry( 0, members  ) ) );
-            raft.raftMachine.startTimers();
+            raft.raftMachine.postRecoveryActions();
         }
         net.start();
         awaitBootstrapped();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightLogEntriesCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/InFlightLogEntriesCacheTest.java
@@ -25,16 +25,30 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class InFlightLogEntriesCacheTest
 {
     @Test
+    public void shouldNotCacheUntilEnabled() throws Exception
+    {
+        InFlightMap<Object> cache = new InFlightMap<>();
+        Object entry = new Object();
+
+        cache.put( 1L, entry );
+        assertNull( cache.get( 1L ) );
+
+        cache.enable();
+        cache.put( 1L, entry );
+        assertEquals( entry, cache.get( 1L ) );
+    }
+
+    @Test
     public void shouldRegisterAndUnregisterValues() throws Exception
     {
         InFlightMap<Object> entries = new InFlightMap<>();
+        entries.enable();
 
         Map<Long, Object> logEntryList = new HashMap<>();
         logEntryList.put(1L, new Object() );
@@ -65,6 +79,7 @@ public class InFlightLogEntriesCacheTest
     public void shouldNotReinsertValues() throws Exception
     {
         InFlightMap<Object> entries = new InFlightMap<>();
+        entries.enable();
         Object addedObject = new Object();
         entries.put( 1L, addedObject );
         entries.put( 1L, addedObject );
@@ -74,6 +89,7 @@ public class InFlightLogEntriesCacheTest
     public void shouldNotReplaceRegisteredValues() throws Exception
     {
         InFlightMap<Object> cache = new InFlightMap<>();
+        cache.enable();
         Object first = new Object();
         Object second = new Object();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
@@ -90,7 +90,7 @@ public class BatchAppendLogEntriesTest
 
         BatchAppendLogEntries batchAppend = new BatchAppendLogEntries( baseIndex, offset, entries );
 
-        InFlightMap<RaftLogEntry> cache = new InFlightMap<>();
+        InFlightMap<RaftLogEntry> cache = new InFlightMap<>( true );
 
         //when
         batchAppend.applyTo( cache, log );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommandTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommandTest.java
@@ -44,7 +44,7 @@ public class TruncateLogCommandTest
         Log log = logProvider.getLog( getClass() );
         long fromIndex = 2L;
         TruncateLogCommand truncateLogCommand = new TruncateLogCommand( fromIndex );
-        InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>();
+        InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>( true );
 
         inFlightMap.put( 0L, new RaftLogEntry( 0L, valueOf( 0 ) ) );
         inFlightMap.put( 1L, new RaftLogEntry( 1L, valueOf( 1 ) ) );
@@ -71,7 +71,7 @@ public class TruncateLogCommandTest
         long fromIndex = 1L;
         TruncateLogCommand truncateLogCommand = new TruncateLogCommand( fromIndex );
 
-        InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>();
+        InFlightMap<RaftLogEntry> inFlightMap = new InFlightMap<>( true );
 
         inFlightMap.put( 0L, new RaftLogEntry( 0L, valueOf( 0 ) ) );
         inFlightMap.put( 2L, new RaftLogEntry( 1L, valueOf( 1 ) ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
@@ -79,7 +79,7 @@ public class ElectionTest
                 .build();
 
         raft.installCoreState( new RaftCoreState( new MembershipEntry( 0, asSet( myself, member1, member2 )  ) ) );
-        raft.startTimers();
+        raft.postRecoveryActions();
 
         timeouts.invokeTimeout( RaftMachine.Timeouts.ELECTION );
 
@@ -112,7 +112,7 @@ public class ElectionTest
 
         raft.installCoreState(
                 new RaftCoreState( new MembershipEntry( 0, asSet( myself, member1, member2 ) ) ));
-        raft.startTimers();
+        raft.postRecoveryActions();
 
         timeouts.invokeTimeout( RaftMachine.Timeouts.ELECTION );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -62,7 +62,7 @@ public class RaftStateTest
         //Test that updates applied to the raft state will be refelcted in the entry cache.
 
         //given
-        InFlightMap<RaftLogEntry> cache = new InFlightMap<>();
+        InFlightMap<RaftLogEntry> cache = new InFlightMap<>( true );
         RaftState raftState = new RaftState( member( 0 ),
                 new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CommandApplicationProcessTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CommandApplicationProcessTest.java
@@ -81,7 +81,7 @@ public class CommandApplicationProcessTest
     private final int flushEvery = 10;
     private final int batchSize = 16;
 
-    private InFlightMap<RaftLogEntry> inFlightMap = spy( new InFlightMap<>() );
+    private InFlightMap<RaftLogEntry> inFlightMap = spy( new InFlightMap<>( true ) );
     private final Monitors monitors = new Monitors();
     private CoreState coreState = mock( CoreState.class );
     private final CommandApplicationProcess applicationProcess = new CommandApplicationProcess(


### PR DESCRIPTION
A long recovery during startup could lead to the in-flight map
being filled up with enough entries to exhaust memory. This was
an unnoticed side-effect of a recent refactoring which was
previously protected against by holding the core state monitor
during the entire recovery step.

changelog: Fix OOM during startup.