### PR TITLE
Fix `None.get` bug, happening because of missing owningPipe 

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+
+public class TestFunction
+{
+    @UserFunction( "test.toSet" )
+    public List<Object> toSet(@Name("values") List<Object> list) {
+        return new ArrayList<>( new LinkedHashSet(list) );
+    }
+}

--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestFunction.java
@@ -20,16 +20,32 @@
 package org.neo4j.internal.cypher.acceptance;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;
 
 public class TestFunction
 {
+    @Context
+    public GraphDatabaseService db;
+
     @UserFunction( "test.toSet" )
-    public List<Object> toSet(@Name("values") List<Object> list) {
-        return new ArrayList<>( new LinkedHashSet(list) );
+    public List<Object> toSet(@Name("values") List<Object> list)
+    {
+        return new ArrayList<>( new LinkedHashSet<>( list ) );
+    }
+
+    @UserFunction( "test.nodeList" )
+    public List<Object> nodeList()
+    {
+        Result result = db.execute( "MATCH (n) RETURN n LIMIT 1" );
+        Object node = result.next().get( "n" );
+        return Collections.singletonList( node );
     }
 }

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -30,14 +30,14 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
 
     val n1 = createLabeledNode("Tweet")
     val n2 = createLabeledNode("User")
-    val r = relate(n2, n1, "POSTED")
+    relate(n2, n1, "POSTED")
 
     val query = """MATCH(t:Tweet) WITH t LIMIT 1
                |WITH collect(t) AS tweets
                |RETURN test.toSet([ tweet IN tweets | [ (tweet)<-[:POSTED]-(user) | user] ]) AS users""".stripMargin
 
     val result = executeWithCostPlannerOnly(query)
-    println(result.toList)
+    result.toList should equal(List(Map("users" -> List(List(n2)))))
   }
 
   test("pattern comprehension outside function call") {
@@ -45,7 +45,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
 
     val n1 = createLabeledNode("Tweet")
     val n2 = createLabeledNode("User")
-    val r = relate(n2, n1, "POSTED")
+    relate(n2, n1, "POSTED")
 
     val query = """MATCH(t:Tweet) WITH t LIMIT 1
                   |WITH collect(t) AS tweets
@@ -53,7 +53,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
                   |RETURN test.toSet(pattern) AS users""".stripMargin
 
     val result = executeWithCostPlannerOnly(query)
-    println(result.toList)
+    result.toList should equal(List(Map("users" -> List(List(n2)))))
   }
 
   test("with named path") {

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/InList.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/InList.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v3_1.commands
 
 import org.neo4j.cypher.internal.compiler.v3_1._
-import expressions.{Closure, Expression}
+import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.{Closure, Expression}
 import org.neo4j.cypher.internal.compiler.v3_1.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v3_1.helpers.ListSupport
-import pipes.QueryState
+import org.neo4j.cypher.internal.compiler.v3_1.pipes.QueryState
 
-import collection.Seq
+import scala.collection.Seq
 
 abstract class InList(collectionExpression: Expression, id: String, predicate: Predicate)
   extends Predicate

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/expressions/CoerceTo.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/expressions/CoerceTo.scala
@@ -32,7 +32,7 @@ case class CoerceTo(expr: Expression, typ: CypherType) extends Expression {
 
   def symbolTableDependencies = expr.symbolTableDependencies
 
-  override def rewrite(f: (Expression) => Expression): Expression = copy(f(expr), typ)
+  override def rewrite(f: (Expression) => Expression): Expression = f(CoerceTo(expr.rewrite(f), typ))
 
   override def arguments: Seq[Expression] = Seq(expr)
   override protected def calculateType(symbols: SymbolTable) = typ

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/expressions/NestedPipeExpression.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/expressions/NestedPipeExpression.scala
@@ -34,9 +34,9 @@ case class NestedPipeExpression(pipe: Pipe, inner: Expression) extends Expressio
     pipe.createResults(innerState).map(ctx => inner(ctx)).toIndexedSeq
   }
 
-  override def rewrite(f: (Expression) => Expression) = f(this)
+  override def rewrite(f: (Expression) => Expression) = f(NestedPipeExpression(pipe, inner.rewrite(f)))
 
-  override def arguments = Nil
+  override def arguments = List(inner)
 
   override def calculateType(symbols: SymbolTable): CypherType = CTList(CTPath)
 


### PR DESCRIPTION
changelog: Fixes bug which materializes as a `None.get` stacktrace, typically by Cypher queries involving nested list/map/pattern comprehensions. 