### PR TITLE
Count store support for cartesian products

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planDescription/InternalPlanDescription.scala
@@ -116,7 +116,7 @@ object InternalPlanDescription {
     }
     case class ExpandExpression(from: String, relName: String, relTypes:Seq[String], to: String,
                                 direction: SemanticDirection, minLength: Int, maxLength: Option[Int]) extends Argument
-    case class CountNodesExpression(ident: String, label: List[Option[String]]) extends Argument
+    case class CountNodesExpression(ident: String, labels: List[Option[String]]) extends Argument
     case class CountRelationshipsExpression(ident: String, startLabel: Option[String],
                                             typeNames: Seq[String], endLabel: Option[String]) extends Argument
     case class SourceCode(className: String, sourceCode: String) extends Argument {

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planDescription/InternalPlanDescription.scala
@@ -116,7 +116,7 @@ object InternalPlanDescription {
     }
     case class ExpandExpression(from: String, relName: String, relTypes:Seq[String], to: String,
                                 direction: SemanticDirection, minLength: Int, maxLength: Option[Int]) extends Argument
-    case class CountNodesExpression(ident: String, label: Option[String]) extends Argument
+    case class CountNodesExpression(ident: String, label: List[Option[String]]) extends Argument
     case class CountRelationshipsExpression(ident: String, startLabel: Option[String],
                                             typeNames: Seq[String], endLabel: Option[String]) extends Argument
     case class SourceCode(className: String, sourceCode: String) extends Argument {

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -186,8 +186,8 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       case AllNodesScan(IdName(ident), _) =>
         AllNodesScanPipe(ident)(id = id)
 
-      case NodeCountFromCountStore(IdName(ident), label, _) =>
-        NodeCountFromCountStorePipe(ident, label.map(LazyLabel.apply))(id = id)
+      case NodeCountFromCountStore(IdName(ident), labels, _) =>
+        NodeCountFromCountStorePipe(ident, labels.map(l => l.map(LazyLabel.apply)))(id = id)
 
       case RelationshipCountFromCountStore(IdName(ident), startLabel, typeNames, endLabel, _) =>
         RelationshipCountFromCountStorePipe(ident, startLabel.map(LazyLabel.apply), LazyTypes(typeNames.map(_.name)), endLabel.map(LazyLabel.apply))(id = id)

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlan2PlanDescription.scala
@@ -83,7 +83,7 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
         PlanDescriptionImpl(id, "LoadCSV", NoChildren, Seq.empty, variables)
 
       case NodeCountFromCountStore(IdName(variable), labelName, _) =>
-        val arguments = Seq(CountNodesExpression(variable, labelName.map(_.name)))
+        val arguments = Seq(CountNodesExpression(variable, labelName.map(l => l.map(_.name))))
         PlanDescriptionImpl(id, "NodeCountFromCountStore", NoChildren, arguments, variables)
 
       case NodeIndexContainsScan(_, label, propertyKey, valueExpr, _) =>
@@ -148,7 +148,7 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
         PlanDescriptionImpl(id, "EmptyResult", children, Seq.empty, variables)
       case NodeCountFromCountStore(IdName(id), labelName, arguments) =>
         PlanDescriptionImpl(id = idMap(plan), "NodeCountFromCountStore", NoChildren,
-                            Seq(CountNodesExpression(id, labelName.map(_.name))), variables)
+                            Seq(CountNodesExpression(id, labelName.map(l => l.map(_.name)))), variables)
 
       case RelationshipCountFromCountStore(IdName(id), start, types, end, arguments) =>
         PlanDescriptionImpl(id = idMap(plan), "RelationshipCountFromCountStore", NoChildren,

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/LogicalPlan2PlanDescription.scala
@@ -82,8 +82,8 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
       case _: LoadCSV =>
         PlanDescriptionImpl(id, "LoadCSV", NoChildren, Seq.empty, variables)
 
-      case NodeCountFromCountStore(IdName(variable), labelName, _) =>
-        val arguments = Seq(CountNodesExpression(variable, labelName.map(l => l.map(_.name))))
+      case NodeCountFromCountStore(IdName(variable), labelNames, _) =>
+        val arguments = Seq(CountNodesExpression(variable, labelNames.map(l => l.map(_.name))))
         PlanDescriptionImpl(id, "NodeCountFromCountStore", NoChildren, arguments, variables)
 
       case NodeIndexContainsScan(_, label, propertyKey, valueExpr, _) =>

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/NodeCountFromCountStore.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/NodeCountFromCountStore.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.ast.LabelName
 import org.neo4j.cypher.internal.ir.v3_3.{CardinalityEstimation, IdName, PlannerQuery}
 
 
-case class NodeCountFromCountStore(idName: IdName, labelName: Option[LabelName], argumentIds: Set[IdName])
+case class NodeCountFromCountStore(idName: IdName, labelName: List[Option[LabelName]], argumentIds: Set[IdName])
                                     (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalLeafPlan {
 

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -413,10 +413,10 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
     RollUpApply(lhs, rhs, collectionName, variableToCollect, nullable)(lhs.solved)
   }
 
-  def planCountStoreNodeAggregation(query: PlannerQuery, projectedColumn: IdName, label: Option[LabelName], argumentIds: Set[IdName])
+  def planCountStoreNodeAggregation(query: PlannerQuery, projectedColumn: IdName, labels: List[Option[LabelName]], argumentIds: Set[IdName])
                                    (implicit context: LogicalPlanningContext): LogicalPlan = {
     val solved = RegularPlannerQuery(query.queryGraph, query.horizon)
-    NodeCountFromCountStore(projectedColumn, label, argumentIds)(solved)
+    NodeCountFromCountStore(projectedColumn, labels, argumentIds)(solved)
   }
 
   def planCountStoreRelationshipAggregation(query: PlannerQuery, idName: IdName, startLabel: Option[LabelName],

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/NodeCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/NodeCountFromCountStorePipeTest.scala
@@ -33,7 +33,7 @@ class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructio
     implicit val table = new SemanticTable()
     table.resolvedLabelIds.put("A", LabelId(12))
 
-    val pipe = NodeCountFromCountStorePipe("count(n)", Some(LazyLabel(LabelName("A") _)))()
+    val pipe = NodeCountFromCountStorePipe("count(n)", List(Some(LazyLabel(LabelName("A") _))))()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].nodeCountByCountStore(12)).thenReturn(42L).getMock[QueryContext]
@@ -44,7 +44,7 @@ class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructio
   test("should return zero if label is missing") {
     implicit val table = new SemanticTable()
 
-    val pipe = NodeCountFromCountStorePipe("count(n)", Some(LazyLabel(LabelName("A") _)))()
+    val pipe = NodeCountFromCountStorePipe("count(n)", List(Some(LazyLabel(LabelName("A") _))))()
 
     val mockedContext: QueryContext = mock[QueryContext]
     when(mockedContext.nodeCountByCountStore(12)).thenReturn(42L)
@@ -55,7 +55,7 @@ class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructio
   }
 
   test("should return a count for nodes without a label") {
-    val pipe = NodeCountFromCountStorePipe("count(n)", None)()
+    val pipe = NodeCountFromCountStorePipe("count(n)", List(None))()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].nodeCountByCountStore(NameId.WILDCARD)).thenReturn(42L).getMock[QueryContext]

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlannerTest.scala
@@ -44,6 +44,12 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
     countStorePlanner(plannerQuery) should beCountPlanFor("n")
   }
 
