### PR TITLE
Added additional arguments to `neo4j-admin import` to match capabilities in `neo4j-import`

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -69,8 +69,8 @@ public interface Configuration
     {
         return DEFAULT_LEGACY_STYLE_QUOTING;
     }
-
     int KB = 1024, MB = KB * KB;
+    int DEFAULT_BUFFER_SIZE_4MB = 4 * MB;
 
     class Default implements Configuration
     {
@@ -83,7 +83,7 @@ public interface Configuration
         @Override
         public int bufferSize()
         {
-            return 4 * MB;
+            return DEFAULT_BUFFER_SIZE_4MB;
         }
 
         @Override

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedBatchImporterConfigurationForNeo4jAdmin.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms.config;
+
+import org.neo4j.unsafe.impl.batchimport.Configuration;
+/**
+ * Provides a wrapper around {@link Configuration} with overridden defaults for neo4j-admin import
+ * Use all available processors
+ */
+public class WrappedBatchImporterConfigurationForNeo4jAdmin implements Configuration
+{
+    private Configuration defaults;
+
+    public WrappedBatchImporterConfigurationForNeo4jAdmin( Configuration defaults)
+    {
+        this.defaults = defaults;
+    }
+
+    @Override
+    public int batchSize()
+    {
+        return defaults.batchSize();
+    }
+
+    @Override
+    public int movingAverageSize()
+    {
+        return defaults.movingAverageSize();
+    }
+
+    @Override
+    public int maxNumberOfProcessors()
+    {
+        return Configuration.allAvailableProcessors();
+    }
+
+    @Override
+    public int denseNodeThreshold()
+    {
+        return defaults.denseNodeThreshold();
+    }
+
+    @Override
+    public long pageCacheMemory()
+    {
+        return defaults.pageCacheMemory();
+    }
+
+    @Override
+    public long maxMemoryUsage()
+    {
+        return defaults.maxMemoryUsage();
+    }
+
+    @Override
+    public boolean sequentialBackgroundFlushing()
+    {
+        return defaults.sequentialBackgroundFlushing();
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms.config;
+
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+/**
+ * Provides a wrapper around {@link Configuration} with overridden defaults for neo4j-admin import
+ * Always trim strings
+ * Import emptyQuotedStrings as empty Strings
+ * Buffer size is set to 4MB
+ */
+
+public class WrappedCsvInputConfigurationForNeo4jAdmin implements Configuration
+{
+    private Configuration defaults;
+
+    public WrappedCsvInputConfigurationForNeo4jAdmin( Configuration defaults)
+    {
+        this.defaults = defaults;
+    }
+
+    @Override
+    public char delimiter()
+    {
+        return defaults.delimiter();
+    }
+
+    @Override
+    public char arrayDelimiter()
+    {
+        return defaults.arrayDelimiter();
+    }
+
+    @Override
+    public char quotationCharacter()
+    {
+        return defaults.quotationCharacter();
+    }
+
+    @Override
+    public int bufferSize()
+    {
+        return DEFAULT_BUFFER_SIZE_4MB;
+    }
+
+    @Override
+    public boolean multilineFields()
+    {
+        return defaults.multilineFields();
+    }
+
+    @Override
+    public boolean trimStrings()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean emptyQuotedStringsAsNull()
+    {
+        return false;
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.commandline.dbms;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.commandline.admin.RealOutsideWorld;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
@@ -38,6 +38,7 @@ import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class CsvImporterTest

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -78,6 +78,11 @@ public interface Configuration
      */
     default int maxNumberOfProcessors()
     {
+        return allAvailableProcessors();
+    }
+
+    static int allAvailableProcessors()
+    {
         return Runtime.getRuntime().availableProcessors();
     }
 


### PR DESCRIPTION
`neo4j-admin import` misses few functionalities that has been found useful in `neo4j-import`

We are porting the functionality either as is or with sensible defaults into `neo4j-admin` before removing `neo4j-import` in entirety.

This PR deals with:

- Use all available processors `--processors=(all available processors)`
- Always trim strings `--trim-strings=true`
- Import emptyQuotedStrings as empty Strings `--ignore-empty-strings=false`
- Buffer size is set to 4MB `--read-buffer-size=4194304`
