### PR TITLE
Always close cursors in compiled runtime

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/ClassGenerator.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ClassGenerator.java
@@ -155,7 +155,7 @@ public class ClassGenerator implements AutoCloseable
         return new CodeBlock( this, emitter.method( declaration ), declaration.parameters() );
     }
 
-    FieldReference getField( String name )
+    public FieldReference getField( String name )
     {
         return fields == null ? null : fields.get( name );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -20,8 +20,6 @@
 package org.neo4j.kernel.impl.core;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.SortItem
 import org.neo4j.cypher.internal.compiler.v3_2.commands._
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{One, ZeroOneOrMany}
-import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans.{Projection, UnwindCollection, _}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.{SortDescription, plans}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.{CantCompileQueryException, logical}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Expression
@@ -75,14 +75,14 @@ object LogicalPlanConverter {
 
   private def projectionAsCodeGenPlan(projection: plans.Projection) = new CodeGenPlan {
 
-    override val logicalPlan = projection
+    override val logicalPlan: Projection = projection
 
-    override def produce(context: CodeGenContext) = {
+    override def produce(context: CodeGenContext): (Option[JoinTableMethod], List[Instruction]) = {
       context.pushParent(this)
       asCodeGenPlan(projection.lhs.get).produce(context)
     }
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val projectionOpName = context.registerOperator(projection)
       val columns = immutableMapValues(projection.expressions,
                                        (e: ast.Expression) => ExpressionConverter.createExpression(e)(context))
@@ -110,14 +110,14 @@ object LogicalPlanConverter {
 
   private def produceResultsAsCodeGenPlan(produceResults: ProduceResult) = new CodeGenPlan {
 
-    override val logicalPlan = produceResults
+    override val logicalPlan: ProduceResult = produceResults
 
-    override def produce(context: CodeGenContext) = {
+    override def produce(context: CodeGenContext): (Option[JoinTableMethod], List[Instruction]) = {
       context.pushParent(this)
       asCodeGenPlan(produceResults.lhs.get).produce(context)
     }
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (None.type, List[AcceptVisitor]) = {
       val produceResultOpName = context.registerOperator(produceResults)
       val projections = produceResults.columns.map(c =>
         c -> ExpressionConverter.createMaterializeExpressionForVariable(c)(context)).toMap
@@ -134,7 +134,7 @@ object LogicalPlanConverter {
       context.addVariable(allNodesScan.idName.name, variable)
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)
       val opName = context.registerOperator(logicalPlan)
-      (methodHandle, WhileLoop(variable, ScanAllNodes(opName), actions) :: tl)
+      (methodHandle, WhileLoop(variable, context.namer.newVarName(), ScanAllNodes(opName), actions) :: tl)
     }
   }
 
@@ -147,7 +147,7 @@ object LogicalPlanConverter {
       context.addVariable(nodeByLabelScan.idName.name, nodeVar)
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)
       val opName = context.registerOperator(logicalPlan)
-      (methodHandle, WhileLoop(nodeVar, ScanForLabel(opName, nodeByLabelScan.label.name, labelVar), actions) :: tl)
+      (methodHandle, WhileLoop(nodeVar, context.namer.newVarName(), ScanForLabel(opName, nodeByLabelScan.label.name, labelVar), actions) :: tl)
     }
   }
 
@@ -176,7 +176,7 @@ object LogicalPlanConverter {
           //collection, create set and for each element of the set do an index lookup
           case ManyQueryExpression(e: ast.ListLiteral) =>
             val expression = ToSet(createExpression(e)(context))
-            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any, nullable = false)
+            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any)
 
             ForEachExpression(expressionVar, expression,
                               indexSeekFun(opName, context.namer.newVarName(), LoadVariable(expressionVar), nodeVar,
@@ -185,8 +185,7 @@ object LogicalPlanConverter {
           //Unknown, try to cast to collection and then same as above
           case ManyQueryExpression(e) =>
             val expression = ToSet(CastToCollection(createExpression(e)(context)))
-            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any,
-                                         nullable = false)
+            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any)
             ForEachExpression(expressionVar, expression,
                               indexSeekFun(opName, context.namer.newVarName(), LoadVariable(expressionVar), nodeVar,
                                            actions))
@@ -223,16 +222,14 @@ object LogicalPlanConverter {
                                               createExpression(value)(context), actions)
               case _ =>
                 val expression = createExpression(e)(context)
-                val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any,
-                                             nullable = false)
+                val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any)
                 ForEachExpression(expressionVar, expression,
                                   SeekNodeById(opName, nodeVar, LoadVariable(expressionVar), actions))
             }
 
           case exp =>
             val expression = ToSet(CastToCollection(createExpression(exp)(context)))
-            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any,
-                                         nullable = false)
+            val expressionVar = Variable(context.namer.newVarName(), CodeGenType.Any)
             ForEachExpression(expressionVar, expression,
                               SeekNodeById(opName, nodeVar, LoadVariable(expressionVar), actions))
         }