+  test("should plan a count for cartesian node count no labels") {
+    val plannerQuery = producePlannerQuery("MATCH (n), (m)", "n")
+
+    countStorePlanner(plannerQuery) should beCountPlanFor("n")
+  }
+
   test("should not plan a count for node count when there is a predicate on the node") {
     // When
     val plannerQuery = producePlannerQuery("MATCH (n) WHERE n.prop", "n")
@@ -172,7 +178,7 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
     }
   }
 
-  private def beCountPlanFor(variable: String) = new IsCountPlan(variable, false)
+  private def beCountPlanFor(variable: String) = IsCountPlan(variable, false)
   private def notBeCountPlan = new IsCountPlan("", true)
 
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.compatibility.v3_2.{ExecutionResultWrapper => E
 import org.neo4j.cypher.internal.compatibility.v3_3.{ExecutionResultWrapper, exceptionHandler}
 import org.neo4j.cypher.internal.compiler.v3_3._
 import org.neo4j.cypher.internal.compiler.v3_3.executionplan._
-import org.neo4j.cypher.internal.compiler.v3_3.planDescription._
 import org.neo4j.cypher.internal.compiler.v3_3.planDescription.InternalPlanDescription.Arguments
+import org.neo4j.cypher.internal.compiler.v3_3.planDescription._
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{InternalResultVisitor, QualifiedName}
 import org.neo4j.cypher.internal.compiler.{v2_3, v3_1, v3_2}
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection => SemanticDirection2_3, notification => notification_2_3}
@@ -323,7 +323,7 @@ object RewindableExecutionResult {
           Arguments.ExpandExpression(from, relName, relTypes, to, dir, min, max)
         case Arguments3_1.SourceCode(className, sourceCode) =>
           Arguments.SourceCode(className, sourceCode)
-        case Arguments3_1.CountNodesExpression(ident, label) => Arguments.CountNodesExpression(ident, label.map(_.name))
+        case Arguments3_1.CountNodesExpression(ident, label) => Arguments.CountNodesExpression(ident, List(label.map(_.name)))
         case Arguments3_1.CountRelationshipsExpression(ident, startLabel, typeNames, endLabel) => Arguments
           .CountRelationshipsExpression(ident, startLabel.map(_.name), typeNames.names, endLabel.map(_.name))
         case Arguments3_1.LegacyExpressions(expressions) => Arguments.LegacyExpressions(
@@ -471,7 +471,7 @@ object RewindableExecutionResult {
           Arguments.ExpandExpression(from, relName, relTypes, to, dir, min, max)
         case Arguments3_2.SourceCode(className, sourceCode) =>
           Arguments.SourceCode(className, sourceCode)
-        case Arguments3_2.CountNodesExpression(ident, label) => Arguments.CountNodesExpression(ident, label)
+        case Arguments3_2.CountNodesExpression(ident, label) => Arguments.CountNodesExpression(ident, List(label))
         case Arguments3_2.CountRelationshipsExpression(ident, startLabel, typeNames, endLabel) => Arguments
           .CountRelationshipsExpression(ident, startLabel, typeNames, endLabel)
         case Arguments3_2.LegacyExpressions(expressions) => Arguments.LegacyExpressions(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -43,12 +43,6 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result.columnAs[Node]("n").toList should equal(List(n1, n2, n3, n4, n5))
   }
 
-  test("foo") {
-    createNode()
-    createNode()
-    println(executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n), (m) RETURN count(*)").toList)
-  }
-
   // Not TCK material -- no character type
   test("comparing string and chars should work nicely") {
     val n1 = createNode(Map("x" -> "Anders"))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -43,6 +43,12 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result.columnAs[Node]("n").toList should equal(List(n1, n2, n3, n4, n5))
   }
 
+  test("foo") {
+    createNode()
+    createNode()
+    println(executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n), (m) RETURN count(*)").toList)
+  }
+
   // Not TCK material -- no character type
   test("comparing string and chars should work nicely") {
     val n1 = createNode(Map("x" -> "Anders"))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -657,6 +657,97 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     result2.toList should equal(List(Map("count(r)" -> 1)))
   }
 
+  test("count store on two unlabeled nodes") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n), (m) RETURN count(n)", f = { result =>
+
+        // Then
+        result.columnAs("count(n)").toSet[Int] should equal(Set(9))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store on two unlabeled nodes and count(*)") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n), (m) RETURN count(*)", f = { result =>
+
+        // Then
+        result.columnAs("count(*)").toSet[Int] should equal(Set(9))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store on one labeled node and one unlabeled") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n:User),(m) RETURN count(n)", f = { result =>
+
+        // Then
+        result.columnAs("count(n)").toSet[Int] should equal(Set(6))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store on one labeled node and one unlabeled and count(*)") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n:User),(m) RETURN count(*)", f = { result =>
+
+        // Then
+        result.columnAs("count(*)").toSet[Int] should equal(Set(6))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store on two labeled nodes") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n:User),(m:User) RETURN count(n)", f = { result =>
+
+        // Then
+        result.columnAs("count(n)").toSet[Int] should equal(Set(4))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store with many nodes") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n:User),(m),(o:User),(p) RETURN count(*)", f = { result =>
+
+        // Then
+        result.columnAs("count(*)").toSet[Int] should equal(Set(36))
+
+      }, allRuntimes = true)
+  }
+
+  test("count store with many but odd number of nodes") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n:User),(m),(o:User),(p), (q) RETURN count(*)", f = { result =>
+
+        // Then
+        result.columnAs("count(*)").toSet[Int] should equal(Set(108))
+
+      }, allRuntimes = true)
+  }
+
   def withModel(label1: String = "User",
                 label2: String = "User",
                 type1: String = "KNOWS",

--- a/enterprise/cypher/cypher-compiled-runtime-3.3/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.3/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/LogicalPlanConverter.scala
@@ -27,9 +27,9 @@ import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.spi.SortItem
 import org.neo4j.cypher.internal.compiler.v3_3.commands._
 import org.neo4j.cypher.internal.compiler.v3_3.helpers.{One, ZeroOneOrMany}
-import org.neo4j.cypher.internal.compiler.v3_3.planner.{CantCompileQueryException, logical}
-import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{SortDescription, plans}
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{SortDescription, plans}
+import org.neo4j.cypher.internal.compiler.v3_3.planner.{CantCompileQueryException, logical}
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.Eagerly.immutableMapValues
 import org.neo4j.cypher.internal.frontend.v3_3.{InternalException, ast, symbols}
@@ -566,7 +566,7 @@ object LogicalPlanConverter {
       val (methodHandle, actions :: tl) = context.popParent().consume(context, this)
       val opName = context.registerOperator(logicalPlan)
 
-      val label: Option[(Option[Int], String)] = nodeCount.labelName.map(l => l.id(context.semanticTable).map(_.id) -> l.name)
+      val label = nodeCount.labelName.map(ll => ll.map(l => l.id(context.semanticTable).map(_.id) -> l.name))
       (methodHandle, NodeCountFromCountStoreInstruction(opName, variable, label, actions) :: tl)
     }
   }

