### PR TITLE
Reverted fix to Selection cost

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
@@ -92,7 +92,9 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
     CardinalityCostModel(lazyPlan, pleaseLazy) should be < CardinalityCostModel(eagerPlan, pleaseLazy)
   }
 
-  test("multiple property expressions are counted for in cost") {
+  //TODO this is ignore since the fix introduced regressions
+  //see https://github.com/neo4j/neo4j/pull/9383
+  ignore("multiple property expressions are counted for in cost") {
     val cardinality = 10.0
     val card10 = solvedWithEstimation(cardinality)
     val plan =
@@ -104,5 +106,4 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
     val costForArgument = cardinality *   .1
     CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(costForSelection + costForArgument))
   }
-
 }

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -130,22 +130,16 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
   }
 
   test("should solve optional matches with arguments and predicates") {
-    val plan = planFor(
-      """MATCH (n:X)
-        |OPTIONAL MATCH (n)-[r]-(m:Y)
-        |WHERE m.prop = 42
-        |RETURN m""".stripMargin).plan.endoRewrite(unnestOptional)
+    val plan = planFor("""MATCH (n)
+                         |OPTIONAL MATCH (n)-[r]-(m)
+                         |WHERE m.prop = 42
+                         |RETURN m""".stripMargin).plan.endoRewrite(unnestOptional)
     val s = solved
-    val allNodesN: LogicalPlan = NodeByLabelScan(IdName("n"), LabelName("X") _, Set.empty)(solved)
-    val propEquality: Expression =
-      In(Property(varFor("m"), PropertyKeyName("prop") _) _, ListLiteral(List(SignedDecimalIntegerLiteral("42") _)) _) _
-
-    val labelCheck: Expression =
-      HasLabels(varFor("m"), List(LabelName("Y") _)) _
-
+    val allNodesN:LogicalPlan = AllNodesScan(IdName("n"),Set())(s)
+    val predicate: Expression = In(Property(varFor("m"), PropertyKeyName("prop") _) _, ListLiteral(List(SignedDecimalIntegerLiteral("42") _)) _) _
     plan should equal(
       OptionalExpand(allNodesN, IdName("n"), SemanticDirection.BOTH, Seq.empty, IdName("m"), IdName("r"), ExpandAll,
-        Seq(propEquality, labelCheck))(s)
+                     Vector(predicate))(s)
     )
   }
 }


### PR DESCRIPTION
A bug fix in the way we calculate the cost-per-row of `Selection`,
https://github.com/neo4j/neo4j/pull/8937, lead to regressions. This
reverts those changes and we need to investigate more about why the fix
introduced regressions.

changelog: [3.1] Reverted a planner cost model calculation fix that was taking into account multiple predicates in a way that caused bad plans and worse performance for some queries