### PR TITLE
3.3 import feature parity

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -40,6 +40,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 
 import static org.neo4j.csv.reader.Configuration.DEFAULT;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT_MAX_MEMORY_PERCENT;
@@ -49,7 +50,6 @@ public class ImportCommand implements AdminCommand
 {
     public static final String DEFAULT_REPORT_FILE_NAME = "import.report";
     private static final String[] allowedModes = {"database", "csv"};
-    private static final String[] allowedDelimiterCharacters = {",", "TAB", ";", "|", ":", "#"};
     private static final Arguments databaseArguments = new Arguments()
             .withArgument( new MandatoryNamedArg( "mode", "database", "Import a pre-3.0 installation." )
             {
@@ -109,10 +109,11 @@ public class ImportCommand implements AdminCommand
                     "Whether or not fields from input source can span multiple lines," +
                             " i.e. contain newline characters." ) )
             .withArgument( new OptionalNamedArg( "delimiter",
-                    allowedDelimiterCharacters,
-                    String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
+                    "delimiter-character",
+                    String.valueOf( COMMAS.delimiter() ),
+                    "Delimiter character between values in CSV data." ) )
             .withArgument( new OptionalNamedArg( "array-delimiter",
-                    allowedDelimiterCharacters,
+                    "array-delimiter-character",
                     String.valueOf( COMMAS.arrayDelimiter() ),
                     "Delimiter character between array elements within a value in CSV data." ) )
             .withArgument( new OptionalNamedArg( "max-memory",
@@ -170,10 +171,10 @@ public class ImportCommand implements AdminCommand
                     "Whether or not fields from input source can span multiple lines," +
                             " i.e. contain newline characters." ) )
             .withArgument( new OptionalNamedArg( "delimiter",
-                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.delimiter() ),
                     String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
             .withArgument( new OptionalNamedArg( "array-delimiter",
-                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.delimiter() ),
                     String.valueOf( COMMAS.arrayDelimiter() ),
                     "Delimiter character between array elements within a value in CSV data." ) )
             .withArgument( new OptionalNamedArg( "max-memory",

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -40,7 +40,6 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
-import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 
 import static org.neo4j.csv.reader.Configuration.DEFAULT;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT_MAX_MEMORY_PERCENT;
@@ -116,6 +115,12 @@ public class ImportCommand implements AdminCommand
                     "array-delimiter-character",
                     String.valueOf( COMMAS.arrayDelimiter() ),
                     "Delimiter character between array elements within a value in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "quote",
+                    "quotation-character",
+                    String.valueOf( COMMAS.quotationCharacter() ),
+                    "Character to treat as quotation character for values in CSV data. "
+                            + "Quotes can be escaped as per RFC 4180 by doubling them, for example \"\" would be " +
+                            "interpreted as a literal \". You cannot escape using \\." ) )
             .withArgument( new OptionalNamedArg( "max-memory",
                     "max-memory-that-importer-can-use",
                     String.valueOf( DEFAULT_MAX_MEMORY_PERCENT ) + "%",
@@ -177,6 +182,12 @@ public class ImportCommand implements AdminCommand
                     String.valueOf( COMMAS.delimiter() ),
                     String.valueOf( COMMAS.arrayDelimiter() ),
                     "Delimiter character between array elements within a value in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "quote",
+                    "quotation-character",
+                    String.valueOf( COMMAS.quotationCharacter() ),
+                    "Character to treat as quotation character for values in CSV data. "
+                            + "Quotes can be escaped as per RFC 4180 by doubling them, for example \"\" would be " +
+                            "interpreted as a literal \". You cannot escape using \\." ) )
             .withArgument( new OptionalNamedArg( "max-memory",
                     "max-memory-that-importer-can-use",
                     String.valueOf( DEFAULT_MAX_MEMORY_PERCENT ) + "%",

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -41,6 +41,8 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
 
+import static org.neo4j.csv.reader.Configuration.DEFAULT;
+import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT_MAX_MEMORY_PERCENT;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
 
 public class ImportCommand implements AdminCommand
@@ -102,13 +104,25 @@ public class ImportCommand implements AdminCommand
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
                     "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "multiline-fields",
+                    DEFAULT.multilineFields(),
+                    "Whether or not fields from input source can span multiple lines," +
+                            " i.e. contain newline characters." ) )
             .withArgument( new OptionalNamedArg( "delimiter",
                     allowedDelimiterCharacters,
                     String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
             .withArgument( new OptionalNamedArg( "array-delimiter",
                     allowedDelimiterCharacters,
                     String.valueOf( COMMAS.arrayDelimiter() ),
-                    "Delimiter character between array elements within a value in CSV data." ) );
+                    "Delimiter character between array elements within a value in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "max-memory",
+                    "max-memory-that-importer-can-use",
+                    String.valueOf( DEFAULT_MAX_MEMORY_PERCENT ) + "%",
+                    "Maximum memory that neo4j-admin can use for various data structures and caching " +
+                            "to improve performance. " +
+                            "Values can be plain numbers, like 10000000 or e.g. 20G for 20 gigabyte, or even e.g. 70%" +
+                            "." ) );
+
     private static final Arguments allArguments = new Arguments()
             .withDatabase()
             .withAdditionalConfig()
@@ -151,14 +165,24 @@ public class ImportCommand implements AdminCommand
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
                     "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "multiline-fields",
+                    DEFAULT.multilineFields(),
+                    "Whether or not fields from input source can span multiple lines," +
+                            " i.e. contain newline characters." ) )
             .withArgument( new OptionalNamedArg( "delimiter",
                     allowedDelimiterCharacters,
                     String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
             .withArgument( new OptionalNamedArg( "array-delimiter",
                     allowedDelimiterCharacters,
                     String.valueOf( COMMAS.arrayDelimiter() ),
-                    "Delimiter character between array elements within a value in CSV data." ) );
-
+                    "Delimiter character between array elements within a value in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "max-memory",
+                    "max-memory-that-importer-can-use",
+                    String.valueOf( DEFAULT_MAX_MEMORY_PERCENT ) + "%",
+                    "Maximum memory that neo4j-admin can use for various data structures and caching " +
+                            "to improve performance. " +
+                            "Values can be plain numbers, like 10000000 or e.g. 20G for 20 gigabyte, or even e.g. 70%" +
+                            "." ) );
     public static Arguments databaseArguments()
     {
         return databaseArguments;

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -41,10 +41,13 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
 
+import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
+
 public class ImportCommand implements AdminCommand
 {
     public static final String DEFAULT_REPORT_FILE_NAME = "import.report";
     private static final String[] allowedModes = {"database", "csv"};
+    private static final String[] allowedDelimiterCharacters = {",", "TAB", ";", "|", ":", "#"};
     private static final Arguments databaseArguments = new Arguments()
             .withArgument( new MandatoryNamedArg( "mode", "database", "Import a pre-3.0 installation." )
             {
@@ -98,7 +101,14 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
-                    "If relationships referring to missing nodes should be ignored during the import." ) );
+                    "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalNamedArg( "delimiter",
+                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "array-delimiter",
+                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.arrayDelimiter() ),
+                    "Delimiter character between array elements within a value in CSV data." ) );
     private static final Arguments allArguments = new Arguments()
             .withDatabase()
             .withAdditionalConfig()
