### PR TITLE
Fix out-of-bounds issue when applying fixed-reference high-limit format records during recovery or cluster store-copy. Bumps transaction log version.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageCommandReaderFactory.java
@@ -39,7 +39,7 @@ public class RecordStorageCommandReaderFactory implements CommandReaderFactory
 
     public RecordStorageCommandReaderFactory()
     {
-        readers = new CommandReader[10]; // pessimistic size
+        readers = new CommandReader[11]; // pessimistic size
         readers[-LogEntryVersion.V2_0.byteCode()] = new PhysicalLogCommandReaderV2_0();
         readers[-LogEntryVersion.V2_1.byteCode()] = new PhysicalLogCommandReaderV2_1();
         readers[-LogEntryVersion.V2_2.byteCode()] = new PhysicalLogCommandReaderV2_2();
@@ -49,6 +49,8 @@ public class RecordStorageCommandReaderFactory implements CommandReaderFactory
         readers[-LogEntryVersion.V2_2_10.byteCode()] = new PhysicalLogCommandReaderV2_2_10();
         readers[-LogEntryVersion.V2_3_5.byteCode()] = new PhysicalLogCommandReaderV2_2_10();
         readers[-LogEntryVersion.V3_0_2.byteCode()] = new PhysicalLogCommandReaderV3_0_2();
+        // The 3_0_10 version bump is only to prevent mixed-version clusters; format is otherwise backwards compatible.
+        readers[-LogEntryVersion.V3_0_10.byteCode()] = new PhysicalLogCommandReaderV3_0_2();
 
         // A little extra safety check so that we got 'em all
         LogEntryVersion[] versions = LogEntryVersion.values();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
@@ -47,6 +47,7 @@ public enum Record
     public static final byte CREATED_IN_TX = 2;
     public static final byte REQUIRE_SECONDARY_UNIT = 4;
     public static final byte HAS_SECONDARY_UNIT = 8;
+    public static final byte USES_FIXED_REFERENCE_FORMAT = 16;
 
 
     private byte byteValue;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/Command.java
@@ -226,9 +226,10 @@ public abstract class Command implements StorageCommand
 
         private boolean writeNodeRecord( WritableChannel channel, NodeRecord record ) throws IOException
         {
-            byte flags = bitFlags(  bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
-                                    bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
-                                    bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ) );
+            byte flags = bitFlags( bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
+                                   bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
+                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ),
+                                   bitFlag( record.isUseFixedReferences(), Record.USES_FIXED_REFERENCE_FORMAT ) );
             channel.put( flags );
             if ( record.inUse() )
             {
@@ -274,7 +275,8 @@ public abstract class Command implements StorageCommand
             byte flags = bitFlags( bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
                                    bitFlag( record.isCreated(), Record.CREATED_IN_TX ),
                                    bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
-                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ));
+                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ),
+                                   bitFlag( record.isUseFixedReferences(), Record.USES_FIXED_REFERENCE_FORMAT ) );
             channel.put( flags );
             if ( record.inUse() )
             {
@@ -322,7 +324,8 @@ public abstract class Command implements StorageCommand
         {
             byte flags = bitFlags( bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
                                    bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
-                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ) );
+                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ),
+                                   bitFlag( record.isUseFixedReferences(), Record.USES_FIXED_REFERENCE_FORMAT ) );
             channel.put( flags );
             channel.putShort( (short) record.getType() );
             channel.putLong( record.getNext() );
@@ -401,7 +404,8 @@ public abstract class Command implements StorageCommand
             byte flags = bitFlags( bitFlag( record.inUse(), Record.IN_USE.byteValue() ),
                                    bitFlag( record.getRelId() != -1, Record.REL_PROPERTY.byteValue() ),
                                    bitFlag( record.requiresSecondaryUnit(), Record.REQUIRE_SECONDARY_UNIT ),
-                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ) );
+                                   bitFlag( record.hasSecondaryUnitId(), Record.HAS_SECONDARY_UNIT ),
+                                   bitFlag( record.isUseFixedReferences(), Record.USES_FIXED_REFERENCE_FORMAT ) );
 
             channel.put( flags ); // 1
             channel.putLong( record.getNextProp() ).putLong( record.getPrevProp() ); // 8 + 8

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
@@ -209,6 +209,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requireSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         int type = shortToUnsignedInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
@@ -223,6 +224,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         {
             record.setSecondaryUnitId( channel.getLong() );
         }
+        record.setUseFixedReferences( usesFixedReferenceFormat );
         return record;
     }
 
@@ -404,6 +406,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requiresSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         NodeRecord record;
         Collection<DynamicRecord> dynamicLabelRecords = new ArrayList<>();
@@ -419,6 +422,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
             {
                 record.setSecondaryUnitId( channel.getLong() );
             }
