### PR TITLE
listConfig requires admin rights

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -50,7 +50,7 @@ public class BuiltInDbmsProcedures
     @Procedure( name = "dbms.listConfig", mode = DBMS )
     public Stream<ConfigResult> listConfig( @Name( value = "searchString", defaultValue = "" ) String searchString )
     {
-        if( !securityContext.isAdmin() )
+        if ( !securityContext.isAdmin() )
         {
             throw new AuthorizationViolationException( PERMISSION_DENIED );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProceduresIT.java
@@ -29,6 +29,7 @@ import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
+import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 
 import static org.hamcrest.Matchers.hasItem;
@@ -74,7 +75,7 @@ public class BuiltInDbmsProceduresIT extends KernelIntegrationTest
         RawIterator<Object[],ProcedureException> stream =
                 dbmsOperations().procedureCallDbms( procedureName( "dbms", "listConfig" ),
                         Arrays.asList( GraphDatabaseSettings.strict_config_validation.name() ).toArray(),
-                        AnonymousContext.none() );
+                        SecurityContext.AUTH_DISABLED );
 
         // Then
         List<Object[]> config = asList( stream );

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -48,6 +48,7 @@ import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.factory.Edition;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.proc.TypeMappers;
@@ -65,6 +66,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.api.proc.Context.KERNEL_TRANSACTION;
+import static org.neo4j.kernel.api.proc.Context.SECURITY_CONTEXT;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
@@ -305,6 +307,7 @@ public class BuiltInProceduresTest
         procs.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ), false );
         procs.registerComponent( DependencyResolver.class, ( ctx ) -> ctx.get( DEPENDENCY_RESOLVER ), false );
         procs.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> ctx.get( GRAPHDATABASEAPI ), false );
+        procs.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ), true );
 
         procs.registerType( Node.class, new TypeMappers.SimpleConverter( NTNode, Node.class ) );
         procs.registerType( Relationship.class, new TypeMappers.SimpleConverter( NTRelationship, Relationship.class ) );
@@ -356,6 +359,7 @@ public class BuiltInProceduresTest
         ctx.put( KERNEL_TRANSACTION, tx );
         ctx.put( DEPENDENCY_RESOLVER, resolver );
         ctx.put( GRAPHDATABASEAPI, graphDatabaseAPI );
+        ctx.put( SECURITY_CONTEXT, SecurityContext.AUTH_DISABLED );
         when( graphDatabaseAPI.getDependencyResolver() ).thenReturn( resolver );
         when( resolver.resolveDependency( Procedures.class ) ).thenReturn( procs );
         return Iterators


### PR DESCRIPTION
changelog: Enforced admin execute rights for some procedures:
- `dbms.listConfig` requires admin privilege.
- `dbms.listActiveLocks` can only be used on a query the user owns unless the user is admin.