### PR TITLE
Make `StoreMigrationIT` parameters protected

### DIFF
--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
@@ -92,8 +92,8 @@ public class StoreMigrationIT
         return result;
     }
 
-    private final RecordFormats from;
-    private final RecordFormats to;
+    protected final RecordFormats from;
+    protected final RecordFormats to;
 
     @Parameterized.Parameters( name = "Migrate: {0}->{1}" )
     public static Iterable<Object[]> data() throws IOException


### PR DESCRIPTION
This is so that tests extending `StoreMigrationIT` can use them.