### PR TITLE
Remove NEW_THREAD scheduling strategy from Noe4jJobScheduler

### DIFF
--- a/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
@@ -29,22 +29,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.NEW_THREAD;
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.POOLED;
-
 /**
  * To be expanded, the idea here is to have a database-global service for running jobs, handling jobs crashing and so on.
  */
 public interface JobScheduler extends Lifecycle
 {
-    enum SchedulingStrategy
-    {
-        /** Create a new thread each time a job is scheduled */
-        NEW_THREAD,
-        /** Run the job from a pool of threads, shared among all groups with this strategy */
-        POOLED
-    }
-
     /**
      * Represents a common group of jobs, defining how they should be scheduled.
      */
@@ -53,24 +42,17 @@ public interface JobScheduler extends Lifecycle
         public static final String THREAD_ID = "thread-id";
         public static final Map<String, String> NO_METADATA = Collections.emptyMap();
 
+        private final AtomicInteger threadCounter = new AtomicInteger();
         private final String name;
-        private final SchedulingStrategy strategy;
-        private final AtomicInteger threadCounter = new AtomicInteger( 0 );
 
-        public Group( String name, SchedulingStrategy strategy )
+        public Group( String name )
         {
             this.name = name;
-            this.strategy = strategy;
         }
 
         public String name()
         {
             return name;
-        }
-
-        public SchedulingStrategy strategy()
-        {
-            return strategy;
         }
 
         /**
@@ -98,89 +80,89 @@ public interface JobScheduler extends Lifecycle
     class Groups
     {
         /** Session workers, these perform the work of actually executing client queries.  */
-        public static final Group sessionWorker = new Group( "Session", NEW_THREAD );
+        public static final Group sessionWorker = new Group( "Session" );
 
         /** Background index population */
-        public static final Group indexPopulation = new Group( "IndexPopulation", POOLED );
+        public static final Group indexPopulation = new Group( "IndexPopulation" );
 
         /** Push transactions from master to slaves */
-        public static final Group masterTransactionPushing = new Group( "TransactionPushing", POOLED );
+        public static final Group masterTransactionPushing = new Group( "TransactionPushing" );
 
         /**
          * Rolls back idle transactions on the server.
          */
-        public static final Group serverTransactionTimeout = new Group( "ServerTransactionTimeout", POOLED );
+        public static final Group serverTransactionTimeout = new Group( "ServerTransactionTimeout" );
 
         /**
          * Aborts idle slave lock sessions on the master.
          */
-        public static final Group slaveLocksTimeout = new Group( "SlaveLocksTimeout", POOLED );
+        public static final Group slaveLocksTimeout = new Group( "SlaveLocksTimeout" );
 
         /**
          * Pulls updates from the master.
          */
-        public static final Group pullUpdates = new Group( "PullUpdates", POOLED );
+        public static final Group pullUpdates = new Group( "PullUpdates" );
 
         /**
          * Gathers approximated data about the underlying data store.
          */
-        public static final Group indexSamplingController = new Group( "IndexSamplingController", POOLED );
-        public static final Group indexSampling = new Group( "IndexSampling", POOLED );
+        public static final Group indexSamplingController = new Group( "IndexSamplingController" );
+        public static final Group indexSampling = new Group( "IndexSampling" );
 
         /**
          * Rotates internal diagnostic logs
          */
-        public static final Group internalLogRotation = new Group( "InternalLogRotation", POOLED );
+        public static final Group internalLogRotation = new Group( "InternalLogRotation" );
 
         /**
          * Rotates query logs
          */
-        public static final Group queryLogRotation = new Group( "queryLogRotation", POOLED );
+        public static final Group queryLogRotation = new Group( "queryLogRotation" );
 
         /**
          * Checkpoint and store flush
          */
-        public static final Group checkPoint = new Group( "CheckPoint", POOLED );
+        public static final Group checkPoint = new Group( "CheckPoint" );
 
         /**
          * Raft Log pruning
          */
-        public static final Group raftLogPruning = new Group( "RaftLogPruning", POOLED );
+        public static final Group raftLogPruning = new Group( "RaftLogPruning" );
 
         /**
          * Network IO threads for the Bolt protocol.
          */
-        public static final Group boltNetworkIO = new Group( "BoltNetworkIO", NEW_THREAD );
+        public static final Group boltNetworkIO = new Group( "BoltNetworkIO" );
 
         /**
          * Reporting thread for Metrics events
          */
-        public static final Group metricsEvent = new Group( "MetricsEvent", POOLED );
+        public static final Group metricsEvent = new Group( "MetricsEvent" );
 
         /**
          * UDC timed events.
          */
-        public static Group udc  = new Group( "UsageDataCollection", POOLED );
+        public static Group udc  = new Group( "UsageDataCollection" );
 
         /**
          * Storage maintenance.
          */
-        public static Group storageMaintenance = new Group( "StorageMaintenance", POOLED );
+        public static Group storageMaintenance = new Group( "StorageMaintenance" );
 
         /**
          * Native security.
          */
-        public static Group nativeSecurity = new Group( "NativeSecurity", POOLED );
+        public static Group nativeSecurity = new Group( "NativeSecurity" );
 
         /**
          * File watch service group
          */
-        public static Group fileWatch = new Group( "FileWatcher", NEW_THREAD );
+        public static Group fileWatch = new Group( "FileWatcher" );
 
         /**
          * Recovery cleanup.
          */
-        public static Group recoveryCleanup = new Group( "RecoveryCleanup", POOLED );
+        public static Group recoveryCleanup = new Group( "RecoveryCleanup" );
 
         private Groups()
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/segmented/SegmentedRaftLog.java
@@ -31,13 +31,12 @@ import org.neo4j.causalclustering.core.replication.ReplicatedContent;
 import org.neo4j.causalclustering.messaging.marshalling.ChannelMarshal;
 import org.neo4j.cursor.IOCursor;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * The segmented RAFT log is an append only log supporting the operations required to support
@@ -116,7 +115,7 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
             rotateSegment( state.appendIndex, state.appendIndex, state.terms.latest() );
         }
 
