### PR TITLE
Remove blacklisted items

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -5,8 +5,3 @@ Ordering is well defined across all types, ascending
 Ordering is well defined across all types, descending
 Ordering for lists, ascending
 Ordering for lists, descending
-
-// Long chain of comparison operators
-Long chains of integer comparisons
-Long chains of floating point comparisons
-Long chains of string comparisons


### PR DESCRIPTION
Since the update to 3.1.4 we no longer need to blacklist tests in 3.1
compatibility mode