### PR TITLE
Improvements for rel-type checking for traversing relationships

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -123,7 +123,7 @@ final class TransactionBoundQueryContext(tc: TransactionalContextWrapper)
       case None =>
         tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
       case Some(typeIds) =>
-        tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds: _*)
+        tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds.toArray)
     }
     new BeansAPIRelationshipIterator(relationships, nodeManager)
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -122,6 +122,8 @@ final class TransactionBoundQueryContext(tc: TransactionalContextWrapper)
     val relationships = types match {
       case None =>
         tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
+      case Some(Seq(typeId)) =>
+        tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeId)
       case Some(typeIds) =>
         tc.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds.toArray)
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -137,7 +137,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
       case None =>
         transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
       case Some(typeIds) =>
-        transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds: _*)
+        transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds.toArray)
     }
     new BeansAPIRelationshipIterator(relationships, entityAccessor)
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -136,6 +136,8 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     val relationships = types match {
       case None =>
         transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
+      case Some(Seq(typeId)) =>
+        transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeId)
       case Some(typeIds) =>
         transactionalContext.statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds.toArray)
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -181,7 +181,11 @@ public interface ReadOperations
 
     RelationshipIterator nodeGetRelationships( long nodeId,
             Direction direction,
-            int... relTypes ) throws EntityNotFoundException;
+            int[] relTypes ) throws EntityNotFoundException;
+
+    RelationshipIterator nodeGetRelationships( long nodeId,
+            Direction direction,
+            int relType ) throws EntityNotFoundException;
 
     RelationshipIterator nodeGetRelationships( long nodeId, Direction direction ) throws EntityNotFoundException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/NodeItemHelper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/NodeItemHelper.java
@@ -50,6 +50,11 @@ public abstract class NodeItemHelper
     }
 
     @Override
