### PR TITLE
Suggestion: Singleton annotation on procedures et al

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/procedure/Singleton.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Singleton.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * If the procedure or function is annotated with @Singleton, only a single instance of the class will be invoked.
+ */
+@Target( ElementType.TYPE )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface Singleton
+{
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
@@ -43,10 +43,10 @@ public class FieldInjectionsTest
 
         // Expect
         exception.expect( ProcedureException.class );
-        exception.expectMessage( "Field `someState` on `ProcedureWithNonInjectedMemberFields` " +
-                                 "is not annotated as a @Context and is not static. " +
-                                 "If you want to store state along with your procedure, " +
-                                 "please use a static field." );
+        exception.expectMessage( "Field `someState` on `ProcedureWithNonInjectedMemberFields` is not annotated " +
+                                 "as a @Context nor is the class `ProcedureWithNonInjectedMemberFields` annotated with " +
+                                 "@Singleton. If you want to store state along with your procedure or function " +
+                                 "please either mark the class with @Singleton or use a static field." );
 
         // When
         injections.setters( ProcedureWithNonInjectedMemberFields.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureTest.java
@@ -41,6 +41,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.Singleton;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -201,15 +202,16 @@ public class ReflectiveProcedureTest
     {
         // Expect
         exception.expect( ProcedureException.class );
-        exception.expectMessage( String.format("Procedures must return a Stream of records, where a record is a concrete class%n" +
-                                 "that you define, with public non-final fields defining the fields in the record.%n" +
-                                 "If you''d like your procedure to return `String`, you could define a record class " +
-                                 "like:%n" +
-                                 "public class Output '{'%n" +
-                                 "    public String out;%n" +
-                                 "'}'%n" +
-                                 "%n" +
-                                 "And then define your procedure as returning `Stream<Output>`." ));
+        exception.expectMessage(
+                String.format( "Procedures must return a Stream of records, where a record is a concrete class%n" +
+                               "that you define, with public non-final fields defining the fields in the record.%n" +
+                               "If you''d like your procedure to return `String`, you could define a record class " +
+                               "like:%n" +
+                               "public class Output '{'%n" +
+                               "    public String out;%n" +
+                               "'}'%n" +
+                               "%n" +
+                               "And then define your procedure as returning `Stream<Output>`." ) );
 
         // When
         compile( ProcedureWithInvalidRecordOutput.class ).get( 0 );
@@ -220,10 +222,11 @@ public class ReflectiveProcedureTest
     {
         // Expect
         exception.expect( ProcedureException.class );
-        exception.expectMessage( String.format("The field `gdb` in the class named `ProcedureWithStaticContextAnnotatedField` is " +
-                                 "annotated as a @Context field,%n" +
-                                 "but it is static. @Context fields must be public, non-final and non-static,%n" +
-                                 "because they are reset each time a procedure is invoked." ));
+        exception.expectMessage(
+                String.format( "The field `gdb` in the class named `ProcedureWithStaticContextAnnotatedField` is " +
+                               "annotated as a @Context field,%n" +
+                               "but it is static. @Context fields must be public, non-final and non-static,%n" +
+                               "because they are reset each time a procedure is invoked." ) );
 
         // When
         compile( ProcedureWithStaticContextAnnotatedField.class ).get( 0 );
@@ -246,7 +249,7 @@ public class ReflectiveProcedureTest
         CallableProcedure proc = compile( ProcedureWithOverriddenName.class ).get( 0 );
 
         // Then
-        assertEquals("org.mystuff.thisisActuallyTheName", proc.signature().name().toString() );
+        assertEquals( "org.mystuff.thisisActuallyTheName", proc.signature().name().toString() );
     }
 
     @Test
@@ -256,7 +259,7 @@ public class ReflectiveProcedureTest
         CallableProcedure proc = compile( ProcedureWithSingleName.class ).get( 0 );
 
         // Then
-        assertEquals("singleName", proc.signature().name().toString() );
+        assertEquals( "singleName", proc.signature().name().toString() );
     }
 
     @Test
@@ -278,7 +281,7 @@ public class ReflectiveProcedureTest
     public void shouldSupportProcedureDeprecation() throws Throwable
     {
         // Given
-        Log log = mock(Log.class);
+        Log log = mock( Log.class );
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
                 components, log, ProcedureConfig.DEFAULT );
 
@@ -314,9 +317,9 @@ public class ReflectiveProcedureTest
     {
         // Given
         ProcedureConfig config = new ProcedureConfig( Config.defaults().with(
-                genericMap( procedure_whitelist.name(), "org.neo4j.kernel.impl.proc.listCoolPeople") ) );
+                genericMap( procedure_whitelist.name(), "org.neo4j.kernel.impl.proc.listCoolPeople" ) ) );
 
-        Log log = mock(Log.class);
+        Log log = mock( Log.class );
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
                 components, log, config );
 
