### PR TITLE
Fixed error using pruning var expander with aggregation over path variable

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -35,7 +35,8 @@ case object pruningVarExpander extends Rewriter {
       val lowerDistinctLand: Option[Set[String]] = plan match {
         case Aggregation(left, groupExpr, aggrExpr) if aggrExpr.values.forall(isDistinct) =>
 
-          val variablesInTheDistinctSet = groupExpr.values.flatMap(_.dependencies.map(_.name)).toSet
+          val variablesInTheDistinctSet = (groupExpr.values.flatMap(_.dependencies.map(_.name)) ++
+            aggrExpr.values.flatMap(_.dependencies.map(_.name))).toSet
           Some(variablesInTheDistinctSet)
 
         case expand: VarExpand

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -78,7 +78,7 @@ case object pruningVarExpander extends Rewriter {
     case _ => false
   }
 
-  override def apply(input: AnyRef) = {
+  override def apply(input: AnyRef): AnyRef = {
     input match {
       case plan: LogicalPlan =>
         val distinctSet = findDistinctSet(plan)
@@ -89,8 +89,9 @@ case object pruningVarExpander extends Rewriter {
               // These constants were selected by benchmarking on randomized graphs, with different
               // degrees of interconnection.
               FullPruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
-            else
+            else if (length.max.get > 1)
               PruningVarExpand(lhs, fromId, dir, relTypes, toId, length.min, length.max.get, predicates)(expand.solved)
+            else expand
         })
         plan.endoRewrite(innerRewriter)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -617,6 +617,21 @@ return p""")
     res.toSet should equal(Set(Map("n" -> node1)))
   }
 
+  test("should handle distinct collect where the path is needed") {
+    // Given
+    val n1 = createNode()
+    val n2 = createNode()
+    val n3 = createNode()
+    relate(n1, n2)
+    relate(n3, createNode())
+
+    // When
+    val result = executeWithAllPlannersAndCompatibilityMode("MATCH p=(n)-[*0..3]-() RETURN size(COLLECT(DISTINCT p)) AS size")
+
+    // Then
+    result.toList should equal(List(Map("size" -> 8)))
+  }
+
   /**
    * Append variable to keys and transform value arrays to lists
    */


### PR DESCRIPTION
If the aggregation expression depends on the relationship identifier,
directly or indirectly via a path we should not use the pruning
varexpander.

changelog: Fixed error using pruning var expander with aggregation over path variable, and disallowed for maxlength=1 patterns.