### PR TITLE
Allow multiple values in lockingUniqueIndexSeek

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/IndexSeekMode.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/IndexSeekMode.scala
@@ -69,7 +69,7 @@ case object LockingUniqueIndexSeek extends IndexSeekMode {
 
   override def indexFactory(descriptor: IndexDescriptor): MultipleValueQuery =
     (state: QueryState) => (x: Seq[Any]) => {
-      state.query.lockingUniqueIndexSeek(descriptor, assertSingleValue(x)).toIterator
+      state.query.lockingUniqueIndexSeek(descriptor, x).toIterator
     }
 
   override def name: String = "NodeUniqueIndexSeek(Locking)"

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/DelegatingQueryContext.scala
@@ -138,8 +138,8 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   override def withAnyOpenQueryContext[T](work: (QueryContext) => T): T = inner.withAnyOpenQueryContext(work)
 
-  override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] =
-    singleDbHit(inner.lockingUniqueIndexSeek(index, value))
+  override def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Option[Node] =
+    singleDbHit(inner.lockingUniqueIndexSeek(index, values))
 
   override def getRelTypeId(relType: String): Int = singleDbHit(inner.getRelTypeId(relType))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContext.scala
@@ -96,7 +96,7 @@ trait QueryContext extends TokenContext {
 
   def indexScan(index: IndexDescriptor): Iterator[Node]
 
-  def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node]
+  def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Option[Node]
 
   def getNodesByLabel(id: Int): Iterator[Node]
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/QueryContextAdaptation.scala
@@ -123,7 +123,7 @@ trait QueryContextAdaptation {
 
   override def getNodesByLabel(id: Int): scala.Iterator[Node] = ???
 
-  override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] = ???
+  override def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Option[Node] = ???
 
   override def callReadOnlyProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): scala.Iterator[Array[AnyRef]] = ???
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/ExceptionTranslatingQueryContext.scala
@@ -173,8 +173,8 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def getRelTypeName(id: Int) =
     translateException(inner.getRelTypeName(id))
 
-  override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any) =
-    translateException(inner.lockingUniqueIndexSeek(index, value))
+  override def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]) =
+    translateException(inner.lockingUniqueIndexSeek(index, values))
 
   override def getImportURL(url: URL) =
     translateException(inner.getImportURL(url))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -271,9 +271,10 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   override def indexScanByEndsWith(index: IndexDescriptor, value: String) =
     mapToScalaENFXSafe(transactionalContext.statement.readOperations().indexQuery(index, IndexQuery.stringSuffix(index.property, value)))(nodeOps.getById)
 
-  override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] = {
-    indexSearchMonitor.lockingUniqueIndexSeek(index, value)
-    val nodeId = transactionalContext.statement.readOperations().nodeGetFromUniqueIndexSeek(index, IndexQuery.exact(index.property, value))
+  override def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Option[Node] = {
+    indexSearchMonitor.lockingUniqueIndexSeek(index, values)
+    val predicates = index.properties.zip(values).map(p => IndexQuery.exact(p._1, p._2))
+    val nodeId = transactionalContext.statement.readOperations().nodeGetFromUniqueIndexSeek(index, predicates: _*)
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }
 
@@ -745,6 +746,6 @@ object TransactionBoundQueryContext {
   trait IndexSearchMonitor {
     def indexSeek(index: IndexDescriptor, values: Seq[Any]): Unit
 
-    def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Unit
+    def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Unit
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
@@ -138,7 +138,7 @@ class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPla
     val assertReadOnlyMonitorListener = new IndexSearchMonitor {
       override def indexSeek(index: IndexDescriptor, value: Seq[Any]): Unit = {}
 
-      override def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Unit = {
+      override def lockingUniqueIndexSeek(index: IndexDescriptor, values: Seq[Any]): Unit = {
         lockingIndexSearchCalled = true
       }
     }


### PR DESCRIPTION
For updating queries like

```
MATCH (n:L {prop1: 42, prop2: 1337}) REMOVE/DELETE ..
```

where there is a `NODE KEY` constraint on `L:{prop1,prop2}` we will
use a `lockingUniqueIndexSeek` which thus must be able to cope with
composite indexes.