### PR TITLE
Hazelcast instance creation no longer blocks startup

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -188,8 +188,18 @@ public abstract class ServerBootstrapper implements Bootstrapper
     {
         try
         {
+            /*
+             * We want to interrupt the main thread which has start()ed lifecycle instances that may be blocked
+             * somewhere. If we don't do that, then the JVM will hang on the final join() for non daemon threads.
+             */
+            Thread t = Thread.currentThread();
+            log.debug( "Installing signal handler to interrupt thread named " + t.getName() );
             // SIGTERM is invoked when system service is stopped
-            Signal.handle( new Signal( SIGTERM ), ( signal ) -> System.exit( 0 ) );
+            Signal.handle( new Signal( SIGTERM ), ( signal ) ->
+            {
+                t.interrupt();
+                System.exit( 0 );
+            } );
         }
         catch ( Throwable e )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -37,7 +37,7 @@ public interface CoreTopologyService extends TopologyService
      *
      * @return True if the cluster ID was successfully CAS:ed, otherwise false.
      */
-    boolean setClusterId( ClusterId clusterId );
+    boolean setClusterId( ClusterId clusterId ) throws InterruptedException;
 
     interface Listener
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/identity/ClusterBinder.java
@@ -121,7 +121,7 @@ public class ClusterBinder implements Supplier<Optional<ClusterId>>
         return Optional.ofNullable( clusterId );
     }
 
-    private void publishClusterId( ClusterId localClusterId ) throws BindingException
+    private void publishClusterId( ClusterId localClusterId ) throws BindingException, InterruptedException
     {
         boolean success = topologyService.setClusterId( localClusterId );
         if ( !success )


### PR DESCRIPTION
Since the main thread is responsible for starting lifecycles, it was
 blocking on HC instance creation while also ignoring interrupts. This
 meant that stopping an instance that has not yet joined a cluster was
 impossible as shutdown would block on waiting for the main thread to join().
Moving HC instance creation to its own daemon thread and having waiters on it
 be responsive to interrupts solves this issue.

changelog: It is now possible to cleanly shutdown CC instances before they join the cluster