### PR TITLE
refuse_to_be_leader is controlled by multi_dc_license

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -40,6 +40,7 @@ import org.neo4j.causalclustering.core.consensus.term.MonitoredTermStateStorage;
 import org.neo4j.causalclustering.core.consensus.term.TermState;
 import org.neo4j.causalclustering.core.consensus.vote.VoteState;
 import org.neo4j.causalclustering.core.replication.SendToMyself;
+import org.neo4j.causalclustering.core.state.RefuseToBeLeaderStrategy;
 import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.discovery.CoreTopologyService;
@@ -135,7 +136,8 @@ public class ConsensusModule
 
         raftMachine = new RaftMachine( myself, termState, voteState, raftLog, electionTimeout, heartbeatInterval,
                 raftTimeoutService, outbound, logProvider, raftMembershipManager, logShipping, inFlightMap,
-                config.get( CausalClusteringSettings.refuse_to_be_leader ), platformModule.monitors, systemClock() );
+                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ),
+                platformModule.monitors, systemClock() );
 
         life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RefuseToBeLeaderStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/RefuseToBeLeaderStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.Log;
+
+import static org.neo4j.causalclustering.core.CausalClusteringSettings.multi_dc_license;
+import static org.neo4j.causalclustering.core.CausalClusteringSettings.refuse_to_be_leader;
+
+/**
+ * Simple utility class to abstract the interplay between multi dc feature licensing and
+ * the refuse_to_be_leader config. refuse_to_be_leader should only be taken into consideration (i.e.
+ * its value respected) when the multi dc license has been set to true. Otherwise, it will
+ * always return false.
+ */
+public class RefuseToBeLeaderStrategy
+{
+    public static boolean shouldRefuseToBeLeader( Config config )
+    {
+        boolean multiDcLicensed = config.get( CausalClusteringSettings.multi_dc_license );
+        boolean refuseToBeLeader = config.get( refuse_to_be_leader );
+
+        return refuseToBeLeader && multiDcLicensed;
+    }
+
+    public static boolean shouldRefuseToBeLeader( Config config, Log log )
+    {
+        boolean multiDcLicensed = config.get( CausalClusteringSettings.multi_dc_license );
+        boolean refuseToBeLeader = config.get( refuse_to_be_leader );
+
+        if ( refuseToBeLeader && !multiDcLicensed )
+        {
+            /*
+             * This means the user wants this instance to refuse to be leader but has not enabled multi_dc_license.
+             * Issue a warning so they can see and fix that.
+             */
+            log.warn( String.format( "%s setting cannot be set to true unless %s is also set to true. Please refer to" +
+                    " the Neo4j documentation for more information.", refuse_to_be_leader.name(), multi_dc_license
+                    .name() ) );
+        }
+
+        return shouldRefuseToBeLeader( config );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClusterTopology.java
@@ -35,6 +35,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiMap;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.state.RefuseToBeLeaderStrategy;
 import org.neo4j.causalclustering.identity.ClusterId;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
@@ -42,7 +43,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 
 import static java.util.Collections.emptyMap;
-
 import static org.neo4j.helpers.SocketAddressFormat.socketAddress;
 import static org.neo4j.helpers.collection.Iterables.asSet;
 
@@ -162,7 +162,7 @@ public class HazelcastClusterTopology
     private static boolean canBeBootstrapped( HazelcastInstance hazelcastInstance, Config config )
     {
         Set<Member> members = hazelcastInstance.getCluster().getMembers();
-        Boolean refuseToBeLeader = config.get( CausalClusteringSettings.refuse_to_be_leader );
+        Boolean refuseToBeLeader = RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config );
 
         if ( refuseToBeLeader )
         {
@@ -248,7 +248,7 @@ public class HazelcastClusterTopology
         memberAttributeConfig.setStringAttribute( CLIENT_CONNECTOR_ADDRESSES, clientConnectorAddresses.toString() );
 
         memberAttributeConfig.setBooleanAttribute( REFUSE_TO_BE_LEADER_KEY,
-                config.get( CausalClusteringSettings.refuse_to_be_leader ) );
+                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config )  );
 
         return memberAttributeConfig;
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/RefuseToBeLeaderStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/RefuseToBeLeaderStrategyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.Log;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RefuseToBeLeaderStrategyTest
+{
+    @Test
+    public void shouldReturnFalseByDefault() throws Exception
+    {
+        Config config = Config.empty();
+
+        assertFalse( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+
+    @Test
+    public void shouldReturnFalseIfLicenseIsUnsetAndRefuseToBeLeaderIsTrue() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.refuse_to_be_leader.name(), "true" ) );
+
+        assertFalse( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+
+    @Test
+    public void shouldLogWarningIfLicenseIsUnsetAndRefuseToBeLeaderIsTrue() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.refuse_to_be_leader.name(), "true" ) );
+
+        Log logMock = mock( Log.class );
+
+        RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logMock );
+
+        verify( logMock, times( 1 ) ).warn( anyString() );
+    }
+
+    @Test
+    public void shouldReturnFalseIfLicenseIsFalseAndRefuseToBeLeaderIsTrue() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.refuse_to_be_leader.name(), "true" ) );
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.multi_dc_license.name(), "false" ) );
+
+        assertFalse( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+
+    @Test
+    public void shouldReturnFalseIfLicenseIsFalseAndRefuseToBeLeaderIsFalse() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.refuse_to_be_leader.name(), "false" ) );
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.multi_dc_license.name(), "false" ) );
+
+        assertFalse( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+
+    @Test
+    public void shouldReturnTrueIfLicenseIsTrueAndRefuseToBeLeaderIsTrue() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.refuse_to_be_leader.name(), "true" ) );
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.multi_dc_license.name(), "true" ) );
+
+        assertTrue( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+
+    @Test
+    public void shouldReturnFalseIfLicenseIsTrueAndRefuseToBeLeaderIsUnset() throws Exception
+    {
+        Config config = Config.empty();
+        config.augment( MapUtil.stringMap( CausalClusteringSettings.multi_dc_license.name(), "true" ) );
+
+        assertFalse( RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
@@ -41,7 +41,8 @@ public class WillNotBecomeLeaderIT
     @Rule
     public final ClusterRule clusterRule =
             new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
-                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );
+                    .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() )
+                    .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" );
 
     @Rule
     public ExpectedException exceptionMatcher = ExpectedException.none();


### PR DESCRIPTION
The CC setting refuse_to_be_leader is deemed to be a multi dc
 specific feature and as such must be controlled by the multi_dc_license
 switch. The implemented behaviour is that unless the license toggle is
 set to true, the follower pin will always default to false, regardless
 of the actual value.