### PR TITLE
Accessing maps and lists with null should return null

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -459,4 +459,8 @@ order by a.age""").toList)
   test("accessing a list with null as upper bound should return null") {
     executeWithAllPlanners("RETURN [1,2,3][1..null] AS result").toList should equal(List(Map("result" -> null)))
   }
+
+  test("accessing a map with null should return null") {
+    executeWithAllPlanners("RETURN {key: 1337}[null] AS result").toList should equal(List(Map("result" -> null)))
+  }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -445,13 +445,18 @@ order by a.age""").toList)
   test("returning * and additional unaliased columns should not give duplicate returned columns 2") {
     val n = createNode(Map("foo" -> 42))
 
-    val result = executeWithAllPlanners("MATCH (n) RETURN *, n.foo ORDER BY n.foo SKIP 0 LIMIT 5 ")
-    println(result.executionPlanDescription())
-
-    result.toList should equal(List(Map("n"-> n, "n.foo" -> 42)))
+    executeWithAllPlanners("MATCH (n) RETURN *, n.foo ORDER BY n.foo SKIP 0 LIMIT 5 ").toList should equal(List(Map("n"-> n, "n.foo" -> 42)))
   }
 
   test("accessing a list with null should return null") {
     executeWithAllPlanners("RETURN [1,2,3][null] AS result").toList should equal(List(Map("result" -> null)))
+  }
+
+  test("accessing a list with null as lower bound should return null") {
+    executeWithAllPlanners("RETURN [1,2,3][null..5] AS result").toList should equal(List(Map("result" -> null)))
+  }
+
+  test("accessing a list with null as upper bound should return null") {
+    executeWithAllPlanners("RETURN [1,2,3][1..null] AS result").toList should equal(List(Map("result" -> null)))
   }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -450,4 +450,8 @@ order by a.age""").toList)
 
     result.toList should equal(List(Map("n"-> n, "n.foo" -> 42)))
   }
+
+  test("accessing a list with null should return null") {
+    executeWithAllPlanners("RETURN [1,2,3][null] AS result").toList should equal(List(Map("result" -> null)))
+  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/CollectionSliceExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/CollectionSliceExpression.scala
@@ -21,8 +21,8 @@ package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
-import pipes.QueryState
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 
 case class CollectionSliceExpression(collection: Expression, from: Option[Expression], to: Option[Expression])
@@ -38,53 +38,57 @@ case class CollectionSliceExpression(collection: Expression, from: Option[Expres
     }
 
   private def fullSlice(from: Expression, to: Expression)(collectionValue: Iterable[Any], ctx: ExecutionContext, state: QueryState) = {
-    val fromValue = asInt(from, ctx, state)
-    val toValue = asInt(to, ctx, state)
-
-    val size = collectionValue.size
-
-    if (fromValue >= 0 && toValue >= 0)
-      collectionValue.slice(fromValue, toValue)
-    else if (fromValue >= 0) {
-      val end = size + toValue
-      collectionValue.slice(fromValue, end)
-    } else if (toValue >= 0) {
-      val start = size + fromValue
-      collectionValue.slice(start, toValue)
-    } else {
-      val start = size + fromValue
-      val end = size + toValue
-      collectionValue.slice(start, end)
+    val maybeFromValue = asInt(from, ctx, state)
+    val maybeToValue = asInt(to, ctx, state)
+    (maybeFromValue, maybeToValue) match {
+      case (None, _) => null
+      case (_, None) => null
+      case (Some(fromValue), Some(toValue)) =>
+        val size = collectionValue.size
+        if (fromValue >= 0 && toValue >= 0)
+          collectionValue.slice(fromValue, toValue)
+        else if (fromValue >= 0) {
+          val end = size + toValue
+          collectionValue.slice(fromValue, end)
+        } else if (toValue >= 0) {
+          val start = size + fromValue
+          collectionValue.slice(start, toValue)
+        } else {
+          val start = size + fromValue
+          val end = size + toValue
+          collectionValue.slice(start, end)
+        }
     }
   }
 
   private def fromSlice(from: Expression)(collectionValue: Iterable[Any], ctx: ExecutionContext, state: QueryState) = {
     val fromValue = asInt(from, ctx, state)
-    val size = collectionValue.size
-
-    if (fromValue >= 0)
-      collectionValue.drop(fromValue)
-    else {
-      val end = size + fromValue
-      collectionValue.drop(end)
+    fromValue match {
+      case None => null
+      case Some(value) if value >= 0 => collectionValue.drop(value)
+      case Some(value) =>
+        val end = collectionValue.size + value
+        collectionValue.drop(end)
     }
   }
 
   private def toSlice(from: Expression)(collectionValue: Iterable[Any], ctx: ExecutionContext, state: QueryState) = {
     val toValue = asInt(from, ctx, state)
-    val size = collectionValue.size
-
-    if (toValue >= 0)
-      collectionValue.take(toValue)
-    else {
-      val end = size + toValue
-      collectionValue.take(end)
+    toValue match {
+      case None => null
+      case Some(value) if value >= 0 => collectionValue.take(value)
+      case Some(value) =>
+        val end = collectionValue.size + value
+        collectionValue.take(end)
     }
   }
 
 
-  def asInt(e: Expression, ctx: ExecutionContext, state: QueryState): Int =
-    CastSupport.castOrFail[Number](e(ctx)(state)).intValue()
+  def asInt(e: Expression, ctx: ExecutionContext, state: QueryState): Option[Int] = {
+    val index = e(ctx)(state)
+    if (index == null) None
+    else Some(CastSupport.castOrFail[Number](index).intValue())
+  }
 
   def compute(value: Any, ctx: ExecutionContext)(implicit state: QueryState): Any = {
     val collectionValue: Iterable[Any] = makeTraversable(value)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
@@ -33,8 +33,9 @@ with CollectionSupport {
   def compute(value: Any, ctx: ExecutionContext)(implicit state: QueryState): Any = {
     value match {
       case IsMap(m) =>
-        val idx = CastSupport.castOrFail[String](index(ctx))
-        m(state.query).getOrElse(idx, null)
+        val item = index(ctx)
+        if (item == null) null
+        else m(state.query).getOrElse(CastSupport.castOrFail[String](item), null)
 
       case IsCollection(collection) =>
         val item = index(ctx)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
@@ -37,14 +37,18 @@ with CollectionSupport {
         m(state.query).getOrElse(idx, null)
 
       case IsCollection(collection) =>
-        var idx = CastSupport.castOrFail[Number](index(ctx)).intValue()
-        val collectionValue = collection.toVector
+        val item = index(ctx)
+        if (item == null) null
+        else {
+          var idx = CastSupport.castOrFail[Number](item).intValue()
+          val collectionValue = collection.toVector
 
-        if (idx < 0)
-          idx = collectionValue.size + idx
+          if (idx < 0)
+            idx = collectionValue.size + idx
 
-        if (idx >= collectionValue.size || idx < 0) null
-        else collectionValue.apply(idx)
+          if (idx >= collectionValue.size || idx < 0) null
+          else collectionValue.apply(idx)
+        }
 
       case _ =>
         throw new CypherTypeException(s"""

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
@@ -35,7 +35,10 @@ with CollectionSupport {
       case IsMap(m) =>
         val item = index(ctx)
         if (item == null) null
-        else m(state.query).getOrElse(CastSupport.castOrFail[String](item), null)
+        else {
+          val key = CastSupport.castOrFail[String](item)
+          m(state.query).getOrElse(key, null)
+        }
 
       case IsCollection(collection) =>
         val item = index(ctx)


### PR DESCRIPTION
The following should all return `null` instead of failing with a `NullPointerException`

```
list[null]
list[null..5]
list[1..null]
map[null]
```
Note the docs failure is expected in 2.3

changelog: Fixed error with accessing maps and lists with null, so it now evaluates to null instead