### PR TITLE
Revert #9242 3.2-unwind-issues - fixes compiled runtime regression

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.codegen;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -175,11 +174,7 @@ public abstract class CompiledConversionUtils
 
     public static Object loadParameter( Object value )
     {
-        if (value == null)
-        {
-            return null;
-        }
-        else if ( value instanceof Node )
+        if ( value instanceof Node )
         {
             return new NodeIdWrapperImpl( ((Node) value).getId() );
         }
@@ -187,37 +182,6 @@ public abstract class CompiledConversionUtils
         {
             return new RelationshipIdWrapperImpl( ((Relationship) value).getId() );
         }
-        else if ( value instanceof List<?>)
-        {
-            List<?> list = (List<?>) value;
-            ArrayList<Object> copy = new ArrayList<>( list.size() );
-            for ( Object o : list )
-            {
-                copy.add( loadParameter( o ));
-            }
-            return copy;
-        }
-        else if ( value instanceof Map<?, ?>)
-        {
-            Map<String, ?> map = (Map<String, ?>) value;
-            HashMap<String,Object> copy = new HashMap<>( map.size() );
-            for ( Map.Entry<String,?> entry : map.entrySet() )
-            {
-                copy.put( entry.getKey(), loadParameter( entry.getValue() ) );
-            }
-            return copy;
-        }
-        else if ( value.getClass().isArray())
-        {
-            int length = Array.getLength( value );
-            Object[] copy = new Object[length];
-            for ( int i = 0; i < length; i++ )
-            {
-                copy[i] = Array.get(value, i);
-            }
-            return copy;
-        }
-
         else
         {
             return value;
@@ -418,31 +382,6 @@ public abstract class CompiledConversionUtils
             return -1L;
         }
         return value.id();
-    }
-
-    @SuppressWarnings( "unused" ) // called from compiled code
-    public static long extractLong(Object obj)
-    {
-        if (obj == null)
-        {
-            return -1L;
-        }
-        else if (obj instanceof NodeIdWrapper)
-        {
-            return ((NodeIdWrapper) obj).id();
-        }
-        else if (obj instanceof RelationshipIdWrapper)
-        {
-            return ((RelationshipIdWrapper) obj).id();
-        }
-        else if (obj instanceof Long)
-        {
-            return (Long) obj;
-        }
-        else
-        {
-            throw new IllegalArgumentException( format( "Can not be converted to long: %s", obj.getClass().getName() ) );
-        }
     }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -563,43 +563,6 @@ return p""")
     resultWithAlias.close()
   }
 
-  test("should handle unwind on a list of nodes in both runtimes") {
-    // Given
-    val node1 = createNode()
-    val node2 = createNode()
-    relate(createLabeledNode("Ping"), node1, "PING_DAY")
-    relate(createLabeledNode("Ping"), node2, "PING_DAY")
-    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
-    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
-
-    // When
-    val res =
-      executeWithAllPlannersAndRuntimesAndCompatibilityMode("UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c", "p" -> List(node1, node2))
-
-    //Then
-    res.toList should equal(List(Map("c" -> 2)))
-  }
-
-  test("should handle unwind followed by expand into on a list of nodes in both runtimes") {
-    // Given
-    val node1 = createNode("prop" -> 1)
-    val node2 = createLabeledNode(Map("prop" -> 2), "Ping")
-    relate(node2, node1, "PING_DAY")
-    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
-    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
-    relate(createLabeledNode("Ping"), createNode(), "PING_DAY")
-
-    // When
-    val res =
-      executeWithAllPlannersAndRuntimesAndCompatibilityMode( """UNWIND {p1} AS n1
-                                                               |UNWIND {p2} AS n2
-                                                               |MATCH (n1)<-[:PING_DAY]-(n2) RETURN n1.prop, n2.prop""".stripMargin,
-                                                             "p1" -> List(node1), "p2" -> List(node2))
-
-    //Then
-    res.toList should equal(List(Map("n1.prop" -> 1, "n2.prop" -> 2)))
-  }
-
   test("should handle distinct, variable length and relationship predicate") {
     // Given
     val node1 = createNode()

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -36,9 +36,9 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, fromVar.codeGenType, dir)
+      generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, dir)
     else
-      generator.nodeGetRelationshipsWithDirectionAndTypes(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq)
+      generator.nodeGetRelationshipsWithDirectionAndTypes(iterVar, fromVar.name, dir, types.keys.toIndexedSeq)
     generator.incrementDbHits()
   }
 
@@ -46,10 +46,6 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
                              (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
-  }
-
-  def foo[E](generator: MethodStructure[E]) = fromVar.codeGenType match {
-    case c if c.isPrimitive => generator.loadVariable(fromVar.name)
   }
 
   override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextRelationship(iterVar)

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -36,9 +36,9 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
-      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, toVar.name, toVar.codeGenType)
+      generator.connectingRelationships(iterVar, fromVar.name, dir, toVar.name)
     else
-      generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, types.keys.toIndexedSeq, toVar.name, toVar.codeGenType)
+      generator.connectingRelationships(iterVar, fromVar.name, dir, types.keys.toIndexedSeq, toVar.name)
     generator.incrementDbHits()
   }
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProperty.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/NodeProperty.scala
@@ -50,20 +50,20 @@ case class NodeProperty(token: Option[Int], propName: String, nodeIdVar: Variabl
 
   override def propertyByName[E](body: MethodStructure[E], localName: String) =
     if (nodeIdVar.nullable)
-      body.ifNotStatement(body.isNull(nodeIdVar.name, nodeIdVar.codeGenType)) {ifBody =>
-        ifBody.nodeGetPropertyForVar(nodeIdVar.name, nodeIdVar.codeGenType, propKeyVar, localName)
+      body.ifNotStatement(body.isNull(nodeIdVar.name, CodeGenType.primitiveNode)) {ifBody =>
+        ifBody.nodeGetPropertyForVar(nodeIdVar.name, propKeyVar, localName)
       }
     else
-      body.nodeGetPropertyForVar(nodeIdVar.name, nodeIdVar.codeGenType, propKeyVar, localName)
+      body.nodeGetPropertyForVar(nodeIdVar.name, propKeyVar, localName)
 
   //TODO will probably need to send in type so that nodes can be unboxed
   override def propertyById[E](body: MethodStructure[E], localName: String) =
     if (nodeIdVar.nullable)
-      body.ifNotStatement(body.isNull(nodeIdVar.name, nodeIdVar.codeGenType)) {ifBody =>
-        ifBody.nodeGetPropertyById(nodeIdVar.name, nodeIdVar.codeGenType, token.get, localName)
+      body.ifNotStatement(body.isNull(nodeIdVar.name, CodeGenType.primitiveNode)) {ifBody =>
+        ifBody.nodeGetPropertyById(nodeIdVar.name, token.get, localName)
       }
     else
-      body.nodeGetPropertyById(nodeIdVar.name, nodeIdVar.codeGenType, token.get, localName)
+      body.nodeGetPropertyById(nodeIdVar.name, token.get, localName)
 
   override def codeGenType(implicit context: CodeGenContext) = CodeGenType.Any
 }

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -128,7 +128,7 @@ trait MethodStructure[E] {
   def unbox(expression:E, codeGenType: CodeGenType): E
   def toFloat(expression:E): E
 
-  // parameters, and external data loading
+  // parameters
   def expectParameter(key: String, variableName: String, codeGenType: CodeGenType): Unit
 
   // map
@@ -147,17 +147,17 @@ trait MethodStructure[E] {
   def lookupLabelIdE(labelName: String): E
   def lookupRelationshipTypeId(typeIdVar: String, typeName: String): Unit
   def lookupRelationshipTypeIdE(typeName: String): E
-  def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection): Unit
-  def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection, typeVars: Seq[String]): Unit
-  def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, toNode:String, toNodeType: CodeGenType)
-  def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, types: Seq[String], toNode: String, toNodeType: CodeGenType)
+  def nodeGetRelationshipsWithDirection(iterVar: String, nodeVar: String, direction: SemanticDirection): Unit
+  def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, direction: SemanticDirection, typeVars: Seq[String]): Unit
+  def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, toNode:String)
+  def connectingRelationships(iterVar: String, fromNode: String, dir: SemanticDirection, types: Seq[String], toNode: String)
   def nextNode(targetVar: String, iterVar: String): Unit
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit
   def hasNextNode(iterVar: String): E
   def hasNextRelationship(iterVar: String): E
-  def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
-  def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit
+  def nodeGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
+  def nodeGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
   def nodeIdSeek(nodeIdVar: String, expression: E, codeGenType: CodeGenType)(block: MethodStructure[E] => Unit): Unit
   def relationshipGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String): Unit
   def relationshipGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_2/GeneratedMethodStructureTest.scala
@@ -125,7 +125,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         Operation("look up rel type", _.lookupRelationshipTypeId("foo", "bar")),
         Operation("all relationships for node", (m) => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
-          m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
+          m.nodeGetRelationshipsWithDirection("foo", "node", SemanticDirection.OUTGOING)
         }),
         Operation("has label", m => {
           m.lookupLabelId("label", "A")
@@ -137,12 +137,12 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           m.lookupPropertyKey("prop", "prop")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
-          m.nodeGetPropertyForVar("node", CodeGenType.primitiveNode, "prop", "propVar")
+          m.nodeGetPropertyForVar("node", "prop", "propVar")
         }),
         Operation("property by id for node", m => {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.declareProperty("propVar")
-          m.nodeGetPropertyById("node", CodeGenType.primitiveNode, 13, "propVar")
+          m.nodeGetPropertyById("node", 13, "propVar")
         }),
         Operation("property by name for relationship", m => {
           m.lookupPropertyKey("prop", "prop")
@@ -153,7 +153,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         Operation("property by id for relationship", m => {
           m.declareAndInitialize("rel", CodeGenType.primitiveRel)
           m.declareProperty("propVar")
-          m.nodeGetPropertyById("rel", CodeGenType.primitiveNode, 13, "propVar")
+          m.nodeGetPropertyById("rel", 13, "propVar")
         }),
         Operation("rel type", m => {
           m.createRelExtractor("bar")
@@ -164,12 +164,12 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
           m.lookupRelationshipTypeId("a", "A")
           m.lookupRelationshipTypeId("b", "B")
-          m.nodeGetRelationshipsWithDirectionAndTypes("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING, Seq("a", "b"))
+          m.nodeGetRelationshipsWithDirectionAndTypes("foo", "node", SemanticDirection.OUTGOING, Seq("a", "b"))
         }),
         Operation("next relationship", (m) => {
           m.createRelExtractor("r")
           m.declareAndInitialize("node", CodeGenType.primitiveNode)
-          m.nodeGetRelationshipsWithDirection("foo", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
+          m.nodeGetRelationshipsWithDirection("foo", "node", SemanticDirection.OUTGOING)
           m.nextRelationshipAndNode("nextNode", "foo", SemanticDirection.OUTGOING, "node", "r")
         }),
     Operation("expand into", (m) => {
@@ -200,7 +200,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       m.allNodesScan("nodeIter")
       m.whileLoop(m.hasNextNode("nodeIter")) { b1 =>
         b1.nextNode("node", "nodeIter")
-        b1.nodeGetRelationshipsWithDirection("relIter", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
+        b1.nodeGetRelationshipsWithDirection("relIter", "node", SemanticDirection.OUTGOING)
         b1.whileLoop(b1.hasNextRelationship("relIter")) { b2 =>
           b2.nextRelationshipAndNode("nextNode", "relIter", SemanticDirection.OUTGOING, "node", "r")
         }


### PR DESCRIPTION
This reverts commit db639e667c321590d217acd69e39dbde9fa8825b, reversing
changes made to ee0ddcd0a1a57b0bd51718c8991794a25f3e05a1.
