### PR TITLE
Fix bug in reuse of linked page cursors

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -66,6 +66,7 @@ abstract class MuninnPageCursor extends PageCursor
     private int filePageSize;
     private int offset;
     private boolean outOfBounds;
+    private boolean isLinkedCursor;
     // This is a String with the exception message if usePreciseCursorErrorStackTraces is false, otherwise it is a
     // CursorExceptionWithPreciseStackTrace with the message and stack trace pointing more or less directly at the
     // offending code.
@@ -124,34 +125,34 @@ abstract class MuninnPageCursor extends PageCursor
     @Override
     public final void close()
     {
-        MuninnPageCursor cursor = this;
-        do
+        if ( pagedFile == null )
         {
-            if ( cursor.pagedFile != null )
-            {
-                cursor.unpinCurrentPage();
-                cursor.releaseCursor();
-                // We null out the pagedFile field to allow it and its (potentially big) translation table to be garbage
-                // collected when the file is unmapped, since the cursors can stick around in thread local caches, etc.
-                cursor.pagedFile = null;
-            }
+            return; // already closed
         }
-        while ( (cursor = cursor.getAndClearLinkedCursor()) != null );
+        closeLinks( this );
+        if ( !isLinkedCursor )
+        {
+            releaseCursor();
+        }
     }
 
-    private MuninnPageCursor getAndClearLinkedCursor()
+    private void closeLinks( MuninnPageCursor cursor )
     {
-        MuninnPageCursor cursor = linkedCursor;
-        linkedCursor = null;
-        return cursor;
+        while ( cursor != null && cursor.pagedFile != null )
+        {
+            cursor.unpinCurrentPage();
+            // We null out the pagedFile field to allow it and its (potentially big) translation table to be garbage
+            // collected when the file is unmapped, since the cursors can stick around in thread local caches, etc.
+            cursor.pagedFile = null;
+            cursor = cursor.linkedCursor;
+        }
     }
 
     private void closeLinkedCursorIfAny()
     {
         if ( linkedCursor != null )
         {
-            linkedCursor.close();
-            linkedCursor = null;
+            closeLinks( linkedCursor );
         }
     }
 
@@ -165,7 +166,16 @@ abstract class MuninnPageCursor extends PageCursor
             // This cursor has been closed
             throw new IllegalStateException( "Cannot open linked cursor on closed page cursor" );
         }
-        linkedCursor = (MuninnPageCursor) pf.io( pageId, pf_flags );
+        if ( linkedCursor != null )
+        {
+            linkedCursor.initialiseFlags( pf, pageId, pf_flags );
+            linkedCursor.rewind();
+        }
+        else
+        {
+            linkedCursor = (MuninnPageCursor) pf.io( pageId, pf_flags );
+            linkedCursor.isLinkedCursor = true;
+        }
         return linkedCursor;
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2847,6 +2847,49 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         }
     }
 
+    @Test
+    public void pageCursorCloseWithClosedLinkedCursorShouldNotReturnSameObjectToCursorPoolTwice() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize ) )
+        {
+            PageCursor a = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            a.openLinkedCursor( 0 );
+            a.openLinkedCursor( 0 ).close();
+            a.close();
+
+            PageCursor x = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            PageCursor y = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            PageCursor z = pf.io( 0, PF_SHARED_WRITE_LOCK );
+
+            assertNotSame( x, y );
+            assertNotSame( x, z );
+            assertNotSame( y, z );
+            x.close();
+            y.close();
+            z.close();
+        }
+    }
+
+    @Test
+    public void pageCursorCloseMustNotClosePreviouslyLinkedCursorThatGotReused() throws Exception
+    {
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage * 2, recordSize );
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL );
+        try ( PagedFile pf = pageCache.map( file, filePageSize ) )
+        {
+            PageCursor a = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            a.openLinkedCursor( 0 ).close();
+            PageCursor x = pf.io( 0, PF_SHARED_WRITE_LOCK );
+            a.close();
+            assertTrue( x.next( 1 ) );
+            x.close();
+        }
+    }
+
     private interface PageCursorAction
     {
         void apply( PageCursor cursor );


### PR DESCRIPTION
Previously, when a linked cursor is closed it is returned to the cursor pool.
It could then be reused by another PagedFile.io() call, while still being considered linked by the parent cursor. Thus, when the parent cursor was closed, it would also close the previously-linked-now-reused cursor.

This bug is fixed by never returning linked cursors to the pool. They now stick around, forever being "linked" to their parent, and then reused as necessary by the parent cursor.