+            record.setUseFixedReferences( usesFixedReferenceFormat );
         }
         else
         {
@@ -436,6 +440,8 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requiresSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
+
         RelationshipRecord record;
         if ( inUse )
         {
@@ -454,6 +460,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
             {
                 record.setSecondaryUnitId( channel.getLong() );
             }
+            record.setUseFixedReferences( usesFixedReferenceFormat );
         }
         else
         {
@@ -525,8 +532,10 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         boolean nodeProperty = !bitFlag( flags, Record.REL_PROPERTY.byteValue() );
         boolean requireSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         record.setRequiresSecondaryUnit( requireSecondaryUnit );
+        record.setUseFixedReferences( usesFixedReferenceFormat );
 
         long nextProp = channel.getLong(); // 8
         long prevProp = channel.getLong(); // 8

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
@@ -209,6 +209,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requireSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         int type = shortToUnsignedInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
@@ -223,6 +224,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         {
             record.setSecondaryUnitId( channel.getLong() );
         }
+        record.setUseFixedReferences( usesFixedReferenceFormat );
         return record;
     }
 
@@ -404,6 +406,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requiresSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         NodeRecord record;
         Collection<DynamicRecord> dynamicLabelRecords = new ArrayList<>();
@@ -419,6 +422,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
             {
                 record.setSecondaryUnitId( channel.getLong() );
             }
+            record.setUseFixedReferences( usesFixedReferenceFormat );
         }
         else
         {
@@ -436,6 +440,8 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         boolean inUse = bitFlag( flags, Record.IN_USE.byteValue() );
         boolean requiresSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
+
         RelationshipRecord record;
         if ( inUse )
         {
@@ -454,6 +460,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
             {
                 record.setSecondaryUnitId( channel.getLong() );
             }
+            record.setUseFixedReferences( usesFixedReferenceFormat );
         }
         else
         {
@@ -525,8 +532,10 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         boolean nodeProperty = !bitFlag( flags, Record.REL_PROPERTY.byteValue() );
         boolean requireSecondaryUnit = bitFlag( flags, Record.REQUIRE_SECONDARY_UNIT );
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
+        boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
         record.setRequiresSecondaryUnit( requireSecondaryUnit );
+        record.setUseFixedReferences( usesFixedReferenceFormat );
 
         long nextProp = channel.getLong(); // 8
         long prevProp = channel.getLong(); // 8

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersion.java
@@ -93,9 +93,13 @@ public enum LogEntryVersion
     // as of 2016-05-30: neo4j 3.0.2 legacy index IndexDefineCommand maps write size as short instead of byte
     // See comment for V2.2.10 for version number explanation
     // log entry layout hasn't changed since 2_3 so just use that one
-    V3_0_2( -9, LogEntryParsersV2_3.class );
+    V3_0_2( -9, LogEntryParsersV2_3.class ),
+    // as of 2017-05-26: the records in command log entries include a bit that specifies if the command is serialised
+    // using a fixed-width reference format, or not. This change is technically backwards compatible, so we bump the
+    // log version to prevent mixed-version clusters from forming.
+    V3_0_10( -10, LogEntryParsersV2_3.class );
 
-    public static final LogEntryVersion CURRENT = V3_0_2;
+    public static final LogEntryVersion CURRENT = V3_0_10;
     private static final LogEntryVersion[] ALL = values();
     private static final LogEntryVersion[] LOOKUP_BY_VERSION = new LogEntryVersion[ALL.length + 1]; // pessimistic size
     static

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0Test.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.NeoStoreRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -96,6 +97,48 @@ public class PhysicalLogCommandReaderV3_0Test
         assertEquals( before, relationshipCommand.getBefore() );
         verifySecondaryUnit( before, relationshipCommand.getBefore() );
         assertEquals( after, relationshipCommand.getAfter() );
+    }
+
+    @Test
+    public void readRelationshipCommandWithFixedReferenceFormat300() throws IOException
+    {
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        before.setUseFixedReferences( true );
+        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        after.setUseFixedReferences( true );
+        new Command.RelationshipCommand( before, after ).serialize( channel );
+
+        PhysicalLogCommandReaderV3_0 reader = new PhysicalLogCommandReaderV3_0();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.RelationshipCommand );
+
+        Command.RelationshipCommand relationshipCommand = (Command.RelationshipCommand) command;
+        assertEquals( before, relationshipCommand.getBefore() );
+        assertTrue( relationshipCommand.getBefore().isUseFixedReferences() );
+        assertEquals( after, relationshipCommand.getAfter() );
+        assertTrue( relationshipCommand.getAfter().isUseFixedReferences() );
+    }
+
+    @Test
+    public void readRelationshipCommandWithFixedReferenceFormat302() throws IOException
+    {
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        RelationshipRecord before = new RelationshipRecord( 42, true, 1, 2, 3, 4, 5, 6, 7, true, true );
+        before.setUseFixedReferences( true );
+        RelationshipRecord after = new RelationshipRecord( 42, true, 1, 8, 3, 4, 5, 6, 7, true, true );
+        after.setUseFixedReferences( true );
+        new Command.RelationshipCommand( before, after ).serialize( channel );
+
+        PhysicalLogCommandReaderV3_0_2 reader = new PhysicalLogCommandReaderV3_0_2();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.RelationshipCommand );
+
+        Command.RelationshipCommand relationshipCommand = (Command.RelationshipCommand) command;
+        assertEquals( before, relationshipCommand.getBefore() );
+        assertTrue( relationshipCommand.getBefore().isUseFixedReferences() );
+        assertEquals( after, relationshipCommand.getAfter() );
+        assertTrue( relationshipCommand.getAfter().isUseFixedReferences() );
     }
 
     @Test
