### PR TITLE
When credentials have expired you should only be able to change password

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/SecurityContext.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.security;
 
+import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
+
 /** Controls the capabilities of a KernelTransaction. */
 public interface SecurityContext
 {
@@ -28,6 +30,14 @@ public interface SecurityContext
 
     SecurityContext freeze();
     SecurityContext withMode( AccessMode mode );
+
+    default void assertCredentialsNotExpired()
+    {
+        if ( subject().getAuthenticationResult().equals( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) )
+        {
+            throw mode().onViolation( PERMISSION_DENIED );
+        }
+    }
 
     default String description()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInDbmsProcedures.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
@@ -37,10 +38,14 @@ public class BuiltInDbmsProcedures
     @Context
     public GraphDatabaseAPI graph;
 
+    @Context
+    public SecurityContext securityContext;
+
     @Description( "List all procedures in the DBMS." )
     @Procedure( name = "dbms.procedures", mode = DBMS )
     public Stream<ProcedureResult> listProcedures()
     {
+        securityContext.assertCredentialsNotExpired();
         return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllProcedures().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
                 .map( ProcedureResult::new );
@@ -50,6 +55,7 @@ public class BuiltInDbmsProcedures
     @Procedure(name = "dbms.functions", mode = DBMS)
     public Stream<FunctionResult> listFunctions()
     {
+        securityContext.assertCredentialsNotExpired();
         return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllFunctions().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
                 .map( FunctionResult::new );

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthProcedures.java
@@ -54,6 +54,7 @@ public class AuthProcedures
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.newUser( username, password, requirePasswordChange );
     }
 
@@ -61,6 +62,7 @@ public class AuthProcedures
     @Procedure( name = "dbms.security.deleteUser", mode = DBMS )
     public void deleteUser( @Name( "username" ) String username ) throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         if ( securityContext.subject().hasUsername( username ) )
         {
             throw new InvalidArgumentsException( "Deleting yourself (user '" + username + "') is not allowed." );
@@ -99,6 +101,7 @@ public class AuthProcedures
     @Procedure( name = "dbms.security.listUsers", mode = DBMS )
     public Stream<UserResult> listUsers() throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         Set<String> usernames = userManager.getAllUsernames();
 
         if ( usernames.isEmpty() )

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -97,6 +97,17 @@ public class AuthProceduresIT
         assertEmpty( login("andres", "banana"), "CALL dbms.changePassword('abc')" );
     }
 
+    @Test
+    public void newUserShouldNotBeAbleToCallOtherProcedures() throws Throwable
+    {
+        // Given
+        authManager.newUser( "andres", "banana", true );
+        BasicSecurityContext user = login("andres", "banana");
+
+        // Then
+        assertFail( user, "CALL dbms.procedures", "The credentials you provided were valid, but must be changed before you can use this instance." );
+    }
+
     //---------- create user -----------
 
     @Test

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -226,6 +226,7 @@ public class AuthProceduresIT
         db = (GraphDatabaseAPI) createGraphDatabase( fs );
         authManager = db.getDependencyResolver().resolveDependency( BasicAuthManager.class );
         admin = login( "neo4j", "neo4j" );
+        admin.subject().setPasswordChangeNoLongerRequired();
     }
 
     @After

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresIT.java
@@ -87,6 +87,16 @@ public class AuthProceduresIT
         assertFail( admin, "CALL dbms.changePassword( 'neo4j' )", "Old password and new password cannot be the same." );
     }
 
