### PR TITLE
Lowers batch size of input-reading stages in import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -374,7 +374,7 @@ public class ParallelBatchImporter implements BatchImporter
 
     private static Configuration configWithRecordsPerPageBasedBatchSize( Configuration source, RecordStore<?> store )
     {
-        return Configuration.withBatchSize( source, store.getRecordsPerPage() * 100 );
+        return Configuration.withBatchSize( source, store.getRecordsPerPage() * 10 );
     }
 
     private void executeStage( Stage stage )


### PR DESCRIPTION
because the batches would be quite big for data that has a large
amount of property data and would risk out of memory. With this change
the batch size is around a couple of thosands, down from a couple of
tens of thousands (page size based)