@@ -174,6 +217,58 @@ public class PhysicalLogCommandReaderV3_0Test
     }
 
     @Test
+    public void readRelationshipGroupCommandWithFixedReferenceFormat300() throws IOException
+    {
+        // Given
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        RelationshipGroupRecord before = new RelationshipGroupRecord( 42, 3 );
+        before.setUseFixedReferences( true );
+        RelationshipGroupRecord after = new RelationshipGroupRecord( 42, 3, 4, 5, 6, 7, 8, true );
+        after.setUseFixedReferences( true );
+
+        new Command.RelationshipGroupCommand( before, after ).serialize( channel );
+
+        // When
+        PhysicalLogCommandReaderV3_0 reader = new PhysicalLogCommandReaderV3_0();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.RelationshipGroupCommand);
+
+        Command.RelationshipGroupCommand relationshipGroupCommand = (Command.RelationshipGroupCommand) command;
+
+        // Then
+        assertEquals( before, relationshipGroupCommand.getBefore() );
+        assertEquals( after, relationshipGroupCommand.getAfter() );
+        assertTrue( relationshipGroupCommand.getBefore().isUseFixedReferences() );
+        assertTrue( relationshipGroupCommand.getAfter().isUseFixedReferences() );
+    }
+
+    @Test
+    public void readRelationshipGroupCommandWithFixedReferenceFormat302() throws IOException
+    {
+        // Given
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        RelationshipGroupRecord before = new RelationshipGroupRecord( 42, 3 );
+        before.setUseFixedReferences( true );
+        RelationshipGroupRecord after = new RelationshipGroupRecord( 42, 3, 4, 5, 6, 7, 8, true );
+        after.setUseFixedReferences( true );
+
+        new Command.RelationshipGroupCommand( before, after ).serialize( channel );
+
+        // When
+        PhysicalLogCommandReaderV3_0_2 reader = new PhysicalLogCommandReaderV3_0_2();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.RelationshipGroupCommand);
+
+        Command.RelationshipGroupCommand relationshipGroupCommand = (Command.RelationshipGroupCommand) command;
+
+        // Then
+        assertEquals( before, relationshipGroupCommand.getBefore() );
+        assertEquals( after, relationshipGroupCommand.getAfter() );
+        assertTrue( relationshipGroupCommand.getBefore().isUseFixedReferences() );
+        assertTrue( relationshipGroupCommand.getAfter().isUseFixedReferences() );
+    }
+
+    @Test
     public void shouldReadNeoStoreCommand() throws Throwable
     {
         // Given
@@ -194,6 +289,58 @@ public class PhysicalLogCommandReaderV3_0Test
         // Then
         assertEquals( before.getNextProp(), neoStoreCommand.getBefore().getNextProp() );
         assertEquals( after.getNextProp(), neoStoreCommand.getAfter().getNextProp() );
+    }
+
+    @Test
+    public void nodeCommandWithFixedReferenceFormat300() throws Exception
+    {
+        // Given
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        NodeRecord before = new NodeRecord( 42, true, false, 33, 99, 66 );
+        NodeRecord after = new NodeRecord( 42, true, false, 33, 99, 66 );
+        before.setUseFixedReferences( true );
+        after.setUseFixedReferences( true );
+
+        new Command.NodeCommand( before, after ).serialize( channel );
+
+        // When
+        PhysicalLogCommandReaderV3_0 reader = new PhysicalLogCommandReaderV3_0();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.NodeCommand);
+
+        Command.NodeCommand nodeCommand = (Command.NodeCommand) command;
+
+        // Then
+        assertEquals( before, nodeCommand.getBefore() );
+        assertEquals( after, nodeCommand.getAfter() );
+        assertTrue( nodeCommand.getBefore().isUseFixedReferences() );
+        assertTrue( nodeCommand.getAfter().isUseFixedReferences() );
+    }
+
+    @Test
+    public void nodeCommandWithFixedReferenceFormat302() throws Exception
+    {
+        // Given
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        NodeRecord before = new NodeRecord( 42, true, false, 33, 99, 66 );
+        NodeRecord after = new NodeRecord( 42, true, false, 33, 99, 66 );
+        before.setUseFixedReferences( true );
+        after.setUseFixedReferences( true );
+
+        new Command.NodeCommand( before, after ).serialize( channel );
+
+        // When
+        PhysicalLogCommandReaderV3_0_2 reader = new PhysicalLogCommandReaderV3_0_2();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.NodeCommand);
+
+        Command.NodeCommand nodeCommand = (Command.NodeCommand) command;
+
+        // Then
+        assertEquals( before, nodeCommand.getBefore() );
+        assertEquals( after, nodeCommand.getAfter() );
+        assertTrue( nodeCommand.getBefore().isUseFixedReferences() );
+        assertTrue( nodeCommand.getAfter().isUseFixedReferences() );
     }
 
     @Test
