### PR TITLE
Avoid duplicated monitors for label scan store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.scan;
 import java.util.function.Supplier;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.labelscan.LoggingMonitor;
 import org.neo4j.kernel.configuration.Config;
@@ -38,8 +37,6 @@ import org.neo4j.logging.Log;
 public class NativeLabelScanStoreExtension extends
         KernelExtensionFactory<NativeLabelScanStoreExtension.Dependencies>
 {
-    private static final String NAME = LabelIndex.NATIVE.name();
-
     public interface Dependencies
     {
         Config getConfig();
@@ -55,7 +52,7 @@ public class NativeLabelScanStoreExtension extends
 
     public NativeLabelScanStoreExtension()
     {
-        super( NAME );
+        super( NativeLabelScanStore.NATIVE_LABEL_INDEX_TAG );
     }
 
     @Override
@@ -63,7 +60,7 @@ public class NativeLabelScanStoreExtension extends
     {
         Log log = dependencies.getLogService().getInternalLog( NativeLabelScanStore.class );
         Monitors monitors = dependencies.monitors();
-        monitors.addMonitorListener( new LoggingMonitor( log ), NativeLabelScanStore.NATIVE_INDEX_TAG );
+        monitors.addMonitorListener( new LoggingMonitor( log ), NativeLabelScanStore.NATIVE_LABEL_INDEX_TAG );
         NativeLabelScanStore labelScanStore = new NativeLabelScanStore(
                 dependencies.pageCache(),
                 context.storeDir(),
@@ -71,6 +68,6 @@ public class NativeLabelScanStoreExtension extends
                 dependencies.getConfig().get( GraphDatabaseSettings.read_only ),
                 monitors );
 
-        return new LabelScanStoreProvider( NAME, labelScanStore );
+        return new LabelScanStoreProvider( NativeLabelScanStore.NATIVE_LABEL_INDEX_TAG, labelScanStore );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/scan/NativeLabelScanStoreExtension.java
@@ -63,7 +63,7 @@ public class NativeLabelScanStoreExtension extends
     {
         Log log = dependencies.getLogService().getInternalLog( NativeLabelScanStore.class );
         Monitors monitors = dependencies.monitors();
-        monitors.addMonitorListener( new LoggingMonitor( log ) );
+        monitors.addMonitorListener( new LoggingMonitor( log ), NativeLabelScanStore.NATIVE_INDEX_TAG );
         NativeLabelScanStore labelScanStore = new NativeLabelScanStore(
                 dependencies.pageCache(),
                 context.storeDir(),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -96,10 +96,9 @@ public class NativeLabelScanStore implements LabelScanStore
     private static final byte REBUILDING = (byte) 0x01;
 
     /**
-     * Native index monitor tag, to distinguish monitors for native index store
-     * from others.
+     * Native label index tag, to distinguish native label index from other label indexes
      */
-    public static final String NATIVE_INDEX_TAG = GraphDatabaseSettings.LabelIndex.NATIVE.name();
+    public static final String NATIVE_LABEL_INDEX_TAG = GraphDatabaseSettings.LabelIndex.NATIVE.name();
 
     /**
      * Whether or not this label scan store is read-only.
@@ -184,7 +183,7 @@ public class NativeLabelScanStore implements LabelScanStore
         this.singleWriter = new NativeLabelScanWriter( 1_000 );
         this.readOnly = readOnly;
         this.monitors = monitors;
-        this.monitor = monitors.newMonitor( Monitor.class, NATIVE_INDEX_TAG );
+        this.monitor = monitors.newMonitor( Monitor.class, NATIVE_LABEL_INDEX_TAG );
     }
 
     /**
@@ -351,8 +350,8 @@ public class NativeLabelScanStore implements LabelScanStore
      */
     private boolean instantiateTree() throws IOException
     {
-        monitors.addMonitorListener( treeMonitor(), NATIVE_INDEX_TAG );
-        GBPTree.Monitor monitor = monitors.newMonitor( GBPTree.Monitor.class, NATIVE_INDEX_TAG );
+        monitors.addMonitorListener( treeMonitor(), NATIVE_LABEL_INDEX_TAG );
+        GBPTree.Monitor monitor = monitors.newMonitor( GBPTree.Monitor.class, NATIVE_LABEL_INDEX_TAG );
         MutableBoolean isRebuilding = new MutableBoolean();
         Header.Reader readRebuilding =
                 (pageCursor, length) -> isRebuilding.setValue( pageCursor.getByte() == REBUILDING );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.neo4j.cursor.RawCursor;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.index.internal.gbptree.Header;
 import org.neo4j.index.internal.gbptree.Hit;
@@ -93,6 +94,12 @@ public class NativeLabelScanStore implements LabelScanStore
      * Written in header to indicate native label scan store is rebuilding
      */
     private static final byte REBUILDING = (byte) 0x01;
+
+    /**
+     * Native index monitor tag, to distinguish monitors for native index store
+     * from others.
+     */
+    public static final String NATIVE_INDEX_TAG = GraphDatabaseSettings.LabelIndex.NATIVE.name();
 
     /**
      * Whether or not this label scan store is read-only.
@@ -177,7 +184,7 @@ public class NativeLabelScanStore implements LabelScanStore
         this.singleWriter = new NativeLabelScanWriter( 1_000 );
         this.readOnly = readOnly;
         this.monitors = monitors;
-        this.monitor = monitors.newMonitor( Monitor.class );
+        this.monitor = monitors.newMonitor( Monitor.class, NATIVE_INDEX_TAG );
     }
 
     /**
@@ -344,8 +351,8 @@ public class NativeLabelScanStore implements LabelScanStore
      */
     private boolean instantiateTree() throws IOException
     {
-        monitors.addMonitorListener( treeMonitor() );
-        GBPTree.Monitor monitor = monitors.newMonitor( GBPTree.Monitor.class );
+        monitors.addMonitorListener( treeMonitor(), NATIVE_INDEX_TAG );
+        GBPTree.Monitor monitor = monitors.newMonitor( GBPTree.Monitor.class, NATIVE_INDEX_TAG );
         MutableBoolean isRebuilding = new MutableBoolean();
         Header.Reader readRebuilding =
                 (pageCursor, length) -> isRebuilding.setValue( pageCursor.getByte() == REBUILDING );

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -632,7 +632,27 @@ public class AssertableLogProvider extends AbstractLogProvider<Log> implements T
         }
     }
 
+    public void assertNoLogCallContaining( String partOfMessage )
+    {
+        if ( containsLogCallContaining( partOfMessage ) )
+        {
+            fail( format(
+                    "Expected no log statement containing '%s', but at least one found. Actual log calls were:\n%s",
+                    partOfMessage, serialize( logCalls.iterator() ) ) );
+        }
+    }
+
     public void assertContainsLogCallContaining( String partOfMessage )
+    {
+        if ( !containsLogCallContaining( partOfMessage ) )
+        {
+            fail( format(
+                    "Expected at least one log statement containing '%s', but none found. Actual log calls were:\n%s",
+                    partOfMessage, serialize( logCalls.iterator() ) ) );
+        }
+    }
+
+    boolean containsLogCallContaining( String partOfMessage )
     {
         synchronized (logCalls)
         {
@@ -640,13 +660,11 @@ public class AssertableLogProvider extends AbstractLogProvider<Log> implements T
             {
                 if ( logCall.toString().contains( partOfMessage ) )
                 {
-                    return;
+                    return true;
                 }
             }
-            fail( format(
-                    "Expected at least one log statement containing '%s', but none found. Actual log calls were:\n%s", partOfMessage, serialize( logCalls.iterator() )
-            ) );
         }
+        return false;
     }
 
     public void assertContainsMessageContaining( String partOfMessage )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStore.java
@@ -23,7 +23,9 @@ import org.apache.lucene.store.LockObtainFailedException;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.api.labelscan.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -35,6 +37,11 @@ import org.neo4j.storageengine.api.schema.LabelScanReader;
 
 public class LuceneLabelScanStore implements LabelScanStore
 {
+    /**
+     * Lucene label index tag, to distinguish lucene label index from other label indexes
+     */
+    public static final String LUCENE_LABEL_INDEX_TAG = GraphDatabaseSettings.LabelIndex.LUCENE.name();
+
     private final LuceneLabelScanIndexBuilder indexBuilder;
     private volatile LabelScanIndex luceneIndex;
     // We get in a full store stream here in case we need to fully rebuild the store if it's missing or corrupted.

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.api.impl.labelscan;
 
 import java.util.function.Supplier;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings.LabelIndex;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -45,7 +44,6 @@ import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFa
 @Service.Implementation(KernelExtensionFactory.class)
 public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<LuceneLabelScanStoreExtension.Dependencies>
 {
-    private static final String NAME = LabelIndex.LUCENE.name();
 
     public interface Dependencies
     {
@@ -82,12 +80,13 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
         LuceneLabelScanIndexBuilder indexBuilder = getIndexBuilder( context, directoryFactory, fileSystem, config );
         LogProvider logger = dependencies.getLogService().getInternalLogProvider();
         Monitors monitors = dependencies.monitors();
-        monitors.addMonitorListener( new LoggingMonitor( logger.getLog( LuceneLabelScanStore.class ) ), NAME );
+        monitors.addMonitorListener( new LoggingMonitor( logger.getLog( LuceneLabelScanStore.class ) ),
+                LuceneLabelScanStore.LUCENE_LABEL_INDEX_TAG );
         LuceneLabelScanStore scanStore = new LuceneLabelScanStore( indexBuilder,
                 new FullLabelStream( dependencies.indexStoreView() ),
-                monitors.newMonitor( LabelScanStore.Monitor.class, NAME ) );
+                monitors.newMonitor( LabelScanStore.Monitor.class, LuceneLabelScanStore.LUCENE_LABEL_INDEX_TAG ) );
 
-        return new LabelScanStoreProvider( NAME, scanStore );
+        return new LabelScanStoreProvider( LuceneLabelScanStore.LUCENE_LABEL_INDEX_TAG, scanStore );
     }
 
     private LuceneLabelScanIndexBuilder getIndexBuilder( KernelContext context, DirectoryFactory directoryFactory,

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreExtension.java
@@ -82,10 +82,10 @@ public class LuceneLabelScanStoreExtension extends KernelExtensionFactory<Lucene
         LuceneLabelScanIndexBuilder indexBuilder = getIndexBuilder( context, directoryFactory, fileSystem, config );
         LogProvider logger = dependencies.getLogService().getInternalLogProvider();
         Monitors monitors = dependencies.monitors();
-        monitors.addMonitorListener( new LoggingMonitor( logger.getLog( LuceneLabelScanStore.class ) ) );
+        monitors.addMonitorListener( new LoggingMonitor( logger.getLog( LuceneLabelScanStore.class ) ), NAME );
         LuceneLabelScanStore scanStore = new LuceneLabelScanStore( indexBuilder,
                 new FullLabelStream( dependencies.indexStoreView() ),
-                monitors.newMonitor( LabelScanStore.Monitor.class ) );
+                monitors.newMonitor( LabelScanStore.Monitor.class, NAME ) );
 
         return new LabelScanStoreProvider( NAME, scanStore );
     }

--- a/community/neo4j/src/test/java/org/neo4j/index/LabelScanStoreLogging.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/LabelScanStoreLogging.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.api.labelscan.LabelScanWriter;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+public class LabelScanStoreLogging
+{
+
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void noLuceneLabelScanStoreMonitorMessages() throws Throwable
+    {
+        AssertableLogProvider logProvider = new AssertableLogProvider( true );
+        File storeDir = testDirectory.directory();
+        GraphDatabaseService database = new TestGraphDatabaseFactory()
+                        .setInternalLogProvider( logProvider )
+                        .newEmbeddedDatabase( storeDir );
+        try
+        {
+
+            DependencyResolver resolver = ((GraphDatabaseAPI) database).getDependencyResolver();
+
+            NativeLabelScanStore labelScanStore = resolver.resolveDependency( NativeLabelScanStore.class );
+            try ( LabelScanWriter labelScanWriter = labelScanStore.newWriter() )
+            {
+                labelScanWriter.write( NodeLabelUpdate.labelChanges( 1, new long[]{}, new long[]{1} ) );
+            }
+            labelScanStore.stop();
+            labelScanStore.shutdown();
+
+            labelScanStore.init();
+            labelScanStore.start();
+
+            logProvider.assertNoLogCallContaining( "LuceneLabelScanStore" );
+            logProvider.assertContainsLogCallContaining( "NativeLabelScanStore" );
+            logProvider.assertContainsMessageContaining( "Scan store recovery completed: Number of cleaned crashed pointers" );
+        }
+        finally
+        {
+            database.shutdown();
+        }
+    }
+}

--- a/community/neo4j/src/test/java/org/neo4j/index/LabelScanStoreLoggingTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/LabelScanStoreLoggingTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.api.impl.labelscan.LuceneLabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
@@ -34,7 +35,7 @@ import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
-public class LabelScanStoreLogging
+public class LabelScanStoreLoggingTest
 {
 
     @Rule
@@ -64,9 +65,10 @@ public class LabelScanStoreLogging
             labelScanStore.init();
             labelScanStore.start();
 
-            logProvider.assertNoLogCallContaining( "LuceneLabelScanStore" );
-            logProvider.assertContainsLogCallContaining( "NativeLabelScanStore" );
-            logProvider.assertContainsMessageContaining( "Scan store recovery completed: Number of cleaned crashed pointers" );
+            logProvider.assertNoLogCallContaining( LuceneLabelScanStore.class.getName() );
+            logProvider.assertContainsLogCallContaining( NativeLabelScanStore.class.getName() );
+            logProvider.assertContainsMessageContaining(
+                    "Scan store recovery completed: Number of cleaned crashed pointers" );
         }
         finally
         {


### PR DESCRIPTION
Use label scan store tags to separate monitors for native and lucene label scan indexes.