### PR TITLE
Pooled concurrent merge scheduler for lucene indexes.

### DIFF
--- a/community/lucene-index/src/main/java/org/apache/lucene/index/PooledConcurrentMergeScheduler.java
+++ b/community/lucene-index/src/main/java/org/apache/lucene/index/PooledConcurrentMergeScheduler.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.helpers.NamedThreadFactory;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+/**
+ * Lucene indexes merge scheduler that execute merges in a thread pool instead of starting separate thread for each
+ * merge. Each writer have it's own scheduler but all of them use shared pool.
+ *
+ * Current implementation is minimalistic in a number of things it knows about lucene internals to simplify
+ * migrations overhead. It wraps up lucene internal merge tasks and execute them in a common thread pool.
+ * In case if pool and queue exhausted merge will be performed in callers thread.
+ * Since we cant rely on lucene per writer merge threads we need to perform writer tasks counting ourselves to prevent
+ * cases while writer will be closed in the middle of merge and will wait for all writer related merges to complete
+ * before allowing close of writer scheduler.
+ */
+public class PooledConcurrentMergeScheduler extends ConcurrentMergeScheduler
+{
+    private static final int POOL_QUEUE_CAPACITY =
+            FeatureToggles.getInteger( PooledConcurrentMergeScheduler.class, "pool.queue.capacity", 100 );
+    private static final int POOL_MINIMUM_THREADS =
+            FeatureToggles.getInteger( PooledConcurrentMergeScheduler.class, "pool.minimum.threads", 4 );
+
+    private AtomicInteger writerTaskCounter = new AtomicInteger();
+
+    @Override
+    public synchronized void merge( IndexWriter writer, MergeTrigger trigger, boolean newMergesFound )
+            throws IOException
+    {
+        while ( true )
+        {
+            MergePolicy.OneMerge merge = writer.getNextMerge();
+            if ( merge == null )
+            {
+                return;
+            }
+            boolean success = false;
+            try
+            {
+                MergeThread mergeThread = getMergeThread( writer, merge );
+                writerTaskCounter.incrementAndGet();
+                PooledConcurrentMergePool.mergeThreadsPool.submit( mergeTask( mergeThread ) );
+                success = true;
+            }
+            finally
+            {
+                if ( !success )
+                {
+                    writerTaskCounter.decrementAndGet();
+                    writer.mergeFinish( merge );
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        waitForAllTasks();
+        super.close();
+    }
+
+    @Override
+    protected void updateMergeThreads()
+    {
+        //noop
+    }
+
+    @Override
+    void removeMergeThread()
+    {
+        // noop
+    }
+
+    AtomicInteger getWriterTaskCounter()
+    {
+        return writerTaskCounter;
+    }
+
+    private Runnable mergeTask( MergeThread mergeThread )
+    {
+        return new MergeTask( mergeThread, writerTaskCounter );
+    }
+
+    private void waitForAllTasks()
+    {
+        while ( writerTaskCounter.get() > 0 )
+        {
+            LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 10 ) );
+        }
+    }
+
+    private static class PooledConcurrentMergePool
+    {
+        private static final ExecutorService mergeThreadsPool =
+                new ThreadPoolExecutor( 0, getMaximumPoolSize(), 60L, TimeUnit.SECONDS,
+                        new ArrayBlockingQueue<>( POOL_QUEUE_CAPACITY ),
+                        new NamedThreadFactory( "Lucene-Merge", true ), new ThreadPoolExecutor.CallerRunsPolicy() );
+
+        private static int getMaximumPoolSize()
+        {
+            return Math.max( 1, Math.min( POOL_MINIMUM_THREADS, Runtime.getRuntime().availableProcessors() / 2 ) );
+        }
+    }
+
+    private class MergeTask implements Runnable
+    {
+        private final MergeThread mergeThread;
+        private final AtomicInteger taskCounter;
+
+        MergeTask( MergeThread mergeThread, AtomicInteger taskCounter )
+        {
+            this.mergeThread = mergeThread;
+            this.taskCounter = taskCounter;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                mergeThread.run();
+            }
+            finally
+            {
+                taskCounter.decrementAndGet();
+            }
+        }
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
@@ -25,6 +25,7 @@ import org.apache.lucene.codecs.lucene54.Lucene54Codec;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KeepOnlyLastCommitDeletionPolicy;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
+import org.apache.lucene.index.PooledConcurrentMergeScheduler;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 
 import org.neo4j.index.impl.lucene.legacy.LuceneDataSource;
@@ -55,6 +56,9 @@ public final class IndexWriterConfigs
     private static final double POPULATION_RAM_BUFFER_SIZE_MB = FeatureToggles.getDouble( IndexWriterConfigs.class,
             "population.ram.buffer.size", 50 );
 
+    private static final boolean CUSTOM_MERGE_SCHEDULER =
+            FeatureToggles.flag( IndexWriterConfigs.class, "custom.merge.scheduler", true );
+
     /**
      * Default postings format for schema and label scan store indexes.
      */
@@ -83,6 +87,10 @@ public final class IndexWriterConfigs
                 return CODEC_BLOCK_TREE_ORDS_POSTING_FORMAT ? blockTreeOrdsPostingsFormat : postingFormat;
             }
         });