@@ -240,6 +387,54 @@ public class PhysicalLogCommandReaderV3_0Test
         assertEquals( before.getNextProp(), neoStoreCommand.getBefore().getNextProp() );
         assertEquals( after.getNextProp(), neoStoreCommand.getAfter().getNextProp() );
         verifySecondaryUnit( after, neoStoreCommand.getAfter() );
+    }
+
+    @Test
+    public void readPropertyCommandWithFixedReferenceFormat300() throws IOException
+    {
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        PropertyRecord before = new PropertyRecord( 1 );
+        PropertyRecord after = new PropertyRecord( 2 );
+        before.setUseFixedReferences( true );
+        after.setUseFixedReferences( true );
+
+        new Command.PropertyCommand( before, after ).serialize( channel );
+
+        PhysicalLogCommandReaderV3_0 reader = new PhysicalLogCommandReaderV3_0();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.PropertyCommand);
+
+        Command.PropertyCommand neoStoreCommand = (Command.PropertyCommand) command;
+
+        // Then
+        assertEquals( before.getNextProp(), neoStoreCommand.getBefore().getNextProp() );
+        assertEquals( after.getNextProp(), neoStoreCommand.getAfter().getNextProp() );
+        assertTrue( neoStoreCommand.getBefore().isUseFixedReferences() );
+        assertTrue( neoStoreCommand.getAfter().isUseFixedReferences() );
+    }
+
+    @Test
+    public void readPropertyCommandWithFixedReferenceFormat302() throws IOException
+    {
+        InMemoryClosableChannel channel = new InMemoryClosableChannel();
+        PropertyRecord before = new PropertyRecord( 1 );
+        PropertyRecord after = new PropertyRecord( 2 );
+        before.setUseFixedReferences( true );
+        after.setUseFixedReferences( true );
+
+        new Command.PropertyCommand( before, after ).serialize( channel );
+
+        PhysicalLogCommandReaderV3_0_2 reader = new PhysicalLogCommandReaderV3_0_2();
+        Command command = reader.read( channel );
+        assertTrue( command instanceof Command.PropertyCommand);
+
+        Command.PropertyCommand neoStoreCommand = (Command.PropertyCommand) command;
+
+        // Then
+        assertEquals( before.getNextProp(), neoStoreCommand.getBefore().getNextProp() );
+        assertEquals( after.getNextProp(), neoStoreCommand.getAfter().getNextProp() );
+        assertTrue( neoStoreCommand.getBefore().isUseFixedReferences() );
+        assertTrue( neoStoreCommand.getAfter().isUseFixedReferences() );
     }
 
     @Test


### PR DESCRIPTION
In Neo4j 3.0.6 we introduced the fixed-reference variant of the high_limit
format. The fixed references are faster to read and write, but has a much lower
limit on the IDs it can use. Never the less, since all the references are of
a known fixed length, it can omit the meta-data for reference width that the
variable reference format cannot. Thus, it is sometimes possible for the fixed
reference format to store some records in a single record unit, where the
variablce reference width format would use two record units.

It turns out that we did not store in the transaction log, whether a record
would be applied to the store using a variable width, or a fixed width,
reference format. The absence of this information gets interpreted as if we are
always using the variable length reference format. This could cause problems
during recovery or cluster store copy. A record that fits a record unit using
the fixed reference format, but would require two record units using the
variable width format, would end up overwriting a part of its adjacent record,
or would go out of bounds on the page.

To solve this problem, we now record to the log whether a record was using the
fixed width, or the variable width record format. Fortunately, the record
headers in the transaction log had plenty of spare bits for this purpose. The
previously unused bit that I have taken for this purpose is always zero in the
existing transaction logs. This mirrors the bug exactly, in that the use of
fixed reference format defaulted to `false`. Thus, it can be argued that taking
this bit into use is not a format change. For this reason, I introduce no new
log version, _and_ I fix the bug for both 3.0.x log formats.