--- a/enterprise/cypher/cypher-compiled-runtime-3.3/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.3/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/spi/MethodStructure.scala
@@ -102,6 +102,7 @@ trait MethodStructure[E] {
   def loadVariable(varName: String): E
 
   // arithmetic
+  def multiplyPrimitive(lhs: E, rhs: E): E
   def addExpression(lhs: E, rhs: E): E
   def subtractExpression(lhs: E, rhs: E): E
   def multiplyExpression(lhs: E, rhs: E): E

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedMethodStructure.scala
@@ -30,9 +30,9 @@ import org.neo4j.collection.primitive._
 import org.neo4j.collection.primitive.hopscotch.LongKeyIntValueTable
 import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.CompositeKey
 import org.neo4j.cypher.internal.codegen._
-import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.{CodeGenContext, QueryExecutionEvent}
-import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.ir.expressions.{BoolType, FloatType, CodeGenType, CypherCodeGenType, ListReferenceType, LongType, ReferenceType, RepresentationType, Parameter => _}
+import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.ir.expressions.{BoolType, CodeGenType, CypherCodeGenType, FloatType, ListReferenceType, LongType, ReferenceType, RepresentationType, Parameter => _}
 import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.spi._
+import org.neo4j.cypher.internal.compiled_runtime.v3_3.codegen.{CodeGenContext, QueryExecutionEvent}
 import org.neo4j.cypher.internal.compiler.v3_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v3_3.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{NodeIdWrapper, RelationshipIdWrapper}
@@ -41,13 +41,13 @@ import org.neo4j.cypher.internal.frontend.v3_3.symbols.{CTNode, CTRelationship, 
 import org.neo4j.cypher.internal.frontend.v3_3.{ParameterNotFoundException, SemanticDirection, symbols}
 import org.neo4j.cypher.internal.spi.v3_3.codegen.GeneratedMethodStructure.CompletableFinalizer
 import org.neo4j.cypher.internal.spi.v3_3.codegen.Methods._
+import org.neo4j.cypher.internal.spi.v3_3.codegen.Templates.{createNewInstance, handleKernelExceptions, newRelationshipDataExtractor, tryCatch}
 import org.neo4j.graphdb.Direction
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.schema.index.{IndexDescriptor, IndexDescriptorFactory}
 import org.neo4j.kernel.api.schema.{IndexQuery, LabelSchemaDescriptor}
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
-import org.neo4j.cypher.internal.spi.v3_3.codegen.Templates.{createNewInstance, handleKernelExceptions, newRelationshipDataExtractor, tryCatch}
 
 import scala.collection.mutable
 
@@ -465,6 +465,8 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   }
 
   override def loadVariable(varName: String) = generator.load(varName)
+
+  override def multiplyPrimitive(lhs: Expression, rhs: Expression) = multiply(lhs, rhs)
 
   override def addExpression(lhs: Expression, rhs: Expression) = math(Methods.mathAdd, lhs, rhs)
 


### PR DESCRIPTION
For queries such as `MATCH (m),(n),(o),... RETURN count(*)` there is no
need to do the full cartesian product, we can use the count store
directly instead.