+        if ( CUSTOM_MERGE_SCHEDULER )
+        {
+            writerConfig.setMergeScheduler( new PooledConcurrentMergeScheduler() );
+        }
 
         LogByteSizeMergePolicy mergePolicy = new LogByteSizeMergePolicy();
         mergePolicy.setNoCFSRatio( MERGE_POLICY_NO_CFS_RATIO );

--- a/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
+++ b/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.apache.lucene.index;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.test.ThreadTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class PooledConcurrentMergeSchedulerTest
+{
+
+    private TestPooledConcurrentMergeScheduler mergeScheduler;
+    private IndexWriter indexWriter = mock( IndexWriter.class );
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mergeScheduler = new TestPooledConcurrentMergeScheduler();
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        mergeScheduler.getExecutionLatch().countDown();
+    }
+
+    @Test
+    public void doNotAddMergeTaskWhenWriterDoesNotHaveMergesToDo() throws Exception
+    {
+        IndexWriter indexWriter = mock( IndexWriter.class );
+
+        mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
+
+        assertEquals( 0, mergeScheduler.getWriterTaskCounter().get() );
+    }
+
+    @Test
+    public void addMergeTaskWhenWriterHasOneMergeToPerform() throws IOException
+    {
+        SegmentCommitInfo segmentCommitInfo = getSegmentCommitInfo();
+
+        Mockito.when( indexWriter.getNextMerge() ).thenReturn( new TestOneMerge( segmentCommitInfo ) )
+                .thenReturn( null );
+
+        mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
+
+        assertEquals( 1, mergeScheduler.getWriterTaskCounter().get() );
+    }
+
+    @Test
+    public void addTwoMergeTasksWhenWriterHastwoMergeToPerform() throws IOException
+    {
+        SegmentCommitInfo segmentCommitInfo = getSegmentCommitInfo();
+
+        Mockito.when( indexWriter.getNextMerge() ).thenReturn( new TestOneMerge( segmentCommitInfo ) )
+                .thenReturn( new TestOneMerge( segmentCommitInfo ) ).thenReturn( null );
+
+        mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
+
+        assertEquals( 2, mergeScheduler.getWriterTaskCounter().get() );
+    }
+
+    @Test( timeout = 5000 )
+    public void writerCloseWaitForMergesInMergeQueue() throws IOException, InterruptedException
+    {
+        indexWriter = mock( IndexWriter.class );
+        SegmentCommitInfo segmentCommitInfo = getSegmentCommitInfo();
+
+        Mockito.when( indexWriter.getNextMerge() ).thenReturn( new TestOneMerge( segmentCommitInfo ) )
+                .thenReturn( null );
+
+        mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
+
+        assertEquals( 1, mergeScheduler.getWriterTaskCounter().get() );
+
+        Thread closeSchedulerThread = ThreadTestUtils.fork( () -> mergeScheduler.close() );
+        ThreadTestUtils.awaitThreadState( closeSchedulerThread, 500, Thread.State.TIMED_WAITING );
+        mergeScheduler.getExecutionLatch().countDown();
+        closeSchedulerThread.join();
+
+        assertEquals( 0, mergeScheduler.getWriterTaskCounter().get() );
+    }
+
+    private SegmentCommitInfo getSegmentCommitInfo()
+    {
+        SegmentInfo segmentInfo =
+                new SegmentInfo( mock( Directory.class ), Version.LATEST, "test", Integer.MAX_VALUE, true,
+                        mock( Codec.class ), MapUtil.stringMap(), RandomUtils.nextBytes( 16 ), MapUtil.stringMap() );
+        return new SegmentCommitInfo( segmentInfo, 1, 1L, 1L, 1L );
+    }
+
+    private class TestPooledConcurrentMergeScheduler extends PooledConcurrentMergeScheduler
+    {
+
+        private CountDownLatch executionLatch = new CountDownLatch( 1 );
+
+        @Override
+        protected synchronized MergeThread getMergeThread( IndexWriter writer, MergePolicy.OneMerge merge )
+                throws IOException
+        {
+            return new BlockingMerge( writer, merge, executionLatch );
+        }
+
+        CountDownLatch getExecutionLatch()
+        {
+            return executionLatch;
+        }
+
+        class BlockingMerge extends ConcurrentMergeScheduler.MergeThread
+        {
+
+            private CountDownLatch executionLatch;
+
+            BlockingMerge( IndexWriter writer, MergePolicy.OneMerge merge, CountDownLatch executionLatch )
+            {
+                super( writer, merge );
+                this.executionLatch = executionLatch;
+            }
+
+            @Override
+            public void run()
+            {
+                try
+                {
+                    executionLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( "Interrupted while waiting for a latch", e );
+                }
+            }
+        }
+    }
+
+    private class TestOneMerge extends MergePolicy.OneMerge
+    {
+
+        TestOneMerge( SegmentCommitInfo segmentCommitInfo )
+        {
+            super( Collections.singletonList( segmentCommitInfo ) );
+        }
+    }
+}