@@ -140,7 +150,14 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
-                    "If relationships referring to missing nodes should be ignored during the import." ) );
+                    "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalNamedArg( "delimiter",
+                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.delimiter() ), "Delimiter character between values in CSV data." ) )
+            .withArgument( new OptionalNamedArg( "array-delimiter",
+                    allowedDelimiterCharacters,
+                    String.valueOf( COMMAS.arrayDelimiter() ),
+                    "Delimiter character between array elements within a value in CSV data." ) );
 
     public static Arguments databaseArguments()
     {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -77,4 +77,10 @@ public class WrappedCsvInputConfigurationForNeo4jAdmin implements Configuration
     {
         return false;
     }
+
+    @Override
+    public boolean legacyStyleQuoting()
+    {
+        return true;
+    }
 }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -81,6 +81,6 @@ public class WrappedCsvInputConfigurationForNeo4jAdmin implements Configuration
     @Override
     public boolean legacyStyleQuoting()
     {
-        return true;
+        return false;
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
@@ -22,7 +22,7 @@ package org.neo4j.commandline.dbms;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +56,7 @@ public class CsvImporterTest
         File reportLocation = testDir.file( "the_report" );
 
         File inputFile = testDir.file( "foobar.csv" );
-        List<String> lines = Arrays.asList( "foo,bar,baz" );
+        List<String> lines = Collections.singletonList( "foo\\tbar\\tbaz" );
         Files.write( inputFile.toPath(), lines, Charset.defaultCharset() );
 
         try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
@@ -67,8 +67,11 @@ public class CsvImporterTest
                                 DatabaseManagementSystemSettings.database_path.name(), dbDir.getAbsolutePath(),
                                 GraphDatabaseSettings.logs_directory.name(), logDir.getAbsolutePath() ) );
             CsvImporter csvImporter = new CsvImporter(
-                    Args.parse( String.format( "--report-file=%s", reportLocation.getAbsolutePath() ),
-                            String.format( "--nodes=%s", inputFile.getAbsolutePath() ) ), config,
+                    Args.parse(
+                            String.format( "--report-file=%s", reportLocation.getAbsolutePath() ),
+                            String.format( "--nodes=%s", inputFile.getAbsolutePath() ),
+                            "--delimiter=TAB" ),
+                    config,
                     outsideWorld );
             csvImporter.doImport();
         }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -198,88 +198,88 @@ public class ImportCommandTest
             Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
             usage.printUsageForCommand( new ImportCommandProvider(), ps::println );
 
