### PR TITLE
More debug info for failed transaction apply

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
@@ -27,42 +27,63 @@ public class LifecycleException
     extends RuntimeException
 {
 
-    private static String humanReadableMessage( Object instance, LifecycleStatus from, LifecycleStatus to )
+    private static String humanReadableMessage(
+            Object instance, LifecycleStatus from, LifecycleStatus to, Throwable cause )
     {
-        switch(to)
+        String instanceStr = String.valueOf( instance );
+        StringBuilder message = new StringBuilder();
+        switch ( to )
         {
             case STOPPED:
-                if(from == LifecycleStatus.NONE)
+                if ( from == LifecycleStatus.NONE )
                 {
-                    return String.format( "Component '%s' failed to initialize. Please see attached cause exception" +
-                            ".", instance.toString() );
+                    message.append( "Component '" ).append( instanceStr ).append( "' failed to initialize" );
                 }
-                if(from == LifecycleStatus.STARTED)
+                else if ( from == LifecycleStatus.STARTED )
                 {
-                    return String.format( "Component '%s' failed to stop. Please see attached cause exception.",
-                            instance.toString()  );
+                    message.append( "Component '" ).append( instanceStr ).append( "' failed to stop" );
                 }
                 break;
             case STARTED:
-                if(from == LifecycleStatus.STOPPED)
+                if ( from == LifecycleStatus.STOPPED )
                 {
-                    return String.format( "Component '%s' was successfully initialized, but failed to start. Please " +
-                            "see attached cause exception.", instance.toString() );
+                    message.append( "Component '" ).append( instanceStr )
+                           .append( "' was successfully initialized, but failed to start" );
                 }
                 break;
             case SHUTDOWN:
-                return String.format( "Component '%s' failed to shut down. Please " +
-                        "see attached cause exception.", instance.toString() );
+                message.append( "Component '" ).append( instanceStr ).append( "' failed to shut down" );
+                break;
             default:
                 break;
         }
+        if ( message.length() == 0 )
+        {
+            message.append( "Component '" ).append( instanceStr ).append( "' failed to transition from " )
+                   .append( from.name().toLowerCase() ).append( " to " ).append( to.name().toLowerCase() );
+        }
+        message.append( '.' );
+        if ( cause != null )
+        {
+            Throwable root = rootCause( cause );
+            message.append( " Please see the attached cause exception \"" ).append( root.getMessage() ).append( "\"." );
+        }
 
-        return String.format( "Failed to transition component '%s' from %s to %s. Please see attached cause exception",
-                instance.toString(), from.name(), to.name() );
+        return message.toString();
+    }
+
+    private static Throwable rootCause( Throwable cause )
+    {
+        int i = 0; // Guard against infinite self-cause exception-loops.
+        while ( cause.getCause() != null && i++ < 100 )
+        {
+            cause = cause.getCause();
+        }
+        return cause;
     }
 
     public LifecycleException( Object instance, LifecycleStatus from, LifecycleStatus to, Throwable cause )
     {
-        super( humanReadableMessage( instance, from, to ), cause);
+        super( humanReadableMessage( instance, from, to, cause ), cause);
     }
 }

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/LifecycleException.java
@@ -66,7 +66,12 @@ public class LifecycleException
         if ( cause != null )
         {
             Throwable root = rootCause( cause );
-            message.append( " Please see the attached cause exception \"" ).append( root.getMessage() ).append( "\"." );
+            message.append( " Please see the attached cause exception \"" ).append( root.getMessage() ).append( '"' );
+            if ( root.getCause() != null )
+            {
+                message.append( " (root cause cycle detected)" );
+            }
+            message.append( '.' );
         }
 
         return message.toString();

--- a/community/common/src/test/java/org/neo4j/kernel/lifecycle/TestLifecycleException.java
+++ b/community/common/src/test/java/org/neo4j/kernel/lifecycle/TestLifecycleException.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.lifecycle;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.kernel.lifecycle.LifecycleStatus.NONE;
@@ -36,7 +37,7 @@ public class TestLifecycleException
     {
         assertThat(
                 exceptionFor( NONE, STOPPED ).getMessage(),
-                is("Component 'SomeComponent' failed to initialize. Please see attached cause exception."));
+                is( "Component 'SomeComponent' failed to initialize." ) );
     }
 
     @Test
@@ -44,7 +45,7 @@ public class TestLifecycleException
     {
         assertThat(
                 exceptionFor( STOPPED, STARTED ).getMessage(),
-                is("Component 'SomeComponent' was successfully initialized, but failed to start. Please see attached cause exception."));
+                is( "Component 'SomeComponent' was successfully initialized, but failed to start." ) );
     }
 
     @Test
@@ -52,7 +53,7 @@ public class TestLifecycleException
     {
         assertThat(
                 exceptionFor( STARTED, STOPPED ).getMessage(),
-                is("Component 'SomeComponent' failed to stop. Please see attached cause exception."));
+                is( "Component 'SomeComponent' failed to stop." ) );
     }
 
     @Test
