### PR TITLE
print environment variables usage as part of help

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import org.neo4j.helpers.Args;
 
 import static java.lang.String.format;
+
 import static org.neo4j.commandline.Util.neo4jVersion;
 
 public class AdminTool

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandUsage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/CommandUsage.java
@@ -45,6 +45,7 @@ class CommandUsage
             output.accept( Arguments.rightColumnFormatted( left, arguments.usage(), left.length() + 1 ) );
         }
         output.accept( "" );
+        Usage.printEnvironmentVariables( output );
         output.accept( command.allArguments().description( command.description() ) );
     }
 }

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -52,7 +52,6 @@ public class Usage
         output.accept( "Manage your Neo4j instance." );
         output.accept( "" );
 
-        output.accept( "environment variables:" );
         printEnvironmentVariables( output );
 
         output.accept( "available commands:" );
@@ -62,8 +61,9 @@ public class Usage
         output.accept( format( "Use %s help <command> for more details.", scriptName ) );
     }
 
-    private void printEnvironmentVariables( Consumer<String> output )
+    static void printEnvironmentVariables( Consumer<String> output )
     {
+        output.accept( "environment variables:" );
         output.accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
         output.accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         output.accept( "    NEO4J_HOME    Neo4j home directory." );

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -19,17 +19,17 @@
  */
 package org.neo4j.commandline.admin;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import org.neo4j.commandline.arguments.Arguments;
 
@@ -163,6 +163,13 @@ public class HelpCommandTest
             helpCommand.execute( "foobar" );
 
             assertEquals( String.format( "usage: neo4j-admin foobar [--database=<name>]%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "This is a description of the foobar command.%n" +
                             "%n" +

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.commandline.admin;
 
+import java.util.Collections;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Collections;
-import java.util.function.Consumer;
-import javax.annotation.Nonnull;
 
 import org.neo4j.commandline.arguments.Arguments;
 
@@ -50,16 +50,21 @@ public class UsageTest
     public void shouldPrintUsageForACommand() throws Exception
     {
         // given
-        AdminCommand.Provider commandProvier = mockCommand( "bam", "A summary", AdminCommandSection.general() );
-        AdminCommand.Provider[] commands = new AdminCommand.Provider[]{commandProvier};
+        AdminCommand.Provider commandProvider = mockCommand( "bam", "A summary", AdminCommandSection.general() );
+        AdminCommand.Provider[] commands = new AdminCommand.Provider[]{commandProvider};
         final Usage usage = new Usage( "neo4j-admin", new CannedLocator( commands ) );
 
         // when
-        usage.printUsageForCommand( commandProvier, out );
+        usage.printUsageForCommand( commandProvider, out );
 
         // then
         InOrder ordered = inOrder( out );
         ordered.verify( out ).accept( "usage: neo4j-admin bam " );
+        ordered.verify( out ).accept( "" );
+        ordered.verify( out ).accept( "environment variables:" );
+        ordered.verify( out ).accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
+        ordered.verify( out ).accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
+        ordered.verify( out ).accept( "    NEO4J_HOME    Neo4j home directory." );
         ordered.verify( out ).accept( "" );
         ordered.verify( out ).accept( "description" );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -331,6 +331,13 @@ public class CheckConsistencyCommandTest
                             "                                     [--check-label-scan-store[=<true|false>]]%n" +
                             "                                     [--check-property-owners[=<true|false>]]%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "This command allows for checking the consistency of a database or a backup%n" +
                             "thereof. It cannot be used with a database which is currently in use.%n" +
                             "%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.commandline.dbms;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
@@ -37,6 +31,12 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Predicate;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.CommandLocator;
@@ -53,6 +53,7 @@ import org.neo4j.test.rule.TestDirectory;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -65,6 +66,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 
@@ -356,6 +358,13 @@ public class DumpCommandTest
             usage.printUsageForCommand( new DumpCommandProvider(), ps::println );
 
             assertEquals( String.format( "usage: neo4j-admin dump [--database=<name>] --to=<destination-path>%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Dump a database into a single-file archive. The archive can be used by the load%n" +
                             "command. <destination-path> can be a file or directory (in which case a file%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -217,6 +217,13 @@ public class ImportCommandTest
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--from=<source-directory>]%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "Import a collection of CSV files with --mode=csv (default), or a database from a%n" +
                             "pre-3.0 installation with --mode=database.%n" +
                             "%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -308,6 +308,13 @@ public class LoadCommandTest
             assertEquals( String.format( "usage: neo4j-admin load --from=<archive-path> [--database=<name>]%n" +
                             "                        [--force[=<true|false>]]%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "Load a database from an archive. <archive-path> must be an archive created with%n" +
                             "the dump command. <database> is the name of the database to create. Existing%n" +
                             "databases can be replaced by specifying --force. It is not possible to replace a%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
@@ -90,6 +90,13 @@ public class StoreInfoCommandTest
 
             assertEquals( String.format( "usage: neo4j-admin store-info --store=<path-to-dir>%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "Prints information about a Neo4j database store, such as what version of Neo4j%n" +
                             "created it. Note that this command expects a path to a store directory, for%n" +
                             "example --store=data/databases/graph.db.%n" +

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -133,9 +133,15 @@ public class SetDefaultAdminCommandIT
         assertNoAuthIniFile();
 
         verify( out ).stdErrLine( "not enough arguments" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( String.format( "environment variables:" ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine(
                 String.format( "Sets the user to become admin if users but no roles are present, for example%n" +
                         "when upgrading to neo4j 3.1 enterprise." ) );
@@ -151,9 +157,15 @@ public class SetDefaultAdminCommandIT
         assertNoAuthIniFile();
 
         verify( out ).stdErrLine( "unrecognized arguments: 'bar'" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-default-admin <username>" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( String.format( "environment variables:" ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine(
                 String.format( "Sets the user to become admin if users but no roles are present, for example%n" +
                         "when upgrading to neo4j 3.1 enterprise." ) );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -137,6 +137,13 @@ public class SetDefaultAdminCommandTest
 
             assertEquals( String.format( "usage: neo4j-admin set-default-admin <username>%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "Sets the user to become admin if users but no roles are present, for example%n" +
                             "when upgrading to neo4j 3.1 enterprise.%n" ),
                     baos.toString() );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.commandline.admin.security;
 
+import java.io.File;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
 
 import org.neo4j.commandline.admin.AdminTool;
 import org.neo4j.commandline.admin.BlockerLocator;
@@ -112,9 +112,14 @@ public class SetInitialPasswordCommandIT
         assertNoAuthIniFile();
 
         verify( out ).stdErrLine( "not enough arguments" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( String.format( "environment variables:" ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );
         verify( out ).exit( 1 );
         verifyNoMoreInteractions( out );
@@ -128,9 +133,15 @@ public class SetInitialPasswordCommandIT
         assertNoAuthIniFile();
 
         verify( out ).stdErrLine( "unrecognized arguments: 'bar'" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out, times( 3 ) ).stdErrLine( "" );
         verify( out ).stdErrLine( "usage: neo4j-admin set-initial-password <password>" );
-        verify( out, times( 2 ) ).stdErrLine( "" );
+        verify( out ).stdErrLine( String.format( "environment variables:" ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
+        verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
+
         verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );
         verify( out ).exit( 1 );
         verifyNoMoreInteractions( out );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -139,6 +139,13 @@ public class SetInitialPasswordCommandTest
 
             assertEquals( String.format( "usage: neo4j-admin set-initial-password <password>%n" +
                             "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
+                            "%n" +
                             "Sets the initial password of the initial admin user ('neo4j').%n" ),
                     baos.toString() );
         }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -19,6 +19,14 @@
  */
 package org.neo4j.backup;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -27,14 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.CommandLocator;
@@ -53,6 +53,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -67,6 +68,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.backup.OnlineBackupCommand.MAX_OLD_BACKUPS;
 import static org.neo4j.backup.OnlineBackupCommand.STATUS_CC_ERROR;
 import static org.neo4j.backup.OnlineBackupCommand.STATUS_CC_INCONSISTENT;
@@ -625,6 +627,13 @@ public class OnlineBackupCommandTest
                             "                          [--cc-indexes[=<true|false>]]%n" +
                             "                          [--cc-label-scan-store[=<true|false>]]%n" +
                             "                          [--cc-property-owners[=<true|false>]]%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Perform an online backup from a running Neo4j enterprise server. Neo4j's backup%n" +
                             "service must have been configured on the server beforehand.%n" +

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.restore;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.Usage;
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class RestoreDatabaseCommandTest
@@ -177,6 +178,13 @@ public class RestoreDatabaseCommandTest
 
             assertEquals( String.format( "usage: neo4j-admin restore --from=<backup-directory> [--database=<name>]%n" +
                             "                           [--force[=<true|false>]]%n" +
+                            "%n" +
+                            "environment variables:%n" +
+                            "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
+                            "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
+                            "    NEO4J_HOME    Neo4j home directory.%n" +
+                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Restore a backed up database.%n" +
                             "%n" +


### PR DESCRIPTION
```
./bin/neo4j-admin help dump
usage: neo4j-admin dump [--database=<name>] --to=<destination-path>

environment variables:
    NEO4J_CONF    Path to directory which contains neo4j.conf.
    NEO4J_DEBUG   Set to anything to enable debug output.
    NEO4J_HOME    Neo4j home directory.
    HEAP_SIZE     Set size of JVM heap during command execution.
                  Takes a number and a unit, for example 512m.

Dump a database into a single-file archive. The archive can be used by the load
command. <destination-path> can be a file or directory (in which case a file
called <database>.dump will be created). It is not possible to dump a database
that is mounted in a running Neo4j server.

options:
  --database=<name>         Name of database. [default:graph.db]
  --to=<destination-path>   Destination (file or folder) of database dump.
```