### PR TITLE
Handling START clauses in cost planner

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConverters.scala
@@ -20,11 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v3_2.ast.convert.plannerQuery
 
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.plannerQuery.ClauseConverters._
-import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.frontend.v3_2.{Foldable, SemanticTable, ast}
-import org.neo4j.cypher.internal.ir.v3_2.{PeriodicCommit, UnionQuery}
 import org.neo4j.cypher.internal.ir.v3_2.exception.CantHandleQueryException
+import org.neo4j.cypher.internal.ir.v3_2.{PeriodicCommit, UnionQuery}
 
 object StatementConverters {
   import Foldable._
@@ -38,7 +37,8 @@ object StatementConverters {
     classOf[And],
     classOf[Or],
     // classOf[ReturnAll],
-    classOf[UnaliasedReturnItem]
+    classOf[UnaliasedReturnItem],
+    classOf[Start]
   )
 
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -903,10 +903,10 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     graph.argumentIds should equal(Set(IdName("xes"), IdName("x"), IdName("y")))
   }
 
-  val one = SignedDecimalIntegerLiteral("1")(pos)
-  val two = SignedDecimalIntegerLiteral("2")(pos)
-  val three = SignedDecimalIntegerLiteral("3")(pos)
-  val collection = ListLiteral(Seq(one, two, three))(pos)
+  private val one = SignedDecimalIntegerLiteral("1")(pos)
+  private val two = SignedDecimalIntegerLiteral("2")(pos)
+  private val three = SignedDecimalIntegerLiteral("3")(pos)
+  private val collection = ListLiteral(Seq(one, two, three))(pos)
 
   test("UNWIND [1,2,3] AS x MATCH (n) WHERE n.prop = x RETURN n") {
     val query = buildPlannerQuery("UNWIND [1,2,3] AS x MATCH (n) WHERE n.prop = x RETURN n")
@@ -1027,35 +1027,6 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     tail.queryGraph.patternNodes should equal(Set(IdName("x"), IdName("d")))
 
     tail.queryGraph.optionalMatches should be (empty)
-  }
-
-  test("START n=node:nodes(name = \"A\") RETURN n") {
-    val query = buildPlannerQuery("START n=node:nodes(name = \"A\") RETURN n")
-
-    val hint: LegacyIndexHint = NodeByIdentifiedIndex(varFor("n"), "nodes", "name", StringLiteral("A")_)_
-
-    query.queryGraph.hints should equal(Set(hint))
-    query.tail should equal(None)
-  }
-
-  test("START n=node:nodes(\"name:A\") RETURN n") {
-    val query = buildPlannerQuery("START n=node:nodes(\"name:A\") RETURN n")
-
-    val hint: LegacyIndexHint = NodeByIndexQuery(varFor("n"), "nodes", StringLiteral("name:A")_)_
-
-    query.queryGraph.hints should equal(Set(hint))
-    query.tail should equal(None)
-  }
-
-  test("START n=rel:relationships(\"name:A\") RETURN n") {
-    val query = buildPlannerQuery("START r=rel:relationships(\"name:A\") RETURN r")
-
-    val hint: LegacyIndexHint = RelationshipByIndexQuery(varFor("r"), "relationships", StringLiteral("name:A") _) _
-
-    query.queryGraph.hints should equal(Set(hint))
-    query.queryGraph.patternRelationships should not(be(empty))
-
-    query.tail should equal(None)
   }
 
   def relType(name: String): RelTypeName = RelTypeName(name)_

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
@@ -82,6 +82,11 @@ class StartClauseRewriterTest extends CypherFunSuite with AstRewritingTestSuppor
                   "MATCH (n) WHERE id(n) IN {id}")
   }
 