@@ -60,10 +61,24 @@ public class TestLifecycleException
     {
         assertThat(
                 exceptionFor( STOPPED, SHUTDOWN ).getMessage(),
-                is("Component 'SomeComponent' failed to shut down. Please see attached cause exception."));
+                is( "Component 'SomeComponent' failed to shut down." ) );
+    }
+
+    @Test
+    public void shouldIncludeRootCauseMessageInExceptionMessage() throws Exception
+    {
+        Exception root = new Exception( "big bad root cause" );
+        Exception intermediate = new Exception( "intermediate exception", root );
+        assertThat( exceptionFor( STARTED, STOPPED, intermediate ).getMessage(),
+                containsString( root.getMessage() ) );
     }
 
     private LifecycleException exceptionFor( LifecycleStatus from, LifecycleStatus to )
+    {
+        return exceptionFor( from, to, null );
+    }
+
+    private LifecycleException exceptionFor( LifecycleStatus from, LifecycleStatus to, Throwable cause )
     {
         return new LifecycleException( new Object()
         {
@@ -72,7 +87,7 @@ public class TestLifecycleException
             {
                 return "SomeComponent";
             }
-        }, from, to, null );
+        }, from, to, cause );
     }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
@@ -30,9 +30,4 @@ public class TransactionApplyKernelException extends KernelException
     {
         super( Status.General.UnknownError, cause, message, parameters );
     }
-
-    public TransactionApplyKernelException( String message, Object... parameters )
-    {
-        super( Status.General.UnknownError, message, parameters );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/TransactionApplyKernelException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions;
+
+/**
+ * A {@link KernelException} thrown by a {@link org.neo4j.storageengine.api.StorageEngine} if it failed to apply a
+ * transaction.
+ */
+public class TransactionApplyKernelException extends KernelException
+{
+    public TransactionApplyKernelException( Throwable cause, String message,
+                                               Object... parameters )
+    {
+        super( Status.General.UnknownError, cause, message, parameters );
+    }
+
+    public TransactionApplyKernelException( String message, Object... parameters )
+    {
+        super( Status.General.UnknownError, message, parameters );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionToApply.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionToApply.java
@@ -192,7 +192,7 @@ public class TransactionToApply implements CommandsToApply, AutoCloseable
             accept( counter );
             return String.valueOf( counter.count );
         }
-        catch ( IOException e )
+        catch ( Throwable e )
         {
             return "(unable to count: " + e.getMessage() + ")";
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -355,8 +355,10 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
         }
         catch ( Throwable cause )
         {
-            databaseHealth.panic( cause );
-            throw new TransactionApplyKernelException( cause, "Failed to apply transaction: %s", batch );
+            TransactionApplyKernelException kernelException =
+                    new TransactionApplyKernelException( cause, "Failed to apply transaction: %s", batch );
+            databaseHealth.panic( kernelException );
+            throw kernelException;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -34,6 +34,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.TransactionApplyKernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
@@ -70,7 +71,6 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.DefaultIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
@@ -117,6 +117,7 @@ import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StorageStatement;
+import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.storageengine.api.lock.ResourceLocker;
@@ -355,7 +356,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
         catch ( Throwable cause )
         {
             databaseHealth.panic( cause );
-            throw cause;
+            throw new TransactionApplyKernelException( cause, "Failed to apply transaction: %s", batch );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
@@ -121,6 +121,7 @@ public class BatchingTransactionAppender extends LifecycleAdapter implements Tra
 
                     TransactionCommitment commitment = appendToLog( tx.transactionRepresentation(), transactionId );
                     tx.commitment( commitment, transactionId );
+                    tx.logPosition( commitment.logPosition() );
                     tx = tx.next();
                     lastTransactionId = transactionId;
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCommitment.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionCommitment.java
@@ -40,6 +40,11 @@ class TransactionCommitment implements Commitment
         this.transactionIdStore = transactionIdStore;
     }
 
+    public LogPosition logPosition()
+    {
+        return logPosition;
+    }
+
     @Override
     public void publishAsCommitted()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
@@ -138,6 +138,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
             long txId = transaction.getCommitEntry().getTxId();
             TransactionToApply tx = new TransactionToApply( txRepresentation, txId );
             tx.commitment( NO_COMMITMENT, txId );
+            tx.logPosition( transaction.getStartEntry().getStartPosition() );
             transactionsToApply.queue( tx );
             return false;
         }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandsToApply.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/CommandsToApply.java
@@ -41,4 +41,10 @@ public interface CommandsToApply extends CommandStream
      * of some groups and in extension their whole batches.
      */
     boolean requiresApplicationOrdering();
+
+    /**
+     * @return A string describing the contents of this batch of commands.
+     */
+    @Override
+    String toString();
 }


### PR DESCRIPTION
We're not in a good spot if we fail to apply a transaction. Such failures would
happen after a transaction has already been committed, or during recovery. Both
are awful places for exceptions to pop out.

This commit captures exceptions that occur during apply, and wraps them in
another exception that adds information about the transaction, e.g. log
position, which might be helpful for debugging the cause of the failure.