### PR TITLE
Clears batch inserter cache on commit even if only reading

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccess.java
@@ -114,9 +114,9 @@ public class DirectRecordAccess<KEY extends Comparable<KEY>,RECORD extends Abstr
 
     private class DirectRecordProxy implements RecordProxy<KEY,RECORD,ADDITIONAL>
     {
-        private KEY key;
-        private RECORD record;
-        private ADDITIONAL additionalData;
+        private final KEY key;
+        private final RECORD record;
+        private final ADDITIONAL additionalData;
         private boolean changed = false;
         private final boolean created;
 
@@ -224,6 +224,8 @@ public class DirectRecordAccess<KEY extends Comparable<KEY>,RECORD extends Abstr
     {
         if ( changeCounter.value() == 0 )
         {
+            // Clear the batch anyway since otherwise pure reads will fill it up more and more
+            batch.clear();
             return;
         }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.AbstractRecordStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess.Loader;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class DirectRecordAccessTest
+{
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldClearCacheOnCommitEvenIfNoWrites() throws Exception
+    {
+        // GIVEN
+        AbstractRecordStore<NodeRecord> store = mock( AbstractRecordStore.class );
+        Loader<Long,NodeRecord,Void> loader = mock( Loader.class );
+        DirectRecordAccess<Long,NodeRecord,Void> access = new DirectRecordAccess<>( store, loader );
+
+        // WHEN loading w/o commit
+        access.getOrLoad( 0L, null );
+        verify( loader, times( 1 ) ).load( 0L, null );
+        reset( loader );
+        access.getOrLoad( 0L, null );
+
+        // THEN records should be cached
+        verifyNoMoreInteractions( loader );
+
+        // and WHEN loading after commit
+        access.commit();
+        access.getOrLoad( 0L, null );
+
+        // THEN records should be read again
+        verify( loader, times( 1 ) ).load( 0L, null );
+    }
+}


### PR DESCRIPTION
otherwise the cache would grow indefinitely if there were no writes