### PR TITLE
Fix bug in GBPTree shut down

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -797,18 +797,36 @@ public class GBPTree<KEY,VALUE> implements Closeable
                 return;
             }
 
-            if ( !changesSinceLastCheckpoint )
+            internalIndexClose();
+        }
+        catch ( IOException ioe )
+        {
+            try
             {
-                clean = true;
-                forceState();
+                pagedFile.flushAndForce();
+                internalIndexClose();
             }
-            pagedFile.close();
-            closed = true;
+            catch ( IOException e )
+            {
+                ioe.addSuppressed( e );
+                throw ioe;
+            }
         }
         finally
         {
             writerCheckpointMutex.unlock();
         }
+    }
+
+    private void internalIndexClose() throws IOException
+    {
+        if ( !changesSinceLastCheckpoint )
+        {
+            clean = true;
+            forceState();
+        }
+        pagedFile.close();
+        closed = true;
     }
 
     /**

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -455,7 +455,7 @@ public class GBPTreeTest
         // GIVEN
         IOException no = new IOException( "No" );
         AtomicBoolean throwOnNextIO = new AtomicBoolean();
-        PageCache controlledPageCache = pageCacheThatThrowOnIOWhenToldTo( no, throwOnNextIO );
+        PageCache controlledPageCache = pageCacheThatThrowExceptionWhenToldTo( no, throwOnNextIO );
         try ( GBPTree<MutableLong, MutableLong> index = index().with( controlledPageCache ).build() )
         {
             // WHEN
@@ -475,31 +475,6 @@ public class GBPTreeTest
                 writer.put( new MutableLong( 1 ), new MutableLong( 1 ) );
             }
         }
-    }
-
-    private PageCache pageCacheThatThrowOnIOWhenToldTo( final IOException e, final AtomicBoolean throwOnNextIO )
-    {
-        return new DelegatingPageCache( createPageCache( 256 ) )
-            {
-                @Override
-                public PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException
-                {
-                    return new DelegatingPagedFile( super.map( file, pageSize, openOptions ) )
-                    {
-                        @Override
-                        public PageCursor io( long pageId, int pf_flags ) throws IOException
-                        {
-                            if ( throwOnNextIO.get() )
-                            {
-                                throwOnNextIO.set( false );
-                                assert e != null;
-                                throw e;
-                            }
-                            return super.io( pageId, pf_flags );
-                        }
-                    };
-                }
-            };
     }
 
     @Test
@@ -1144,6 +1119,59 @@ public class GBPTreeTest
                 assertThat( e.getMessage(), containsString( PointerChecking.WRITER_TRAVERSE_OLD_STATE_MESSAGE ) );
             }
         }
+    }
+
+    /* IO failure on close */
+
+    @Test
+    public void mustRetryCloseIfFailure() throws Exception
+    {
+        // GIVEN
+        AtomicBoolean throwOnNext = new AtomicBoolean();
+        IOException exception = new IOException( "My failure" );
+        PageCache pageCache = pageCacheThatThrowExceptionWhenToldTo( exception, throwOnNext );
+        try ( GBPTree<MutableLong, MutableLong> index = index().with( pageCache ).build() )
+        {
+            // WHEN
+            throwOnNext.set( true );
+        }
+    }
+
+    private PageCache pageCacheThatThrowExceptionWhenToldTo( final IOException e, final AtomicBoolean throwOnNextIO )
+    {
+        return new DelegatingPageCache( createPageCache( 256 ) )
+        {
+            @Override
+            public PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException
+            {
+                return new DelegatingPagedFile( super.map( file, pageSize, openOptions ) )
+                {
+                    @Override
+                    public PageCursor io( long pageId, int pf_flags ) throws IOException
+                    {
+                        maybeThrow();
+                        return super.io( pageId, pf_flags );
+                    }
+
+                    @Override
+                    public void flushAndForce( IOLimiter limiter ) throws IOException
+                    {
+                        maybeThrow();
+                        super.flushAndForce( limiter );
+                    }
+
+                    private void maybeThrow() throws IOException
+                    {
+                        if ( throwOnNextIO.get() )
+                        {
+                            throwOnNextIO.set( false );
+                            assert e != null;
+                            throw e;
+                        }
+                    }
+                };
+            }
+        };
     }
 
     private void insert( GBPTree<MutableLong,MutableLong> index, long key, long value ) throws IOException

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -1014,7 +1014,7 @@ public class MuninnPageCache implements PageCache
         return false;
     }
 