-        readerPoolPruner = scheduler.scheduleRecurring( new JobScheduler.Group( "reader-pool-pruner", POOLED ),
+        readerPoolPruner = scheduler.scheduleRecurring( new JobScheduler.Group( "reader-pool-pruner" ),
                 () -> readerPool.prune( READER_POOL_MAX_AGE, MINUTES ), READER_POOL_MAX_AGE, READER_POOL_MAX_AGE, MINUTES );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/membership/MembershipWaiter.java
@@ -26,14 +26,13 @@ import java.util.function.Supplier;
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.state.ExposedRaftState;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * Waits until member has "fully joined" the raft membership.
@@ -77,7 +76,7 @@ public class MembershipWaiter
         Evaluator evaluator = new Evaluator( raft, catchUpFuture, dbHealthSupplier );
 
         JobScheduler.JobHandle jobHandle = jobScheduler.schedule(
-                new JobScheduler.Group( getClass().toString(), POOLED ),
+                new JobScheduler.Group( getClass().toString() ),
                 evaluator, currentCatchupDelayInMs, MILLISECONDS );
 
         catchUpFuture.whenComplete( ( result, e ) -> jobHandle.cancel( true ) );
@@ -117,7 +116,7 @@ public class MembershipWaiter
             {
                 currentCatchupDelayInMs += SECONDS.toMillis( 1 );
                 long longerDelay = currentCatchupDelayInMs < maxCatchupLag ? currentCatchupDelayInMs : maxCatchupLag;
-                jobScheduler.schedule( new JobScheduler.Group( MembershipWaiter.class.toString(), POOLED ), this,
+                jobScheduler.schedule( new JobScheduler.Group( MembershipWaiter.class.toString() ), this,
                         longerDelay, MILLISECONDS );
             }
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/DelayedRenewableTimeoutService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/DelayedRenewableTimeoutService.java
@@ -30,14 +30,13 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 
 import static java.lang.System.nanoTime;
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * A bare bones, wall clock based implementation of the {@link RenewableTimeoutService}. It uses a scheduled thread
@@ -174,7 +173,7 @@ public class DelayedRenewableTimeoutService extends LifecycleAdapter implements 
     @Override
     public void start()
     {
-        jobHandle = scheduler.scheduleRecurring( new JobScheduler.Group( "Scheduler", POOLED ), this, TIMER_RESOLUTION,
+        jobHandle = scheduler.scheduleRecurring( new JobScheduler.Group( "Scheduler" ), this, TIMER_RESOLUTION,
                 TIMER_RESOLUTION_UNIT );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -69,14 +69,12 @@ import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.Dependencies;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.time.Clocks;
-
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.NEW_THREAD;
 
 public class CoreServerModule
 {
@@ -222,8 +220,8 @@ public class CoreServerModule
         // batches messages from raft server -> core state
         // core state will drop messages if not ready
         life.add( batchingMessageHandler );
-        life.add( new ContinuousJob( jobScheduler, new JobScheduler.Group( "raft-batch-handler", NEW_THREAD ),
-                batchingMessageHandler, logProvider ) );
+        final JobScheduler.Group group = new JobScheduler.Group( "raft-batch-handler" );
+        life.add( new ContinuousJob( jobScheduler.threadFactory( group ), batchingMessageHandler, logProvider ) );
 
         life.add( raftServer ); // must start before core state so that it can trigger snapshot downloads when necessary
         life.add( coreLife );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
@@ -22,11 +22,10 @@ package org.neo4j.causalclustering.helper;
 import java.util.concurrent.CancellationException;
 
 import org.neo4j.function.ThrowingAction;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.neo4j.scheduler.JobScheduler.SchedulingStrategy.POOLED;
 
 /**
  * A robust job catches and logs any exceptions, but keeps running if the job
@@ -48,13 +47,13 @@ public class RobustJobSchedulerWrapper
 
     public JobScheduler.JobHandle schedule( String name, long delayMillis, ThrowingAction<Exception> action )
     {
-        return delegate.schedule( new JobScheduler.Group( name, POOLED ),
+        return delegate.schedule( new JobScheduler.Group( name ),
                 () -> withErrorHandling( action ), delayMillis, MILLISECONDS );
     }
 
     public JobScheduler.JobHandle scheduleRecurring( String name, long periodMillis, ThrowingAction<Exception> action )
     {
-        return delegate.scheduleRecurring( new JobScheduler.Group( name, POOLED ),
+        return delegate.scheduleRecurring( new JobScheduler.Group( name ),
                 () -> withErrorHandling( action ), periodMillis, MILLISECONDS );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ContinuousJobTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/ContinuousJobTest.java
@@ -25,11 +25,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.LockSupport;
 
-import org.neo4j.scheduler.JobScheduler.Group;
-import org.neo4j.scheduler.JobScheduler.SchedulingStrategy;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.scheduler.JobScheduler.Group;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.lessThan;
@@ -39,7 +38,8 @@ import static org.junit.Assert.assertTrue;
 public class ContinuousJobTest
 {
     private static final long DEFAULT_TIMEOUT_MS = 15_000;
-    private Group jobGroup = new Group( "test", SchedulingStrategy.NEW_THREAD );
+    private final Group jobGroup = new Group( "test" );
+    private final Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
 
     @Test
     public void shouldRunJobContinuously() throws Throwable
@@ -48,8 +48,8 @@ public class ContinuousJobTest
         CountDownLatch latch = new CountDownLatch( 10 );
         Runnable task = latch::countDown;
 
-        Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
-        ContinuousJob continuousJob = new ContinuousJob( scheduler, jobGroup, task, NullLogProvider.getInstance() );
+        ContinuousJob continuousJob =
+                new ContinuousJob( scheduler.threadFactory( jobGroup ), task, NullLogProvider.getInstance() );
 
         // when
         try ( Lifespan ignored = new Lifespan( scheduler, continuousJob ) )
@@ -71,8 +71,8 @@ public class ContinuousJobTest
             semaphore.release();
         };
 
-        Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
-        ContinuousJob continuousJob = new ContinuousJob( scheduler, jobGroup, task, NullLogProvider.getInstance() );
+        ContinuousJob continuousJob =
+                new ContinuousJob( scheduler.threadFactory( jobGroup ), task, NullLogProvider.getInstance() );
 
         // when
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
Since the best way to create a new thread by using the scheduler is to
use the thread factory, this changes will make more straightforward
how to create new thread using the scheduler.  And also note that the
NEW_THREAD strategy was unsupported in several schedule methods.