### PR TITLE
Wait for recovery cleaner to complete in LabelScanStoreLoggingTest

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.lifecycle;
 
+import java.util.Arrays;
+
 public class Lifecycles
 {
     private Lifecycles()
@@ -27,43 +29,57 @@ public class Lifecycles
 
     public static Lifecycle multiple( final Iterable<? extends Lifecycle> lifecycles )
     {
-        return new Lifecycle()
+        return new CombinedLifecycle( lifecycles );
+    }
+
+    public static Lifecycle multiple( Lifecycle... lifecycles )
+    {
+        return new CombinedLifecycle( Arrays.asList( lifecycles ) );
+    }
+
+    private static class CombinedLifecycle implements Lifecycle
+    {
+        private final Iterable<? extends Lifecycle> lifecycles;
+
+        CombinedLifecycle( Iterable<? extends Lifecycle> lifecycles )
         {
-            @Override
-            public void init() throws Throwable
-            {
-                for ( Lifecycle lifecycle : lifecycles )
-                {
-                    lifecycle.init();
-                }
-            }
+            this.lifecycles = lifecycles;
+        }
 
-            @Override
-            public void start() throws Throwable
+        @Override
+        public void init() throws Throwable
+        {
+            for ( Lifecycle lifecycle : lifecycles )
             {
-                for ( Lifecycle lifecycle : lifecycles )
-                {
-                    lifecycle.start();
-                }
+                lifecycle.init();
             }
+        }
 
-            @Override
-            public void stop() throws Throwable
+        @Override
+        public void start() throws Throwable
+        {
+            for ( Lifecycle lifecycle : lifecycles )
             {
-                for ( Lifecycle lifecycle : lifecycles )
-                {
-                    lifecycle.stop();
-                }
+                lifecycle.start();
             }
+        }
 
-            @Override
-            public void shutdown() throws Throwable
+        @Override
+        public void stop() throws Throwable
+        {
+            for ( Lifecycle lifecycle : lifecycles )
             {
-                for ( Lifecycle lifecycle : lifecycles )
-                {
-                    lifecycle.shutdown();
-                }
+                lifecycle.stop();
             }
-        };
+        }
+
+        @Override
+        public void shutdown() throws Throwable
+        {
+            for ( Lifecycle lifecycle : lifecycles )
+            {
+                lifecycle.shutdown();
+            }
+        }
     }
 }

--- a/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
+++ b/community/common/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
@@ -34,7 +34,7 @@ public class Lifecycles
 
     public static Lifecycle multiple( Lifecycle... lifecycles )
     {
-        return new CombinedLifecycle( Arrays.asList( lifecycles ) );
+        return multiple( Arrays.asList( lifecycles ) );
     }
 
     private static class CombinedLifecycle implements Lifecycle

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerMonitor;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.info.JvmChecker;
@@ -61,6 +60,7 @@ import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.SystemNanoClock;
 import org.neo4j.udc.UsageData;
@@ -286,7 +286,7 @@ public class PlatformModule
         return life.add( logService );
     }
 
-    protected Neo4jJobScheduler createJobScheduler()
+    protected JobScheduler createJobScheduler()
     {
         return new Neo4jJobScheduler();
     }


### PR DESCRIPTION
Fix recently introduced component start race by waiting for cleanup job
to be always completed before checking recovery log messages.