-    private void clearEvictorException()
+    void clearEvictorException()
     {
         if ( evictorException != null )
         {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -257,6 +257,7 @@ final class MuninnPagedFile implements PagedFile, Flushable
             flushAndForceInternal( flushEvent.flushEventOpportunity(), false, limiter );
             syncDevice();
         }
+        pageCache.clearEvictorException();
     }
 
     void flushAndForceForClose() throws IOException
@@ -274,6 +275,7 @@ final class MuninnPagedFile implements PagedFile, Flushable
             flushAndForceInternal( flushEvent.flushEventOpportunity(), true, IOLimiter.unlimited() );
             syncDevice();
         }
+        pageCache.clearEvictorException();
     }
 
     private void markAllDirtyPagesAsClean()

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFilesystemAbstraction.java
@@ -37,7 +37,7 @@ import org.neo4j.test.impl.ChannelOutputStream;
 
 public class LimitedFilesystemAbstraction extends DelegatingFileSystemAbstraction
 {
-    private boolean outOfSpace;
+    private volatile boolean outOfSpace;
 
     public LimitedFilesystemAbstraction( FileSystemAbstraction delegate )
     {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -3362,7 +3362,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
     }
 
     @Test( timeout = SHORT_TIMEOUT_MILLIS )
-    public void mustRecoverFromFullDriveWhenMoreStorageBecomesAvailable() throws IOException
+    public void mustRecoverViaFileCloseFromFullDriveWhenMoreStorageBecomesAvailable() throws IOException
     {
         final AtomicBoolean hasSpace = new AtomicBoolean();
         FileSystemAbstraction fs = new DelegatingFileSystemAbstraction( this.fs )
@@ -3401,13 +3401,78 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
         }
         catch ( IOException ignore )
         {
-            // We're not out of space! Salty tears...
+            // We're out of space! Salty tears...
         }
 
         // Fix the situation:
         hasSpace.set( true );
 
         // Closing the last reference of a paged file implies a flush, and it mustn't throw:
+        pagedFile.close();
+
+        try ( PagedFile pf = pageCache.map( file( "a" ), filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( cursor.next() ); // this should not throw
+        }
+    }
+
+    @Test
+    public void mustRecoverViaFileFlushFromFullDriveWhenMoreStorageBecomesAvailable() throws Exception
+    {
+
+        final AtomicBoolean hasSpace = new AtomicBoolean();
+        final AtomicBoolean hasThrown = new AtomicBoolean();
+        FileSystemAbstraction fs = new DelegatingFileSystemAbstraction( this.fs )
+        {
+            @Override
+            public StoreChannel open( File fileName, String mode ) throws IOException
+            {
+                return new DelegatingStoreChannel( super.open( fileName, mode ) )
+                {
+                    @Override
+                    public void writeAll( ByteBuffer src, long position ) throws IOException
+                    {
+                        if ( !hasSpace.get() )
+                        {
+                            hasThrown.set( true );
+                            throw new IOException( "No space left on device" );
+                        }
+                        super.writeAll( src, position );
+                    }
+                };
+            }
+        };
+
+        fs.create( file( "a" ) ).close();
+
+        getPageCache( fs, maxPages, pageCachePageSize, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL );
+        PagedFile pagedFile = pageCache.map( file( "a" ), filePageSize );
+
+        try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            //noinspection InfiniteLoopStatement
+            while ( !hasThrown.get() ) // Keep writing until we get an exception! (when the cache starts evicting stuff)
+            {
+                assertTrue( cursor.next() );
+                writeRecords( cursor );
+            }
+        }
+        catch ( IOException ignore )
+        {
+            // We're out of space! Salty tears...
+        }
+
+        // Fix the situation:
+        hasSpace.set( true );
+
+        // Flushing the paged file implies the eviction exception gets cleared, and mustn't itself throw:
+        pagedFile.flushAndForce();
+
+        try ( PageCursor cursor = pagedFile.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( cursor.next() ); // this should not throw
+        }
         pagedFile.close();
     }
 


### PR DESCRIPTION
If the page cache eviction thread encounters an exception during eviction, such
as running out of storage space, then that exception will be stored in a field
an delivered to the next unfortunate passersby accessing the page cache.
If this is the GBPTree in the process of shutting down, then the exception
would bubble out without any attempt at recovering the situation.
This behaviour was different from how the record stores shut down, and it would
prevent shut down even after the fault had been corrected, such as more space
becoming available.

@burqen Can I ask you to add some GBPTree specific tests for this?