+  test("START r=rel({id})") {
+    shouldRewrite("START r=rel({id})",
+                  "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`) WHERE id(r) IN {id}")
+  }
+
   private def shouldRewrite(from: String, to: String) {
     //START uses UnsignedDecimalIntegerLiteral whereas IN uses signed
     //this is not important for this test so just ignore by rewriting

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilationState
+import org.neo4j.cypher.internal.compiler.v3_2.planner.AstRewritingTestSupport
+import org.neo4j.cypher.internal.compiler.v3_2.test_helpers.ContextHelper
+import org.neo4j.cypher.internal.frontend.v3_2.ast.rewriters.{CNFNormalizer, startClauseRewriter}
+import org.neo4j.cypher.internal.frontend.v3_2.ast.{Query, SignedDecimalIntegerLiteral, UnsignedDecimalIntegerLiteral}
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, topDown}
+
+class StartClauseRewriterTest extends CypherFunSuite with AstRewritingTestSupport {
+
+  test("START n=node(0)") {
+    shouldRewrite(
+      "START n=node(0)",
+      "MATCH (n) WHERE id(n) IN [0]")
+  }
+
+  test("START n=node(0,1)") {
+    shouldRewrite(
+      "START n=node(0,1)",
+      "MATCH (n) WHERE id(n) IN [0,1]")
+  }
+
+  test("START n=node(0),m=node(1)") {
+    shouldRewrite(
+      "START n=node(0),m=node(1)",
+      "MATCH (n),(m) WHERE id(n) IN [0] AND id(m) IN [1]")
+  }
+
+  private def shouldRewrite(from: String, to: String) {
+    //START uses UnsignedDecimalIntegerLiteral whereas IN uses signed
+    //this is not important for this test so just ignore by rewriting
+    val original = parser.parse(from).asInstanceOf[Query].endoRewrite(topDown(Rewriter.lift {
+        case u@UnsignedDecimalIntegerLiteral(v) => SignedDecimalIntegerLiteral(v)(u.position)
+      }))
+    val expected = parser.parse(to).asInstanceOf[Query].endoRewrite(CNFNormalizer.instance(ContextHelper.create()))
+
+    val input = CompilationState(null, null, null, Some(original))
+    val result = startClauseRewriter.transform(input, ContextHelper.create())
+
+    result.statement should equal(expected)
+  }
+
+  private def shouldNotRewrite(q: String) {
+    shouldRewrite(q, q)
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
@@ -77,6 +77,11 @@ class StartClauseRewriterTest extends CypherFunSuite with AstRewritingTestSuppor
       "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`)")
   }
 
+  test("START n=node({id})") {
+    shouldRewrite("START n=node({id})",
+                  "MATCH (n) WHERE id(n) IN {id}")
+  }
+
   private def shouldRewrite(from: String, to: String) {
     //START uses UnsignedDecimalIntegerLiteral whereas IN uses signed
     //this is not important for this test so just ignore by rewriting

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
@@ -53,6 +53,30 @@ class StartClauseRewriterTest extends CypherFunSuite with AstRewritingTestSuppor
       "MATCH (n)")
   }
 
+  test("START r=rel(0)") {
+    shouldRewrite(
+      "START r=rel(0)",
+      "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`) WHERE id(r) IN [0]")
+  }
+
+  test("START r=rel(0,1)") {
+    shouldRewrite(
+      "START r=rel(0,1)",
+      "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`) WHERE id(r) IN [0,1]")
+  }
+
+  test("START r=rel(0),rr=rel(1)") {
+    shouldRewrite(
+      "START r=rel(0),rr=rel(1)",
+      "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`),(`  UNNAMED15`)-[rr]->(`  UNNAMED16`) WHERE id(r) IN [0] AND id(rr) IN [1]")
+  }
+
+  test("START r=rel(*)") {
+    shouldRewrite(
+      "START r=rel(*)",
+      "MATCH (`  UNNAMED6`)-[r]->(`  UNNAMED7`)")
+  }
+
   private def shouldRewrite(from: String, to: String) {
     //START uses UnsignedDecimalIntegerLiteral whereas IN uses signed
     //this is not important for this test so just ignore by rewriting

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/StartClauseRewriterTest.scala
@@ -47,6 +47,12 @@ class StartClauseRewriterTest extends CypherFunSuite with AstRewritingTestSuppor
       "MATCH (n),(m) WHERE id(n) IN [0] AND id(m) IN [1]")
   }
 
