### PR TITLE
fixes #9390 apply nodefilter only on endNode

### DIFF
--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
@@ -23,12 +23,27 @@ import common.Neo4jAlgoTestCase;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.neo4j.graphalgo.GraphAlgoFactory;
 import org.neo4j.graphalgo.PathFinder;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.PathExpanderBuilder;
+import org.neo4j.graphdb.PathExpanders;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.impl.StandardExpander;
 import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.helpers.collection.Iterables;
@@ -36,7 +51,10 @@ import org.neo4j.helpers.collection.Iterables;
 import static common.Neo4jAlgoTestCase.MyRelTypes.R1;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphalgo.GraphAlgoFactory.shortestPath;
 import static org.neo4j.graphdb.Direction.BOTH;
 import static org.neo4j.graphdb.Direction.INCOMING;
@@ -57,7 +75,7 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Label E = Label.label( "E" );
         final Label F = Label.label( "F" );
         final RelationshipType relType = RelationshipType.withName( "TO" );
-        recursiveSnowFlake( null, 0, 4, 5, new Label[] { A, B, C, D, E }, relType );
+        recursiveSnowFlake( null, 0, 4, 5, new Label[]{A, B, C, D, E}, relType );
         final Node a = graphDb.findNodes( A ).next();
         final ResourceIterator<Node> allE = graphDb.findNodes( E );
         while ( allE.hasNext() )
@@ -79,8 +97,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         }
         final long totalTime = System.currentTimeMillis() - start;
         assertEquals(
-                "There are 625 different end nodes. The algorithm should start one traversal for each such node. "
-                        + "That is 625*2 visited nodes if traversal is interrupted correctly.", 1250,
+                "There are 625 different end nodes. The algorithm should start one traversal for each such node. " +
+                        "That is 625*2 visited nodes if traversal is interrupted correctly.", 1250,
                 countingPathExpander.nodesVisited.intValue() );
     }
 
@@ -93,9 +111,13 @@ public class TestShortestPath extends Neo4jAlgoTestCase
             {
                 final Node node = graphDb.createNode( labels[level] );
                 if ( parent != null )
+                {
                     parent.createRelationshipTo( node, relType );
+                }
                 if ( level < desiredLevel )
+                {
                     recursiveSnowFlake( node, level + 1, desiredLevel, branchingFactor, labels, relType );
+                }
             }
         }
         else
@@ -115,7 +137,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //   \__/
         graph.makeEdge( "s", "t" );
         graph.makeEdge( "s", "t" );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             final Iterable<Path> paths = finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) );
             assertPaths( paths, "s,t", "s,t" );
             assertPaths( asList( finder.findSinglePath( graph.getNode( "s" ), graph.getNode( "t" ) ) ), "s,t" );
@@ -139,7 +162,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "q", "t" );
         graph.makeEdge( "n", "o" );
         graph.makeEdge( "o", "t" );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             final Iterable<Path> paths = finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) );
             assertPaths( paths, "s,m,o,t", "s,n,o,t" );
         }, PathExpanders.forTypeAndDirection( R1, BOTH ), 6 );
@@ -166,9 +190,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "2", "t" );
         graph.makeEdge( "4", "t" );
         testShortestPathFinder(
-                finder -> assertPaths( finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) ),
-                        "s,1,2,t", "s,1,4,t", "s,3,2,t", "s,3,4,t" ),
-                PathExpanders.forTypeAndDirection( R1, BOTH ), 3 );
+                finder -> assertPaths( finder.findAllPaths( graph.getNode( "s" ), graph.getNode( "t" ) ), "s,1,2,t",
+                        "s,1,4,t", "s,3,2,t", "s,3,4,t" ), PathExpanders.forTypeAndDirection( R1, BOTH ), 3 );
     }
 
     @Test
@@ -198,7 +221,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         //         (d)
         //
         graph.makeEdgeChain( "a,b,c,d,b,c,e" );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             final Node a = graph.getNode( "a" );
             final Node e = graph.getNode( "e" );
             assertPaths( finder.findAllPaths( a, e ), "a,b,c,e", "a,b,c,e" );
@@ -220,7 +244,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Node d = graph.getNode( "d" );
         final Node b = graph.getNode( "b" );
         b.setProperty( "skip", true );