-            assertEquals( "usage: neo4j-admin import [--mode=csv] [--database=<name>]\n" +
-                            "                          [--additional-config=<config-file-path>]\n" +
-                            "                          [--report-file=<filename>]\n" +
-                            "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]\n" +
-                            "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]\n" +
-                            "                          [--id-type=<STRING|INTEGER|ACTUAL>]\n" +
-                            "                          [--input-encoding=<character-set>]\n" +
-                            "                          [--ignore-extra-columns[=<true|false>]]\n" +
-                            "                          [--ignore-duplicate-nodes[=<true|false>]]\n" +
-                            "                          [--ignore-missing-nodes[=<true|false>]]\n" +
-                            "                          [--multiline-fields[=<true|false>]]\n" +
-                            "                          [--delimiter=<delimiter-character>]\n" +
-                            "                          [--array-delimiter=<array-delimiter-character>]\n" +
-                            "                          [--quote=<quotation-character>]\n" +
-                            "                          [--max-memory=<max-memory-that-importer-can-use>]\n" +
-                            "usage: neo4j-admin import --mode=database [--database=<name>]\n" +
-                            "                          [--additional-config=<config-file-path>]\n" +
-                            "                          [--from=<source-directory>]\n" +
-                            "\n" +
-                            "Import a collection of CSV files with --mode=csv (default), or a database from a\n" +
-                            "pre-3.0 installation with --mode=database.\n" +
-                            "\n" +
-                            "options:\n" +
-                            "  --database=<name>\n" +
-                            "      Name of database. [default:graph.db]\n" +
-                            "  --additional-config=<config-file-path>\n" +
-                            "      Configuration file to supply additional configuration in. [default:]\n" +
-                            "  --mode=<database|csv>\n" +
-                            "      Import a collection of CSV files or a pre-3.0 installation. [default:csv]\n" +
-                            "  --from=<source-directory>\n" +
-                            "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).\n" +
-                            "      [default:]\n" +
-                            "  --report-file=<filename>\n" +
-                            "      File in which to store the report of the csv-import.\n" +
-                            "      [default:import.report]\n" +
-                            "  --nodes[:Label1:Label2]=<\"file1,file2,...\">\n" +
-                            "      Node CSV header and data. Multiple files will be logically seen as one big\n" +
-                            "      file from the perspective of the importer. The first line must contain the\n" +
-                            "      header. Multiple data sources like these can be specified in one import,\n" +
-                            "      where each data source has its own header. Note that file groups must be\n" +
-                            "      enclosed in quotation marks. [default:]\n" +
-                            "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">\n" +
-                            "      Relationship CSV header and data. Multiple files will be logically seen as\n" +
-                            "      one big file from the perspective of the importer. The first line must\n" +
-                            "      contain the header. Multiple data sources like these can be specified in\n" +
-                            "      one import, where each data source has its own header. Note that file\n" +
-                            "      groups must be enclosed in quotation marks. [default:]\n" +
-                            "  --id-type=<STRING|INTEGER|ACTUAL>\n" +
-                            "      Each node must provide a unique id. This is used to find the correct nodes\n" +
-                            "      when creating relationships. Possible values are:\n" +
-                            "        STRING: arbitrary strings for identifying nodes,\n" +
-                            "        INTEGER: arbitrary integer values for identifying nodes,\n" +
-                            "        ACTUAL: (advanced) actual node ids.\n" +
-                            "      For more information on id handling, please see the Neo4j Manual:\n" +
-                            "      https://neo4j.com/docs/operations-manual/current/tools/import/\n" +
-                            "      [default:STRING]\n" +
-                            "  --input-encoding=<character-set>\n" +
-                            "      Character set that input data is encoded in. [default:UTF-8]\n" +
-                            "  --ignore-extra-columns=<true|false>\n" +
-                            "      If un-specified columns should be ignored during the import.\n" +
-                            "      [default:false]\n" +
-                            "  --ignore-duplicate-nodes=<true|false>\n" +
-                            "      If duplicate nodes should be ignored during the import. [default:false]\n" +
-                            "  --ignore-missing-nodes=<true|false>\n" +
-                            "      If relationships referring to missing nodes should be ignored during the\n" +
-                            "      import. [default:false]\n" +
-                            "  --multiline-fields=<true|false>\n" +
-                            "      Whether or not fields from input source can span multiple lines, i.e.\n" +
-                            "      contain newline characters. [default:false]\n" +
-                            "  --delimiter=<,>\n" +
-                            "      Delimiter character between values in CSV data. [default:,]\n" +
-                            "  --array-delimiter=<,>\n" +
-                            "      Delimiter character between array elements within a value in CSV data.\n" +
-                            "      [default:;]\n" +
-                            "  --quote=<quotation-character>\n" +
-                            "      Character to treat as quotation character for values in CSV data. Quotes\n" +
-                            "      can be escaped as per RFC 4180 by doubling them, for example \"\" would be\n" +
-                            "      interpreted as a literal \". You cannot escape using \\. [default:\"]\n" +
-                            "  --max-memory=<max-memory-that-importer-can-use>\n" +
-                            "      Maximum memory that neo4j-admin can use for various data structures and\n" +
-                            "      caching to improve performance. Values can be plain numbers, like 10000000\n" +
-                            "      or e.g. 20G for 20 gigabyte, or even e.g. 70%. [default:90%]\n",
+            assertEquals( String.format( "usage: neo4j-admin import [--mode=csv] [--database=<name>]%n" +
+                            "                          [--additional-config=<config-file-path>]%n" +
+                            "                          [--report-file=<filename>]%n" +
+                            "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]%n" +
+                            "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]%n" +
+                            "                          [--id-type=<STRING|INTEGER|ACTUAL>]%n" +
+                            "                          [--input-encoding=<character-set>]%n" +
+                            "                          [--ignore-extra-columns[=<true|false>]]%n" +
+                            "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
+                            "                          [--ignore-missing-nodes[=<true|false>]]%n" +
+                            "                          [--multiline-fields[=<true|false>]]%n" +
+                            "                          [--delimiter=<delimiter-character>]%n" +
+                            "                          [--array-delimiter=<array-delimiter-character>]%n" +
+                            "                          [--quote=<quotation-character>]%n" +
+                            "                          [--max-memory=<max-memory-that-importer-can-use>]%n" +
+                            "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
+                            "                          [--additional-config=<config-file-path>]%n" +
+                            "                          [--from=<source-directory>]%n" +
+                            "%n" +
+                            "Import a collection of CSV files with --mode=csv (default), or a database from a%n" +
+                            "pre-3.0 installation with --mode=database.%n" +
+                            "%n" +
+                            "options:%n" +
+                            "  --database=<name>%n" +
+                            "      Name of database. [default:graph.db]%n" +
+                            "  --additional-config=<config-file-path>%n" +
+                            "      Configuration file to supply additional configuration in. [default:]%n" +
+                            "  --mode=<database|csv>%n" +
+                            "      Import a collection of CSV files or a pre-3.0 installation. [default:csv]%n" +
+                            "  --from=<source-directory>%n" +
+                            "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).%n" +
+                            "      [default:]%n" +
+                            "  --report-file=<filename>%n" +
+                            "      File in which to store the report of the csv-import.%n" +
+                            "      [default:import.report]%n" +
+                            "  --nodes[:Label1:Label2]=<\"file1,file2,...\">%n" +
+                            "      Node CSV header and data. Multiple files will be logically seen as one big%n" +
+                            "      file from the perspective of the importer. The first line must contain the%n" +
+                            "      header. Multiple data sources like these can be specified in one import,%n" +
+                            "      where each data source has its own header. Note that file groups must be%n" +
+                            "      enclosed in quotation marks. [default:]%n" +
+                            "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">%n" +
+                            "      Relationship CSV header and data. Multiple files will be logically seen as%n" +
+                            "      one big file from the perspective of the importer. The first line must%n" +
+                            "      contain the header. Multiple data sources like these can be specified in%n" +
+                            "      one import, where each data source has its own header. Note that file%n" +
+                            "      groups must be enclosed in quotation marks. [default:]%n" +
+                            "  --id-type=<STRING|INTEGER|ACTUAL>%n" +
+                            "      Each node must provide a unique id. This is used to find the correct nodes%n" +
+                            "      when creating relationships. Possible values are:%n" +
+                            "        STRING: arbitrary strings for identifying nodes,%n" +
+                            "        INTEGER: arbitrary integer values for identifying nodes,%n" +
+                            "        ACTUAL: (advanced) actual node ids.%n" +
+                            "      For more information on id handling, please see the Neo4j Manual:%n" +
+                            "      https://neo4j.com/docs/operations-manual/current/tools/import/%n" +
+                            "      [default:STRING]%n" +
+                            "  --input-encoding=<character-set>%n" +
+                            "      Character set that input data is encoded in. [default:UTF-8]%n" +
+                            "  --ignore-extra-columns=<true|false>%n" +
+                            "      If un-specified columns should be ignored during the import.%n" +
+                            "      [default:false]%n" +
+                            "  --ignore-duplicate-nodes=<true|false>%n" +
+                            "      If duplicate nodes should be ignored during the import. [default:false]%n" +
+                            "  --ignore-missing-nodes=<true|false>%n" +
+                            "      If relationships referring to missing nodes should be ignored during the%n" +
+                            "      import. [default:false]%n" +
+                            "  --multiline-fields=<true|false>%n" +
+                            "      Whether or not fields from input source can span multiple lines, i.e.%n" +
+                            "      contain newline characters. [default:false]%n" +
+                            "  --delimiter=<,>%n" +
+                            "      Delimiter character between values in CSV data. [default:,]%n" +
+                            "  --array-delimiter=<,>%n" +
+                            "      Delimiter character between array elements within a value in CSV data.%n" +
+                            "      [default:;]%n" +
+                            "  --quote=<quotation-character>%n" +
+                            "      Character to treat as quotation character for values in CSV data. Quotes%n" +
+                            "      can be escaped as per RFC 4180 by doubling them, for example \"\" would be%n" +
+                            "      interpreted as a literal \". You cannot escape using \\. [default:\"]%n" +
+                            "  --max-memory=<max-memory-that-importer-can-use>%n" +
+                            "      Maximum memory that neo4j-admin can use for various data structures and%n" +
+                            "      caching to improve performance. Values can be plain numbers, like 10000000%n" +
+                            "      or e.g. 20G for 20 gigabyte, or even e.g. 70%%. [default:90%%]%n"),
                     baos.toString() );
         }
     }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -209,8 +209,8 @@ public class ImportCommandTest
                             "                          [--ignore-duplicate-nodes[=<true|false>]]\n" +
                             "                          [--ignore-missing-nodes[=<true|false>]]\n" +
                             "                          [--multiline-fields[=<true|false>]]\n" +