--- a/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
+++ b/community/lucene-index/src/test/java/org/apache/lucene/index/PooledConcurrentMergeSchedulerTest.java
@@ -63,7 +63,7 @@ public class PooledConcurrentMergeSchedulerTest
 
         mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
 
-        assertEquals( 0, mergeScheduler.getWriterTaskCounter().get() );
+        assertEquals( 0, mergeScheduler.getWriterTaskCount() );
     }
 
     @Test
@@ -76,7 +76,7 @@ public class PooledConcurrentMergeSchedulerTest
 
         mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
 
-        assertEquals( 1, mergeScheduler.getWriterTaskCounter().get() );
+        assertEquals( 1, mergeScheduler.getWriterTaskCount() );
     }
 
     @Test
@@ -89,7 +89,7 @@ public class PooledConcurrentMergeSchedulerTest
 
         mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
 
-        assertEquals( 2, mergeScheduler.getWriterTaskCounter().get() );
+        assertEquals( 2, mergeScheduler.getWriterTaskCount() );
     }
 
     @Test( timeout = 5000 )
@@ -103,14 +103,14 @@ public class PooledConcurrentMergeSchedulerTest
 
         mergeScheduler.merge( indexWriter, MergeTrigger.EXPLICIT, false );
 
-        assertEquals( 1, mergeScheduler.getWriterTaskCounter().get() );
+        assertEquals( 1, mergeScheduler.getWriterTaskCount() );
 
         Thread closeSchedulerThread = ThreadTestUtils.fork( () -> mergeScheduler.close() );
         ThreadTestUtils.awaitThreadState( closeSchedulerThread, 500, Thread.State.TIMED_WAITING );
         mergeScheduler.getExecutionLatch().countDown();
         closeSchedulerThread.join();
 
-        assertEquals( 0, mergeScheduler.getWriterTaskCounter().get() );
+        assertEquals( 0, mergeScheduler.getWriterTaskCount() );
     }
 
     private SegmentCommitInfo getSegmentCommitInfo()


### PR DESCRIPTION
Lucene indexes merge scheduler that execute merges in a thread pool instead of starting separate thread for each
merge. Each writer have it's own scheduler but all of them use shared pool.
Current implementation is minimalistic in a number of things it knows about lucene internals to simplify
migrations overhead. It wraps up lucene internal merge tasks and execute them in a common thread pool.
In case if pool and queue exhausted merge will be performed in callers thread.