@@ -244,7 +241,7 @@ object LogicalPlanConverter {
   private def nodeIndexSeekAsCodeGenPlan(indexSeek: NodeIndexSeek) = {
     def indexSeekFun(opName: String, descriptorVar: String, expression: CodeGenExpression,
                      nodeVar: Variable, actions: Instruction) =
-      WhileLoop(nodeVar, IndexSeek(opName, indexSeek.label.name, indexSeek.propertyKeys.map(_.name),
+      WhileLoop(nodeVar, s"${nodeVar.name}Iter",  IndexSeek(opName, indexSeek.label.name, indexSeek.propertyKeys.map(_.name),
                                    descriptorVar, expression), actions)
 
     sharedIndexSeekAsCodeGenPlan(indexSeekFun)(indexSeek.idName.name, indexSeek.valueExpr, indexSeek)
@@ -274,7 +271,7 @@ object LogicalPlanConverter {
       (otherSymbol, lhsMethod :: rightInstructions)
     }
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       if (child.logicalPlan eq logicalPlan.lhs.get) {
         val joinNodes = nodeHashJoin.nodes.map(n => context.getVariable(n.name))
         val probeTableName = context.namer.newVarName()
@@ -332,10 +329,11 @@ object LogicalPlanConverter {
       val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val typeVar2TypeName = expand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(expand)
+      val iterVar = context.namer.newVarName()
       val expandGenerator = ExpandAllLoopDataGenerator(opName, fromNodeVar, expand.dir, typeVar2TypeName, toNodeVar,
-                                                       relVar)
+                                                       relVar, iterVar)
 
-      (methodHandle, WhileLoop(relVar, expandGenerator, action) :: tl)
+      (methodHandle, WhileLoop(relVar, iterVar, expandGenerator, action) :: tl)
     }
 
     private def expandIntoConsume(context: CodeGenContext,
@@ -348,10 +346,11 @@ object LogicalPlanConverter {
       val (methodHandle, action :: tl) = context.popParent().consume(context, this)
       val typeVar2TypeName = expand.types.map(t => context.namer.newVarName() -> t.name).toMap
       val opName = context.registerOperator(expand)
+      val iterVar = context.namer.newVarName()
       val expandGenerator = ExpandIntoLoopDataGenerator(opName, fromNodeVar, expand.dir, typeVar2TypeName, toNodeVar,
-                                                        relVar)
+                                                        relVar, iterVar)
 
-      (methodHandle, WhileLoop(relVar, expandGenerator, action) :: tl)
+      (methodHandle, WhileLoop(relVar, iterVar, expandGenerator, action) :: tl)
     }
   }
 
@@ -399,10 +398,11 @@ object LogicalPlanConverter {
         case (acc, predicate) => If(predicate, acc)
       }
 
+      val iterVar = context.namer.newVarName()
       val expand = ExpandAllLoopDataGenerator(opName, fromNodeVar, optionalExpand.dir, typeVar2TypeName, toNodeVar,
-                                              relVar)
+                                              relVar, iterVar)
 
-      val loop = WhileLoop(relVar, expand, instructionWithPredicates)
+      val loop = WhileLoop(relVar, iterVar, expand, instructionWithPredicates)
 
       (methodHandle, NullingInstruction(loop, yieldFlag, action, relVar, toNodeVar) :: tl)
     }
@@ -435,10 +435,11 @@ object LogicalPlanConverter {
         case (acc, predicate) => If(predicate, acc)
       }
 
+      val iterVar = context.namer.newVarName()
       val expand = ExpandIntoLoopDataGenerator(opName, fromNodeVar, optionalExpand.dir, typeVar2TypeName, toNodeVar,
-                                               relVar)
+                                               relVar, iterVar)
 
-      val loop = WhileLoop(relVar, expand, instructionWithPredicates)
+      val loop = WhileLoop(relVar, iterVar, expand, instructionWithPredicates)
 
       (methodHandle, NullingInstruction(loop, yieldFlag, action, relVar) :: tl)
     }