-                            "                          [--delimiter=<,|TAB|;|||:|#>]\n" +
-                            "                          [--array-delimiter=<,|TAB|;|||:|#>]\n" +
+                            "                          [--delimiter=<delimiter-character>]\n" +
+                            "                          [--array-delimiter=<array-delimiter-character>]\n" +
                             "                          [--max-memory=<max-memory-that-importer-can-use>]\n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]\n" +
                             "                          [--additional-config=<config-file-path>]\n" +
@@ -266,9 +266,9 @@ public class ImportCommandTest
                             "  --multiline-fields=<true|false>\n" +
                             "      Whether or not fields from input source can span multiple lines, i.e.\n" +
                             "      contain newline characters. [default:false]\n" +
-                            "  --delimiter=<,|TAB|;|||:|#>\n" +
+                            "  --delimiter=<,>\n" +
                             "      Delimiter character between values in CSV data. [default:,]\n" +
-                            "  --array-delimiter=<,|TAB|;|||:|#>\n" +
+                            "  --array-delimiter=<,>\n" +
                             "      Delimiter character between array elements within a value in CSV data.\n" +
                             "      [default:;]\n" +
                             "  --max-memory=<max-memory-that-importer-can-use>\n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -211,6 +211,7 @@ public class ImportCommandTest
                             "                          [--multiline-fields[=<true|false>]]\n" +
                             "                          [--delimiter=<delimiter-character>]\n" +
                             "                          [--array-delimiter=<array-delimiter-character>]\n" +