+    public RelationshipIterator getRelationships(Direction direction, int relType)
+    {
+        return new CursorRelationshipIterator( relationships(direction, relType) );
+    }
+    @Override
     public RelationshipIterator getRelationships( Direction direction, int[] relTypes )
     {
         relTypes = deduplicate( relTypes );
@@ -75,12 +80,15 @@ public abstract class NodeItemHelper
         for ( int i = 0; i < types.length; i++ )
         {
             int type = types[i];
-            for ( int j = 0; j < unique; j++ )
+            if ( type != -1 )
             {
-                if ( type == types[j] )
+                for ( int j = 0; j < unique; j++ )
                 {
-                    type = -1; // signal that this relationship is not unique
-                    break; // we will not find more than one conflict
+                    if ( type == types[j] )
+                    {
+                        type = -1; // signal that this relationship is not unique
+                        break; // we will not find more than one conflict
+                    }
                 }
             }
             if ( type != -1 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -340,13 +340,24 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public RelationshipIterator nodeGetRelationships( long nodeId, Direction direction, int... relTypes )
+    public RelationshipIterator nodeGetRelationships( long nodeId, Direction direction, int[] relTypes )
             throws EntityNotFoundException
     {
         statement.assertOpen();
         try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getRelationships( direction( direction ), relTypes );
+        }
+    }
+
+    @Override
+    public RelationshipIterator nodeGetRelationships( long nodeId, Direction direction, int relType )
+            throws EntityNotFoundException
+    {
+        statement.assertOpen();
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
+        {
+            return node.get().getRelationships( direction( direction ), relType );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractNodeCursor.java
@@ -126,12 +126,20 @@ public abstract class TxAbstractNodeCursor
     }
 
     @Override
-    public Cursor<RelationshipItem> relationships( Direction direction, int... relTypes )
+    public Cursor<RelationshipItem> relationships( Direction direction, int[] relTypes )
     {
         return state.augmentNodeRelationshipCursor(
                 nodeIsAddedInThisTx ? Cursors.<RelationshipItem>empty() : cursor.get().relationships( direction,
                         relTypes ), nodeState,
                 direction, relTypes );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> relationships(Direction direction, int relType)
+    {
+        return state.augmentNodeRelationshipCursor(
+                nodeIsAddedInThisTx ? Cursors.<RelationshipItem>empty() : cursor.get().relationships(direction, relType), nodeState,
+                direction, new int[]{relType} );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -202,9 +202,16 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
         return nodeRelationshipCursor.get().init(  nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
                 direction, null );
     }
+    @Override
+
+    public Cursor<RelationshipItem> relationships( Direction direction, int relType )
+    {
+        return nodeRelationshipCursor.get().init(  nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
+                direction, relType );
+    }
 
     @Override
-    public Cursor<RelationshipItem> relationships( Direction direction, int... relTypes )
+    public Cursor<RelationshipItem> relationships( Direction direction, int[] relTypes )
     {
         return nodeRelationshipCursor.get().init( nodeRecord.isDense(), nodeRecord.getNextRel(), nodeRecord.getId(),
                 direction, relTypes );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -163,19 +163,46 @@ public class NodeProxy
         return getRelationships( Direction.BOTH, types );
     }
 
+    private static final ResourceIterator<Relationship> NO_RELATIONSHIPS_ITERATOR = new ResourceIterator<Relationship>()
+    {
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return false;
+        }
+
+        @Override
+        public Relationship next()
+        {
+            return null;
+        }
+    };
+
+    private final static ResourceIterable<Relationship> NO_RELATIONSHIPS = new ResourceIterable<Relationship>()
+    {
+        @Override
+        public ResourceIterator<Relationship> iterator()
+        {
+            return NO_RELATIONSHIPS_ITERATOR;
+        }
+    };
+
     @Override
     public ResourceIterable<Relationship> getRelationships( RelationshipType type, Direction dir )
     {
-        return getRelationships( dir, type );
-    }
-
-    @Override
-    public ResourceIterable<Relationship> getRelationships( final Direction direction, RelationshipType... types )
-    {
-        final int[] typeIds;
+        final int typeId;
         try ( Statement statement = actions.statement() )
         {
-            typeIds = relTypeIds( types, statement );
+            typeId = statement.readOperations().relationshipTypeGetForName( type.name() );
+            if ( typeId == NO_SUCH_RELATIONSHIP_TYPE )
+            {
+                return NO_RELATIONSHIPS;
+            }
         }
         return new ResourceIterable<Relationship>()
         {
@@ -186,7 +213,46 @@ public class NodeProxy
                 try
                 {
                     RelationshipConversion result = new RelationshipConversion( actions );
-                    if ( /* typeIds.length == 1 */ false )
+                    result.iterator = statement.readOperations().nodeGetRelationships( nodeId, dir, typeId );
+                    result.statement = statement;
+                    return result;
+                }
+                catch ( EntityNotFoundException e )
+                {
+                    statement.close();
+                    throw new NotFoundException( format( "Node %d not found", nodeId ), e );
+                }
+                catch ( Throwable e )
+                {
+                    statement.close();
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @Override
+    public ResourceIterable<Relationship> getRelationships( final Direction direction, RelationshipType... types )
+    {
+        final int[] typeIds;
+        try ( Statement statement = actions.statement() )
+        {
+            typeIds = relTypeIds( types, statement );
+        }
+        if ( typeIds.length == 0 )
+        {
+            return NO_RELATIONSHIPS;
+        }
+        return new ResourceIterable<Relationship>()
+        {
+            @Override
+            public ResourceIterator<Relationship> iterator()
+            {
+                Statement statement = actions.statement();
+                try
+                {
+                    RelationshipConversion result = new RelationshipConversion( actions );
+                    if ( typeIds.length == 1 )
                     {
                         result.iterator = statement.readOperations().nodeGetRelationships( nodeId, direction, typeIds[0] );
                     }
@@ -243,13 +309,16 @@ public class NodeProxy
     @Override
     public boolean hasRelationship( RelationshipType type, Direction dir )
     {
-        return hasRelationship( dir, type );
+        try ( ResourceIterator<Relationship> rels = getRelationships( type, dir ).iterator() )
+        {
+            return rels.hasNext();
+        }
     }
 
     @Override
     public Relationship getSingleRelationship( RelationshipType type, Direction dir )
     {
-        try ( ResourceIterator<Relationship> rels = getRelationships( dir, type ).iterator() )
+        try ( ResourceIterator<Relationship> rels = getRelationships( type, dir ).iterator() )
         {
             if ( !rels.hasNext() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -186,8 +186,13 @@ public class NodeProxy
                 try
                 {
                     RelationshipConversion result = new RelationshipConversion( actions );
-                    result.iterator = statement.readOperations().nodeGetRelationships(
-                            nodeId, direction, typeIds );
+                    if ( /* typeIds.length == 1 */ false )
+                    {
+                        result.iterator = statement.readOperations().nodeGetRelationships( nodeId, direction, typeIds[0] );
+                    }
+                    else {
+                        result.iterator = statement.readOperations().nodeGetRelationships( nodeId, direction, typeIds );
+                    }
                     result.statement = statement;
                     return result;
                 }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/NodeItem.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/NodeItem.java
@@ -59,7 +59,13 @@ public interface NodeItem
      * @return relationship cursor for current node
      * @throws IllegalStateException if no current node is selected
      */
-    Cursor<RelationshipItem> relationships( Direction direction, int... typeIds );
+    Cursor<RelationshipItem> relationships(Direction direction, int typeId);
+
+    /**
+     * @return relationship cursor for current node
+     * @throws IllegalStateException if no current node is selected
+     */
+    Cursor<RelationshipItem> relationships( Direction direction, int[] typeIds );
 
     /**
      * @return relationship cursor for current node
@@ -114,6 +120,13 @@ public interface NodeItem
      * @return label ids attached to this node.
      */
     PrimitiveIntIterator getLabels();
+
+    /**
+     * @param direction {@link Direction} to filter on.
+     * @param typeId relationship type id to filter on.
+     * @return relationship ids for the given direction and relationship type.
+     */
+    RelationshipIterator getRelationships(Direction direction, int typeId);
 
     /**
      * @param direction {@link Direction} to filter on.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/NodeState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/NodeState.java
@@ -65,4 +65,5 @@ public interface NodeState extends PropertyContainerState
     PrimitiveLongIterator getAddedRelationships( Direction direction );
 
     PrimitiveLongIterator getAddedRelationships( Direction direction, int[] relTypes );
+
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -78,7 +78,7 @@ public class RelationshipIT extends KernelIntegrationTest
             assertRels( statement.nodeGetRelationships( refNode, BOTH, relType1 ),
                     fromRefToOther1, fromOtherToRef);
 
-            assertRels( statement.nodeGetRelationships( refNode, BOTH, relType1, relType2 ),
+            assertRels( statement.nodeGetRelationships( refNode, BOTH, new int[] { relType1, relType2 } ),
                     fromRefToOther1, fromRefToOther2, fromRefToRef, fromRefToThird, fromOtherToRef);
 
 
@@ -86,7 +86,7 @@ public class RelationshipIT extends KernelIntegrationTest
 
             assertRels( statement.nodeGetRelationships( refNode, INCOMING, relType1 ) /* none */);
 
-            assertRels( statement.nodeGetRelationships( refNode, OUTGOING, relType1, relType2 ),
+            assertRels( statement.nodeGetRelationships( refNode, OUTGOING, new int[] { relType1, relType2 } ),
                     fromRefToOther1, fromRefToOther2, fromRefToThird, fromRefToRef);
 
             // when
@@ -102,14 +102,14 @@ public class RelationshipIT extends KernelIntegrationTest
             assertRels( statement.nodeGetRelationships( refNode, BOTH, relType1 ),
                     fromRefToOther1, fromOtherToRef);
 
-            assertRels( statement.nodeGetRelationships( refNode, BOTH, relType1, relType2 ),
+            assertRels( statement.nodeGetRelationships( refNode, BOTH, new int[]{ relType1, relType2 }),
                     fromRefToOther1, fromRefToOther2, fromRefToRef, fromRefToThird, fromOtherToRef);
 
             assertRels( statement.nodeGetRelationships( refNode, INCOMING ), fromOtherToRef );
 
             assertRels( statement.nodeGetRelationships( refNode, INCOMING, relType1 ) /* none */);
 
-            assertRels( statement.nodeGetRelationships( refNode, OUTGOING, relType1, relType2 ),
+            assertRels( statement.nodeGetRelationships( refNode, OUTGOING, new int[]{ relType1, relType2 } ),
                     fromRefToOther1, fromRefToOther2, fromRefToThird, fromRefToRef);
         }
     }
@@ -192,7 +192,7 @@ public class RelationshipIT extends KernelIntegrationTest
             long otherNode = statement.nodeCreate();
             theRel = statement.relationshipCreate( relType1, refNode, otherNode );
 
-            assertRels( statement.nodeGetRelationships( refNode, Direction.OUTGOING, relType2, relType1 ), theRel );
+            assertRels( statement.nodeGetRelationships( refNode, Direction.OUTGOING, new int[]{ relType1, relType2 } ), theRel );
 
             commit();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
@@ -170,6 +170,12 @@ public class StubCursors
             }
 
             @Override
+            public Cursor<RelationshipItem> relationships( Direction direction, int relTypes )
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public Cursor<RelationshipItem> relationships( Direction direction )
             {
                 throw new UnsupportedOperationException();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -134,7 +134,7 @@ public class NodeProxySingleRelationshipTest
         when( nodeActions.statement() ).thenReturn( stmt );
         when( readOps.relationshipTypeGetForName( loves.name() ) ).thenReturn( 2 );
 
-        when( readOps.nodeGetRelationships( eq( 1L ), eq( Direction.OUTGOING ), eq( 2 ) ) ).thenAnswer( new Answer<RelationshipIterator>()
+        when( readOps.nodeGetRelationships( eq( 1L ), eq( Direction.OUTGOING ), eq(new int[] { 2 }) ) ).thenAnswer( new Answer<RelationshipIterator>()
         {
             @Override
             public RelationshipIterator answer( InvocationOnMock invocation ) throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -134,7 +134,7 @@ public class NodeProxySingleRelationshipTest
         when( nodeActions.statement() ).thenReturn( stmt );
         when( readOps.relationshipTypeGetForName( loves.name() ) ).thenReturn( 2 );
 
-        when( readOps.nodeGetRelationships( eq( 1L ), eq( Direction.OUTGOING ), eq(new int[] { 2 }) ) ).thenAnswer( new Answer<RelationshipIterator>()
+        when( readOps.nodeGetRelationships( eq( 1L ), eq( Direction.OUTGOING ), eq(2 ) ) ).thenAnswer( new Answer<RelationshipIterator>()
         {
             @Override
             public RelationshipIterator answer( InvocationOnMock invocation ) throws Throwable


### PR DESCRIPTION
* removed rel-type check for rel-records of dense nodes as each chain has a single rel-type
* added single-rel-type check instead of array iteration for single rel-types
* removed varargs for rel-type-id array from Kernel-API and below
* added dedicated method to ReadOperations if you only have a single rel-type, so no arrays are allocated on the way

I didn't change the tx-state handling for single rel-types, it's use of boxed values and non-primitive functions and collections should also be revisited.