+    @Test
+    public void newUserShouldBeAbleToChangePassword() throws Throwable
+    {
+        // Given
+        authManager.newUser( "andres", "banana", true );
+
+        // Then
+        assertEmpty( login("andres", "banana"), "CALL dbms.changePassword('abc')" );
+    }
+
     //---------- create user -----------
 
     @Test

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -93,6 +93,7 @@ public class EnterpriseBuiltInDbmsProcedures
     @Procedure( name = "dbms.setTXMetaData", mode = DBMS )
     public void setTXMetaData( @Name( value = "data" ) Map<String,Object> data )
     {
+        securityContext.assertCredentialsNotExpired();
         int totalCharSize = data.entrySet().stream()
                 .mapToInt( e -> e.getKey().length() + e.getValue().toString().length() )
                 .sum();
@@ -172,6 +173,7 @@ public class EnterpriseBuiltInDbmsProcedures
     @Procedure(name = "dbms.functions", mode = DBMS)
     public Stream<FunctionResult> listFunctions()
     {
+        securityContext.assertCredentialsNotExpired();
         return graph.getDependencyResolver().resolveDependency( Procedures.class ).getAllFunctions().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
                 .map( FunctionResult::new );
@@ -198,6 +200,7 @@ public class EnterpriseBuiltInDbmsProcedures
     @Procedure( name = "dbms.procedures", mode = DBMS )
     public Stream<ProcedureResult> listProcedures()
     {
+        securityContext.assertCredentialsNotExpired();
         Procedures procedures = graph.getDependencyResolver().resolveDependency( Procedures.class );
         return procedures.getAllProcedures().stream()
                 .sorted( ( a, b ) -> a.name().toString().compareTo( b.name().toString() ) )
@@ -246,6 +249,7 @@ public class EnterpriseBuiltInDbmsProcedures
     @Procedure( name = "dbms.listQueries", mode = DBMS )
     public Stream<QueryStatusResult> listQueries() throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         try
         {
             return getKernelTransactions().activeTransactions().stream()
@@ -265,6 +269,7 @@ public class EnterpriseBuiltInDbmsProcedures
     public Stream<QueryTerminationResult> killQuery( @Name( "id" ) String idText )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         try
         {
             long queryId = fromExternalString( idText ).kernelQueryId();
@@ -288,6 +293,7 @@ public class EnterpriseBuiltInDbmsProcedures
     public Stream<QueryTerminationResult> killQueries( @Name( "ids" ) List<String> idTexts )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         try
         {
             Set<Long> queryIds = idTexts

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecurityProcedures.java
@@ -49,6 +49,7 @@ public class SecurityProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.clearAuthCache", mode = DBMS )
     public void clearAuthenticationCache()
     {
+        securityContext.assertCredentialsNotExpired();
         if ( !securityContext.isAdmin() )
         {
             throw new AuthorizationViolationException( PERMISSION_DENIED );

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/UserManagementProcedures.java
@@ -40,6 +40,7 @@ public class UserManagementProcedures extends AuthProceduresBase
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.newUser( username, password, requirePasswordChange );
     }
 
@@ -58,7 +59,7 @@ public class UserManagementProcedures extends AuthProceduresBase
             @Name( value = "requirePasswordChange", defaultValue = "false" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
-        changeUserPassword( securityContext.subject().username(), password, requirePasswordChange );
+        setUserPassword( securityContext.subject().username(), password, requirePasswordChange );
     }
 
     @Description( "Change the given user's password." )
@@ -67,11 +68,8 @@ public class UserManagementProcedures extends AuthProceduresBase
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws InvalidArgumentsException, IOException
     {
-        userManager.setUserPassword( username, newPassword, requirePasswordChange );
-        if ( securityContext.subject().hasUsername( username ) )
-        {
-            securityContext.subject().setPasswordChangeNoLongerRequired();
-        }
+        securityContext.assertCredentialsNotExpired();
+        setUserPassword( username, newPassword, requirePasswordChange );
     }
 
     @Description( "Assign a role to the user." )
@@ -79,6 +77,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     public void addRoleToUser( @Name( "roleName" ) String roleName, @Name( "username" ) String username )
             throws IOException, InvalidArgumentsException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.addRoleToUser( roleName, username );
     }
 
@@ -87,6 +86,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     public void removeRoleFromUser( @Name( "roleName" ) String roleName, @Name( "username" ) String username )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.removeRoleFromUser( roleName, username );
     }
 
@@ -94,6 +94,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.deleteUser", mode = DBMS )
     public void deleteUser( @Name( "username" ) String username ) throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         if ( userManager.deleteUser( username ) )
         {
             kickoutUser( username, "deletion" );
@@ -104,6 +105,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.suspendUser", mode = DBMS )
     public void suspendUser( @Name( "username" ) String username ) throws IOException, InvalidArgumentsException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.suspendUser( username );
         kickoutUser( username, "suspension" );
     }
@@ -114,6 +116,7 @@ public class UserManagementProcedures extends AuthProceduresBase
             @Name( value = "requirePasswordChange", defaultValue = "true" ) boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.activateUser( username, requirePasswordChange );
     }
 
@@ -121,6 +124,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.listUsers", mode = DBMS )
     public Stream<UserResult> listUsers() throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         Set<String> users = userManager.getAllUsernames();
         if ( users.isEmpty() )
         {
@@ -136,6 +140,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.listRoles", mode = DBMS )
     public Stream<RoleResult> listRoles() throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         Set<String> roles = userManager.getAllRoleNames();
         return roles.stream().map( this::roleResultForName );
     }
@@ -145,6 +150,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     public Stream<StringResult> listRolesForUser( @Name( "username" ) String username )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         return userManager.getRoleNamesForUser( username ).stream().map( StringResult::new );
     }
 
@@ -153,6 +159,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     public Stream<StringResult> listUsersForRole( @Name( "roleName" ) String roleName )
             throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         return userManager.getUsernamesForRole( roleName ).stream().map( StringResult::new );
     }
 
@@ -160,6 +167,7 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.createRole", mode = DBMS )
     public void createRole( @Name( "roleName" ) String roleName ) throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.newRole( roleName );
     }
 
@@ -167,6 +175,17 @@ public class UserManagementProcedures extends AuthProceduresBase
     @Procedure( name = "dbms.security.deleteRole", mode = DBMS )
     public void deleteRole( @Name( "roleName" ) String roleName ) throws InvalidArgumentsException, IOException
     {
+        securityContext.assertCredentialsNotExpired();
         userManager.deleteRole( roleName );
+    }
+
+    private void setUserPassword( String username, String newPassword, boolean requirePasswordChange )
+            throws IOException, InvalidArgumentsException
+    {
+        userManager.setUserPassword( username, newPassword, requirePasswordChange );
+        if ( securityContext.subject().hasUsername( username ) )
+        {
+            securityContext.subject().setPasswordChangeNoLongerRequired();
+        }
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/UserManagementProceduresLoggingTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import org.neo4j.function.ThrowingAction;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
-import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -671,7 +671,7 @@ public class UserManagementProceduresLoggingTest
 
         TestShiroSubject( String name )
         {
-            super( mock( SecurityManager.class ), null );
+            super( mock( SecurityManager.class ), AuthenticationResult.SUCCESS );
             this.name = name;
         }
 


### PR DESCRIPTION
changelog: [3.1] Fixed so a user whose credentials have expired aren't allowed to call procedures apart from `changePassword` and `showCurrentUser`