### PR TITLE
Make max auth max failed attempts configurable

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -547,6 +547,10 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<File> auth_store =
             pathSetting( "unsupported.dbms.security.auth_store.location", NO_DEFAULT );
 
+    @Internal
+    public static final Setting<Integer> auth_max_failed_attempts =
+            setting( "unsupported.dbms.security.auth_max_failed_attempts", INTEGER, "3", min( 0 ) );
+
     @Description( "A list of procedures and user defined functions (comma separated) that are allowed full access to " +
             "the database. The list may contain both fully-qualified procedure names, and partial names with the " +
             "wildcard '*'. Note that this enables these procedures to bypass security. Use with caution." )

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -24,6 +24,7 @@ import java.time.Clock;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthManager;
@@ -35,6 +36,7 @@ import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.UserManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.security.Credential;
 import org.neo4j.kernel.impl.security.User;
 import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
@@ -67,9 +69,9 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     }
 
     public BasicAuthManager( UserRepository userRepository, PasswordPolicy passwordPolicy, Clock clock,
-            UserRepository initialUserRepository )
+            UserRepository initialUserRepository, Config config )
     {
-        this( userRepository, passwordPolicy, new RateLimitedAuthenticationStrategy( clock, 3 ), initialUserRepository );
+        this( userRepository, passwordPolicy, createAuthenticationStrategy( clock, config ), initialUserRepository );
     }
 
     @Override
@@ -244,5 +246,11 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
         {
             throw invalidToken( ", scheme '" + scheme + "' is not supported." );
         }
+    }
+
+    private static AuthenticationStrategy createAuthenticationStrategy( Clock clock, Config config )
+    {
+        int maxFailedAttempts = config.get( GraphDatabaseSettings.auth_max_failed_attempts );
+        return new RateLimitedAuthenticationStrategy( clock, maxFailedAttempts );
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/CommunitySecurityModule.java
@@ -55,8 +55,8 @@ public class CommunitySecurityModule extends SecurityModule
 
         final PasswordPolicy passwordPolicy = new BasicPasswordPolicy();
 
-        BasicAuthManager authManager =
-                new BasicAuthManager( userRepository, passwordPolicy, Clocks.systemClock(), initialUserRepository );
+        BasicAuthManager authManager = new BasicAuthManager( userRepository, passwordPolicy, Clocks.systemClock(),
+                initialUserRepository, config );
 
         dependencies.lifeSupport().add( dependencies.dependencySatisfier().satisfyDependency( authManager ) );
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategy.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/RateLimitedAuthenticationStrategy.java
@@ -40,8 +40,9 @@ public class RateLimitedAuthenticationStrategy implements AuthenticationStrategy
 
         public boolean authenticationPermitted()
         {
-            return failedAuthAttempts.get() < maxFailedAttempts
-                    || clock.millis() >= ( lastFailedAttemptTime + FAILED_AUTH_COOLDOWN_PERIOD );
+            return maxFailedAttempts <= 0 || // amount of attempts is not limited
+                   failedAuthAttempts.get() < maxFailedAttempts || // less failed attempts than configured
+                   clock.millis() >= (lastFailedAttemptTime + FAILED_AUTH_COOLDOWN_PERIOD); // cool down period expired
         }
 
         public void authSuccess()

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.security.OverriddenAccessMode;
 import org.neo4j.kernel.impl.api.security.RestrictedAccessMode;
 import org.neo4j.time.Clocks;
@@ -46,7 +47,8 @@ public class SecurityContextDescriptionTest
                     new InMemoryUserRepository(),
                     new BasicPasswordPolicy(),
                     Clocks.systemClock(),
-                    new InMemoryUserRepository() );
+                    new InMemoryUserRepository(),
+                    Config.defaults() );
         manager.init();
         manager.start();
         manager.newUser( "johan", "bar", false );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModuleTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -162,6 +163,7 @@ public class EnterpriseSecurityModuleTest
         when( config.get( SecuritySettings.auth_cache_ttl ) ).thenReturn( 0L );
         when( config.get( SecuritySettings.auth_cache_max_capacity ) ).thenReturn( 10 );
         when( config.get( SecuritySettings.security_log_successful_authentication ) ).thenReturn( false );
+        when( config.get( GraphDatabaseSettings.auth_max_failed_attempts ) ).thenReturn( 3 );
     }
 
     private void nativeAuth( boolean authn, boolean authr )


### PR DESCRIPTION
This PR adds new internal configuration option `unsupported.dbms.security.auth_max_failed_attempts` to configure failed auth rate limiting. Previously it was fixed to 3 failed attempts before imposing a "cooldown". Ability to configure this parameter is especially valuable for tests that component behaviour when auth failed.