### PR TITLE
Fix typo in notifications

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -22,7 +22,6 @@ package org.neo4j.bolt.v1.transport.integration;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,9 +38,7 @@ import org.neo4j.bolt.v1.transport.socket.client.WebSocketConnection;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.InputPosition;
-import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.SeverityLevel;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -354,7 +351,7 @@ public class TransportSessionIT
                                 "The provided label is not in the database.",
                                 "One of the labels in your query is not available in the database, " +
                                 "make sure you didn't misspell it or that the label is available when " +
-                                "you run this statement in your application (the missing label name is is: " +
+                                "you run this statement in your application (the missing label name is: " +
                                 "THIS_IS_NOT_A_LABEL)",
                                 SeverityLevel.WARNING, new InputPosition( 9, 1, 10 ) ) ) ) );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -46,12 +46,12 @@ public interface NotificationDetail
 
         public static NotificationDetail label( final String labelName )
         {
-            return createNotificationDetail( "the missing label name is", labelName, true );
+            return createNotificationDetail( "the missing label name", labelName, true );
         }
 
         public static NotificationDetail relationshipType( final String relType )
         {
-            return createNotificationDetail( "the missing relationship type is", relType, true );
+            return createNotificationDetail( "the missing relationship type", relType, true );
         }
 
         public static NotificationDetail procedureWarning( final String procedure, final String warning )
@@ -61,7 +61,7 @@ public interface NotificationDetail
 
         public static NotificationDetail propertyName( final String name )
         {
-            return createNotificationDetail( "the missing property name is", name, true );
+            return createNotificationDetail( "the missing property name", name, true );
         }
 
         public static NotificationDetail joinKey( List<String> identifiers )


### PR DESCRIPTION
Warnings produced on missing labels, missing properties, and missing
relationship types all contained a typo where the message was saying
e.g. _the missing label is is: X_, one _is_ is good enough.