+  test("START n=node(*)") {
+    shouldRewrite(
+      "START n=node(*)",
+      "MATCH (n)")
+  }
+
   private def shouldRewrite(from: String, to: String) {
     //START uses UnsignedDecimalIntegerLiteral whereas IN uses signed
     //this is not important for this test so just ignore by rewriting

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Hint.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/Hint.scala
@@ -45,7 +45,7 @@ sealed trait UsingHint extends Hint
 
 // allowed on start item
 
-sealed trait LegacyIndexHint extends Hint {
+sealed trait LegacyIndexHint extends UsingHint {
   self: StartItem =>
 
   def variable: Variable

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
@@ -41,7 +41,7 @@ case object startClauseRewriter extends StatementRewriter {
           val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
           In(invocation, ListLiteral(ids)(pos))(pos)
 
-        //START n=nodes(1,5,7)....
+        //START n=nodes({id})....
         case n@NodeByParameter(variable, parameter) =>
           val pos = n.position
           val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
@@ -52,6 +52,12 @@ case object startClauseRewriter extends StatementRewriter {
           val pos = n.position
           val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
           In(invocation, ListLiteral(ids)(pos))(pos)
+
+        //START r=rel({id})....
+        case r@RelationshipByParameter(variable, parameter) =>
+          val pos = r.position
+          val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
+          In(invocation, parameter)(pos)
       }
 
       val hints = items.collect {

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v3_2.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
+import org.neo4j.cypher.internal.frontend.v3_2.phases.{BaseContext, Condition}
+import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, topDown}
+
+case object startClauseRewriter extends StatementRewriter {
+
+  override def description: String = "Rewrites queries using START to equivalent MATCH queries"
+
+  override def postConditions: Set[Condition] = Set.empty
+  override def instance(context: BaseContext): Rewriter = topDown(Rewriter.lift {
+    case start@Start(items, where) =>
+      val newPredicates = items.collect {
+        case n@NodeByIds(variable, ids) =>
+          val pos = n.position
+          val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
+          val in = In(invocation, ListLiteral(ids)(pos))(pos)
+          in
+      }
+
+      val hints = items.collect {
+        case hint: LegacyIndexHint => hint
+      }
+      val nodes = items.collect {
+        case n: NodeStartItem => NodePattern(Some(n.variable.copyId), Seq.empty, None)(start.position)
+      }
+
+      val allPredicates = (newPredicates ++ where.map(_.expression)).toSet
+      val newWhere =
+        if (allPredicates.isEmpty) None
+        else if (allPredicates.size == 1) Some(Where(allPredicates.head)(start.position))
+        else Some(Where(Ands(allPredicates)(start.position))(start.position))
+      Match(optional = false, Pattern(nodes.map(EveryPath))(start.position), hints, newWhere)(start.position)
+  })
+
+}

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
@@ -41,6 +41,12 @@ case object startClauseRewriter extends StatementRewriter {
           val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
           In(invocation, ListLiteral(ids)(pos))(pos)
 
+        //START n=nodes(1,5,7)....
+        case n@NodeByParameter(variable, parameter) =>
+          val pos = n.position
+          val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)
+          In(invocation, parameter)(pos)
+
         //START r=rels(1,5,7)....
         case n@RelationshipByIds(variable, ids) =>
           val pos = n.position

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/startClauseRewriter.scala
@@ -31,6 +31,10 @@ case object startClauseRewriter extends StatementRewriter {
   override def instance(context: BaseContext): Rewriter = topDown(Rewriter.lift {
     case start@Start(items, where) =>
       val newPredicates = items.collect {
+        //We can safely ignore AllNodes here, i.e. nodes(*) since that is corresponding to
+        //no predicate on the identifier
+
+        //START n=nodes(1,5,7)....
         case n@NodeByIds(variable, ids) =>
           val pos = n.position
           val invocation = FunctionInvocation(FunctionName(functions.Id.name)(pos), variable.copyId)(pos)

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/CompilationPhases.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/phases/CompilationPhases.scala
@@ -38,6 +38,7 @@ object CompilationPhases {
       Namespacer andThen
       rewriteEqualityToInPredicate andThen
       CNFNormalizer andThen
+      startClauseRewriter andThen
       LateAstRewriting
 
 }

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
@@ -94,7 +94,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
     }
   }
 
-  def size = patternRelationships.size
+  def size: Int = patternRelationships.size
 
   def isEmpty: Boolean = this == QueryGraph.empty
 
@@ -111,7 +111,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
       patternRelationships = patternRelationships + rel
     )
 
-  def addPatternRelationships(rels: Seq[PatternRelationship]) =
+  def addPatternRelationships(rels: Seq[PatternRelationship]): QueryGraph =
     rels.foldLeft[QueryGraph](this)((qg, rel) => qg.addPatternRelationship(rel))
 
   def addShortestPath(shortestPath: ShortestPathPattern): QueryGraph = {
@@ -149,7 +149,9 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
     copy(selections = selections ++ newSelections)
   }
 
-  def addHints(addedHints: GenTraversableOnce[Hint]): QueryGraph = copy(hints = hints ++ addedHints)
+  def addHints(addedHints: GenTraversableOnce[Hint]): QueryGraph = {
+    copy(hints = hints ++ addedHints)
+  }
 
   def withoutHints(hintsToIgnore: GenTraversableOnce[Hint]): QueryGraph = copy(hints = hints -- hintsToIgnore)
 
@@ -181,10 +183,10 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
 
   def withSelections(selections: Selections): QueryGraph = copy(selections = selections)
 
-  def withPatternRelationships(patterns: Set[PatternRelationship]) =
+  def withPatternRelationships(patterns: Set[PatternRelationship]): QueryGraph =
    copy(patternRelationships = patterns)
 
-  def withPatternNodes(nodes: Set[IdName]) =
+  def withPatternNodes(nodes: Set[IdName]): QueryGraph =
     copy(patternNodes = nodes)
 
   def knownProperties(idName: IdName): Set[Property] =
@@ -237,7 +239,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   val allHints: Set[Hint] =
     if (optionalMatches.isEmpty) hints else hints ++ optionalMatches.flatMap(_.allHints)
 
-  def numHints = allHints.size
+  def numHints: Int = allHints.size
 
   def ++(other: QueryGraph): QueryGraph =
     QueryGraph(
@@ -262,7 +264,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
 
   def covers(other: QueryGraph): Boolean = other.isCoveredBy(this)
 
-  def hasOptionalPatterns = optionalMatches.nonEmpty
+  def hasOptionalPatterns: Boolean = optionalMatches.nonEmpty
 
   def patternNodeLabels: Map[IdName, Set[LabelName]] =
     patternNodes.collect { case node: IdName => node -> selections.labelsOnNode(node) }.toMap
@@ -350,7 +352,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
     containsMergeRecursive
   }
 
-  def writeOnly = !containsReads && containsUpdates
+  def writeOnly: Boolean = !containsReads && containsUpdates
 
   def addMutatingPatterns(patterns: MutatingPattern*): QueryGraph =
     copy(mutatingPatterns = mutatingPatterns ++ patterns)
@@ -359,7 +361,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
 object QueryGraph {
   val empty = QueryGraph()
 
-  def coveredIdsForPatterns(patternNodeIds: Set[IdName], patternRels: Set[PatternRelationship]) = {
+  def coveredIdsForPatterns(patternNodeIds: Set[IdName], patternRels: Set[PatternRelationship]): Set[IdName] = {
     val patternRelIds = patternRels.flatMap(_.coveredIds)
     patternNodeIds ++ patternRelIds
   }

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/helpers/PatternConverters.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/helpers/PatternConverters.scala
@@ -30,9 +30,9 @@ object PatternConverters {
   object DestructResult { def empty = DestructResult(Seq.empty, Seq.empty, Seq.empty) }
 
   case class DestructResult(nodeIds: Seq[IdName], rels: Seq[PatternRelationship], shortestPaths: Seq[ShortestPathPattern]) {
-    def addNodeId(newId: IdName*) = copy(nodeIds = nodeIds ++ newId)
-    def addRel(r: PatternRelationship*) = copy(rels = rels ++ r)
-    def addShortestPaths(r: ShortestPathPattern*) = copy(shortestPaths = shortestPaths ++ r)
+    def addNodeId(newId: IdName*): DestructResult = copy(nodeIds = nodeIds ++ newId)
+    def addRel(r: PatternRelationship*): DestructResult = copy(rels = rels ++ r)
+    def addShortestPaths(r: ShortestPathPattern*): DestructResult = copy(shortestPaths = shortestPaths ++ r)
   }
 
   implicit class PatternElementDestructor(val pattern: PatternElement) extends AnyVal {
@@ -47,10 +47,16 @@ object PatternConverters {
       DestructResult(nodeIds = Seq(IdName(node.variable.get.name)), Seq.empty, Seq.empty)
   }
 
+  //RelationshipChain(
+  // NodePattern(Some(Variable(  UNNAMED6)),List(),Some(Variable(  UNNAMED7))),
+  // RelationshipPattern(Some(Variable(r)),List(),None,None,OUTGOING,false),
+  // NodePattern(Some(Variable(  UNNAMED8)),List(),Some(Variable(  UNNAMED9))))
   implicit class RelationshipChainDestructor(val chain: RelationshipChain) extends AnyVal {
     def destructedRelationshipChain: DestructResult = chain match {
       // (a)->[r]->(b)
-      case RelationshipChain(NodePattern(Some(leftNodeId), Seq(), None), RelationshipPattern(Some(relId), relTypes, length, None, direction, _), NodePattern(Some(rightNodeId), Seq(), None)) =>
+      case RelationshipChain(NodePattern(Some(leftNodeId), Seq(), None),
+                             RelationshipPattern(Some(relId), relTypes, length, None, direction, _),
+                             NodePattern(Some(rightNodeId), Seq(), None)) =>
         val leftNode = IdName(leftNodeId.name)
         val rightNode = IdName(rightNodeId.name)
         val r = PatternRelationship(IdName(relId.name), (leftNode, rightNode), direction, relTypes, length.asPatternLength)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -26,7 +26,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("START n=node:index(key = \"value\") RETURN n") {
     val node = createNode()
     graph.inTx {
-      graph.index.forNodes("index").add(node, "key", "value")
+      graph.index().forNodes("index").add(node, "key", "value")
     }
 
     val result = executeWithAllPlannersAndCompatibilityMode("""START n=node:index(key = "value") RETURN n""").toList
@@ -37,7 +37,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("START n=node:index(\"key:value\") RETURN n") {
     val node = createNode()
     graph.inTx {
-      graph.index.forNodes("index").add(node, "key", "value")
+      graph.index().forNodes("index").add(node, "key", "value")
     }
 
     val result = executeWithAllPlannersAndCompatibilityMode("""START n=node:index("key:value") RETURN n""").toList
@@ -50,8 +50,8 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val otherNode = createNode(Map("prop" -> 21))
 
     graph.inTx {
-      graph.index.forNodes("index").add(node, "key", "value")
-      graph.index.forNodes("index").add(otherNode, "key", "value")
+      graph.index().forNodes("index").add(node, "key", "value")
+      graph.index().forNodes("index").add(otherNode, "key", "value")
     }
 
     val result = executeWithAllPlannersAndCompatibilityMode("""START n=node:index("key:value") WHERE n.prop = 42 RETURN n""").toList
@@ -65,7 +65,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val relationship = relate(node, otherNode)
 
     graph.inTx {
-      val relationshipIndex = graph.index.forRelationships("relIndex")
+      val relationshipIndex = graph.index().forRelationships("relIndex")
       relationshipIndex.add(relationship, "key", "value")
     }
 
@@ -106,13 +106,44 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result should equal(List(Map("n"-> node1), Map("n" -> node2)))
   }
 
+  test("START r=rel(0) RETURN r") {
+    val rel = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0) RETURN id(r)").toList
+
+    result should equal(List(Map("id(r)"-> rel)))
+  }
+
+  test("START r=rel(0,1) RETURN r") {
+    val rel1 = relate(createNode(), createNode()).getId
+    val rel2 = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0,1) RETURN id(r)").toList
+
+    result should equal(List(Map("id(r)"-> rel1),Map("id(r)"-> rel2)))
+  }
+
+  test("START r=rel(0),rr=rel(1) RETURN r") {
+    val rel1 = relate(createNode(), createNode()).getId
+    val rel2 = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0),rr=rel(1) RETURN id(r), id(rr)").toList
+
+    result should equal(List(Map("id(r)"-> rel1, "id(rr)"-> rel2)))
+  }
+
+  test("START r=rel(*) RETURN r") {
+    val rel1 = relate(createNode(), createNode()).getId
+    val rel2 = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("START r=rel(*) RETURN id(r)").toList
+
+    result should equal(List(Map("id(r)"-> rel1),Map("id(r)"-> rel2)))
+  }
+
   test("Relationship legacy index mk II") {
     val node = createNode(Map("prop" -> 42))
     val otherNode = createNode(Map("prop" -> 21))
     val relationship = relate(node, otherNode)
 
     graph.inTx {
-      val relationshipIndex = graph.index.forRelationships("relIndex")
+      val relationshipIndex = graph.index().forRelationships("relIndex")
       relationshipIndex.add(relationship, "key", "value")
     }
 
@@ -131,7 +162,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val relationship = relate(node, otherNode)
 
     graph.inTx {
-      val relationshipIndex = graph.index.forRelationships("relIndex")
+      val relationshipIndex = graph.index().forRelationships("relIndex")
       relationshipIndex.add(relationship, "key", "value")
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -98,6 +98,14 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result should equal(List(Map("n"-> node1, "m" -> node2)))
   }
 
+  test("START n=node(*) RETURN n") {
+    val node1 = createNode()
+    val node2 = createNode()
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("START n=node(*) RETURN n").toList
+
+    result should equal(List(Map("n"-> node1), Map("n" -> node2)))
+  }
+
   test("Relationship legacy index mk II") {
     val node = createNode(Map("prop" -> 42))
     val otherNode = createNode(Map("prop" -> 21))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -77,7 +77,16 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   test("START n=node(0) RETURN n") {
     val node = createNode()
+    createNode()
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("START n=node(0) RETURN n").toList
+
+    result should equal(List(Map("n"-> node)))
+  }
+
+  test("START n=node({id}) RETURN n") {
+    val node = createNode()
+    createNode()
+    val result = executeWithAllPlannersAndCompatibilityMode("START n=node({id}) RETURN n", "id" -> node.getId).toList
 
     result should equal(List(Map("n"-> node)))
   }
@@ -87,13 +96,32 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val node2 = createNode()
     val result = executeWithAllPlannersAndCompatibilityMode("START n=node(0,1) RETURN n").toList
 
-    result should equal(List(Map("n"-> node1), Map("n" -> node2)))
+    result should equal(List(Map("n" -> node1), Map("n" -> node2)))
+  }
+
+  test("START n=node({id}) RETURN n, id-> [0,1]") {
+
+    val node1 = createNode()
+    val node2 = createNode()
+    val result = executeWithAllPlannersAndCompatibilityMode("START n=node({id}) RETURN n",
+                                                            "id" -> List(node1.getId, node2.getId)).toList
+
+    result should equal(List(Map("n" -> node1), Map("n" -> node2)))
   }
 
   test("START n=node(0),m=node(1) RETURN n") {
     val node1 = createNode()
     val node2 = createNode()
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("START n=node(0),m=node(1) RETURN n,m").toList
+
+    result should equal(List(Map("n"-> node1, "m" -> node2)))
+  }
+
+  test("START n=node({id1}),m=node({id2}) RETURN n") {
+    val node1 = createNode()
+    val node2 = createNode()
+    val result = executeWithAllPlannersAndCompatibilityMode("START n=node({id1}),m=node({id2}) RETURN n,m",
+                                                                       "id1" -> node1.getId, "id2" -> node2.getId).toList
 
     result should equal(List(Map("n"-> node1, "m" -> node2)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -141,6 +141,14 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result should equal(List(Map("id(r)"-> rel)))
   }
 
+  test("START r=rel({id}) RETURN r") {
+    val rel = relate(createNode(), createNode()).getId
+    relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel({id}) RETURN id(r)", "id" -> rel).toList
+
+    result should equal(List(Map("id(r)"-> rel)))
+  }
+
   test("START r=rel(0,1) RETURN r") {
     val rel1 = relate(createNode(), createNode()).getId
     val rel2 = relate(createNode(), createNode()).getId
@@ -149,10 +157,27 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result should equal(List(Map("id(r)"-> rel1),Map("id(r)"-> rel2)))
   }
 
+  test("START r=rel({id}) RETURN r, id -> [0,1]") {
+    val rel1 = relate(createNode(), createNode()).getId
+    val rel2 = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel({id}) RETURN id(r)", "id" -> List(rel1,rel2)).toList
+
+    result should equal(List(Map("id(r)"-> rel1),Map("id(r)"-> rel2)))
+  }
+
   test("START r=rel(0),rr=rel(1) RETURN r") {
     val rel1 = relate(createNode(), createNode()).getId
     val rel2 = relate(createNode(), createNode()).getId
     val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0),rr=rel(1) RETURN id(r), id(rr)").toList
+
+    result should equal(List(Map("id(r)"-> rel1, "id(rr)"-> rel2)))
+  }
+
+  test("START r=rel({id1}),rr=rel({id2}) RETURN r") {
+    val rel1 = relate(createNode(), createNode()).getId
+    val rel2 = relate(createNode(), createNode()).getId
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel({id1}),rr=rel({id2}) RETURN id(r), id(rr)",
+                                                            "id1" -> rel1, "id2" -> rel2).toList
 
     result should equal(List(Map("id(r)"-> rel1, "id(rr)"-> rel2)))
   }


### PR DESCRIPTION
We used to rely on the rule planner for most `START` queries, i.e. we would fail and fallback on the rule planner. Since we no longer have the rule planner around we need to support all legacy `START` queries in the cost planner. This is implemented as a rewriter that simply rewrites queries using `START` to an equivalent `MATCH` query.

changelog: Fixed error with `START` clauses in 3.2 caused by the removal of the rule planner.