### PR TITLE
Allow concurrent index drops during indexes forcing operation 

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxy.java
@@ -178,7 +178,7 @@ public class ContractCheckingIndexProxy extends DelegatingIndexProxy
                 throw new IllegalStateException("Cannot call " + name + "() after index has been closed" );
         }
         else
-            throw new IllegalStateException("Cannot call " + name + "() before index has been started" );
+            throw new IllegalStateException("Cannot call " + name + "() when index state is " + state.get() );
     }
 
     private void ensureNoOpenCalls(String name)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -74,7 +74,7 @@ public final class IndexMap implements Cloneable
         return removedProxy;
     }
 
-    public void foreachIndexProxy( BiConsumer<Long, IndexProxy> consumer )
+    public void forEachIndexProxy( BiConsumer<Long, IndexProxy> consumer )
     {
         for ( Map.Entry<Long, IndexProxy> entry : indexesById.entrySet() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.checkPoint;
@@ -38,7 +39,8 @@ public class CheckPointScheduler extends LifecycleAdapter
      * The max number of consecutive check point failures that can be tolerated before treating
      * check point failures more seriously, with a panic.
      */
-    static final int MAX_CONSECUTIVE_FAILURES_TOLERANCE = 3;
+    static final int MAX_CONSECUTIVE_FAILURES_TOLERANCE =
+            FeatureToggles.getInteger( CheckPointScheduler.class, "failure_tolerance", 10 );
 
     private final CheckPointer checkPointer;
     private final IOLimiter ioLimiter;


### PR DESCRIPTION
Currently index drop operation that will be performed concurrently with checkpoint
can fail index forcing operation.
This PR will change that behaviour and will add additional checks during forcing of indexes state
to allow both operations to succeed.
The case when index can't be forced for some other reason then drop will still fail index forcing.
changelog: [3.1] Allow concurrent index drops during indexes forcing operation