@@ -335,9 +338,9 @@ public class ReflectiveProcedureTest
     {
         // Given
         ProcedureConfig config = new ProcedureConfig( Config.defaults().with(
-                genericMap( procedure_whitelist.name(), "org.neo4j.kernel.impl.proc.NOTlistCoolPeople") ) );
+                genericMap( procedure_whitelist.name(), "org.neo4j.kernel.impl.proc.NOTlistCoolPeople" ) ) );
 
-        Log log = mock(Log.class);
+        Log log = mock( Log.class );
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
                 components, log, config );
 
@@ -346,8 +349,9 @@ public class ReflectiveProcedureTest
                 procedureCompiler.compileProcedure( SingleReadOnlyProcedure.class, Optional.empty(), false );
         // Then
         verify( log )
-                .warn( "The procedure 'org.neo4j.kernel.impl.proc.listCoolPeople' is not on the whitelist and won't be loaded." );
-        assertThat( proc.isEmpty(), is(true) );
+                .warn( "The procedure 'org.neo4j.kernel.impl.proc.listCoolPeople' is not on the whitelist and won't " +
+                       "be loaded." );
+        assertThat( proc.isEmpty(), is( true ) );
     }
 
     @Test
@@ -355,8 +359,8 @@ public class ReflectiveProcedureTest
     {
         // Given
         ProcedureConfig config = new ProcedureConfig( Config.defaults().with(
-                genericMap( procedure_whitelist.name(), "empty") ) );
-        Log log = mock(Log.class);
+                genericMap( procedure_whitelist.name(), "empty" ) ) );
+        Log log = mock( Log.class );
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
                 components, log, config );
 
@@ -373,8 +377,8 @@ public class ReflectiveProcedureTest
     {
         // Given
         ProcedureConfig config = new ProcedureConfig( Config.defaults().with(
-                genericMap( procedure_whitelist.name(), "") ) );
-        Log log = mock(Log.class);
+                genericMap( procedure_whitelist.name(), "" ) ) );
+        Log log = mock( Log.class );
         ReflectiveProcedureCompiler procedureCompiler = new ReflectiveProcedureCompiler( new TypeMappers(), components,
                 components, log, config );
 
@@ -383,8 +387,9 @@ public class ReflectiveProcedureTest
                 procedureCompiler.compileProcedure( SingleReadOnlyProcedure.class, Optional.empty(), false );
         // Then
         verify( log )
-                .warn( "The procedure 'org.neo4j.kernel.impl.proc.listCoolPeople' is not on the whitelist and won't be loaded." );
-        assertThat( proc.isEmpty(), is(true) );
+                .warn( "The procedure 'org.neo4j.kernel.impl.proc.listCoolPeople' is not on the whitelist and won't " +
+                       "be loaded." );
+        assertThat( proc.isEmpty(), is( true ) );
     }
 
     public static class MyOutputRecord
@@ -425,6 +430,20 @@ public class ReflectiveProcedureTest
         }
     }
 
