### PR TITLE
Avoid accumulation of index updates during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -59,9 +59,9 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
      * and puts those updates into {@code target}.
      *
      * @param nodeId id of node to load.
-     * @param target {@link Collection} to add updates into.
+     * @return node updates container
      */
-    void nodeAsUpdates( long nodeId, Collection<NodeUpdates> target );
+    NodeUpdates nodeAsUpdates( long nodeId );
 
     DoubleLongRegister indexUpdatesAndSize( long indexId, DoubleLongRegister output );
 
@@ -129,8 +129,9 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
         }
 
         @Override
-        public void nodeAsUpdates( long nodeId, Collection<NodeUpdates> target )
+        public NodeUpdates nodeAsUpdates( long nodeId )
         {
+            return null;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -56,7 +56,7 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
 
     /**
      * Produces {@link NodeUpdates} objects from reading node {@code nodeId}, its labels and properties
-     * and puts those updates into {@code target}.
+     * and puts those updates into node updates container.
      *
      * @param nodeId id of node to load.
      * @return node updates container

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -439,11 +439,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
         {
             for ( IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate : updates )
             {
-                IndexUpdater updater = updaterMap.getUpdater( indexUpdate.indexKey().schema() );
-                if ( updater != null )
-                {
-                    updater.process( indexUpdate );
-                }
+                processUpdate( updaterMap, indexUpdate );
             }
         }
     }
@@ -543,16 +539,22 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                 {
                     IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate = indexEntryUpdates.next();
                     monitor.applyingRecoveredUpdate( indexUpdate );
-                    IndexUpdater updater = updaterMap.getUpdater( indexUpdate.indexKey().schema() );
-                    if ( updater != null )
-                    {
-                        updater.process( indexUpdate );
-                    }
+                    processUpdate( updaterMap, indexUpdate );
                 }
                 monitor.recoveredUpdatesApplied();
             }
         }
         recoveredNodeIds.clear();
+    }
+
+    private void processUpdate( IndexUpdaterMap updaterMap, IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate )
+            throws IOException, IndexEntryConflictException
+    {
+        IndexUpdater updater = updaterMap.getUpdater( indexUpdate.indexKey().schema() );
+        if ( updater != null )
+        {
+            updater.process( indexUpdate );
+        }
     }
 
     private Iterator<NodeUpdates> recoveredNodeUpdatesIterator()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,10 +34,9 @@ import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
 import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
-import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
@@ -115,7 +115,9 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     {
         void applyingRecoveredData( PrimitiveLongSet recoveredNodeIds );
 
-        void appliedRecoveredData( Iterable<NodeUpdates> updates );
+        void applyingRecoveredUpdate( IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate );
+
+        void recoveredUpdatesApplied();
 
         void populationCompleteOn( IndexDescriptor descriptor );
 
@@ -127,13 +129,19 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     public static class MonitorAdapter implements Monitor
     {
         @Override
-        public void appliedRecoveredData( Iterable<NodeUpdates> updates )
+        public void recoveredUpdatesApplied()
         {   // Do nothing
         }
 
         @Override
         public void applyingRecoveredData( PrimitiveLongSet recoveredNodeIds )
         {   // Do nothing
+        }
+
+        @Override
+        public void applyingRecoveredUpdate( IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate )
+        {
+            // empty
         }
 
         @Override
@@ -440,12 +448,6 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
         }
     }
 
-    public void convertToIndexUpdatesAndApply( Iterable<NodeUpdates> updates, IndexUpdateMode updateMode )
-            throws IOException, IndexEntryConflictException
-    {
-        apply( Iterables.flatMap( this::convertToIndexUpdates, updates ), updateMode );
-    }
-
     @Override
     public Iterable<IndexEntryUpdate<LabelSchemaDescriptor>> convertToIndexUpdates( NodeUpdates nodeUpdates )
     {
@@ -534,28 +536,29 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                     updater.remove( recoveredNodeIds );
                 }
 
-                Iterable<NodeUpdates> updates = readNodeUpdatesFromRecoveredStore();
-                convertToIndexUpdatesAndApply( updates, IndexUpdateMode.RECOVERY );
-                monitor.appliedRecoveredData( updates );
+                Iterator<NodeUpdates> updates = recoveredNodeUpdatesIterator();
+                Iterator<IndexEntryUpdate<LabelSchemaDescriptor>> indexEntryUpdates =
+                        Iterators.flatMap( nodeUpdates -> convertToIndexUpdates( nodeUpdates ).iterator(), updates );
+                while ( indexEntryUpdates.hasNext() )
+                {
+                    IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate = indexEntryUpdates.next();
+                    monitor.applyingRecoveredUpdate( indexUpdate );
+                    IndexUpdater updater = updaterMap.getUpdater( indexUpdate.indexKey().schema() );
+                    if ( updater != null )
+                    {
+                        updater.process( indexUpdate );
+                    }
+                }
+                monitor.recoveredUpdatesApplied();
             }
         }
         recoveredNodeIds.clear();
     }
 
-    private Iterable<NodeUpdates> readNodeUpdatesFromRecoveredStore()
+    private Iterator<NodeUpdates> recoveredNodeUpdatesIterator()
     {
-        final List<NodeUpdates> nodeUpdates = new ArrayList<>();
-        recoveredNodeIds.visitKeys( new PrimitiveLongVisitor<RuntimeException>()
-        {
-            @Override
-            public boolean visited( long nodeId )
-            {
-                storeView.nodeAsUpdates( nodeId, nodeUpdates );
-                return false;
-            }
-        } );
-
-        return nodeUpdates;
+        PrimitiveLongIterator nodeIdIterator = recoveredNodeIds.iterator();
+        return new NodeUpdatesIterator( storeView, nodeIdIterator );
     }
 
     public void dropIndex( IndexRule rule )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIterator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.util.Iterator;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+
+class NodeUpdatesIterator implements Iterator<NodeUpdates>
+{
+
+    private final IndexStoreView storeView;
+    private final PrimitiveLongIterator nodeIdIterator;
+    private NodeUpdates nextUpdate;
+
+    NodeUpdatesIterator( IndexStoreView storeView, PrimitiveLongIterator nodeIdIterator )
+    {
+        this.storeView = storeView;
+        this.nodeIdIterator = nodeIdIterator;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        if ( nextUpdate == null )
+        {
+            while ( nodeIdIterator.hasNext() )
+            {
+                long nodeId = nodeIdIterator.next();
+                NodeUpdates updates = storeView.nodeAsUpdates( nodeId );
+                if ( updates != null )
+                {
+                    nextUpdate = updates;
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public NodeUpdates next()
+    {
+        NodeUpdates update = null;
+        if ( hasNext() )
+        {
+            update = this.nextUpdate;
+            this.nextUpdate = null;
+        }
+        return update;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/NodeUpdatesIteratorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NodeUpdatesIteratorTest
+{
+
+    @Test
+    public void iterateOverEmptyNodeIds() throws Exception
+    {
+        IndexStoreView storeView = Mockito.mock( IndexStoreView.class );
+        PrimitiveLongIterator emptyIterator = PrimitiveLongCollections.emptyIterator();
+        NodeUpdatesIterator nodeUpdatesIterator = new NodeUpdatesIterator( storeView, emptyIterator );
+        assertFalse( nodeUpdatesIterator.hasNext() );
+    }
+
+    @Test
+    public void iterateOverUpdatesWithNext() throws Exception
+    {
+        IndexStoreView storeView = Mockito.mock( IndexStoreView.class );
+        NodeUpdates nodeUpdates1 = NodeUpdates.forNode( 1 ).build();
+        NodeUpdates nodeUpdates2 = NodeUpdates.forNode( 2 ).build();
+        when( storeView.nodeAsUpdates( 1 ) ).thenReturn( nodeUpdates1 );
+        when( storeView.nodeAsUpdates( 2 ) ).thenReturn( nodeUpdates2 );
+
+        PrimitiveLongIterator nodeIdIterator = PrimitiveLongCollections.iterator( 1, 2 );
+        NodeUpdatesIterator nodeUpdatesIterator = new NodeUpdatesIterator( storeView, nodeIdIterator );
+
+        assertSame( nodeUpdates1, nodeUpdatesIterator.next() );
+        assertSame( nodeUpdates2, nodeUpdatesIterator.next() );
+        assertFalse( nodeUpdatesIterator.hasNext() );
+
+        verify( storeView ).nodeAsUpdates( 1 );
+        verify( storeView ).nodeAsUpdates( 2 );
+    }
+
+    @Test
+    public void iterateOverUpdatesWithHasNext()
+    {
+        IndexStoreView storeView = Mockito.mock( IndexStoreView.class );
+        NodeUpdates nodeUpdates1 = NodeUpdates.forNode( 1 ).build();
+        NodeUpdates nodeUpdates2 = NodeUpdates.forNode( 2 ).build();
+        when( storeView.nodeAsUpdates( 1 ) ).thenReturn( nodeUpdates1 );
+        when( storeView.nodeAsUpdates( 2 ) ).thenReturn( nodeUpdates2 );
+
+        Deque<NodeUpdates> updates = new ArrayDeque<>( Arrays.asList( nodeUpdates1, nodeUpdates2 ) );
+
+        PrimitiveLongIterator nodeIdIterator = PrimitiveLongCollections.iterator( 1, 2 );
+        NodeUpdatesIterator nodeUpdatesIterator = new NodeUpdatesIterator( storeView, nodeIdIterator );
+
+        while ( nodeUpdatesIterator.hasNext() )
+        {
+            NodeUpdates nodeUpdates = nodeUpdatesIterator.next();
+            assertSame( updates.pop(), nodeUpdates );
+        }
+
+        verify( storeView ).nodeAsUpdates( 1 );
+        verify( storeView ).nodeAsUpdates( 2 );
+    }
+}


### PR DESCRIPTION
Do not collect index updates during recovery since that can cause OOM.
Use iterators instead to iterate over required updates.