+                            "                          [--quote=<quotation-character>]\n" +
                             "                          [--max-memory=<max-memory-that-importer-can-use>]\n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]\n" +
                             "                          [--additional-config=<config-file-path>]\n" +
@@ -271,6 +272,10 @@ public class ImportCommandTest
                             "  --array-delimiter=<,>\n" +
                             "      Delimiter character between array elements within a value in CSV data.\n" +
                             "      [default:;]\n" +
+                            "  --quote=<quotation-character>\n" +
+                            "      Character to treat as quotation character for values in CSV data. Quotes\n" +
+                            "      can be escaped as per RFC 4180 by doubling them, for example \"\" would be\n" +
+                            "      interpreted as a literal \". You cannot escape using \\. [default:\"]\n" +
                             "  --max-memory=<max-memory-that-importer-can-use>\n" +
                             "      Maximum memory that neo4j-admin can use for various data structures and\n" +
                             "      caching to improve performance. Values can be plain numbers, like 10000000\n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.commandline.dbms;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
@@ -208,6 +208,8 @@ public class ImportCommandTest
                             "                          [--ignore-extra-columns[=<true|false>]]%n" +
                             "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
                             "                          [--ignore-missing-nodes[=<true|false>]]%n" +
+                            "                          [--delimiter=<,|TAB|;|||:|#>]%n" +
+                            "                          [--array-delimiter=<,|TAB|;|||:|#>]%n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--from=<source-directory>]%n" +
@@ -258,7 +260,12 @@ public class ImportCommandTest
                             "      If duplicate nodes should be ignored during the import. [default:false]%n" +
                             "  --ignore-missing-nodes=<true|false>%n" +
                             "      If relationships referring to missing nodes should be ignored during the%n" +