+    @Test
+    public void shouldRunSingletonProcedure() throws Throwable
+    {
+        // Given
+        CallableProcedure proc = compile( SingletonProcedure.class ).get( 0 );
+
+        // When
+        RawIterator<Object[],ProcedureException> out1 = proc.apply( new BasicContext(), new Object[0] );
+        RawIterator<Object[],ProcedureException> out2 = proc.apply( new BasicContext(), new Object[0] );
+
+        // Then
+        assertEquals( out1.next()[0], out2.next()[0] );
+    }
+
     public static class SingleReadOnlyProcedure
     {
         @Procedure
@@ -449,7 +468,7 @@ public class ReflectiveProcedureTest
         @Procedure
         public Stream<NonStatic> voidOutput()
         {
-            return Stream.of(new NonStatic());
+            return Stream.of( new NonStatic() );
         }
 
         public class NonStatic
@@ -494,7 +513,7 @@ public class ReflectiveProcedureTest
     public static class ProcedureWithInvalidRecordOutput
     {
         @Procedure
-        public String test( )
+        public String test()
         {
             return "Testing";
         }
@@ -506,7 +525,7 @@ public class ReflectiveProcedureTest
         public static GraphDatabaseService gdb;
 
         @Procedure
-        public Stream<MyOutputRecord> test( )
+        public Stream<MyOutputRecord> test()
         {
             return null;
         }
@@ -515,7 +534,7 @@ public class ReflectiveProcedureTest
     public static class ProcedureThatThrowsNullMsgExceptionAtInvocation
     {
         @Procedure
-        public Stream<MyOutputRecord> throwsAtInvocation( )
+        public Stream<MyOutputRecord> throwsAtInvocation()
         {
             throw new IndexOutOfBoundsException();
         }
@@ -524,7 +543,7 @@ public class ReflectiveProcedureTest
     public static class ProcedureThatThrowsNullMsgExceptionMidStream
     {
         @Procedure
-        public Stream<MyOutputRecord> throwsInStream( )
+        public Stream<MyOutputRecord> throwsInStream()
         {
             return Stream.generate( () ->
             {
@@ -600,6 +619,23 @@ public class ReflectiveProcedureTest
         @Procedure( value = "badProc", deprecatedBy = "newProc" )
         public void badProc()
         {
+        }
+    }
+
+    @Singleton
+    public static class SingletonProcedure
+    {
+        private static long value;
+
+        public SingletonProcedure()
+        {
+            value = System.nanoTime();
+        }
+
+        @Procedure
+        public Stream<MyOutputRecord> value()
+        {
+            return Stream.of( new MyOutputRecord( Long.toHexString( value ) ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -887,7 +887,7 @@ public class ReflectiveUserAggregationFunctionTest
     @Singleton
     public static class SingletonFunction
     {
-        private static long value;
+        private long value;
 
         public SingletonFunction()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -45,6 +45,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Singleton;
 import org.neo4j.procedure.UserAggregationFunction;
 import org.neo4j.procedure.UserAggregationResult;
 import org.neo4j.procedure.UserAggregationUpdate;
@@ -421,6 +422,20 @@ public class ReflectiveUserAggregationFunctionTest
                 fail( "Unexpected function: " + name );
             }
         }
+    }
+
+    @Test
+    public void shouldRunSingletonFunction() throws Throwable
+    {
+        // Given
+        CallableUserAggregationFunction func = compile( SingletonFunction.class ).get( 0 );
+
+        // When
+        CallableUserAggregationFunction.Aggregator aggregator1 = func.create( new BasicContext() );
+        CallableUserAggregationFunction.Aggregator aggregator2 = func.create( new BasicContext() );
+
+        // Then
+        assertEquals( aggregator1.result(), aggregator2.result() );
     }
 
     public static class SingleAggregationFunction
@@ -865,6 +880,44 @@ public class ReflectiveUserAggregationFunctionTest
             String result()
             {
                 return "Testing";
+            }
+        }
+    }
+
+    @Singleton
+    public static class SingletonFunction
+    {
+        private static long value;
+
+        public SingletonFunction()
+        {
+            value = System.nanoTime();
+        }
+
+        @UserAggregationFunction
+        public InnerAggregator test()
+        {
+            return new InnerAggregator( value );
+        }
+
+        public static class InnerAggregator
+        {
+            private final long value;
+
+            public InnerAggregator( long value )
+            {
+                this.value = value;
+            }
+
+            @UserAggregationUpdate
+            public void update()
+            {
+            }
+
+            @UserAggregationResult
+            public long result()
+            {
+                return value;
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -504,7 +504,7 @@ public class ReflectiveUserFunctionTest
     @Singleton
     public static class SingletonFunction
     {
-        private static long value;
+        private long value;
         public SingletonFunction()
         {
             value = System.nanoTime();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Singleton;
 import org.neo4j.procedure.UserFunction;
 
 import static junit.framework.TestCase.assertEquals;
@@ -325,6 +326,19 @@ public class ReflectiveUserFunctionTest
         }
     }
 
+    @Test
+    public void shouldHandleSingletons() throws Throwable
+    {
+        CallableUserFunction func = compile( SingletonFunction.class ).get( 0 );
+
+        // When
+        Object out1 = func.apply( new BasicContext(), new Object[0] );
+        Object out2 = func.apply( new BasicContext(), new Object[0] );
+
+        // Then
+        assertThat(out1, equalTo( out2 ) );
+    }
+
     public static class LoggingFunction
     {
         @Context
@@ -484,6 +498,22 @@ public class ReflectiveUserFunctionTest
         public Object badFunc()
         {
             return null;
+        }
+    }
+
+    @Singleton
+    public static class SingletonFunction
+    {
+        private static long value;
+        public SingletonFunction()
+        {
+            value = System.nanoTime();
+        }
+
+        @UserFunction
+        public long value()
+        {
+            return value;
         }
     }
 


### PR DESCRIPTION
Adds ability to annotate classes containing procedures, user-defined function, and user-defined aggregation functions with `@Singleton`. Whenever that annotation is present we only instantiate the surrounding class once.

Also allows singleton-classes to maintain non-static state.