### PR TITLE
Fix "Continuing with a stub" compiler warnings.

### DIFF
--- a/community/cypher/cypher/LICENSES.txt
+++ b/community/cypher/cypher/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
   Lucene codecs

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -353,10 +353,9 @@
     </dependency>
 
     <!-- other -->
-
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -163,6 +163,11 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+
     <!-- shared java test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/enterprise/cypher/acceptance-spec-suite/pom.xml
+++ b/enterprise/cypher/acceptance-spec-suite/pom.xml
@@ -279,11 +279,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <scope>test</scope>

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -381,11 +381,6 @@
     <!-- other -->
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-
-    <dependency>
         <groupId>com.novus</groupId>
         <artifactId>salat-core_2.11</artifactId>
         <version>1.9.9</version>


### PR DESCRIPTION
Add com.google.code.findbugs.annotations to all cypher projects,
add apache commons-lang3 to cypher.