-                            "      import. [default:false]%n" ),
+                            "      import. [default:false]%n" +
+                            "  --delimiter=<,|TAB|;|||:|#>%n" +
+                            "      Delimiter character between values in CSV data. [default:,]%n" +
+                            "  --array-delimiter=<,|TAB|;|||:|#>%n" +
+                            "      Delimiter character between array elements within a value in CSV data.%n" +
+                            "      [default:;]%n" ),
                     baos.toString() );
         }
     }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -198,74 +198,83 @@ public class ImportCommandTest
             Usage usage = new Usage( "neo4j-admin", mock( CommandLocator.class ) );
             usage.printUsageForCommand( new ImportCommandProvider(), ps::println );
 
-            assertEquals( String.format( "usage: neo4j-admin import [--mode=csv] [--database=<name>]%n" +
-                            "                          [--additional-config=<config-file-path>]%n" +
-                            "                          [--report-file=<filename>]%n" +
-                            "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]%n" +
-                            "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]%n" +
-                            "                          [--id-type=<STRING|INTEGER|ACTUAL>]%n" +
-                            "                          [--input-encoding=<character-set>]%n" +
-                            "                          [--ignore-extra-columns[=<true|false>]]%n" +
-                            "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
-                            "                          [--ignore-missing-nodes[=<true|false>]]%n" +
-                            "                          [--delimiter=<,|TAB|;|||:|#>]%n" +
-                            "                          [--array-delimiter=<,|TAB|;|||:|#>]%n" +
-                            "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
-                            "                          [--additional-config=<config-file-path>]%n" +
-                            "                          [--from=<source-directory>]%n" +
-                            "%n" +
-                            "Import a collection of CSV files with --mode=csv (default), or a database from a%n" +
-                            "pre-3.0 installation with --mode=database.%n" +
-                            "%n" +
-                            "options:%n" +
-                            "  --database=<name>%n" +
-                            "      Name of database. [default:graph.db]%n" +
-                            "  --additional-config=<config-file-path>%n" +
-                            "      Configuration file to supply additional configuration in. [default:]%n" +
-                            "  --mode=<database|csv>%n" +
-                            "      Import a collection of CSV files or a pre-3.0 installation. [default:csv]%n" +
-                            "  --from=<source-directory>%n" +
-                            "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).%n" +
-                            "      [default:]%n" +
-                            "  --report-file=<filename>%n" +
-                            "      File in which to store the report of the csv-import.%n" +
-                            "      [default:import.report]%n" +
-                            "  --nodes[:Label1:Label2]=<\"file1,file2,...\">%n" +
-                            "      Node CSV header and data. Multiple files will be logically seen as one big%n" +
-                            "      file from the perspective of the importer. The first line must contain the%n" +
-                            "      header. Multiple data sources like these can be specified in one import,%n" +
-                            "      where each data source has its own header. Note that file groups must be%n" +
-                            "      enclosed in quotation marks. [default:]%n" +
-                            "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">%n" +
-                            "      Relationship CSV header and data. Multiple files will be logically seen as%n" +
-                            "      one big file from the perspective of the importer. The first line must%n" +
-                            "      contain the header. Multiple data sources like these can be specified in%n" +
-                            "      one import, where each data source has its own header. Note that file%n" +
-                            "      groups must be enclosed in quotation marks. [default:]%n" +
-                            "  --id-type=<STRING|INTEGER|ACTUAL>%n" +
-                            "      Each node must provide a unique id. This is used to find the correct nodes%n" +
-                            "      when creating relationships. Possible values are:%n" +
-                            "        STRING: arbitrary strings for identifying nodes,%n" +
-                            "        INTEGER: arbitrary integer values for identifying nodes,%n" +
-                            "        ACTUAL: (advanced) actual node ids.%n" +
-                            "      For more information on id handling, please see the Neo4j Manual:%n" +
-                            "      https://neo4j.com/docs/operations-manual/current/tools/import/%n" +
-                            "      [default:STRING]%n" +
-                            "  --input-encoding=<character-set>%n" +
-                            "      Character set that input data is encoded in. [default:UTF-8]%n" +
-                            "  --ignore-extra-columns=<true|false>%n" +
-                            "      If un-specified columns should be ignored during the import.%n" +
-                            "      [default:false]%n" +
-                            "  --ignore-duplicate-nodes=<true|false>%n" +
-                            "      If duplicate nodes should be ignored during the import. [default:false]%n" +
-                            "  --ignore-missing-nodes=<true|false>%n" +
-                            "      If relationships referring to missing nodes should be ignored during the%n" +
-                            "      import. [default:false]%n" +
-                            "  --delimiter=<,|TAB|;|||:|#>%n" +
-                            "      Delimiter character between values in CSV data. [default:,]%n" +
-                            "  --array-delimiter=<,|TAB|;|||:|#>%n" +
-                            "      Delimiter character between array elements within a value in CSV data.%n" +
-                            "      [default:;]%n" ),
+            assertEquals( "usage: neo4j-admin import [--mode=csv] [--database=<name>]\n" +
+                            "                          [--additional-config=<config-file-path>]\n" +
+                            "                          [--report-file=<filename>]\n" +
+                            "                          [--nodes[:Label1:Label2]=<\"file1,file2,...\">]\n" +
+                            "                          [--relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">]\n" +
+                            "                          [--id-type=<STRING|INTEGER|ACTUAL>]\n" +
+                            "                          [--input-encoding=<character-set>]\n" +
+                            "                          [--ignore-extra-columns[=<true|false>]]\n" +
+                            "                          [--ignore-duplicate-nodes[=<true|false>]]\n" +
+                            "                          [--ignore-missing-nodes[=<true|false>]]\n" +
+                            "                          [--multiline-fields[=<true|false>]]\n" +
+                            "                          [--delimiter=<,|TAB|;|||:|#>]\n" +
+                            "                          [--array-delimiter=<,|TAB|;|||:|#>]\n" +
+                            "                          [--max-memory=<max-memory-that-importer-can-use>]\n" +
+                            "usage: neo4j-admin import --mode=database [--database=<name>]\n" +
+                            "                          [--additional-config=<config-file-path>]\n" +
+                            "                          [--from=<source-directory>]\n" +
+                            "\n" +
+                            "Import a collection of CSV files with --mode=csv (default), or a database from a\n" +
+                            "pre-3.0 installation with --mode=database.\n" +
+                            "\n" +
+                            "options:\n" +
+                            "  --database=<name>\n" +
+                            "      Name of database. [default:graph.db]\n" +
+                            "  --additional-config=<config-file-path>\n" +
+                            "      Configuration file to supply additional configuration in. [default:]\n" +
+                            "  --mode=<database|csv>\n" +
+                            "      Import a collection of CSV files or a pre-3.0 installation. [default:csv]\n" +
+                            "  --from=<source-directory>\n" +
+                            "      The location of the pre-3.0 database (e.g. <neo4j-root>/data/graph.db).\n" +
+                            "      [default:]\n" +
+                            "  --report-file=<filename>\n" +
+                            "      File in which to store the report of the csv-import.\n" +
+                            "      [default:import.report]\n" +
+                            "  --nodes[:Label1:Label2]=<\"file1,file2,...\">\n" +
+                            "      Node CSV header and data. Multiple files will be logically seen as one big\n" +
+                            "      file from the perspective of the importer. The first line must contain the\n" +
+                            "      header. Multiple data sources like these can be specified in one import,\n" +
+                            "      where each data source has its own header. Note that file groups must be\n" +
+                            "      enclosed in quotation marks. [default:]\n" +
+                            "  --relationships[:RELATIONSHIP_TYPE]=<\"file1,file2,...\">\n" +
+                            "      Relationship CSV header and data. Multiple files will be logically seen as\n" +
+                            "      one big file from the perspective of the importer. The first line must\n" +
+                            "      contain the header. Multiple data sources like these can be specified in\n" +
+                            "      one import, where each data source has its own header. Note that file\n" +
+                            "      groups must be enclosed in quotation marks. [default:]\n" +
+                            "  --id-type=<STRING|INTEGER|ACTUAL>\n" +
+                            "      Each node must provide a unique id. This is used to find the correct nodes\n" +
+                            "      when creating relationships. Possible values are:\n" +
+                            "        STRING: arbitrary strings for identifying nodes,\n" +
+                            "        INTEGER: arbitrary integer values for identifying nodes,\n" +
+                            "        ACTUAL: (advanced) actual node ids.\n" +
+                            "      For more information on id handling, please see the Neo4j Manual:\n" +
+                            "      https://neo4j.com/docs/operations-manual/current/tools/import/\n" +
+                            "      [default:STRING]\n" +
+                            "  --input-encoding=<character-set>\n" +
+                            "      Character set that input data is encoded in. [default:UTF-8]\n" +
+                            "  --ignore-extra-columns=<true|false>\n" +
+                            "      If un-specified columns should be ignored during the import.\n" +
+                            "      [default:false]\n" +
+                            "  --ignore-duplicate-nodes=<true|false>\n" +
+                            "      If duplicate nodes should be ignored during the import. [default:false]\n" +
+                            "  --ignore-missing-nodes=<true|false>\n" +
+                            "      If relationships referring to missing nodes should be ignored during the\n" +
+                            "      import. [default:false]\n" +
+                            "  --multiline-fields=<true|false>\n" +
+                            "      Whether or not fields from input source can span multiple lines, i.e.\n" +
+                            "      contain newline characters. [default:false]\n" +
+                            "  --delimiter=<,|TAB|;|||:|#>\n" +
+                            "      Delimiter character between values in CSV data. [default:,]\n" +
+                            "  --array-delimiter=<,|TAB|;|||:|#>\n" +
+                            "      Delimiter character between array elements within a value in CSV data.\n" +
+                            "      [default:;]\n" +
+                            "  --max-memory=<max-memory-that-importer-can-use>\n" +
+                            "      Maximum memory that neo4j-admin can use for various data structures and\n" +
+                            "      caching to improve performance. Values can be plain numbers, like 10000000\n" +
+                            "      or e.g. 20G for 20 gigabyte, or even e.g. 70%. [default:90%]\n",
                     baos.toString() );
         }
     }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CharacterConverterTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CharacterConverterTest.java
@@ -62,6 +62,16 @@ public class CharacterConverterTest
     }
 
     @Test
+    public void shouldConvert_t_AsTab() throws Exception
+    {
+        // GIVEN
+        char expected = '\t';
+
+        // THEN
+        assertCorrectConversion( expected, "\t" );
+    }
+
+    @Test
     public void shouldConvertSpelledOut_TAB_AsTab() throws Exception
     {
         // GIVEN


### PR DESCRIPTION
These are new functionalities added to `neo4j-admin import` that has been found useful in `neo4j-import`

This PR deals with:

- `--delimiter`, `--array-delimiters`, `--quote`
- `--multiline-fields` to import csv data with line breaks
- `--max-memory` to define maximum memory that the importer can use
- Quoting respects RFC 4180 reported as an issue in https://github.com/neo4j/neo4j/issues/8472
