### PR TITLE
Don't use pruning varexpand when relationship is needed

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -600,6 +600,23 @@ return p""")
     res.toList should equal(List(Map("n1.prop" -> 1, "n2.prop" -> 2)))
   }
 
+  test("should handle distinct, variable length and relationship predicate") {
+    // Given
+    val node1 = createNode()
+    val node2 = createNode()
+    val node3 = createNode()
+    val node4 = createNode()
+    relate(node1, node2, "T", Map("roles" -> "NEO"))
+    relate(node2, node3, "T", Map("roles" -> "NEO"))
+    relate(node2, node4, "T", Map("roles" -> "NEO"))
+
+    // When
+    val res = executeWithAllPlannersAndCompatibilityMode("MATCH (n)-[r:T*2]->() WHERE last(r).roles = 'NEO' RETURN DISTINCT n")
+
+    // Then
+    res.toSet should equal(Set(Map("n" -> node1)))
+  }
+
   /**
    * Append variable to keys and transform value arrays to lists
    */


### PR DESCRIPTION
For queries where the relationship identifier is used in predicate
we can not use pruning varexpand. For example the query

```
MATCH (n)-[r:T*2]->() WHERE last(r).prop = 'foo' RETURN DISTINCT n
```
should not use pruning varexpand since it needs access to all the relationships.

changelog: Fixed error using pruning var-expand when relationship variable is referenced in predicate