-        final Predicate<Node> filter = item -> {
+        final Predicate<Node> filter = item ->
+        {
             final boolean skip = (Boolean) item.getProperty( "skip", false );
             return !skip;
         };
@@ -239,21 +264,22 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Node a = graph.getNode( "a" );
         final Node d = graph.getNode( "d" );
         Collection<Node> touchedByFilter = new HashSet<>();
-        final Predicate<Node> filter = item -> {
-            touchedByFilter.add(item);
+        final Predicate<Node> filter = item ->
+        {
+            touchedByFilter.add( item );
             return true;
         };
-        final PathExpander expander = PathExpanderBuilder.empty().add(MyRelTypes.R1, OUTGOING).addNodeFilter(filter).build();
+        final PathExpander expander =
+                PathExpanderBuilder.empty().add( MyRelTypes.R1, OUTGOING ).addNodeFilter( filter ).build();
         //final PathExpander expander = ((StandardExpander) PathExpanders.forTypeAndDirection(R1, OUTGOING)).addNodeFilter( filter );
-        Path path = Iterables.single( GraphAlgoFactory.shortestPath(expander, 10)
-                .findAllPaths(a,d));
-        assertEquals(3, path.length());
+        Path path = Iterables.single( GraphAlgoFactory.shortestPath( expander, 10 ).findAllPaths( a, d ) );
+        assertEquals( 3, path.length() );
 
-        List<Node> nodes = Iterables.asList(path.nodes());
-        List<Node> intermediateNodes = nodes.subList(1, nodes.size() - 1);
-        assertTrue("touchedByFilter: " + touchedByFilter, touchedByFilter.containsAll(intermediateNodes));
-        assertTrue( "startNode was not filtered", !touchedByFilter.contains(a));
-        assertTrue( "endNode was not filtered", !touchedByFilter.contains(d));
+        List<Node> nodes = Iterables.asList( path.nodes() );
+        List<Node> intermediateNodes = nodes.subList( 1, nodes.size() - 1 );
+        assertTrue( "touchedByFilter: " + touchedByFilter, touchedByFilter.containsAll( intermediateNodes ) );
+        assertTrue( "startNode was not filtered", !touchedByFilter.contains( a ) );
+        assertTrue( "endNode was not filtered", !touchedByFilter.contains( d ) );
     }
 
     @Test
@@ -267,11 +293,13 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         testShortestPathFinder(
                 finder -> assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "b" ) ) ),
                 PathExpanders.allTypesAndDirections(), 0 );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "c" ) ) );
             assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "d" ) ) );
         }, PathExpanders.allTypesAndDirections(), 1 );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "d" ) ) );
             assertPaths( finder.findAllPaths( graph.getNode( "a" ), graph.getNode( "e" ) ) );
         }, PathExpanders.allTypesAndDirections(), 2 );
@@ -328,7 +356,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
          */
         graph.makeEdgeChain( "i,g,f,e,d,c,b,a" );
         graph.makeEdgeChain( "i,h,f" );
-        testShortestPathFinder( finder -> {
+        testShortestPathFinder( finder ->
+        {
             final Node start = graph.getNode( "a" );
             final Node end = graph.getNode( "i" );
             assertPaths( finder.findAllPaths( start, end ), "a,b,c,d,e,f,g,i", "a,b,c,d,e,f,h,i" );
@@ -354,9 +383,8 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         graph.makeEdge( "o", "o" );
         graph.makeEdge( "n", "n" );
         testShortestPathFinder(
-                finder -> assertPaths( finder.findAllPaths( graph.getNode( "m" ), graph.getNode( "p" ) ),
-                        "m,s,n,p", "m,o,n,p" ),
-                PathExpanders.forTypeAndDirection( R1, BOTH ), 3 );
+                finder -> assertPaths( finder.findAllPaths( graph.getNode( "m" ), graph.getNode( "p" ) ), "m,s,n,p",
+                        "m,o,n,p" ), PathExpanders.forTypeAndDirection( R1, BOTH ), 3 );
     }
 
     @Test
@@ -379,12 +407,13 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Node a = graph.getNode( "a" );
         final Node e = graph.getNode( "e" );
         final PathExpander expander = PathExpanders.forTypeAndDirection( R1, OUTGOING );
-        testShortestPathFinder( finder -> assertEquals( 4, Iterables.count( finder.findAllPaths( a, e ) ) ), expander, 10, 10 );
+        testShortestPathFinder( finder -> assertEquals( 4, Iterables.count( finder.findAllPaths( a, e ) ) ), expander,
+                10, 10 );
         for ( int i = 4; i >= 1; i-- )
         {
             final int count = i;
-            testShortestPathFinder( finder -> assertEquals(
-                    count, Iterables.count( finder.findAllPaths( a, e ) ) ), expander, 10, count );
+            testShortestPathFinder( finder -> assertEquals( count, Iterables.count( finder.findAllPaths( a, e ) ) ),
+                    expander, 10, count );
         }
     }
 
@@ -441,11 +470,10 @@ public class TestShortestPath extends Neo4jAlgoTestCase
     {
         final LengthCheckingExpanderWrapper lengthChecker = new LengthCheckingExpanderWrapper( expander );
         final List<PathFinder<Path>> finders = new ArrayList<>();
-        finders.add( maxResultCount != null ? shortestPath( lengthChecker, maxDepth, maxResultCount ) : shortestPath(
-                lengthChecker, maxDepth ) );
-        finders.add( maxResultCount != null
-                ? new TraversalShortestPath( lengthChecker, maxDepth, maxResultCount )
-                : new TraversalShortestPath( lengthChecker, maxDepth ) );
+        finders.add( maxResultCount != null ? shortestPath( lengthChecker, maxDepth, maxResultCount )
+                                            : shortestPath( lengthChecker, maxDepth ) );
+        finders.add( maxResultCount != null ? new TraversalShortestPath( lengthChecker, maxDepth, maxResultCount )
+                                            : new TraversalShortestPath( lengthChecker, maxDepth ) );
         for ( final PathFinder<Path> finder : finders )
         {
             tester.test( finder );

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
@@ -710,7 +710,7 @@ public abstract class StandardExpander implements PathExpander
         @Override
         boolean exclude( Path path )
         {
-            return !predicate.test( path.lastRelationship().getOtherNode( path.endNode() ) );
+            return !predicate.test( path.endNode() );
         }
     }
 


### PR DESCRIPTION
(Added by @burqen)
Previously node filter was applied to node when expanding _from_ it with expansion only happening if node was accepted by the filter. This meant that the node on which collision happened in bidirectional traversal would never be checked against the filter.

This PR changes this to apply filter on the node we are expanding _to_ meaning we will never reach nodes that does not pass the filter.