@@ -594,9 +595,9 @@ object LogicalPlanConverter {
 
   private def unwindAsCodeGenPlan(unwind: plans.UnwindCollection) = new CodeGenPlan with SingleChildPlan {
 
-    override val logicalPlan = unwind
+    override val logicalPlan: UnwindCollection = unwind
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val collection: CodeGenExpression = ExpressionConverter.createExpression(unwind.expression)(context)
 
       // TODO: Handle range
@@ -624,15 +625,15 @@ object LogicalPlanConverter {
 
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)
 
-      (methodHandle, WhileLoop(variable, loopDataGenerator, actions) :: tl)
+      (methodHandle, WhileLoop(variable, context.namer.newVarName(), loopDataGenerator, actions) :: tl)
     }
   }
 
   private def sortAsCodeGenPlan(sort: plans.Sort) = new CodeGenPlan with SingleChildPlan {
 
-    override val logicalPlan = sort
+    override val logicalPlan: Sort = sort
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val opName = context.registerOperator(logicalPlan)
 
       val (variablesToKeep: Map[String, Variable],
@@ -659,9 +660,9 @@ object LogicalPlanConverter {
 
   private def topAsCodeGenPlan(top: Top) = new CodeGenPlan with SingleChildPlan {
 
-    override val logicalPlan = top
+    override val logicalPlan: Top = top
 
-    override def consume(context: CodeGenContext, child: CodeGenPlan) = {
+    override def consume(context: CodeGenContext, child: CodeGenPlan): (Option[JoinTableMethod], List[Instruction]) = {
       val opName = context.registerOperator(logicalPlan)
 
       val (variablesToKeep: Map[String, Variable],

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -24,11 +24,11 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, 
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 
 case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: SemanticDirection,
-                   types: Map[String, String], toVar: Variable, relVar: Variable)
+                   types: Map[String, String], toVar: Variable, relVar: Variable, iterVar: String)
   extends LoopDataGenerator {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.createRelExtractor(relVar.name)
+    generator.setUpRelIteration(relVar.name, iterVar)
     types.foreach {
       case (typeVar,relType) => generator.lookupRelationshipTypeId(typeVar, relType)
     }
@@ -46,10 +46,6 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
                              (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
-  }
-
-  def foo[E](generator: MethodStructure[E]) = fromVar.codeGenType match {
-    case c if c.isPrimitive => generator.loadVariable(fromVar.name)
   }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextRelationship(iterVar)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -24,11 +24,11 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, 
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 
 case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: SemanticDirection,
-                   types: Map[String, String], toVar: Variable, relVar: Variable)
+                   types: Map[String, String], toVar: Variable, relVar: Variable, iterVar: String)
   extends LoopDataGenerator {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    generator.createRelExtractor(relVar.name)
+    generator.setUpRelIteration(relVar.name, iterVar)
     types.foreach {
       case (typeVar,relType) => generator.lookupRelationshipTypeId(typeVar, relType)
     }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/WhileLoop.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/WhileLoop.scala
@@ -22,10 +22,9 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.ir
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compiled_runtime.v3_2.codegen.{CodeGenContext, Variable}
 
-case class WhileLoop(variable: Variable, producer: LoopDataGenerator, action: Instruction) extends Instruction {
+case class WhileLoop(variable: Variable, iterator: String, producer: LoopDataGenerator, action: Instruction) extends Instruction {
 
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
-    val iterator = s"${variable.name}Iter"
     generator.trace(producer.opName) { body =>
       producer.produceIterator(iterator, body)
       body.whileLoop(producer.hasNext(body, iterator)) { loopBody =>

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -166,7 +166,7 @@ trait MethodStructure[E] {
   def indexUniqueSeek(name: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
   def relType(relIdVar: String, typeVar: String): Unit
   def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
-  def createRelExtractor(extractorName: String): Unit
+  def setUpRelIteration(extractorName: String, iteratorName: String): Unit
   def nodeCountFromCountStore(expression: E): E
   def relCountFromCountStore(start: E, end: E, types: E*): E
   def token(t: Int): E

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -426,6 +426,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection) = {
     val local = generator.declare(typeRef[RelationshipIterator], iterVar)
+    generator.assign(local, constant(null))
+    //Make sure cursor is always closed
+    _finalizers.append((_: Boolean) => (block) =>
+      using(block.ifStatement(Expression.notNull(block.load(local.name())))) {inner =>
+        inner.expression(invoke(inner.load(local.name()), method[RelationshipIterator, Unit]("close")))
+      })
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
       body.assign(local, invoke(readOperations, Methods.nodeGetRelationshipsWithDirection, forceLong(nodeVar, nodeVarType),
                                 dir(direction)))
@@ -436,6 +442,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
                                                          direction: SemanticDirection,
                                                          typeVars: Seq[String]) = {
     val local = generator.declare(typeRef[RelationshipIterator], iterVar)
+    generator.assign(local, constant(null))
+    //Make sure cursor is always closed
+    _finalizers.append((_: Boolean) => (block) =>
+      using(block.ifStatement(Expression.notNull(block.load(local.name())))) {inner =>
+        inner.expression(invoke(inner.load(local.name()), method[RelationshipIterator, Unit]("close")))
+      })
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
       body.assign(local, invoke(readOperations, Methods.nodeGetRelationshipsWithDirectionAndTypes,
                                 forceLong(nodeVar, nodeVarType), dir(direction),

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
@@ -49,24 +49,24 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
 
   val modes = Seq(SourceCode.SOURCECODE, ByteCode.BYTECODE)
   val ops = Seq(
-        Operation("create rel extractor", _.createRelExtractor("foo")),
-        Operation("nullable object", m => {
+    Operation("create rel extractor", _.setUpRelIteration("foo", "bar")),
+    Operation("nullable object", m => {
           m.declareAndInitialize("foo", CodeGenType.Any)
           m.generator.assign(typeRef[Object], "bar",
                              m.nullablePrimitive("foo", CodeGenType.Any, Expression.constant("hello")))
 
         }),
-        Operation("load node from parameters", m => {
+    Operation("load node from parameters", m => {
           m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.generator.assign(typeRef[Long], "node", m.node("a", CodeGenType.primitiveNode))
         }),
-        Operation("nullable node", m => {
+    Operation("nullable node", m => {
           m.declareAndInitialize("foo", CodeGenType.primitiveNode)
           m.generator.assign(typeRef[Long], "bar",
                              m.nullablePrimitive("foo", CodeGenType.primitiveNode, m.loadVariable("foo")))
 
         }),
-        Operation("mark variables as null", m => {
+    Operation("mark variables as null", m => {
           m.declareFlag("flag", initialValue = false)
           m.updateFlag("flag", newValue = true)
           m.ifNotStatement(m.generator.load("flag")) { ifBody =>
@@ -75,7 +75,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
            ifBody.markAsNull("object", CodeGenType.Any)
           }
         }),
-        Operation("use a LongsToCount probe table", m => {
+    Operation("use a LongsToCount probe table", m => {
           m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.allocateProbeTable("table", LongsToCountTable)
           m.updateProbeTableCount("table", LongsToCountTable, Seq("a"))
@@ -83,7 +83,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
             inner.allNodesScan("foo")
           }
         }),
-       Operation("use a LongToCount key probe table", m => {
+    Operation("use a LongToCount key probe table", m => {
           m.declareAndInitialize("a", CodeGenType.primitiveNode)
           m.allocateProbeTable("table", LongToCountTable)
           m.updateProbeTableCount("table", LongToCountTable, Seq("a"))
@@ -91,7 +91,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
             inner.allNodesScan("foo")
           }
         }),
-       Operation("use a LongToList probe table", m => {
+    Operation("use a LongToList probe table", m => {
          val table: LongToListTable =
            LongToListTable(SimpleTupleDescriptor(Map("a" -> CodeGenType.primitiveNode)),
                            localMap = Map("b" -> "a"))
@@ -103,7 +103,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
            inner.allNodesScan("foo")
          }
        }),
-       Operation("use a LongsToList probe table", m => {
+    Operation("use a LongsToList probe table", m => {
          val table: LongsToListTable =
            LongsToListTable(SimpleTupleDescriptor(Map("a" -> CodeGenType.primitiveNode,
                                                       "b" -> CodeGenType.primitiveNode)),
@@ -117,57 +117,60 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
            inner.allNodesScan("foo")
          }
        }),
-        Operation("Method invocation", m => {
+    Operation("Method invocation", m => {
           m.invokeMethod(LongToCountTable, "v1", "inner") { inner => {
             inner.allocateProbeTable("v1", LongToCountTable)
           }}
         }),
-        Operation("look up rel type", _.lookupRelationshipTypeId("foo", "bar")),
-        Operation("all relationships for node", (m) => {
+    Operation("look up rel type", _.lookupRelationshipTypeId("foo", "bar")),
+    Operation("all relationships for node", (m) => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
+          m.setUpRelIteration("bar", "foo")
           m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
         }),
-        Operation("has label", m => {
+    Operation("has label", m => {
           m.lookupLabelId("label", "A")
           m.declarePredicate("predVar")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.hasLabel("node", "label", "predVar")
         }),
-        Operation("property by name for node", m => {
+    Operation("property by name for node", m => {
           m.lookupPropertyKey("prop", "prop")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
           m.nodeGetPropertyForVar("node", CodeGenType.primitiveNode, "prop", "propVar")
         }),
-        Operation("property by id for node", m => {
+    Operation("property by id for node", m => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
           m.nodeGetPropertyById("node", CodeGenType.primitiveNode, 13, "propVar")
         }),
-        Operation("property by name for relationship", m => {
+    Operation("property by name for relationship", m => {
           m.lookupPropertyKey("prop", "prop")
           m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
           m.relationshipGetPropertyForVar("rel", "prop", "propVar")
         }),
-        Operation("property by id for relationship", m => {
+    Operation("property by id for relationship", m => {
           m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
           m.nodeGetPropertyById("rel", CodeGenType.primitiveNode, 13, "propVar")
         }),
-        Operation("rel type", m => {
-          m.createRelExtractor("bar")
+    Operation("rel type", m => {
+          m.setUpRelIteration("bar", "foo")
           m.declareAndInitialize("foo", CypherCodeGenType(symbols.CTString, ReferenceType))
           m.relType("bar", "foo")
         }),
-        Operation("all relationships for node and types", (m) => {
+    Operation("all relationships for node and types", (m) => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
+          m.setUpRelIteration("bar", "foo")
           m.lookupRelationshipTypeId("a", "A")
           m.lookupRelationshipTypeId("b", "B")
           m.nodeGetRelationshipsWithDirectionAndTypes("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING, Seq("a", "b"))
         }),
-        Operation("next relationship", (m) => {
-          m.createRelExtractor("r")
+    Operation("next relationship", (m) => {
+          m.setUpRelIteration("r", "rIter")
+          m.setUpRelIteration("bar", "foo")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
           m.nextRelationshipAndNode("nextNode", "foo", SemanticDirection.OUTGOING, "node", "r")
@@ -196,7 +199,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       }
     }),
     Operation("expand from all node", (m) => {
-      m.createRelExtractor("r")
+      m.setUpRelIteration("r", "rIter")
+      m.setUpRelIteration("bar", "relIter")
       m.allNodesScan("nodeIter")
       m.whileLoop(m.hasNextNode("nodeIter")) { b1 =>
         b1.nextNode("node", "nodeIter")

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -174,7 +174,7 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
   private def buildProbeTableWithTwoAllNodeScans(buildInstruction: BuildProbeTable, nodes: Set[Variable]): Seq[Instruction] = {
     val counter = new AtomicInteger(0)
     val buildWhileLoop = nodes.foldRight[Instruction](buildInstruction){
-      case (variable, instruction) => WhileLoop(variable, ScanAllNodes("scanOp" + counter.incrementAndGet()), instruction)
+      case (variable, instruction) => WhileLoop(variable, s"${variable}Iter", ScanAllNodes("scanOp" + counter.incrementAndGet()), instruction)
     }
 
     val buildProbeTableMethod = MethodInvocation(operatorId = Set.empty,
@@ -193,7 +193,7 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
                                                  action = acceptVisitor)
 
     val probeTheTableWhileLoop = probeVars.foldRight[Instruction](probeTheTable){
-      case (variable, instruction) => WhileLoop(variable, ScanAllNodes("scanOp" + counter.incrementAndGet()), instruction)
+      case (variable, instruction) => WhileLoop(variable, "${variable}Iter", ScanAllNodes("scanOp" + counter.incrementAndGet()), instruction)
     }
     Seq(buildProbeTableMethod, probeTheTableWhileLoop)
   }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/CompiledProfilingTest.scala
@@ -52,8 +52,8 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
 
     val variable = Variable("name", CodeGenType.primitiveNode)
     val projectNode = expressions.NodeProjection(variable)
-    val compiled = compile(Seq(WhileLoop(variable,
-      ScanAllNodes("OP1"), AcceptVisitor("OP2", Map("n" -> projectNode)))),
+    val compiled = compile(Seq(WhileLoop(variable,"${variable}Iter",
+                                         ScanAllNodes("OP1"), AcceptVisitor("OP2", Map("n" -> projectNode)))),
       Seq("n"), Map("OP1" -> id1, "OP2" -> id2, "X" -> new Id()))
 
     val readOps = mock[ReadOperations]


### PR DESCRIPTION
Whenever we use `CursorRelationshipIterator` in the compiled runtime
we should always make sure to close it afterwards.

This should go in after https://github.com/neo4j/neo4j/pull/9217